### PR TITLE
Fix UTF-8 encoding issues on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1181,6 +1181,38 @@ Then restart VS Code. The extension provides:
 
 ---
 
+## Troubleshooting
+
+### UTF-8 Encoding Errors on Windows
+
+If you see "stream did not contain valid UTF-8" errors, the issue is likely a BOM (Byte Order Mark) in your `.tnt` files.
+
+**Cause:** Windows tools like PowerShell's `Out-File` and some text editors add BOMs by default. NTNT requires UTF-8 without BOM.
+
+**Solutions:**
+
+1. **When using `ntnt intent init`, always use `-o` flag:**
+   ```bash
+   ntnt intent init greeting.intent -o greeting.tnt  # ✅ Correct
+   ntnt intent init greeting.intent > greeting.tnt   # ❌ May add BOM
+   ```
+
+2. **Configure VS Code** (create/edit `.vscode/settings.json`):
+   ```json
+   {
+     "files.encoding": "utf8",
+     "files.autoGuessEncoding": false
+   }
+   ```
+
+3. **Fix existing files with PowerShell:**
+   ```powershell
+   $content = Get-Content file.tnt -Raw
+   [System.IO.File]::WriteAllText("file.tnt", $content, (New-Object System.Text.UTF8Encoding $false))
+   ```
+
+---
+
 ## Documentation
 
 - [Whitepaper](whitepaper.md) - Complete technical specification and motivation

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,9 +225,12 @@ enum IntentCommands {
     /// Creates a new .tnt file with function stubs and route
     /// registrations based on the intent specification.
     /// 
+    /// IMPORTANT: Always use -o flag to save to a file. Shell redirection
+    /// (>) may add incorrect encoding (BOM) on Windows, causing UTF-8 errors.
+    /// 
     /// Examples:
-    ///   ntnt intent init requirements.intent
     ///   ntnt intent init requirements.intent -o server.tnt
+    ///   ntnt intent init requirements.intent (prints to stdout)
     Init {
         /// The intent file to generate code from
         #[arg(value_name = "INTENT_FILE")]
@@ -1911,7 +1914,8 @@ fn run_intent_init_command(
     
     // Output
     if let Some(output) = output_path {
-        fs::write(output, &scaffolding)?;
+        // Write directly to file with explicit UTF-8 encoding (no BOM)
+        fs::write(output, scaffolding.as_bytes())?;
         println!("{}", format!("Generated {} from intent file", output.display()).green());
         println!();
         println!("Next steps:");
@@ -1919,7 +1923,11 @@ fn run_intent_init_command(
         println!("  2. Run {} to verify", format!("ntnt intent check {}", output.display()).cyan());
     } else {
         // Print to stdout
-        println!("{}", scaffolding);
+        print!("{}", scaffolding);
+        eprintln!();
+        eprintln!("{}", "⚠️  Note: When redirecting to a file, use -o flag instead:".yellow());
+        eprintln!("   {} {}", "ntnt intent init".cyan(), format!("{} -o output.tnt", intent_path.display()).cyan());
+        eprintln!("   Shell redirection (>) may add incorrect encoding (BOM) on Windows");
     }
     
     Ok(())


### PR DESCRIPTION
- Fix ntnt intent init to write UTF-8 without BOM
- Add warning when using stdout redirection instead of -o flag
- Add troubleshooting section to README for Windows encoding issues
- Update CLI help to recommend -o flag over shell redirection

Fixes 'stream did not contain valid UTF-8' errors caused by BOMs added by PowerShell and Windows text editors.

## Description

Brief description of what this PR does.

## Related Issues

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing code to break)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the existing style (`cargo fmt`)
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally (`cargo test`)
- [ ] I have updated documentation if needed
- [ ] My commits have clear, descriptive messages

## Testing

Describe how you tested your changes:

```bash
# Commands used to test
```

## Screenshots (if applicable)

For UI or output changes, include before/after screenshots.
