### PR TITLE
fix(jobs): gate enqueue behind JobEnqueue capability, fix drain_jobs recursion

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -451,9 +451,11 @@ pub enum RuntimeCapability {
     Scheduling,
     /// Job worker runners: work_async, work_jobs, scale_workers
     JobWorkers,
-    /// Job configuration and enqueueing: configure_queue, enqueue, enqueue_in,
-    /// enqueue_at, job_status, cancel_job, retry_job, list_jobs, delete_jobs
+    /// Job configuration and management: configure_queue, job_status,
+    /// cancel_job, retry_job, list_jobs, delete_jobs
     JobConfig,
+    /// Job enqueueing: enqueue, enqueue_in, enqueue_at, enqueue_batch
+    JobEnqueue,
 }
 
 /// Execution mode controls how server-related functions behave
@@ -484,6 +486,7 @@ impl ExecutionMode {
                 RuntimeCapability::Scheduling,
                 RuntimeCapability::JobWorkers,
                 RuntimeCapability::JobConfig,
+                RuntimeCapability::JobEnqueue,
             ],
             ExecutionMode::HotReload => &[
                 RuntimeCapability::HttpServer,
@@ -495,10 +498,11 @@ impl ExecutionMode {
                 RuntimeCapability::HttpConfig,
                 RuntimeCapability::JobConfig,
             ],
-            ExecutionMode::Job => &[RuntimeCapability::JobConfig],
+            ExecutionMode::Job => &[RuntimeCapability::JobConfig, RuntimeCapability::JobEnqueue],
             ExecutionMode::UnitTest => &[
                 RuntimeCapability::TaskSpawning,
                 RuntimeCapability::JobConfig,
+                RuntimeCapability::JobEnqueue,
             ],
         }
     }
@@ -12141,6 +12145,7 @@ c")
         assert!(mode.has(RuntimeCapability::Scheduling));
         assert!(mode.has(RuntimeCapability::JobWorkers));
         assert!(mode.has(RuntimeCapability::JobConfig));
+        assert!(mode.has(RuntimeCapability::JobEnqueue));
     }
 
     #[test]
@@ -12153,6 +12158,7 @@ c")
         assert!(!mode.has(RuntimeCapability::TaskSpawning));
         assert!(!mode.has(RuntimeCapability::Scheduling));
         assert!(!mode.has(RuntimeCapability::JobWorkers));
+        assert!(!mode.has(RuntimeCapability::JobEnqueue));
     }
 
     #[test]
@@ -12164,13 +12170,15 @@ c")
         assert!(!mode.has(RuntimeCapability::TaskSpawning));
         assert!(!mode.has(RuntimeCapability::Scheduling));
         assert!(!mode.has(RuntimeCapability::JobWorkers));
+        assert!(!mode.has(RuntimeCapability::JobEnqueue));
     }
 
     #[test]
     fn test_job_mode_capabilities() {
         let mode = ExecutionMode::Job;
         assert!(mode.has(RuntimeCapability::JobConfig));
-        // Job mode: only JobConfig — no HTTP, no concurrency, no worker spawning
+        assert!(mode.has(RuntimeCapability::JobEnqueue));
+        // Job mode: only job capabilities — no HTTP, no concurrency, no worker spawning
         assert!(!mode.has(RuntimeCapability::HttpServer));
         assert!(!mode.has(RuntimeCapability::HttpConfig));
         assert!(!mode.has(RuntimeCapability::TaskSpawning));
@@ -12182,6 +12190,7 @@ c")
     fn test_unit_test_mode_capabilities() {
         let mode = ExecutionMode::UnitTest;
         assert!(mode.has(RuntimeCapability::JobConfig));
+        assert!(mode.has(RuntimeCapability::JobEnqueue));
         assert!(mode.has(RuntimeCapability::TaskSpawning)); // spawn() works in tests
         assert!(!mode.has(RuntimeCapability::HttpServer));
         assert!(!mode.has(RuntimeCapability::HttpConfig));
@@ -12191,15 +12200,15 @@ c")
 
     #[test]
     fn test_capabilities_returns_correct_slice_lengths() {
-        // Normal has all 6 capabilities
-        assert_eq!(ExecutionMode::Normal.capabilities().len(), 6);
+        // Normal has all 7 capabilities
+        assert_eq!(ExecutionMode::Normal.capabilities().len(), 7);
         // HotReload and Worker have 3 each
         assert_eq!(ExecutionMode::HotReload.capabilities().len(), 3);
         assert_eq!(ExecutionMode::Worker.capabilities().len(), 3);
-        // Job has 1 (JobConfig only)
-        assert_eq!(ExecutionMode::Job.capabilities().len(), 1);
-        // UnitTest has 2 (TaskSpawning + JobConfig)
-        assert_eq!(ExecutionMode::UnitTest.capabilities().len(), 2);
+        // Job has 2 (JobConfig + JobEnqueue)
+        assert_eq!(ExecutionMode::Job.capabilities().len(), 2);
+        // UnitTest has 3 (TaskSpawning + JobConfig + JobEnqueue)
+        assert_eq!(ExecutionMode::UnitTest.capabilities().len(), 3);
     }
 
     // === Capability gate in call_function ===

--- a/src/stdlib/jobs.rs
+++ b/src/stdlib/jobs.rs
@@ -2445,7 +2445,7 @@ pub fn init() -> HashMap<String, Value> {
             name: "enqueue".to_string(),
             arity: 2,
             max_arity: 2,
-            requires: None,
+            requires: Some(crate::interpreter::RuntimeCapability::JobEnqueue),
             func: |args| {
                 if args.len() != 2 {
                     return Err(IntentError::type_error(
@@ -2597,7 +2597,7 @@ pub fn init() -> HashMap<String, Value> {
             name: "enqueue_at".to_string(),
             arity: 3,
             max_arity: 3,
-            requires: None,
+            requires: Some(crate::interpreter::RuntimeCapability::JobEnqueue),
             func: |args| {
                 if args.len() != 3 {
                     return Err(IntentError::type_error(
@@ -2664,7 +2664,7 @@ pub fn init() -> HashMap<String, Value> {
             name: "enqueue_in".to_string(),
             arity: 3,
             max_arity: 3,
-            requires: None,
+            requires: Some(crate::interpreter::RuntimeCapability::JobEnqueue),
             func: |args| {
                 if args.len() != 3 {
                     return Err(IntentError::type_error(
@@ -3195,15 +3195,11 @@ pub fn init() -> HashMap<String, Value> {
                 let mut executed: i64 = 0;
                 let mut errors: Vec<String> = Vec::new();
 
-                // If a source file has been set, build a full interpreter so perform
-                // blocks have access to imports and user functions.  Otherwise fall
-                // back to a naked interpreter (sufficient for tests that don't rely
-                // on application-level imports).
-                let mut drain_interp = if JOB_RUNTIME.get_source_file().is_some() {
-                    create_job_interpreter()
-                } else {
-                    crate::interpreter::Interpreter::new()
-                };
+                // drain_jobs() is a test helper. It should not re-evaluate the
+                // application source file, because top-level drain_jobs() would recurse
+                // through worker bootstrap. Tests register jobs inline, so a bare
+                // interpreter is sufficient here.
+                let mut drain_interp = crate::interpreter::Interpreter::new();
 
                 for job in jobs {
                     let def = match JOB_RUNTIME.get_job(&job.job_type)? {
@@ -3464,7 +3460,7 @@ pub fn init() -> HashMap<String, Value> {
             name: "enqueue_batch".to_string(),
             arity: 2,
             max_arity: 2,
-            requires: None,
+            requires: Some(crate::interpreter::RuntimeCapability::JobEnqueue),
             func: |args| {
                 if args.len() != 2 {
                     return Err(IntentError::type_error(


### PR DESCRIPTION
Fixes #47 and #48.

## What changed

**Issue #47 — Worker bootstrap double-enqueue:**
Added `RuntimeCapability::JobEnqueue` and gated `enqueue`, `enqueue_in`, `enqueue_at`, and `enqueue_batch` behind it. Worker and HotReload modes do NOT have this capability, so top-level enqueue calls are suppressed during bootstrap. Normal, Job, and UnitTest modes retain it.

**Issue #48 — drain_jobs() infinite recursion:**
`drain_jobs()` now always uses `Interpreter::new()` (bare interpreter) instead of `create_job_interpreter()`. It's a testing utility — tests register jobs inline, so the full app context isn't needed. This prevents recursive re-evaluation when `drain_jobs()` appears at the top level of a source file.

## Changes
- `src/interpreter.rs`: New `JobEnqueue` capability variant, updated mode capability lists and tests
- `src/stdlib/jobs.rs`: `requires: Some(JobEnqueue)` on 4 enqueue functions, bare interpreter in `drain_jobs()`

All 1240 tests passing.