### PR TITLE
Tighten std/auth crypto boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ import { now, format } from "std/time"
 import { sha256, uuid } from "std/crypto"
 import { first, last, keys, values, entries, has_key, get_key } from "std/collections"
 import { oauth, enable_auth, get_user, validate_csrf } from "std/auth"
+// Boundary: use std/auth for auth/session/TOTP helpers, and std/crypto for generic crypto helpers like uuid/hash_password/verify_password
 import { open, get, set, del, list } from "std/kv"
 import { log_info, log_warn, log_error, set_log_level } from "std/log"
 import { channel, send, recv, sleep_ms, spawn, await_task, parallel, race } from "std/concurrent"

--- a/CODEX.md
+++ b/CODEX.md
@@ -171,6 +171,7 @@ import { now, format } from "std/time"
 import { sha256, uuid } from "std/crypto"
 import { first, last, keys, values, entries, has_key, get_key } from "std/collections"
 import { oauth, enable_auth, get_user, validate_csrf } from "std/auth"
+// Boundary: use std/auth for auth/session/TOTP helpers, and std/crypto for generic crypto helpers like uuid/hash_password/verify_password
 import { open, get, set, del, list } from "std/kv"
 import { log_info, log_warn, log_error, set_log_level } from "std/log"
 import { channel, send, recv, sleep_ms, spawn, await_task, parallel, race } from "std/concurrent"

--- a/design-docs/dd-059-auth-crypto-boundary.md
+++ b/design-docs/dd-059-auth-crypto-boundary.md
@@ -3,84 +3,48 @@
 ## Status: implemented on branch / awaiting PR review
 
 ## Problem
-`std/auth` should own authentication concerns, not serve as a second home for generic crypto helpers.
+`std/auth` should own authentication concerns, not generic crypto utilities.
 
-That boundary had drifted. Historically, some generic helpers were reachable from `std/auth`, specifically password helpers that already belonged conceptually in `std/crypto`.
-
-On current head, the real remaining overlap was narrower than the original draft assumed:
+On current head, the real remaining overlap was narrower than the first draft assumed:
 - `hash_password` was still exported from `std/auth`
 - `verify_password` was still exported from `std/auth`
-- `uuid` was **already canonical in `std/crypto`** on current head, so there was no active `std/auth` export left to remove there
+- `uuid` was already canonical in `std/crypto`
 
-This DD tightens the boundary all the way instead of carrying a deprecation alias forever.
+So the actual cleanup is to remove the remaining password-helper aliases from `std/auth`, not to pretend all three paths still exist there.
 
 ## Decision
-Hard-remove the remaining generic crypto exports from `std/auth`.
+Hard-remove the remaining generic crypto aliases from `std/auth`.
 
 After this change:
 - `hash_password` must be imported from `std/crypto`
 - `verify_password` must be imported from `std/crypto`
 - `uuid` remains in `std/crypto`
-- auth-owned helpers stay in `std/auth`
+- auth-owned helpers remain in `std/auth`
 
-## What stays in `std/auth`
-This DD does **not** flatten `std/auth` into nothing. The module still owns:
-- OAuth helpers
-- session helpers
-- CSRF helpers
-- auth middleware / current-user helpers
-- TOTP / MFA helpers such as `totp_secret` and `verify_totp`
+## Explicitly In Scope vs Out of Scope
+**In scope**
+- remove `hash_password` from `std/auth`
+- remove `verify_password` from `std/auth`
+- update docs/tests to reflect the hard removal
 
-TOTP remains intentionally in scope for `std/auth` because it is authentication-specific, not a generic crypto utility.
+**Out of scope**
+- moving TOTP helpers out of `std/auth`
+- changing OAuth/session/CSRF/current-user helpers
+- inventing a deprecation bridge or compatibility shim
 
-## Why hard removal is the right call
-- The boundary becomes obvious instead of “mostly true except for a few old helpers”
-- AI agents and humans get one canonical import path for crypto primitives
-- We avoid indefinite warning-only compatibility clutter
-- The local audit did not find substantial app usage of the soon-removed `std/auth` imports
+TOTP stays in `std/auth` because it is authentication-specific, not generic crypto.
 
 ## Local Audit
-I audited the local NTNT app stack and nearby repos before implementing this change.
+I checked the local NTNT app stack before shipping this change.
 
-Substantial local apps using `std/auth` were using auth-owned helpers only, for example:
-- `larri-dashboard`
-- `larri-design-ntnt`
-
-I did **not** find substantial local apps importing the removed names from `std/auth`:
+Substantial local apps do use `std/auth`, but only for auth-owned helpers. I did **not** find substantial local apps importing these soon-removed names from `std/auth`:
 - `uuid`
 - `hash_password`
 - `verify_password`
 
-One nearby repo did show auth-specific usage that should remain untouched:
-- `~/repos/larri-site-template/lib/admin_db.tnt` imports `totp_secret` and `verify_totp` from `std/auth`
-
-That reinforces the intended boundary instead of arguing against it.
-
-## Implementation Notes
-### Runtime/module surface
-- remove `hash_password` from `std/auth`
-- remove `verify_password` from `std/auth`
-- keep the `std/crypto` implementations as the canonical path
-- leave TOTP helpers in `std/auth`
-
-### Docs
-- update the DD to reflect the narrower real scope discovered during implementation
-- update generated docs/comments so they no longer talk about the `std/auth` aliases as merely deprecated
-- make the boundary explicit: generic crypto in `std/crypto`, auth-specific flows in `std/auth`
-
-### Tests
-- add regression coverage that `hash_password` / `verify_password` still work from `std/crypto`
-- add regression coverage that importing `hash_password` from `std/auth` now fails with a missing-export error
-
-## Risks
-| Risk | Why it matters | Mitigation |
-|------|----------------|------------|
-| External apps may still import removed names from `std/auth` | This is a breaking change | Intentional. Break loudly and keep the boundary clean. |
-| Scope creep into TOTP | Could accidentally move auth-specific helpers out of `std/auth` | Keep TOTP explicitly in `std/auth` and document that it is out of scope for this DD. |
-| Draft drift from reality | Original DD assumed `uuid` was still exported from `std/auth` | Update the DD to reflect the actual audited current-head state. |
+One nearby repo, `larri-site-template`, still imports `totp_secret` / `verify_totp` from `std/auth`, which is consistent with the intended boundary and stays untouched.
 
 ## Implementation Checklist
-
 ### Phase 1 — Re-audit current-head reality
 - [x] Re-check whether `uuid` is still exported from `std/auth`
 - [x] Re-check whether `hash_password` is still exported from `std/auth`
@@ -93,15 +57,14 @@ That reinforces the intended boundary instead of arguing against it.
 - [x] Remove `hash_password` export from `std/auth`
 - [x] Remove `verify_password` export from `std/auth`
 - [x] Confirm `std/crypto` remains the canonical import path for both helpers
-- [x] Confirm `uuid` is already canonical in `std/crypto` and does not need a new removal patch in `std/auth`
-- [x] Leave auth-owned helpers, including TOTP, untouched in `std/auth`
+- [x] Confirm `uuid` is already canonical in `std/crypto`
+- [x] Leave TOTP and other auth-owned helpers untouched in `std/auth`
 
 ### Phase 3 — Tests and docs
 - [x] Add a regression test proving password helpers still work from `std/crypto`
-- [x] Add a regression test proving `hash_password` is no longer exported from `std/auth`
-- [x] Update crypto docs/comments so they describe the auth alias as removed, not merely deprecated
+- [x] Add a regression test proving password helpers are no longer exported from `std/auth`
+- [x] Update docs/comments so they reflect hard removal, not deprecation rhetoric
 - [x] Regenerate docs with `ntnt docs --generate`
-- [x] Re-run `ntnt learn`-driven generated docs via the standard docs generation path
 
 ### Phase 4 — Validation and ship readiness
 - [x] Run `cargo fmt`
@@ -114,30 +77,15 @@ That reinforces the intended boundary instead of arguing against it.
 - [x] Open PR with the DD, implementation, and audit context together
 
 ## Validation
-Implemented and validated on branch `feat/dd-059-auth-crypto-boundary`.
+Implemented on branch `feat/dd-059-auth-crypto-boundary`.
 
-Validation loop completed:
-- `cargo fmt`
-- `cargo build --profile dev-release`
-- `cargo test --lib`
-- `cargo test --test language_features_tests --test type_checker_tests --test cli_tests`
-- `cargo build --release --locked`
-- `./target/release/ntnt docs --generate`
-- `cargo fmt -- --check`
-
-Behavior validated:
+Validated behavior:
 - `hash_password` works from `std/crypto`
 - `verify_password` works from `std/crypto`
-- importing `hash_password` from `std/auth` now fails as a missing export
+- importing password helpers from `std/auth` now fails as a missing export
 - TOTP helpers remain in `std/auth`
 
-## Bottom-Line Recommendation
+## Bottom Line
 Ship it.
 
-This is the right kind of breaking change:
-- small
-- conceptually clean
-- locally low-risk
-- boundary-improving
-
-The only real caveat is to keep the scope disciplined: this DD removes the remaining generic crypto aliases from `std/auth`, but it does **not** argue that auth-specific helpers such as TOTP should move.
+This is a small breaking change, but it is the right one: it removes the remaining generic crypto aliases from `std/auth` without dragging auth-specific helpers into unnecessary churn.

--- a/design-docs/dd-059-auth-crypto-boundary.md
+++ b/design-docs/dd-059-auth-crypto-boundary.md
@@ -1,0 +1,143 @@
+# DD-059: Hard-Remove Generic Crypto Exports from `std/auth`
+
+## Status: implemented on branch / awaiting PR review
+
+## Problem
+`std/auth` should own authentication concerns, not serve as a second home for generic crypto helpers.
+
+That boundary had drifted. Historically, some generic helpers were reachable from `std/auth`, specifically password helpers that already belonged conceptually in `std/crypto`.
+
+On current head, the real remaining overlap was narrower than the original draft assumed:
+- `hash_password` was still exported from `std/auth`
+- `verify_password` was still exported from `std/auth`
+- `uuid` was **already canonical in `std/crypto`** on current head, so there was no active `std/auth` export left to remove there
+
+This DD tightens the boundary all the way instead of carrying a deprecation alias forever.
+
+## Decision
+Hard-remove the remaining generic crypto exports from `std/auth`.
+
+After this change:
+- `hash_password` must be imported from `std/crypto`
+- `verify_password` must be imported from `std/crypto`
+- `uuid` remains in `std/crypto`
+- auth-owned helpers stay in `std/auth`
+
+## What stays in `std/auth`
+This DD does **not** flatten `std/auth` into nothing. The module still owns:
+- OAuth helpers
+- session helpers
+- CSRF helpers
+- auth middleware / current-user helpers
+- TOTP / MFA helpers such as `totp_secret` and `verify_totp`
+
+TOTP remains intentionally in scope for `std/auth` because it is authentication-specific, not a generic crypto utility.
+
+## Why hard removal is the right call
+- The boundary becomes obvious instead of “mostly true except for a few old helpers”
+- AI agents and humans get one canonical import path for crypto primitives
+- We avoid indefinite warning-only compatibility clutter
+- The local audit did not find substantial app usage of the soon-removed `std/auth` imports
+
+## Local Audit
+I audited the local NTNT app stack and nearby repos before implementing this change.
+
+Substantial local apps using `std/auth` were using auth-owned helpers only, for example:
+- `larri-dashboard`
+- `larri-design-ntnt`
+
+I did **not** find substantial local apps importing the removed names from `std/auth`:
+- `uuid`
+- `hash_password`
+- `verify_password`
+
+One nearby repo did show auth-specific usage that should remain untouched:
+- `~/repos/larri-site-template/lib/admin_db.tnt` imports `totp_secret` and `verify_totp` from `std/auth`
+
+That reinforces the intended boundary instead of arguing against it.
+
+## Implementation Notes
+### Runtime/module surface
+- remove `hash_password` from `std/auth`
+- remove `verify_password` from `std/auth`
+- keep the `std/crypto` implementations as the canonical path
+- leave TOTP helpers in `std/auth`
+
+### Docs
+- update the DD to reflect the narrower real scope discovered during implementation
+- update generated docs/comments so they no longer talk about the `std/auth` aliases as merely deprecated
+- make the boundary explicit: generic crypto in `std/crypto`, auth-specific flows in `std/auth`
+
+### Tests
+- add regression coverage that `hash_password` / `verify_password` still work from `std/crypto`
+- add regression coverage that importing `hash_password` from `std/auth` now fails with a missing-export error
+
+## Risks
+| Risk | Why it matters | Mitigation |
+|------|----------------|------------|
+| External apps may still import removed names from `std/auth` | This is a breaking change | Intentional. Break loudly and keep the boundary clean. |
+| Scope creep into TOTP | Could accidentally move auth-specific helpers out of `std/auth` | Keep TOTP explicitly in `std/auth` and document that it is out of scope for this DD. |
+| Draft drift from reality | Original DD assumed `uuid` was still exported from `std/auth` | Update the DD to reflect the actual audited current-head state. |
+
+## Implementation Checklist
+
+### Phase 1 — Re-audit current-head reality
+- [x] Re-check whether `uuid` is still exported from `std/auth`
+- [x] Re-check whether `hash_password` is still exported from `std/auth`
+- [x] Re-check whether `verify_password` is still exported from `std/auth`
+- [x] Audit local substantial apps for `std/auth` imports of the soon-removed names
+- [x] Record that TOTP helpers remain intentionally in `std/auth`
+- [x] Update the DD to reflect the narrower real scope on current head
+
+### Phase 2 — Runtime/module boundary cleanup
+- [x] Remove `hash_password` export from `std/auth`
+- [x] Remove `verify_password` export from `std/auth`
+- [x] Confirm `std/crypto` remains the canonical import path for both helpers
+- [x] Confirm `uuid` is already canonical in `std/crypto` and does not need a new removal patch in `std/auth`
+- [x] Leave auth-owned helpers, including TOTP, untouched in `std/auth`
+
+### Phase 3 — Tests and docs
+- [x] Add a regression test proving password helpers still work from `std/crypto`
+- [x] Add a regression test proving `hash_password` is no longer exported from `std/auth`
+- [x] Update crypto docs/comments so they describe the auth alias as removed, not merely deprecated
+- [x] Regenerate docs with `ntnt docs --generate`
+- [x] Re-run `ntnt learn`-driven generated docs via the standard docs generation path
+
+### Phase 4 — Validation and ship readiness
+- [x] Run `cargo fmt`
+- [x] Run `cargo build --profile dev-release`
+- [x] Run `cargo test --lib`
+- [x] Run `cargo test --test language_features_tests --test type_checker_tests --test cli_tests`
+- [x] Run `cargo build --release --locked`
+- [x] Run `./target/release/ntnt docs --generate`
+- [x] Run `cargo fmt -- --check`
+- [x] Open PR with the DD, implementation, and audit context together
+
+## Validation
+Implemented and validated on branch `feat/dd-059-auth-crypto-boundary`.
+
+Validation loop completed:
+- `cargo fmt`
+- `cargo build --profile dev-release`
+- `cargo test --lib`
+- `cargo test --test language_features_tests --test type_checker_tests --test cli_tests`
+- `cargo build --release --locked`
+- `./target/release/ntnt docs --generate`
+- `cargo fmt -- --check`
+
+Behavior validated:
+- `hash_password` works from `std/crypto`
+- `verify_password` works from `std/crypto`
+- importing `hash_password` from `std/auth` now fails as a missing export
+- TOTP helpers remain in `std/auth`
+
+## Bottom-Line Recommendation
+Ship it.
+
+This is the right kind of breaking change:
+- small
+- conceptually clean
+- locally low-risk
+- boundary-improving
+
+The only real caveat is to keep the scope disciplined: this DD removes the remaining generic crypto aliases from `std/auth`, but it does **not** argue that auth-specific helpers such as TOTP should move.

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1697,6 +1697,8 @@ fn get(req) {
 
 ## Authentication (`std/auth`)
 
+Boundary rule: use `std/auth` for auth flows, sessions, CSRF, current-user helpers, and TOTP. Use `std/crypto` for generic crypto helpers like `uuid`, `hash_password`, and `verify_password`.
+
 Full OAuth, session management, CSRF, JWT, and TOTP support — 34 functions.
 
 ### Basic OAuth Setup

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -4323,10 +4323,6 @@ hash_password("secret123", 14)  // => Ok("$2b$14$...")  // Hash with higher cost
 
 - **InvalidCost**: Cost must be between 10 and 31 — *Fix: Use a cost value of 10 or higher (OWASP minimum)*
 
-**Gotchas:**
-
-- `hash_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
-
 **See also:** `verify_password`, `is_valid_hash`
 
 *Since v0.4.0*
@@ -4576,11 +4572,6 @@ verify_password("secret123", "$2b$12$...valid_hash...")  // => Ok(true)  // Corr
 verify_password("wrong", "$2b$12$...valid_hash...")  // => Ok(false)  // Wrong password
 verify_password("secret", "not-a-hash")  // => Err("...")  // Invalid hash format
 ```
-
-**Gotchas:**
-
-- `verify_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
-- `verify_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
 
 **See also:** `hash_password`, `is_valid_hash`
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1831,7 +1831,6 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`enable_auth`](#enableauth) | Initialize the authentication system with OAuth providers. |
 | [`get_session`](#getsession) | Get the current session from the request. |
 | [`get_user`](#getuser) | Get the current authenticated user from the request. |
-| [`hash_password`](#hashpassword) | Hash a password using bcrypt. |
 | [`jwt_decode`](#jwtdecode) | Decode a JWT token WITHOUT verifying the signature. |
 | [`jwt_sign`](#jwtsign) | Create a signed JWT token from claims. |
 | [`jwt_verify`](#jwtverify) | Verify a JWT token and return its claims. |
@@ -1853,7 +1852,6 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`user_sessions`](#usersessions) | Get all active sessions for the current user. |
 | [`validate_csrf`](#validatecsrf) | Validate CSRF token on state-changing requests (POST, PUT, DELETE, PATCH). |
 | [`verify_csrf`](#verifycsrf) | Verify a CSRF token against the session's token. |
-| [`verify_password`](#verifypassword) | Verify a password against a bcrypt hash. |
 | [`verify_totp`](#verifytotp) | Verify a TOTP code against a secret. |
 
 #### `auth_callback`
@@ -2140,34 +2138,6 @@ get_user(req) otherwise return redirect("/login")  // Require auth
 ```
 
 **See also:** `get_session`, `logout_user`
-
-*Since v0.3.11*
-
----
-
-#### `hash_password`
-
-```ntnt
-hash_password(password: String) -> Result<String, String>
-```
-
-Hash a password using bcrypt.
-
-Utility function to hash passwords for custom storage or verification. Uses bcrypt with default cost factor.
-
-**Parameters:**
-
-- `password` — The password to hash
-
-**Returns:** Ok(hash) on success, Err(message) on failure
-
-**Examples:**
-
-```ntnt
-hash_password("mypassword")  // => Ok("$2b$12$...")  // Hash a password
-```
-
-**See also:** `verify_password`
 
 *Since v0.3.11*
 
@@ -2783,35 +2753,6 @@ verify_csrf(req, form["_csrf"])  // Validate form submission
 ```
 
 **See also:** `csrf_token`, `csrf_field`
-
-*Since v0.3.11*
-
----
-
-#### `verify_password`
-
-```ntnt
-verify_password(password: String, hash: String) -> Bool
-```
-
-Verify a password against a bcrypt hash.
-
-Utility function to verify passwords hashed with hash_password.
-
-**Parameters:**
-
-- `password` — The password to verify
-- `hash` — The bcrypt hash to verify against
-
-**Returns:** true if password matches hash, false otherwise
-
-**Examples:**
-
-```ntnt
-verify_password("mypassword", stored_hash)  // => true  // Verify password
-```
-
-**See also:** `hash_password`
 
 *Since v0.3.11*
 
@@ -4384,7 +4325,7 @@ hash_password("secret123", 14)  // => Ok("$2b$14$...")  // Hash with higher cost
 
 **Gotchas:**
 
-- `hash_password()` was previously available in `std/auth` (now deprecated — emits a runtime warning). Always use the `std/crypto` version, which supports a configurable cost factor. The `std/auth` version will be removed in a future release.
+- `hash_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
 
 **See also:** `verify_password`, `is_valid_hash`
 
@@ -4635,6 +4576,11 @@ verify_password("secret123", "$2b$12$...valid_hash...")  // => Ok(true)  // Corr
 verify_password("wrong", "$2b$12$...valid_hash...")  // => Ok(false)  // Wrong password
 verify_password("secret", "not-a-hash")  // => Err("...")  // Invalid hash format
 ```
+
+**Gotchas:**
+
+- `verify_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
+- `verify_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
 
 **See also:** `hash_password`, `is_valid_hash`
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -3666,19 +3666,7 @@ fn delete_all_sessions_for_user_redis(
 // SECTION 9: Password Utilities
 // ============================================================================
 
-/// Hash a password using bcrypt
-pub fn hash_password(password: &str) -> std::result::Result<String, String> {
-    bcrypt::hash(password, bcrypt::DEFAULT_COST)
-        .map_err(|e| format!("Password hashing failed: {}", e))
-}
-
-/// Verify a password against a bcrypt hash
-pub fn verify_password_hash(password: &str, hash: &str) -> bool {
-    bcrypt::verify(password, hash).unwrap_or(false)
-}
-
-// ============================================================================
-// SECTION 11: MFA/TOTP Functions
+// SECTION 9: MFA/TOTP Functions
 // ============================================================================
 
 /// Generate a new TOTP secret
@@ -6871,106 +6859,6 @@ pub fn init() -> HashMap<String, Value> {
             },
         },
     );
-
-    // @ntnt hash_password
-    // @module std/auth
-    // @signature hash_password(password: String) -> Result<String, String>
-    // Hash a password using bcrypt.
-    //
-    // Utility function to hash passwords for custom storage or verification.
-    // Uses bcrypt with default cost factor.
-    // @param password The password to hash
-    // @returns Ok(hash) on success, Err(message) on failure
-    // @see_also verify_password
-    // @since v0.3.11
-    // @tags #auth, #utility
-    // @example hash_password("mypassword") => Ok("$2b$12$...") ~ "Hash a password"
-    module.insert(
-        "hash_password".to_string(),
-        Value::NativeFunction {
-            name: "hash_password".to_string(),
-            arity: 1,
-            max_arity: 1,
-            requires: None,
-            func: |args| {
-                eprintln!("[DEPRECATED] hash_password() in std/auth is deprecated. Use hash_password() from std/crypto instead.");
-                if args.is_empty() {
-                    return Err(IntentError::type_error(
-                        "[auth] hash_password() requires a password".to_string(),
-                    ));
-                }
-
-                let password = match &args[0] {
-                    Value::String(s) => s.clone(),
-                    _ => {
-                        return Err(IntentError::type_error(
-                            "[auth] password must be a string".to_string(),
-                        ))
-                    }
-                };
-
-                match hash_password(&password) {
-                    Ok(hash) => Ok(make_ok(Value::String(hash))),
-                    Err(e) => Ok(make_err(Value::String(e))),
-                }
-            },
-        },
-    );
-
-    // @ntnt verify_password
-    // @module std/auth
-    // @signature verify_password(password: String, hash: String) -> Bool
-    // Verify a password against a bcrypt hash.
-    //
-    // Utility function to verify passwords hashed with hash_password.
-    // @param password The password to verify
-    // @param hash The bcrypt hash to verify against
-    // @returns true if password matches hash, false otherwise
-    // @see_also hash_password
-    // @since v0.3.11
-    // @tags #auth, #utility
-    // @example verify_password("mypassword", stored_hash) => true ~ "Verify password"
-    module.insert(
-        "verify_password".to_string(),
-        Value::NativeFunction {
-            name: "verify_password".to_string(),
-            arity: 2,
-            max_arity: 2,
-            requires: None,
-            func: |args| {
-                eprintln!("[DEPRECATED] verify_password() in std/auth is deprecated. Use verify_password() from std/crypto instead.");
-                if args.len() < 2 {
-                    return Err(IntentError::type_error(
-                        "[auth] verify_password() requires (password, hash)".to_string(),
-                    ));
-                }
-
-                let password = match &args[0] {
-                    Value::String(s) => s.clone(),
-                    _ => {
-                        return Err(IntentError::type_error(
-                            "[auth] password must be a string".to_string(),
-                        ))
-                    }
-                };
-
-                let hash = match &args[1] {
-                    Value::String(s) => s.clone(),
-                    _ => {
-                        return Err(IntentError::type_error(
-                            "[auth] hash must be a string".to_string(),
-                        ))
-                    }
-                };
-
-                Ok(Value::Bool(verify_password_hash(&password, &hash)))
-            },
-        },
-    );
-
-    // ==========================================================================
-    // MFA/2FA Functions
-    // ==========================================================================
 
     // @ntnt totp_secret
     // @module std/auth

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -17,6 +17,10 @@
 //! - OIDC Discovery (auto-configure from issuer)
 //! - ID token claims as user info source
 //!
+//! # Boundary
+//! - `std/auth` is for auth flows, sessions, CSRF, current-user helpers, and TOTP
+//! - generic crypto helpers like `uuid`, `hash_password`, and `verify_password` belong in `std/crypto`
+//!
 //! # Quick Start
 //! ```ntnt
 //! import { oauth, enable_auth, get_user } from "std/auth"

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -310,7 +310,6 @@ pub fn init() -> HashMap<String, Value> {
     // @see_also verify_password, is_valid_hash
     // @since v0.4.0
     // @tags #io
-    // @gotcha `hash_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
     // @example hash_password("secret123") => Ok("$2b$12$...") ~ "Hash with default cost"
     // @example hash_password("secret123", 10) => Ok("$2b$10$...") ~ "Hash with minimum cost (faster but still secure)"
     // @example hash_password("secret123", 14) => Ok("$2b$14$...") ~ "Hash with higher cost (more secure)"
@@ -384,8 +383,6 @@ pub fn init() -> HashMap<String, Value> {
     // @example verify_password("secret123", "$2b$12$...valid_hash...") => Ok(true) ~ "Correct password"
     // @example verify_password("wrong", "$2b$12$...valid_hash...") => Ok(false) ~ "Wrong password"
     // @example verify_password("secret", "not-a-hash") => Err("...") ~ "Invalid hash format"
-    // @gotcha `verify_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
-    // @gotcha `verify_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
     module.insert(
         "verify_password".to_string(),
         Value::NativeFunction {

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -310,7 +310,7 @@ pub fn init() -> HashMap<String, Value> {
     // @see_also verify_password, is_valid_hash
     // @since v0.4.0
     // @tags #io
-    // @gotcha `hash_password()` was previously available in `std/auth` (now deprecated — emits a runtime warning). Always use the `std/crypto` version, which supports a configurable cost factor. The `std/auth` version will be removed in a future release.
+    // @gotcha `hash_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
     // @example hash_password("secret123") => Ok("$2b$12$...") ~ "Hash with default cost"
     // @example hash_password("secret123", 10) => Ok("$2b$10$...") ~ "Hash with minimum cost (faster but still secure)"
     // @example hash_password("secret123", 14) => Ok("$2b$14$...") ~ "Hash with higher cost (more secure)"
@@ -384,6 +384,8 @@ pub fn init() -> HashMap<String, Value> {
     // @example verify_password("secret123", "$2b$12$...valid_hash...") => Ok(true) ~ "Correct password"
     // @example verify_password("wrong", "$2b$12$...valid_hash...") => Ok(false) ~ "Wrong password"
     // @example verify_password("secret", "not-a-hash") => Err("...") ~ "Invalid hash format"
+    // @gotcha `verify_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
+    // @gotcha `verify_password()` used to be available from `std/auth`, but the auth alias has been removed. Import it from `std/crypto`.
     module.insert(
         "verify_password".to_string(),
         Value::NativeFunction {

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -4360,6 +4360,52 @@ print(argon2_verify("wrongpassword", hash))
 }
 
 #[test]
+fn test_crypto_password_helpers_import_from_std_crypto() {
+    let code = r#"
+import { hash_password, verify_password } from "std/crypto"
+
+let hash = hash_password("secret123")
+match hash {
+    Ok(h) => {
+        print("HASHED")
+        print(verify_password("secret123", h))
+    }
+    Err(e) => print(e)
+}
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0, "Should succeed: stderr={}", stderr);
+    assert!(
+        stdout.contains("HASHED"),
+        "Should hash password: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("true"),
+        "Should verify password via std/crypto: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_crypto_password_helpers_removed_from_std_auth() {
+    let code = r#"
+import { hash_password } from "std/auth"
+print(hash_password("secret123"))
+"#;
+    let (_stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_ne!(
+        exit_code, 0,
+        "Import should fail once std/auth alias is removed"
+    );
+    assert!(
+        stderr.contains("'hash_password' is not exported from 'std/auth'"),
+        "Should mention missing std/auth export: stderr={}",
+        stderr
+    );
+}
+
+#[test]
 fn test_collections_includes_strings() {
     let code = r#"
 import { includes } from "std/collections"

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -4375,32 +4375,27 @@ match hash {
 "#;
     let (stdout, stderr, exit_code) = run_ntnt_code(code);
     assert_eq!(exit_code, 0, "Should succeed: stderr={}", stderr);
-    assert!(
-        stdout.contains("HASHED"),
-        "Should hash password: {}",
-        stdout
-    );
-    assert!(
-        stdout.contains("true"),
-        "Should verify password via std/crypto: {}",
-        stdout
-    );
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines[0], "HASHED");
+    assert_eq!(lines[1], "true");
 }
 
 #[test]
 fn test_crypto_password_helpers_removed_from_std_auth() {
     let code = r#"
-import { hash_password } from "std/auth"
+import { hash_password, verify_password } from "std/auth"
 print(hash_password("secret123"))
+print(verify_password("secret123", "fake"))
 "#;
     let (_stdout, stderr, exit_code) = run_ntnt_code(code);
     assert_ne!(
         exit_code, 0,
-        "Import should fail once std/auth alias is removed"
+        "Import should fail once std/auth aliases are removed"
     );
     assert!(
-        stderr.contains("'hash_password' is not exported from 'std/auth'"),
-        "Should mention missing std/auth export: stderr={}",
+        stderr.contains("'hash_password' is not exported from 'std/auth'")
+            || stderr.contains("'verify_password' is not exported from 'std/auth'"),
+        "Should mention missing std/auth exports: stderr={}",
         stderr
     );
 }


### PR DESCRIPTION
## Summary

Implements DD-059 through Phase 4 by hard-removing the remaining generic crypto aliases from `std/auth`.

This PR:
- removes `hash_password` and `verify_password` exports from `std/auth`
- keeps `std/crypto` as the canonical import path for password helpers
- updates DD-059 to reflect the actual current-head scope (`uuid` was already canonical in `std/crypto`)
- adds regression coverage for the boundary
- regenerates stdlib docs

## Local audit

I checked the local NTNT app stack before shipping this:
- substantial local apps (`larri-dashboard`, `larri-design-ntnt`, etc.) do use `std/auth`, but only for auth-owned helpers
- I did **not** find substantial local apps importing `uuid`, `hash_password`, or `verify_password` from `std/auth`
- one nearby repo (`larri-site-template`) still imports `totp_secret` / `verify_totp` from `std/auth`, which remains intentionally in scope

## Boundary decision

After this change:
- `hash_password` → import from `std/crypto`
- `verify_password` → import from `std/crypto`
- `uuid` remains in `std/crypto`
- TOTP, OAuth, session, CSRF, and current-user helpers remain in `std/auth`

## Validation

- `cargo fmt`
- `cargo build --profile dev-release`
- `cargo test --lib`
- `cargo test --test language_features_tests --test type_checker_tests --test cli_tests`
- `cargo build --release --locked`
- `./target/release/ntnt docs --generate`
- `cargo fmt -- --check`
