### PR TITLE
feat: strengthen auth foundation defaults and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "ntnt"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntnt"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 authors = ["NTNT Language Team"]
 description = "NTNT (Intent) - A programming language designed for AI-driven development"

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -41,687 +41,190 @@
 
 ---
 
-## Phase 1: Session Security Hardening
+## Unified Phased Implementation Plan
 
-**Goal:** Make sessions bulletproof. These are table-stakes features that every serious auth system implements.
+This is the single source of truth for how we should build `std/auth` forward. The phases below are the ordered implementation plan, and each phase contains the exact capabilities we want to ship and track with checkboxes.
 
-**Estimated effort:** Medium (2-3 PRs)
+### Phase 0 — Validate Safari ITP Complexity Before Building More
+**Goal:** Prove or kill the speculative Safari ITP workaround before we build more behavior on top of it.
 
-### 1.1 Session ID Rotation on Authentication
-**Priority:** Critical  
-**Reference:** OWASP Session Management Cheat Sheet, Section "Renew the Session ID After Any Privilege Level Change"
+- [x] Josh: Test A login on Safari with ITP fix + correct 30-day TTL
+- [x] Check session persistence after 24h
+- [x] If needed, deploy Test B build with direct cookie-on-redirect
+- [x] Decide whether the ITP workaround stays or gets removed
 
-**Problem:** When a user authenticates, the session ID stays the same. An attacker who obtained the pre-auth session ID (e.g., via session fixation) gets promoted to an authenticated session.
+**Result:** Verified. Phase 0 is complete, and this no longer blocks forward auth work.
 
-**Solution:** After successful OAuth callback, before setting the cookie:
-1. Create the session (as now)
-2. Generate a **new** session ID
-3. Migrate session data to the new ID
-4. Delete the old session
-5. Set the cookie with the new ID
+**Why first:** if the workaround is unnecessary, we should remove that complexity before layering more session behavior on top.
 
-This is automatic — no app developer action required.
+### Phase 1 — Foundation Mini-Phase
+**Goal:** Establish safe defaults and clear diagnostics without spending too long on lower-leverage convenience work.
 
-**Implementation:**
-```rust
-// In handle_auth_callback, after create_session:
-let new_id = generate_session_id();
-migrate_session(&session.id, &new_id);  // copy data, delete old
-session.id = new_id;
-store_session(session);
-```
+- [ ] Production-safe default auth config in `enable_auth`
+- [ ] Startup summary showing providers, routes, session settings, and cookie posture
+- [ ] Typed config validation with actionable errors and typo suggestions
+- [ ] Fatal errors for required missing config, warnings for optional config
 
-- [ ] Add `migrate_session(old_id, new_id)` for all backends
-- [ ] Rotate in `handle_auth_callback` Phase 2 (when cookie is set)
-- [ ] Add `rotate_session(req)` as a public stdlib function for custom auth flows
-- [ ] Tests: verify old session ID is invalid after rotation
+**Ships real value:** apps get a stable auth floor and much better debugging immediately.
 
-### 1.2 Sliding Session Expiry
-**Priority:** High  
-**Reference:** OWASP "Session Expiration"
+### Phase 2 — Route Protection for Real Apps
+**Goal:** Make route protection trivial, especially for file-routed apps like the template.
 
-**Problem:** Sessions have a fixed `expires_at` set at creation time. A user who's actively using the app for 8 hours straight gets logged out at the session boundary, even if they've been active the entire time.
+- [ ] `require_auth()` middleware helper
+- [ ] Configurable protected path patterns
+- [ ] Accept shorthand like `require_auth("/admin/*")`
+- [ ] Support exact path + subtree matching (`/admin` and `/admin/*`)
+- [ ] Work cleanly with file-routed apps, not just hand-written route tables
+- [ ] Smart redirect vs `401`/`403` based on HTML vs API requests
+- [ ] Always exempt `/auth/*` and auth health/debug routes
+- [ ] Expose authenticated session state through helpers instead of ad hoc cookie parsing in handlers
 
-**Solution:** Add optional sliding window that extends `expires_at` on each authenticated request. Controlled by config:
+**Ships real value:** apps stop repeating auth checks in every protected page.
+
+### Phase 3 — Session Core and Cookie Helpers
+**Goal:** Remove the most repetitive and error-prone login/logout/session code.
+
+- [ ] Rotate session ID automatically on successful auth callback/login
+- [ ] Invalidate old session ID immediately after rotation
+- [ ] Preserve intended session data across rotation
+- [ ] Session store migration implemented in Rust for Redis/Postgres/SQLite backends
+- [ ] Keep `migrate_session(old_id, new_id)` internal to Rust/session-store code
+- [ ] Public ntnt API exposes only high-level helpers (`sign_in_session`, `rotate_session`)
+- [ ] `sign_in_session()` helper that persists session + attaches cookie
+- [ ] `sign_out_session()` helper that revokes session + clears cookie
+- [ ] `current_session()` / `current_user()` helper for request-time lookups
+- [ ] Shared auth cookie defaults with per-app overrides
+- [ ] Centralize cookie posture: name, path, same-site, secure, httpOnly, expiry
+- [ ] Log session rotation events when auth security logging is enabled
+
+**Possible public API shape:**
 
 ```ntnt
-enable_auth([google], map {
-    "session_ttl": 86400 * 30,     // max lifetime: 30 days
-    "idle_timeout": 86400 * 7,     // inactive for 7 days → session dies
-    "sliding": true                 // extend idle_timeout on each request
+let resp = redirect("/admin")
+return sign_in_session(resp, map {
+    "subject_id": user["id"],
+    "claims": map { "role": "admin" }
+})
+
+let session = current_session(req)
+let user = current_user(req)
+return sign_out_session(redirect("/login"), req)
+```
+
+**Ships real value:** the template’s verbose login/logout/cookie handling mostly disappears here.
+
+### Phase 4 — Staged Auth Primitives
+**Goal:** Make multi-step auth flows first-class instead of hand-rolled.
+
+- [ ] Distinct pending-auth primitive separate from full authenticated sessions
+- [ ] `begin_auth_challenge()` helper
+- [ ] `current_auth_challenge()` helper
+- [ ] `complete_auth_challenge()` helper
+- [ ] `cancel_auth_challenge()` helper
+- [ ] Explicit TTL and one-time-use semantics for challenges
+- [ ] Safe place for minimal staged-auth metadata
+- [ ] No protected-route access until challenge upgrades into a real session
+- [ ] Works for password → TOTP verification
+- [ ] Works for first login → TOTP setup → forced password change
+- [ ] Works for future MFA and step-up auth flows
+
+**Possible public API shape:**
+
+```ntnt
+let resp = redirect("/admin/verify")
+return begin_auth_challenge(resp, map {
+    "subject_id": user["id"],
+    "kind": "mfa_pending",
+    "ttl": 1800,
+    "data": map { "next": "/admin" }
+})
+
+let challenge = current_auth_challenge(req)
+let resp = redirect("/admin")
+return complete_auth_challenge(resp, req, map {
+    "claims": map { "role": "admin" }
 })
 ```
 
-**Behavior:**
-- Each authenticated request updates `last_active_at` on the session
-- Session is valid if: `now < expires_at AND now - last_active_at < idle_timeout`
-- `expires_at` is an absolute ceiling — even with sliding, session dies after max lifetime
-- If `sliding` is false (default for backward compat), behavior is unchanged
-
-**Implementation:**
-- [ ] Add `last_active_at` field to Session struct
-- [ ] Add `idle_timeout` and `sliding` to AuthConfig
-- [ ] Update `get_user_from_request` to check idle timeout and touch `last_active_at`
-- [ ] Debounce the touch — only write if `last_active_at` is >60s stale (avoid write amplification)
-- [ ] Update session in store on touch (all backends)
-- [ ] Migration: existing sessions default `last_active_at = created_at`
-- [ ] Tests: sliding extends, absolute ceiling holds, idle timeout kills
-
-### 1.3 Absolute Session Lifetime Cap
-**Priority:** High  
-**Reference:** OWASP "Absolute Timeout"
-
-**Problem:** With token refresh, sessions can theoretically live forever (refresh_ttl extends the session). There's no hard cap.
-
-**Solution:** Add `max_lifetime` config (default: 90 days). Sessions beyond this are force-expired regardless of refresh tokens. Already somewhat implemented via `refresh_ttl`, but should be explicit and independently configurable.
-
-- [ ] Add `max_lifetime` to AuthConfig (default: `refresh_ttl` or 90 days)
-- [ ] Check `now - created_at > max_lifetime` in session validation
-- [ ] When max lifetime is hit, session is dead — no auto-refresh possible
-- [ ] Log `[auth] Session {id} exceeded max lifetime, forcing re-auth`
-
-### 1.4 Session Cookie Name Customization
-**Priority:** Low  
-**Reference:** OWASP "Session ID Name Fingerprinting"
-
-**Problem:** Cookie is always `ntnt_session`, which reveals the framework.
-
-**Solution:** Already have `cookie_name` in AuthConfig, but it's hardcoded to `"ntnt_session"`. Allow overriding:
-
-```ntnt
-enable_auth([google], map {
-    "cookie_name": "sid"  // generic, reveals nothing
-})
-```
-
-- [ ] Parse `cookie_name` from config map in `enable_auth`
-- [ ] Default remains `"ntnt_session"` for backward compat
-- [ ] Document the recommendation to use a generic name
-
----
-
-## Phase 2: OAuth Hardening (RFC 9700 Compliance)
-
-**Goal:** Full compliance with RFC 9700 (OAuth 2.0 Security Best Current Practice, published January 2025).
-
-**Estimated effort:** Medium (2-3 PRs)
-
-### 2.1 Refresh Token Rotation
-**Priority:** Critical  
-**Reference:** RFC 9700 §4.14, OWASP
-
-**Problem:** Refresh tokens are long-lived and static. If stolen, an attacker can silently generate new access tokens indefinitely.
-
-**Solution:** On every token refresh, the authorization server should issue a **new** refresh token and invalidate the old one. Our auto-refresh already calls the provider's token endpoint, and most providers (Google, GitHub) return a new refresh token in the response. We should:
-
-1. Always store the new refresh token when returned
-2. Detect refresh token reuse (same old refresh token used twice → possible theft)
-3. On reuse detection: revoke ALL sessions for that user (nuclear option)
-
-**Implementation:**
-- [ ] Add `refresh_token_hash` column to sessions (track which refresh token is current)
-- [ ] On successful refresh: update stored refresh token, update hash
-- [ ] On refresh with stale token (hash mismatch): flag as potential theft
-- [ ] Config option: `"refresh_token_reuse": "revoke_all" | "warn" | "ignore"`
-- [ ] Default: `"warn"` (log + continue) — `"revoke_all"` for strict mode
-- [ ] Tests: rotation works, reuse detected, revocation cascade
-
-### 2.2 State Parameter Entropy and Binding
-**Priority:** Medium  
-**Reference:** RFC 9700 §4.4
-
-**Problem:** Our OAuth state parameter is a UUID (128 bits of entropy — good), but we should also bind it to the user's browser session to prevent state injection attacks.
-
-**Solution:** Include a hash of the user's existing session cookie (if any) or a fingerprint of the request in the OAuth state. Validate on callback.
-
-- [ ] Bind state to pre-auth session or request fingerprint
-- [ ] Validate binding on callback before consuming state
-- [ ] Reject states that don't match the originating browser
-
-### 2.3 Authorization Code Replay Protection
-**Priority:** Medium  
-**Reference:** RFC 9700 §4.5
-
-**Problem:** If an authorization code is intercepted and replayed, the attacker gets a valid session. PKCE mitigates this (which we already use), but we should also enforce single-use codes at our end.
-
-**Current state:** We already consume OAuth state atomically (GETDEL/DELETE...RETURNING), which effectively prevents code replay since the state is consumed. This is already handled. Document and test.
-
-- [ ] Verify and document that our state consumption prevents code replay
-- [ ] Add explicit test for double-callback with same code
-
-### 2.4 Redirect URI Exact Match Validation
-**Priority:** Medium  
-**Reference:** RFC 9700 §4.1
-
-**Problem:** We trust the provider to validate redirect URIs, but we should also validate on our end that the callback came from an expected redirect URI.
-
-- [ ] Store the redirect URI in OAuth state
-- [ ] Validate on callback that the request URI matches
-- [ ] Reject mismatches
-
----
-
-## Phase 3: Developer Experience — 2-3x Easier Than Anything Else
-
-**Goal:** Make ntnt auth the fastest path from zero to production-secure authenticated app in any language. Not by hiding things, but by making the right thing obvious at every layer.
-
-**Design principle: Progressive Disclosure, Not Progressive Complexity.** Every layer should feel complete on its own. You don't learn Layer 2 exists until you need it. When you do need it, it's one clear step — not "now go read 40 pages of docs."
-
-**Estimated effort:** Large (4-5 PRs — this is the DX differentiator)
-
-### The Problem With Auth Today (Every Language)
-
-**What developers actually hate about auth** (sourced from Reddit r/nextjs, r/webdev, Auth0 complaints, Clerk reviews):
-
-1. **"Too many files / too many concepts before hello world."** Auth.js needs auth.ts + middleware.ts + route handler + provider config + adapter setup. Lucia needs db schema + adapter + auth module + middleware + session validation. Laravel Sanctum needs migration + config + middleware group + CORS setup. It's 5-8 files before you see a login page.
-
-2. **"Silent misconfiguration."** Wrong session store URL? Sessions go to memory and vanish on restart — no error. Wrong TTL type? Falls back to default — no warning. Wrong redirect URI? Opaque OAuth error from Google. Developers lose hours to config bugs that could've been caught at startup.
-
-3. **"The docs don't match reality."** Auth.js v5 is an "infinite beta" — docs show v4 patterns, v5 changed everything. Lucia deprecated itself. Firebase auth docs assume the Firebase ecosystem. When the stdlib IS the docs (because it's one function call), there's nothing to get out of sync.
-
-4. **"I can't see what it's doing."** Sessions expire and nobody knows why. Tokens refresh and nobody knows when. The auth system is a black box until something breaks, then you're reading source code to understand what happened.
-
-5. **"Middleware is confusing."** Which routes need auth? What about API routes vs page routes? Public routes? The mental model of "this middleware runs before everything and decides who gets in" is simple in theory, complex in every implementation.
-
-### The ntnt Answer: Four Layers, Each Complete
-
-```
-Layer 0:  enable_auth([google])                           ← works, production-safe
-Layer 1:  enable_auth([google], "balanced")               ← named preset, still one line
-Layer 2:  enable_auth([google], map { "session_ttl": … }) ← custom config
-Layer 3:  oauth_exchange, create_session_from_oauth, …    ← full manual control
-```
-
-**Layer 0 is the key insight.** With zero config, `enable_auth` should:
-- Auto-detect the session store from the environment (REDIS_URL → Redis, DATABASE_URL → Postgres, else → SQLite file in DATA_DIR)
-- Generate a session secret from a hash of the machine ID + app path (stable across restarts in dev, warns in prod to set a real one)
-- Use sane defaults (30-day sessions, 90-day refresh, PKCE, CSRF, HttpOnly+Secure+SameSite)
-- Auto-register `/auth/{provider}`, `/auth/{provider}/callback`, `/auth/logout` routes
-- Print a clear startup summary of what it configured
-
-**The developer writes 4 lines, not 15:**
-
-```ntnt
-import { oauth, enable_auth } from "std/auth"
-load_env(".env")
-enable_auth([oauth("google", get_env("GOOGLE_CLIENT_ID"), get_env("GOOGLE_CLIENT_SECRET"))])
-listen(8080)
-```
-
-That's it. Protected routes, session management, CSRF, PKCE, token refresh, cookie security — all automatic. The `.env` file has two values: `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. Nothing else required.
-
-### 3.1 Zero-Config Defaults (Layer 0)
-**Priority:** Critical — this is the headline feature
-
-**What happens when you call `enable_auth` with no config map:**
-
-| Config | Auto-detected from | Default |
-|--------|-------------------|---------|
-| `session_store` | `REDIS_URL` env → Redis; `DATABASE_URL` env → Postgres; else → `./data/sessions.db` (SQLite) | SQLite |
-| `session_secret` | `AUTH_SESSION_SECRET` env; else → derive from machine ID + app path | Derived (warns in prod) |
-| `session_ttl` | — | 30 days |
-| `refresh_ttl` | — | 90 days |
-| `idle_timeout` | — | 7 days |
-| `sliding` | — | true |
-| `cookie_secure` | `NTNT_ENV` = production → true; else → false | Auto |
-| `cookie_name` | — | `"_session"` (generic, no framework fingerprinting) |
-| `after_login` | — | `"/"` |
-| `after_logout` | — | `"/login"` |
-| `after_failure` | — | `"/login?error=auth_failed"` |
-| `store_tokens` | — | true |
-
-- [ ] Implement env-based session store auto-detection in `enable_auth`
-- [ ] Implement deterministic dev secret derivation (hash of hostname + cwd + "ntnt-dev-session")
-- [ ] Print startup warning when using derived secret: `[auth] ⚠ Using dev session secret. Set AUTH_SESSION_SECRET for production.`
-- [ ] Change default cookie name from `"ntnt_session"` to `"_session"`
-- [ ] Set `idle_timeout: 7 days` and `sliding: true` as defaults (Phase 1.2 prerequisite)
-
-### 3.2 Auto-Route Registration
-**Priority:** Critical — eliminates boilerplate files
-
-**Problem:** Every ntnt app with auth currently needs these 3 lines:
-```ntnt
-get("/auth/{provider}", auth_start)
-get("/auth/{provider}/callback", auth_callback)
-post("/auth/logout", auth_logout)
-```
-
-These are the same in every app. They're never customized. They're boilerplate.
-
-**Solution:** `enable_auth` registers them automatically. If the developer wants custom paths, they override:
-
-```ntnt
-// Auto-registers /auth/google, /auth/google/callback, /auth/logout
-enable_auth([google])
-
-// Custom paths (rare):
-enable_auth([google], map {
-    "auth_prefix": "/login/oauth",    // → /login/oauth/google, /login/oauth/google/callback
-    "logout_path": "/api/logout",     // → POST /api/logout
-    "auto_routes": false              // disable auto-registration entirely, wire your own
-})
-```
-
-- [ ] Register OAuth routes inside `enable_auth` by default
-- [ ] Configurable `auth_prefix` (default: `"/auth"`)
-- [ ] Configurable `logout_path` (default: `"/auth/logout"`)
-- [ ] `auto_routes: false` to opt out completely
-- [ ] Detect conflict: if the app manually registers the same routes, warn instead of crash
-- [ ] Print registered routes in startup log
-
-### 3.3 Startup Config Summary
-**Priority:** High — makes the invisible visible
-
-**Problem:** After `enable_auth`, the developer has no idea what was actually configured. When sessions expire unexpectedly, there's no breadcrumb to trace back to config.
-
-**Solution:** Always print a startup summary. Not behind a flag — always:
-
-```
-┌─ Auth ─────────────────────────────────────┐
-│ Provider:  google (PKCE ✓)                 │
-│ Sessions:  Redis (redis://localhost:6379)   │
-│ TTL:       30d session, 7d idle (sliding)   │
-│ Refresh:   90d (auto-refresh ✓)            │
-│ Cookie:    _session (Secure, HttpOnly, Lax) │
-│ CSRF:      enabled                          │
-│ Routes:    /auth/google → login             │
-│            /auth/google/callback            │
-│            POST /auth/logout                │
-├─ Warnings ─────────────────────────────────┤
-│ ⚠ Using dev session secret                 │
-│   → Set AUTH_SESSION_SECRET in production   │
-└────────────────────────────────────────────┘
-```
-
-In production (no warnings):
-```
-[auth] ✓ google (PKCE) | Redis | 30d/7d sliding | Secure
-```
-
-This is the first thing a developer sees after `enable_auth`. No mystery. No black box.
-
-- [ ] Build the summary printer in `init_auth`
-- [ ] Dev mode: boxed format with full details + warnings
-- [ ] Production mode: single-line compact format
-- [ ] Include every config value that was set (explicit or default)
-- [ ] Flag any value that's using a default with a subtle marker
-
-### 3.4 Typed Config Validation with Actionable Errors
-**Priority:** High — would have caught the `session_ttl: 3600` staging incident
-
-**Problem:** Passing wrong types to `enable_auth` config map fails silently (falls back to defaults). Passing valid types with suspicious values also fails silently.
-
-**Solution:** Two layers of validation:
-
-**Type validation:**
-```
-[auth] ✗ session_ttl: expected Int, got String "3600" — using default 2592000
-        Fix: "session_ttl": 3600  (without quotes)
-```
-
-**Range validation (warnings, not errors):**
-```
-[auth] ⚠ session_ttl: 3600 (1 hour) is unusually short.
-        Common values: 86400 (1 day), 2592000 (30 days), 7776000 (90 days)
-
-[auth] ⚠ session_ttl: 31536000 (365 days) exceeds recommended maximum.
-        OWASP recommends absolute session lifetime ≤ 90 days for sensitive apps.
-```
-
-**Consistency validation:**
-```
-[auth] ⚠ refresh_ttl (7 days) is shorter than session_ttl (30 days).
-        Refresh tokens can't extend sessions past the session TTL.
-        Fix: Set refresh_ttl > session_ttl, or disable refresh (store_tokens: false)
-```
-
-- [ ] Add type validation for every config field in `enable_auth` (Int, String, Bool, URL)
-- [ ] Add range validation: suspiciously short (<5 min), suspiciously long (>365 days)
-- [ ] Add consistency validation: refresh_ttl vs session_ttl, idle_timeout vs session_ttl
-- [ ] Log clear fix suggestions with example values
-- [ ] Never error on valid types with unusual values — warn only (the developer may know what they're doing)
-- [ ] In production: suppress range/consistency warnings (they've been seen in dev)
-
-### 3.5 Auth Health Check Endpoint
-**Priority:** Medium
-
-**Problem:** Developers can't verify auth config is correct without logging in and waiting for something to break.
-
-**Solution:** Add `auth_health` handler — automatically registered in dev mode:
-
-```
-GET /auth/health  (dev mode only, auto-registered)
-```
-
-Returns:
-```json
-{
-    "status": "healthy",
-    "providers": [{"name": "google", "pkce": true, "oidc": true}],
-    "session_store": {"type": "redis", "connected": true, "active_sessions": 42},
-    "config": {
-        "session_ttl": 2592000,
-        "refresh_ttl": 7776000,
-        "idle_timeout": 604800,
-        "sliding": true,
-        "cookie_secure": false,
-        "csrf_enabled": true
-    },
-    "warnings": ["Using dev session secret"],
-    "test_login_url": "/auth/google"
-}
-```
-
-- [ ] Auto-register `/auth/health` GET route in dev mode
-- [ ] Include session store connectivity check
-- [ ] Include active session count
-- [ ] Include full resolved config (so you can see what defaults were applied)
-- [ ] Include `test_login_url` for convenience
-- [ ] Blocked in production (`NTNT_ENV=production` returns 404)
-
-### 3.6 `enable_auth` Presets
-**Priority:** Medium — sugar, not substance, but excellent DX
-
-**Problem:** Even with good defaults, some apps want "just make it more strict" or "just make it more relaxed" without researching what TTL values mean.
-
-**Solution:** Named presets as the second argument:
-
-```ntnt
-enable_auth([google])                         // defaults = "balanced"
-enable_auth([google], "strict")               // banking app
-enable_auth([google], "relaxed")              // personal dashboard
-enable_auth([google], map { ... })            // full custom
-enable_auth([google], map {                   // preset + override
-    "preset": "strict",
-    "after_login": "/dashboard"
-})
-```
-
-| Preset | session_ttl | idle_timeout | sliding | max_lifetime | refresh | description |
-|--------|-------------|--------------|---------|--------------|---------|-------------|
-| `"strict"` | 1 hour | 15 min | true | 24 hours | off | Banking, healthcare, anything PII-heavy |
-| `"balanced"` | 30 days | 7 days | true | 90 days | on | Most web apps (the default) |
-| `"relaxed"` | 90 days | 30 days | true | 365 days | on | Personal tools, dashboards |
-
-**Presets are transparent:** choosing a preset prints every value it sets in the startup summary, so the developer always knows what they got. No magic.
-
-- [ ] Define preset configurations as const maps
+**Ships real value:** the template’s password/TOTP/password-change flow gets much cleaner and more robust.
+
+### Phase 5 — Session Lifecycle and Presets
+**Goal:** Harden session lifetime behavior and make strong defaults ergonomic.
+
+- [ ] Add sliding session expiry support
+- [ ] Throttle refreshes so stores are not updated on every request
+- [ ] Refresh cookie Max-Age/Expires along with sliding sessions
+- [ ] Add absolute maximum session lifetime support
+- [ ] Store session creation time separately from idle expiry
+- [ ] Clear log/error path when max lifetime forces re-auth
+- [ ] Define preset configurations (`consumer`, `admin`, `internal`, `strict`)
 - [ ] Accept String or Map as second arg to `enable_auth`
-- [ ] `"preset"` key in map applies preset first, then overrides
-- [ ] Startup summary shows `[preset: balanced]` or `[custom]`
-- [ ] Document all presets with use case guidance
+- [ ] Allow preset + override merge
+- [ ] Document preset guidance clearly
 
-### 3.7 Protected Route Pattern — `require_auth` Middleware
-**Priority:** High — simplifies the most common auth question: "which routes need auth?"
+**Ships real value:** apps get secure, reusable lifecycle behavior without inventing timeout policy from scratch.
 
-**Problem:** The current middleware (`01_auth.tnt`) is custom per-app. Every app re-implements the same logic: check for session, redirect to login, allow public paths. The middleware file is typically 50+ lines of boilerplate that does the exact same thing.
+### Phase 6 — OAuth Hardening and Observability
+**Goal:** Improve security posture and make auth easier to inspect in production.
 
-**Solution:** Built-in `require_auth` middleware with route patterns:
+- [ ] Refresh token rotation when providers issue a new refresh token
+- [ ] Invalidate old refresh token references where feasible
+- [ ] Log refresh token rotation events
+- [ ] Document provider differences clearly
+- [ ] `/auth/health` endpoint (dev-only by default)
+- [ ] Health output shows config state without leaking secrets
+- [ ] Diagnose common issues like redirect mismatch, missing env, wrong store
 
-```ntnt
-import { require_auth } from "std/auth"
+**Ships real value:** better production safety and far easier troubleshooting.
 
-// Protect everything except explicitly public routes
-use_middleware(require_auth(map {
-    "public": ["/", "/login", "/about", "/api/health"],
-    "login_redirect": "/login"
-}))
-```
+### Phase 7 — Auto-Routes and Convenience UI
+**Goal:** Make the easy path extremely easy without forcing apps into one UI.
 
-Or invert — protect specific routes:
-```ntnt
-use_middleware(require_auth(map {
-    "protected": ["/admin/*", "/api/*", "/settings"],
-    "public_api": ["/api/health", "/api/status"],  // API routes return 401, not redirect
-    "login_redirect": "/login"
-}))
-```
+- [ ] Auto-generate standard auth routes if not overridden
+- [ ] Configurable path prefixes (`/auth/*` by default)
+- [ ] Clear startup log showing registered routes
+- [ ] Path collision detection with app-defined routes
+- [ ] Built-in login page template
+- [ ] Configurable title/logo/copy
+- [ ] Provider buttons generated automatically
+- [ ] Support custom HTML override if needed
 
-**Behavior:**
-- Browser requests (Accept: text/html) → redirect to `login_redirect`
-- API requests (Accept: application/json, or /api/* routes) → return `401 {"error": "Authentication required"}`
-- Glob patterns: `"/admin/*"` matches `/admin/anything`
-- Auth routes (`/auth/*`) are always public (never require auth to log in)
+**Ships real value:** simple apps get auth with almost no wiring, while custom apps still own their design.
 
-**This replaces the custom middleware file in most apps.** For apps that need custom auth logic, `require_auth` is just a function they don't call — they write their own middleware as before.
+### Phase 8 — Advanced Sessions and Security Signals
+**Goal:** Add higher-end capabilities once the core mechanics are excellent.
 
-- [ ] Implement `require_auth(config)` as a stdlib middleware generator
-- [ ] Support `public` (allowlist) and `protected` (denylist) patterns
-- [ ] Glob matching for route patterns
-- [ ] Smart redirect vs 401 based on Accept header
-- [ ] Always exempt `/auth/*` and health check routes
-- [ ] Return the middleware function (compatible with `use_middleware`)
-
-### 3.8 Login Page Generator
-**Priority:** Low-Medium — saves time but not critical
-
-**Problem:** Every app needs a login page. Most login pages are identical: centered card, "Sign in with Google" button, maybe an error message. Developers copy-paste this from examples or build it from scratch.
-
-**Solution:** Built-in login page that works out of the box:
-
-```ntnt
-import { login_page } from "std/auth"
-
-get("/login", login_page)
-```
-
-Renders a clean, minimal login page with buttons for each configured provider. Handles error display (`?error=auth_failed`). Responsive. No external dependencies.
-
-**Customizable via config:**
-```ntnt
-get("/login", login_page(map {
-    "title": "Welcome to MyApp",
-    "logo": "/static/logo.png",
-    "background": "#f5f5f5",
-    "theme": "dark"
-}))
-```
-
-For apps that want full control: don't use `login_page`. Build your own HTML, link to `/auth/google`. Zero lock-in.
-
-- [ ] Implement `login_page` handler with built-in HTML template
-- [ ] Auto-detect configured providers and render buttons for each
-- [ ] Handle `?error=` query param for error display
-- [ ] Accept optional config map for branding (title, logo, colors, theme)
-- [ ] Responsive, accessible, no external CSS/JS dependencies
-- [ ] Include CSRF token in any form elements
-
-### Putting It Together: The Full Competitive Comparison
-
-**Auth.js v5 (Next.js) — minimum viable auth:**
-```
-1. npm install next-auth @auth/core
-2. Create auth.ts (config + providers + adapter)
-3. Create app/api/auth/[...nextauth]/route.ts (route handler)
-4. Create middleware.ts (protected routes)
-5. Add NEXTAUTH_SECRET to .env
-6. Add provider credentials to .env
-7. Set up database adapter (Prisma/Drizzle) if you want sessions
-Files: 4 new files + .env changes. ~60-80 lines of config code.
-```
-
-**Lucia v3 — minimum viable auth:**
-```
-1. npm install lucia @lucia-auth/adapter-*
-2. Create database schema (users + sessions tables)
-3. Run migration
-4. Create lib/auth.ts (Lucia instance + adapter)
-5. Create login route handler
-6. Create callback route handler  
-7. Create middleware for session validation
-8. Create logout handler
-Files: 5-7 new files + migration. ~100-150 lines of auth code.
-```
-
-**Laravel Sanctum — minimum viable auth:**
-```
-1. composer require laravel/sanctum
-2. php artisan vendor:publish --provider="Laravel\Sanctum\SanctumServiceProvider"
-3. php artisan migrate
-4. Add Sanctum middleware to api middleware group
-5. Configure CORS for SPA
-6. Add Socialite for OAuth (separate package)
-Files: config changes across 3-4 files + migration. ~40-60 lines.
-```
-
-**ntnt today (v0.4.6):**
-```
-1. Add 2 env vars to .env (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)
-2. Add ~15 lines to server.tnt (imports, oauth, enable_auth, route registration)
-3. Create middleware/01_auth.tnt (~50 lines of route protection)
-4. Create login page view
-Files: 2 files modified, 1 new middleware, 1 new view. ~70 lines.
-```
-
-**ntnt after Phase 3:**
-```
-1. Add 2 env vars to .env (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)
-2. Add 4 lines to server.tnt:
-   import { oauth, enable_auth, require_auth, login_page } from "std/auth"
-   enable_auth([oauth("google", get_env("GOOGLE_CLIENT_ID"), get_env("GOOGLE_CLIENT_SECRET"))])
-   use_middleware(require_auth(map { "public": ["/", "/login"] }))
-   get("/login", login_page)
-Files: 1 file modified, 0 new files. 4 lines of auth code.
-```
-
-**That's the 3x improvement.** From ~70 lines across 4 files → 4 lines in 1 file. Zero boilerplate files. Zero middleware files. Zero custom login page HTML. And every security feature is still there — PKCE, CSRF, signed cookies, auto-refresh — just automatic.
-
-**The escape hatch is always there:** any of these automatic behaviors can be overridden by passing config, or disabled entirely with `auto_routes: false`. You can always go back to "I'll wire everything manually." But you shouldn't have to.
-
----
-
-## Phase 4: Advanced Session Management
-
-**Goal:** Features that put ntnt auth ahead of every other stdlib.
-
-**Estimated effort:** Large (3-4 PRs)
-
-### 4.1 Device-Aware Sessions
-**Priority:** High
-
-**Problem:** Users can't see or manage where they're logged in. No "your active sessions" page like Google/GitHub.
-
-**Current state:** We already have `user_sessions(req)` and `revoke_session(req, session_id)`. But sessions don't store device metadata.
-
-**Solution:** Capture and store device context at session creation:
-
-```ntnt
-let sessions = user_sessions(req)
-// Returns: [
-//   { session_id: "abc...", device: "Chrome on macOS", ip: "73.x.x.x",
-//     last_active: 1773967904, created: 1773967000, current: true },
-//   { session_id: "def...", device: "Safari on iPhone", ip: "73.x.x.x",
-//     last_active: 1773960000, created: 1773900000, current: false }
-// ]
-```
-
-**Implementation:**
-- [ ] Parse `User-Agent` at session creation → store simplified device string
-- [ ] Store IP at creation (already have `req.ip`)
-- [ ] Add `device`, `ip`, `last_ip` fields to Session
-- [ ] Update `user_sessions` response to include device metadata
-- [ ] Add `last_active_at` tracking (Phase 1.2 prerequisite)
-- [ ] Update `last_ip` on each request (with debounce)
-
-### 4.2 Session Revocation Cascade
-**Priority:** Medium
-
-**Problem:** When a user changes their password or suspects compromise, they need to revoke ALL other sessions instantly.
-
-**Solution:**
-```ntnt
-let count = revoke_all_sessions(req)            // kill all except current
-let count = revoke_all_sessions(req, true)      // kill ALL including current (force re-auth)
-```
-
-- [ ] Add `revoke_all_sessions(req, include_current?)` function
-- [ ] Efficiently delete by user_id across all backends
-- [ ] Return count of revoked sessions
-- [ ] Log security event
-
-### 4.3 Suspicious Activity Detection
-**Priority:** Medium
-
-**Problem:** No visibility into potentially compromised sessions.
-
-**Solution:** Track and flag suspicious patterns:
-- Same session used from two very different IPs simultaneously
-- Session used from a different country than creation
-- Rapid session creation (brute force attempt)
-
-```ntnt
-enable_auth([google], map {
-    "security_events": true,  // enable event logging
-    "ip_change_action": "warn"  // or "revoke" — what to do on IP change
-})
-```
-
-- [ ] Add `security_events` table/key for logging auth events
+- [ ] Store user agent hash / device name on session creation
+- [ ] `list_sessions(user_id)` API
+- [ ] `revoke_session(session_id)` API
+- [ ] `revoke_all_sessions(user_id)` API
+- [ ] Password change hook support for revocation
+- [ ] Account disable hook support for revocation
+- [ ] Optional `revoke_on_password_change: true` config
+- [ ] Add `security_events` storage for auth events
 - [ ] Track IP changes per session
-- [ ] Configurable actions: `"warn"` (log), `"challenge"` (force re-auth), `"revoke"`
-- [ ] Expose via `auth_events(user_id, limit?)` for admin dashboards
-- [ ] Rate limit failed OAuth callbacks (prevent brute force)
+- [ ] Configurable suspicious-activity actions: `warn`, `challenge`, `revoke`
+- [ ] Expose `auth_events(user_id, limit?)` for admin dashboards
+- [ ] Rate limit failed OAuth callbacks
+- [ ] Add `remember_me` and `remember_ttl`
+- [ ] Pass remember-me flag through OAuth state
+- [ ] Set appropriate TTL/persistence on session creation
 
-### 4.4 Remember Me / Persistent vs. Session Cookies
-**Priority:** Low
+**Ships real value:** this is where `std/auth` becomes genuinely standout, not just competent.
 
-**Problem:** Some apps want short-lived sessions by default but offer a "remember me" option for longer persistence.
+### Phase 9 — Internal Cleanup and Complexity Budget
+**Goal:** Keep the implementation maintainable as the feature set grows.
 
-**Solution:**
-```ntnt
-enable_auth([google], map {
-    "remember_me": true,           // enable the feature
-    "remember_ttl": 86400 * 90,    // "remember me" sessions last 90 days
-    "session_ttl": 86400           // default sessions last 1 day
-})
-```
+- [ ] Track auth code size / complexity budget as features land
+- [ ] Split internals into modules when the public API settles:
+  - [ ] `auth/config.rs`
+  - [ ] `auth/session.rs`
+  - [ ] `auth/oauth.rs`
+  - [ ] `auth/providers.rs`
+  - [ ] `auth/security.rs`
+  - [ ] `auth/handlers.rs`
 
-The login page includes a checkbox. `auth_start` reads a query param (`?remember=1`) and stores it in OAuth state. On callback, session TTL is set accordingly.
-
-- [ ] Add `remember_me`, `remember_ttl` to AuthConfig
-- [ ] Pass `remember` flag through OAuth state
-- [ ] Set appropriate TTL on session creation based on flag
-- [ ] Cookie: session cookie (no Max-Age) for short, persistent cookie for remember
-
----
-
-## Phase 5: Validate and Remove Speculative Code
-
-**Goal:** Prove or disprove the Safari ITP fix with real data.
-
-**Estimated effort:** Small (1 PR if removing)
-
-### 5.1 Safari ITP A/B Test
-**Priority:** High (do this NOW — before investing in more features)
-
-**Problem:** We shipped the two-phase exchange token flow for Safari ITP, but then discovered the actual issue was a config mismatch (`session_ttl: 3600` on staging). We haven't proven ITP is a real problem for our use case.
-
-**Test plan:**
-1. ✅ Test A: Log in on Safari with ITP fix + correct 30-day TTL → check persistence after 24h
-2. Test B: Deploy staging with direct cookie-on-redirect (revert ITP fix), same TTL → check persistence after 24h
-3. If both persist → remove ITP fix (saves ~400 lines of complexity)
-4. If only A persists → ITP fix is validated, it stays
-
-- [ ] Josh: Test A login on Safari (done 2026-03-20)
-- [ ] Check session persistence after 24h
-- [ ] If needed: deploy Test B build
-- [ ] Decision: keep or remove ITP code based on data
-
-### 5.2 Complexity Budget
-Every feature in this doc adds code to `auth.rs` (already ~7000 lines). We should track lines of code and consider splitting into sub-modules when it gets unwieldy:
-
-| Module | Scope |
-|--------|-------|
-| `auth/config.rs` | AuthConfig, presets, validation |
-| `auth/session.rs` | Session CRUD, rotation, sliding |
-| `auth/oauth.rs` | OAuth flows, PKCE, state management |
-| `auth/providers.rs` | Built-in provider configs, OIDC discovery |
-| `auth/security.rs` | Rate limiting, suspicious activity, events |
-| `auth/handlers.rs` | auth_start, auth_callback, auth_logout, etc. |
-
-This isn't necessary now, but should happen before Phase 4.
-
----
+**Ships real value:** keeps `std/auth` maintainable without delaying earlier wins.
 
 ## What We Explicitly Won't Do
 
@@ -736,27 +239,105 @@ These are features that other auth systems offer but don't belong in a language 
 
 ---
 
-## Implementation Order
+## Delivery Order
 
-| Order | Phase | Feature | Why This Order |
-|-------|-------|---------|----------------|
-| **0** | 5.1 | Safari ITP A/B test | Must validate before building more |
-| **1** | 3.1 + 3.2 + 3.3 | Zero-config defaults + auto-routes + startup summary | The headline DX improvement — changes the first impression |
-| **2** | 3.4 | Typed config validation | Prevents misconfig (like the 3600 incident) |
-| **3** | 3.7 | `require_auth` middleware | Eliminates the biggest boilerplate file |
-| **4** | 1.1 | Session rotation on auth | Critical security gap |
-| **5** | 1.2 + 1.3 | Sliding sessions + absolute cap | Prerequisite for presets |
-| **6** | 3.6 | Presets | Builds on sliding sessions, gives the "strict/balanced/relaxed" UX |
-| **7** | 2.1 | Refresh token rotation | RFC 9700 compliance |
-| **8** | 3.5 | Auth health check endpoint | DX, catches issues early |
-| **9** | 3.8 | Login page generator | Nice DX, low effort |
-| **10** | 4.1 | Device-aware sessions | Differentiator |
-| **11** | 4.2 | Session revocation cascade | Natural follow-on to 4.1 |
-| **12** | 4.3 | Suspicious activity | Advanced security |
-| **13** | 4.4 | Remember me | Nice-to-have |
-| **14** | 5.2 | Module split | Housekeeping when needed |
+The best delivery order is not just "security first" or "DX first". It should deliver a complete slice each time, where every wave leaves `std/auth` materially more useful in real apps.
 
----
+For template cleanup specifically, the biggest wins are:
+1. section-wide route protection
+2. session/cookie helpers
+3. staged-auth challenge primitives
+
+So the plan should put those cleanup-heavy features first, but still start with a very thin foundation pass so the rest of the work lands on stable defaults and validation.
+
+| Order | Delivery Wave | Feature Bundle | Why This Order |
+|-------|---------------|----------------|----------------|
+| **0** | Validation | 5.1 Safari ITP A/B test | Validate the constraint before optimizing around it |
+| **0.5** | Foundation Mini-Wave | 3.1 + 3.3 + 3.4 zero-config defaults, startup summary, typed config validation | Thin safety pass before the cleanup-heavy auth primitives |
+| **1** | Route Protection | 3.7 + 3.7.1 `require_auth` plus section/file-route protection | Biggest immediate cleanup win for file-routed apps and templates |
+| **2** | Session Core | 1.1 + 3.7.2 session rotation, sign-in/sign-out/current-session helpers | Removes the most repetitive login/logout/cookie boilerplate |
+| **3** | Staged Auth | 3.7.3 challenge primitives for pending auth states | Unlocks password → TOTP, first-login setup, and step-up auth cleanly |
+| **4** | Session Lifecycle | 1.2 + 1.3 + 3.6 sliding sessions, max lifetime, presets | Hardens lifecycle rules after the core mechanics are in place |
+| **5** | OAuth Hardening + Observability | 2.1 + 3.5 refresh token rotation and auth health check | Tightens security posture and makes behavior inspectable |
+| **6** | Auto-Routes + UI Convenience | 3.2 + 3.8 auto-routes and login page generator | Helpful DX layer after the mechanics are already excellent |
+| **7** | Advanced Sessions | 4.1 + 4.2 + 4.3 + 4.4 device sessions, cascade revoke, suspicious activity, remember me | Differentiators layered onto a solid core |
+| **8** | Internal Cleanup | 5.2 module split | Do once the public API and architecture are proven |
+
+### Delivery Wave Deliverables
+
+#### Wave 0.5 — Foundation Mini-Wave
+**Ships:**
+- production-safe default auth config
+- startup summary showing active auth config
+- typed config validation with actionable errors
+
+**Strong value:** creates a stable floor for the cleanup-heavy phases without spending a whole early phase on lower-leverage convenience work.
+
+#### Wave 1 — Route Protection
+**Ships:**
+- `require_auth()` middleware
+- path/subtree protection for file-routed apps
+- HTML redirect vs API `401` behavior
+- section-wide protection for things like `routes/admin/*`
+
+**Strong value:** apps stop re-implementing auth checks in every page handler.
+
+#### Wave 2 — Session Core
+**Ships:**
+- session ID rotation on successful auth
+- `sign_in_session()`
+- `sign_out_session()`
+- `current_session()` / `current_user()`
+- shared cookie defaults and overrides
+
+**Strong value:** the most repetitive and mistake-prone login/logout/cookie code disappears.
+
+#### Wave 3 — Staged Auth
+**Ships:**
+- `begin_auth_challenge()`
+- `current_auth_challenge()`
+- `complete_auth_challenge()`
+- `cancel_auth_challenge()`
+- one-time, TTL-bound pending auth state distinct from real sessions
+
+**Strong value:** multi-step auth becomes a normal pattern instead of ad hoc glue code.
+
+#### Wave 4 — Session Lifecycle
+**Ships:**
+- sliding expiration
+- absolute max lifetime
+- ergonomic presets (`strict`, `balanced`, `relaxed`, etc.)
+
+**Strong value:** apps get secure lifecycle behavior without each team inventing different timeout logic.
+
+#### Wave 5 — OAuth Hardening + Observability
+**Ships:**
+- refresh token rotation
+- auth health check endpoint / diagnostics
+
+**Strong value:** security and operability improve together, which is the right trade for production auth.
+
+#### Wave 6 — Auto-Routes + UI Convenience
+**Ships:**
+- auto-mounted auth routes
+- optional login page generator and convenience UI helpers
+
+**Strong value:** fast starts for simple apps, while custom apps can still own their UX.
+
+#### Wave 7 — Advanced Sessions
+**Ships:**
+- device-aware session tracking
+- revocation cascades
+- suspicious activity signals
+- remember-me semantics built on the hardened lifecycle model
+
+**Strong value:** this is where `std/auth` moves from solid to category-leading.
+
+#### Wave 8 — Internal Cleanup
+**Ships:**
+- module split / internal architecture cleanup
+
+**Strong value:** keeps the implementation maintainable without delaying user-facing wins.
 
 ## Competitive Landscape
 

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [ial.toml](ial.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.8
+> Last updated: v0.4.9
 
 IAL is a term rewriting engine that translates natural language assertions into executable tests
 

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [runtime.toml](runtime.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.8
+> Last updated: v0.4.9
 
 Runtime configuration, environment variables, and CLI commands for NTNT
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2067,7 +2067,7 @@ Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url
 **Parameters:**
 
 - `providers` — Array of provider configs created by oauth() or oauth_discover()
-- `options` — Optional map with keys: session_secret, session_ttl, after_login, after_logout, session_store
+- `options` — Optional map with keys: session_secret, session_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, cookie_name, cookie_secure, session_store, store_tokens
 
 **Returns:** Unit
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from source code doc comments** - Do not edit directly.
 >
-> Last updated: v0.4.8
+> Last updated: v0.4.9
 
 ## Table of Contents
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2067,7 +2067,7 @@ Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url
 **Parameters:**
 
 - `providers` — Array of provider configs created by oauth() or oauth_discover()
-- `options` — Optional map with keys: session_secret, session_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, cookie_name, cookie_secure, session_store, store_tokens
+- `options` — Optional map with keys: session_secret, session_ttl, refresh_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, cookie_name, cookie_secure, session_store, store_tokens
 
 **Returns:** Unit
 

--- a/docs/SYNTAX_REFERENCE.md
+++ b/docs/SYNTAX_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [syntax.toml](syntax.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.8
+> Last updated: v0.4.9
 
 ## Table of Contents
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -533,6 +533,9 @@ impl AritySpec {
     fn exact(n: usize) -> Self {
         Self { min: n, max: n }
     }
+    fn between(min: usize, max: usize) -> Self {
+        Self { min, max }
+    }
     fn at_most(n: usize) -> Self {
         Self { min: 0, max: n }
     }
@@ -937,7 +940,7 @@ impl Interpreter {
         register!(
             "enable_auth",
             Some(RuntimeCapability::HttpConfig),
-            AritySpec::exact(1),
+            AritySpec::between(1, 2),
             Interpreter::sa_enable_auth
         );
         register!(
@@ -1106,8 +1109,19 @@ impl Interpreter {
     }
 
     fn sa_enable_auth(interp: &mut Interpreter, args: &[Expression]) -> Result<Value> {
-        let arg = interp.eval_expression(&args[0])?;
-        let config = interp.parse_auth_config(arg)?;
+        if args.is_empty() || args.len() > 2 {
+            return Err(IntentError::type_error(
+                "enable_auth() requires 1 or 2 arguments (providers, optional config)".to_string(),
+            ));
+        }
+
+        let values = args
+            .iter()
+            .map(|arg| interp.eval_expression(arg))
+            .collect::<Result<Vec<_>>>()?;
+        let config = interp.parse_auth_config(&values)?;
+        crate::stdlib::auth::ensure_auth_session_store(&config)
+            .map_err(IntentError::runtime_error)?;
         interp.setup_auth_routes(&config)?;
         crate::stdlib::auth::init_auth(config);
         Ok(Value::Unit)
@@ -7182,61 +7196,224 @@ impl Interpreter {
     }
 
     /// Parse auth configuration from enable_auth() argument
-    fn parse_auth_config(&self, arg: Value) -> Result<crate::stdlib::auth::AuthConfig> {
-        use crate::stdlib::auth::{value_to_provider, AuthConfig};
+    fn parse_auth_config(&self, args: &[Value]) -> Result<crate::stdlib::auth::AuthConfig> {
+        use crate::stdlib::auth::AuthConfig;
 
-        match arg {
-            // Single provider: enable_auth(google(...))
-            Value::Map(ref map) if map.contains_key("_provider") => {
-                let provider = value_to_provider(&arg)?;
-                let mut config = AuthConfig::default();
-                config.providers.push(provider);
-                Ok(config)
-            }
-            // Config map: enable_auth(map { "providers": [...], ... })
-            Value::Map(ref map) => {
-                let mut config = AuthConfig::default();
+        let mut config = AuthConfig::default();
+        config.cookie_secure = self.default_auth_cookie_secure();
 
-                // Parse providers array
-                if let Some(Value::Array(providers)) = map.get("providers") {
-                    for p in providers {
-                        let provider = value_to_provider(p)?;
-                        config.providers.push(provider);
+        match args {
+            [Value::Map(map)] if map.contains_key("providers") => {
+                config.providers = self.parse_auth_providers(map.get("providers").unwrap())?;
+                for (key, value) in map {
+                    if key == "providers" {
+                        continue;
                     }
-                } else {
-                    return Err(IntentError::type_error(
-                        "enable_auth() requires a provider or config with 'providers' array"
-                            .to_string(),
-                    ));
+                    self.apply_auth_option(&mut config, key, value)?;
                 }
-
-                // Parse optional settings
-                if let Some(Value::String(s)) = map.get("success_url") {
-                    config.success_url = s.clone();
-                }
-                if let Some(Value::String(s)) = map.get("failure_url") {
-                    config.failure_url = s.clone();
-                }
-                if let Some(Value::String(s)) = map.get("cookie_name") {
-                    config.cookie_name = s.clone();
-                }
-                if let Some(Value::Bool(b)) = map.get("cookie_secure") {
-                    config.cookie_secure = *b;
-                }
-                if let Some(Value::Int(i)) = map.get("session_ttl") {
-                    config.session_ttl = *i;
-                }
-
-                Ok(config)
             }
-            _ => Err(IntentError::type_error(
-                "enable_auth() requires a provider or config map".to_string(),
-            )),
+            [providers] => {
+                config.providers = self.parse_auth_providers(providers)?;
+            }
+            [providers, Value::Map(options)] => {
+                config.providers = self.parse_auth_providers(providers)?;
+                for (key, value) in options {
+                    self.apply_auth_option(&mut config, key, value)?;
+                }
+            }
+            [_, other] => {
+                return Err(IntentError::type_error(format!(
+                    "enable_auth() config must be a map, got {}",
+                    other.type_name()
+                )));
+            }
+            _ => {
+                return Err(IntentError::type_error(
+                    "enable_auth() requires a provider, provider array, or config map".to_string(),
+                ));
+            }
+        }
+
+        if config.providers.is_empty() {
+            return Err(IntentError::type_error(
+                "enable_auth() requires at least one provider".to_string(),
+            ));
+        }
+
+        Ok(config)
+    }
+
+    fn parse_auth_providers(
+        &self,
+        value: &Value,
+    ) -> Result<Vec<crate::stdlib::auth::ProviderConfig>> {
+        use crate::stdlib::auth::value_to_provider;
+
+        match value {
+            Value::Array(providers) => providers
+                .iter()
+                .map(value_to_provider)
+                .collect::<Result<Vec<_>>>(),
+            Value::Map(map) if map.contains_key("_provider") => Ok(vec![value_to_provider(value)?]),
+            _ => Err(IntentError::type_error(format!(
+                "enable_auth() providers must be a provider or provider array, got {}",
+                value.type_name()
+            ))),
+        }
+    }
+
+    fn default_auth_cookie_secure(&self) -> bool {
+        if let Ok(env) = std::env::var("NTNT_ENV") {
+            if env.eq_ignore_ascii_case("development") {
+                return false;
+            }
+        }
+
+        if let Ok(site_url) = std::env::var("SITE_URL") {
+            let lower = site_url.to_ascii_lowercase();
+            if lower.starts_with("http://localhost")
+                || lower.starts_with("http://127.0.0.1")
+                || lower.starts_with("http://0.0.0.0")
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn auth_option_suggestion(&self, key: &str) -> Option<String> {
+        let valid = [
+            "providers",
+            "success_url",
+            "failure_url",
+            "logout_url",
+            "after_login",
+            "after_failure",
+            "after_logout",
+            "session_ttl",
+            "cookie_name",
+            "cookie_secure",
+            "session_store",
+            "store_tokens",
+            "session_secret",
+        ];
+
+        valid
+            .iter()
+            .map(|candidate| {
+                (
+                    *candidate,
+                    crate::error::levenshtein_distance(key, candidate),
+                )
+            })
+            .filter(|(_, distance)| *distance <= 4)
+            .min_by_key(|(_, distance)| *distance)
+            .map(|(candidate, _)| candidate.to_string())
+    }
+
+    fn auth_option_type_error(&self, key: &str, expected: &str, value: &Value) -> IntentError {
+        IntentError::type_error(format!(
+            "enable_auth() config[\"{}\"] must be {}, got {}",
+            key,
+            expected,
+            value.type_name()
+        ))
+    }
+
+    fn apply_auth_option(
+        &self,
+        config: &mut crate::stdlib::auth::AuthConfig,
+        key: &str,
+        value: &Value,
+    ) -> Result<()> {
+        match key {
+            "success_url" | "after_login" => match value {
+                Value::String(s) => config.success_url = s.clone(),
+                _ => return Err(self.auth_option_type_error(key, "String", value)),
+            },
+            "failure_url" | "after_failure" => match value {
+                Value::String(s) => config.failure_url = s.clone(),
+                _ => return Err(self.auth_option_type_error(key, "String", value)),
+            },
+            "logout_url" | "after_logout" => match value {
+                Value::String(s) => config.logout_url = s.clone(),
+                _ => return Err(self.auth_option_type_error(key, "String", value)),
+            },
+            "cookie_name" => match value {
+                Value::String(s) => config.cookie_name = s.clone(),
+                _ => return Err(self.auth_option_type_error(key, "String", value)),
+            },
+            "cookie_secure" => match value {
+                Value::Bool(b) => config.cookie_secure = *b,
+                _ => return Err(self.auth_option_type_error(key, "Bool", value)),
+            },
+            "session_ttl" => match value {
+                Value::Int(i) => config.session_ttl = *i,
+                _ => return Err(self.auth_option_type_error(key, "Int", value)),
+            },
+            "session_store" => match value {
+                Value::String(s) => {
+                    config.session_store = if s == "memory" {
+                        crate::stdlib::auth::SessionStore::Memory
+                    } else if s.starts_with("sqlite:") {
+                        let path = s.strip_prefix("sqlite:").unwrap_or("./sessions.db");
+                        let path = if path.is_empty() {
+                            "./sessions.db"
+                        } else {
+                            path
+                        };
+                        crate::stdlib::auth::SessionStore::Sqlite(path.to_string())
+                    } else if s.starts_with("postgres:") || s.starts_with("postgresql:") {
+                        crate::stdlib::auth::SessionStore::Postgres(s.clone())
+                    } else if s.starts_with("redis:") || s.starts_with("valkey:") {
+                        crate::stdlib::auth::SessionStore::Redis(s.clone())
+                    } else {
+                        return Err(IntentError::type_error(format!(
+                            "enable_auth() config[\"session_store\"] must be one of: memory, sqlite:PATH, postgres://..., redis://..., valkey://..."
+                        )));
+                    };
+                }
+                _ => return Err(self.auth_option_type_error(key, "String", value)),
+            },
+            "store_tokens" => match value {
+                Value::Bool(b) => config.store_tokens = *b,
+                _ => return Err(self.auth_option_type_error(key, "Bool", value)),
+            },
+            "session_secret" => match value {
+                Value::String(s) => config.session_secret = s.clone(),
+                _ => return Err(self.auth_option_type_error(key, "String", value)),
+            },
+            "providers" => {}
+            other => {
+                let suggestion = self
+                    .auth_option_suggestion(other)
+                    .map(|s| format!(" Did you mean \"{}\"?", s))
+                    .unwrap_or_default();
+                return Err(IntentError::type_error(format!(
+                    "enable_auth() unknown config key \"{}\".{}",
+                    other, suggestion
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn format_auth_duration(&self, seconds: i64) -> String {
+        if seconds % 86_400 == 0 {
+            format!("{}d", seconds / 86_400)
+        } else if seconds % 3_600 == 0 {
+            format!("{}h", seconds / 3_600)
+        } else if seconds % 60 == 0 {
+            format!("{}m", seconds / 60)
+        } else {
+            format!("{}s", seconds)
         }
     }
 
     /// Set up OAuth routes for the given auth configuration
-    fn setup_auth_routes(&mut self, _config: &crate::stdlib::auth::AuthConfig) -> Result<()> {
+    fn setup_auth_routes(&mut self, config: &crate::stdlib::auth::AuthConfig) -> Result<()> {
         // Create handlers for each provider - use dynamic route with provider param
         // Register a single route with {provider} parameter
         self.server_state.add_route(
@@ -7275,6 +7452,23 @@ impl Interpreter {
                 requires: None,
                 func: crate::stdlib::auth::handle_auth_logout,
             },
+        );
+
+        let providers = config
+            .providers
+            .iter()
+            .map(|provider| provider.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!("[auth] Enabled providers: {}", providers);
+        eprintln!("[auth] Routes: /auth/{{provider}}, /auth/callback, POST /auth/logout");
+        eprintln!(
+            "[auth] Session TTL: {}",
+            self.format_auth_duration(config.session_ttl)
+        );
+        eprintln!(
+            "[auth] Cookie: {} (Secure={}, HttpOnly=true)",
+            config.cookie_name, config.cookie_secure
         );
 
         Ok(())
@@ -15296,5 +15490,130 @@ page
         assert!(names.contains(&"send.tnt".to_string()));
 
         let _ = std::fs::remove_dir_all(&tmp_dir);
+    }
+
+    fn test_auth_provider(name: &str) -> Value {
+        let mut map = HashMap::new();
+        map.insert("_provider".to_string(), Value::Bool(true));
+        map.insert("name".to_string(), Value::String(name.to_string()));
+        map.insert(
+            "client_id".to_string(),
+            Value::String("client-id".to_string()),
+        );
+        map.insert(
+            "client_secret".to_string(),
+            Value::String("client-secret".to_string()),
+        );
+        map.insert(
+            "authorize_url".to_string(),
+            Value::String("https://example.com/oauth/authorize".to_string()),
+        );
+        map.insert(
+            "token_url".to_string(),
+            Value::String("https://example.com/oauth/token".to_string()),
+        );
+        map.insert(
+            "userinfo_url".to_string(),
+            Value::String("https://example.com/oauth/userinfo".to_string()),
+        );
+        map.insert(
+            "scopes".to_string(),
+            Value::Array(vec![Value::String("openid".to_string())]),
+        );
+        map.insert(
+            "user_id_field".to_string(),
+            Value::String("sub".to_string()),
+        );
+        map.insert(
+            "user_email_field".to_string(),
+            Value::String("email".to_string()),
+        );
+        map.insert(
+            "user_name_field".to_string(),
+            Value::String("name".to_string()),
+        );
+        Value::Map(map)
+    }
+
+    #[test]
+    fn enable_auth_accepts_provider_array_plus_options() {
+        let interp = Interpreter::new();
+        let providers = Value::Array(vec![test_auth_provider("google")]);
+        let mut options = HashMap::new();
+        options.insert(
+            "after_login".to_string(),
+            Value::String("/dashboard".to_string()),
+        );
+        options.insert(
+            "cookie_name".to_string(),
+            Value::String("auth_session".to_string()),
+        );
+        options.insert("session_ttl".to_string(), Value::Int(3_600));
+
+        let config = interp
+            .parse_auth_config(&[providers, Value::Map(options)])
+            .unwrap();
+
+        assert_eq!(config.providers.len(), 1);
+        assert_eq!(config.success_url, "/dashboard");
+        assert_eq!(config.cookie_name, "auth_session");
+        assert_eq!(config.session_ttl, 3_600);
+    }
+
+    #[test]
+    fn enable_auth_rejects_unknown_config_keys_with_suggestion() {
+        let interp = Interpreter::new();
+        let providers = Value::Array(vec![test_auth_provider("google")]);
+        let mut options = HashMap::new();
+        options.insert("session_tt".to_string(), Value::Int(3_600));
+
+        let err = interp
+            .parse_auth_config(&[providers, Value::Map(options)])
+            .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("unknown config key \"session_tt\""));
+        assert!(rendered.contains("Did you mean \"session_ttl\"?"));
+    }
+
+    #[test]
+    fn enable_auth_rejects_wrong_option_types() {
+        let interp = Interpreter::new();
+        let providers = Value::Array(vec![test_auth_provider("google")]);
+        let mut options = HashMap::new();
+        options.insert(
+            "cookie_secure".to_string(),
+            Value::String("yes".to_string()),
+        );
+
+        let err = interp
+            .parse_auth_config(&[providers, Value::Map(options)])
+            .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("config[\"cookie_secure\"] must be Bool, got String"));
+    }
+
+    #[test]
+    fn enable_auth_defaults_empty_sqlite_store_path() {
+        let interp = Interpreter::new();
+        let providers = Value::Array(vec![test_auth_provider("google")]);
+        let mut options = HashMap::new();
+        options.insert(
+            "session_store".to_string(),
+            Value::String("sqlite:".to_string()),
+        );
+
+        let config = interp
+            .parse_auth_config(&[providers, Value::Map(options)])
+            .unwrap();
+
+        match config.session_store {
+            crate::stdlib::auth::SessionStore::Sqlite(path) => {
+                assert_eq!(path, "./sessions.db");
+            }
+            other => panic!("expected sqlite session store, got {:?}", other),
+        }
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -7263,23 +7263,7 @@ impl Interpreter {
     }
 
     fn default_auth_cookie_secure(&self) -> bool {
-        if let Ok(env) = std::env::var("NTNT_ENV") {
-            if env.eq_ignore_ascii_case("development") {
-                return false;
-            }
-        }
-
-        if let Ok(site_url) = std::env::var("SITE_URL") {
-            let lower = site_url.to_ascii_lowercase();
-            if lower.starts_with("http://localhost")
-                || lower.starts_with("http://127.0.0.1")
-                || lower.starts_with("http://0.0.0.0")
-            {
-                return false;
-            }
-        }
-
-        true
+        crate::stdlib::auth::default_auth_cookie_secure_env()
     }
 
     fn auth_option_suggestion(&self, key: &str) -> Option<String> {
@@ -7354,25 +7338,8 @@ impl Interpreter {
             },
             "session_store" => match value {
                 Value::String(s) => {
-                    config.session_store = if s == "memory" {
-                        crate::stdlib::auth::SessionStore::Memory
-                    } else if s.starts_with("sqlite:") {
-                        let path = s.strip_prefix("sqlite:").unwrap_or("./sessions.db");
-                        let path = if path.is_empty() {
-                            "./sessions.db"
-                        } else {
-                            path
-                        };
-                        crate::stdlib::auth::SessionStore::Sqlite(path.to_string())
-                    } else if s.starts_with("postgres:") || s.starts_with("postgresql:") {
-                        crate::stdlib::auth::SessionStore::Postgres(s.clone())
-                    } else if s.starts_with("redis:") || s.starts_with("valkey:") {
-                        crate::stdlib::auth::SessionStore::Redis(s.clone())
-                    } else {
-                        return Err(IntentError::type_error(format!(
-                            "enable_auth() config[\"session_store\"] must be one of: memory, sqlite:PATH, postgres://..., redis://..., valkey://..."
-                        )));
-                    };
+                    config.session_store = crate::stdlib::auth::parse_auth_session_store(s)
+                        .map_err(IntentError::type_error)?;
                 }
                 _ => return Err(self.auth_option_type_error(key, "String", value)),
             },

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -7286,6 +7286,7 @@ impl Interpreter {
             "session_store",
             "store_tokens",
             "session_secret",
+            "refresh_ttl",
         ];
 
         valid
@@ -7339,6 +7340,10 @@ impl Interpreter {
             },
             "session_ttl" => match value {
                 Value::Int(i) => config.session_ttl = *i,
+                _ => return Err(self.auth_option_type_error(key, "Int", value)),
+            },
+            "refresh_ttl" => match value {
+                Value::Int(i) => config.refresh_ttl = *i,
                 _ => return Err(self.auth_option_type_error(key, "Int", value)),
             },
             "session_store" => match value {
@@ -15599,5 +15604,19 @@ page
             }
             other => panic!("expected sqlite session store, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn enable_auth_accepts_refresh_ttl_in_options() {
+        let interp = Interpreter::new();
+        let providers = Value::Array(vec![test_auth_provider("google")]);
+        let mut options = HashMap::new();
+        options.insert("refresh_ttl".to_string(), Value::Int(86_400 * 30));
+
+        let config = interp
+            .parse_auth_config(&[providers, Value::Map(options)])
+            .unwrap();
+
+        assert_eq!(config.refresh_ttl, 86_400 * 30);
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -7212,6 +7212,11 @@ impl Interpreter {
                     self.apply_auth_option(&mut config, key, value)?;
                 }
             }
+            [Value::Map(_)] => {
+                return Err(IntentError::type_error(
+                    "enable_auth() config map must include a \"providers\" array".to_string(),
+                ));
+            }
             [providers] => {
                 config.providers = self.parse_auth_providers(providers)?;
             }
@@ -8653,6 +8658,12 @@ impl Interpreter {
             None => (env_port.unwrap_or(port), false, None),
         };
 
+        if let Some(auth_config) = crate::stdlib::auth::get_auth_config() {
+            if !self.server_state.has_route("GET", "/auth/{provider}") {
+                self.setup_auth_routes(&auth_config)?;
+            }
+        }
+
         // Check if any routes or static dirs are registered
         let has_routes = self.server_state.route_count() > 0;
         let has_static = !self.server_state.static_dirs.is_empty();
@@ -9079,6 +9090,12 @@ impl Interpreter {
         };
         use std::sync::Arc;
         use std::thread;
+
+        if let Some(auth_config) = crate::stdlib::auth::get_auth_config() {
+            if !self.server_state.has_route("GET", "/auth/{provider}") {
+                self.setup_auth_routes(&auth_config)?;
+            }
+        }
 
         // Check if any routes are registered
         if self.server_state.route_count() == 0 && self.server_state.static_dirs.is_empty() {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -7393,43 +7393,49 @@ impl Interpreter {
     fn setup_auth_routes(&mut self, config: &crate::stdlib::auth::AuthConfig) -> Result<()> {
         // Create handlers for each provider - use dynamic route with provider param
         // Register a single route with {provider} parameter
-        self.server_state.add_route(
-            "GET",
-            "/auth/{provider}",
-            Value::NativeFunction {
-                name: "_auth_start".to_string(),
-                arity: 1,
-                max_arity: 1,
-                requires: None,
-                func: crate::stdlib::auth::handle_auth_start,
-            },
-        );
+        if !self.server_state.has_route("GET", "/auth/{provider}") {
+            self.server_state.add_route(
+                "GET",
+                "/auth/{provider}",
+                Value::NativeFunction {
+                    name: "_auth_start".to_string(),
+                    arity: 1,
+                    max_arity: 1,
+                    requires: None,
+                    func: crate::stdlib::auth::handle_auth_start,
+                },
+            );
+        }
 
         // Create callback handler: GET /auth/callback
-        self.server_state.add_route(
-            "GET",
-            "/auth/callback",
-            Value::NativeFunction {
-                name: "_auth_callback".to_string(),
-                arity: 1,
-                max_arity: 1,
-                requires: None,
-                func: crate::stdlib::auth::handle_auth_callback,
-            },
-        );
+        if !self.server_state.has_route("GET", "/auth/callback") {
+            self.server_state.add_route(
+                "GET",
+                "/auth/callback",
+                Value::NativeFunction {
+                    name: "_auth_callback".to_string(),
+                    arity: 1,
+                    max_arity: 1,
+                    requires: None,
+                    func: crate::stdlib::auth::handle_auth_callback,
+                },
+            );
+        }
 
         // Create logout handler: POST /auth/logout
-        self.server_state.add_route(
-            "POST",
-            "/auth/logout",
-            Value::NativeFunction {
-                name: "_auth_logout".to_string(),
-                arity: 1,
-                max_arity: 1,
-                requires: None,
-                func: crate::stdlib::auth::handle_auth_logout,
-            },
-        );
+        if !self.server_state.has_route("POST", "/auth/logout") {
+            self.server_state.add_route(
+                "POST",
+                "/auth/logout",
+                Value::NativeFunction {
+                    name: "_auth_logout".to_string(),
+                    arity: 1,
+                    max_arity: 1,
+                    requires: None,
+                    func: crate::stdlib::auth::handle_auth_logout,
+                },
+            );
+        }
 
         let providers = config
             .providers
@@ -8664,9 +8670,7 @@ impl Interpreter {
         };
 
         if let Some(auth_config) = crate::stdlib::auth::get_auth_config() {
-            if !self.server_state.has_route("GET", "/auth/{provider}") {
-                self.setup_auth_routes(&auth_config)?;
-            }
+            self.setup_auth_routes(&auth_config)?;
         }
 
         // Check if any routes or static dirs are registered
@@ -9097,9 +9101,7 @@ impl Interpreter {
         use std::thread;
 
         if let Some(auth_config) = crate::stdlib::auth::get_auth_config() {
-            if !self.server_state.has_route("GET", "/auth/{provider}") {
-                self.setup_auth_routes(&auth_config)?;
-            }
+            self.setup_auth_routes(&auth_config)?;
         }
 
         // Check if any routes are registered

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -1398,6 +1398,19 @@ static REDIS_URL: std::sync::LazyLock<Arc<Mutex<Option<String>>>> =
 static AUTH_CONFIG: std::sync::LazyLock<Arc<Mutex<Option<AuthConfig>>>> =
     std::sync::LazyLock::new(|| Arc::new(Mutex::new(None)));
 
+fn initialize_session_store(store: &SessionStore) -> std::result::Result<(), String> {
+    match store {
+        SessionStore::Sqlite(path) => init_sqlite_sessions(path),
+        SessionStore::Postgres(url) => init_postgres_sessions(url),
+        SessionStore::Redis(url) => init_redis_sessions(url),
+        SessionStore::Memory => Ok(()),
+    }
+}
+
+pub fn ensure_auth_session_store(config: &AuthConfig) -> std::result::Result<(), String> {
+    initialize_session_store(&config.session_store)
+}
+
 /// Initialize auth with config
 pub fn init_auth(config: AuthConfig) {
     let is_prod = std::env::var("NTNT_ENV")
@@ -6351,35 +6364,12 @@ pub fn init() -> HashMap<String, Value> {
                     .unwrap_or(SessionStore::Memory);
 
                 // Initialize database/cache if needed
-                match &session_store {
-                    SessionStore::Sqlite(path) => {
-                        if let Err(e) = init_sqlite_sessions(path) {
-                            eprintln!("[auth] Failed to initialize SQLite sessions: {}", e);
-                            return Err(IntentError::runtime_error(format!(
-                                "Failed to initialize SQLite session store: {}",
-                                e
-                            )));
-                        }
-                    }
-                    SessionStore::Postgres(url) => {
-                        if let Err(e) = init_postgres_sessions(url) {
-                            eprintln!("[auth] Failed to initialize PostgreSQL sessions: {}", e);
-                            return Err(IntentError::runtime_error(format!(
-                                "Failed to initialize PostgreSQL session store: {}",
-                                e
-                            )));
-                        }
-                    }
-                    SessionStore::Redis(url) => {
-                        if let Err(e) = init_redis_sessions(url) {
-                            eprintln!("[auth] Failed to initialize Redis sessions: {}", e);
-                            return Err(IntentError::runtime_error(format!(
-                                "Failed to initialize Redis session store: {}",
-                                e
-                            )));
-                        }
-                    }
-                    SessionStore::Memory => {}
+                if let Err(e) = initialize_session_store(&session_store) {
+                    eprintln!("[auth] Failed to initialize session store: {}", e);
+                    return Err(IntentError::runtime_error(format!(
+                        "Failed to initialize session store: {}",
+                        e
+                    )));
                 }
 
                 // Create auth config

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -1407,6 +1407,49 @@ fn initialize_session_store(store: &SessionStore) -> std::result::Result<(), Str
     }
 }
 
+pub fn default_auth_cookie_secure_env() -> bool {
+    if let Ok(env) = std::env::var("NTNT_ENV") {
+        if env.eq_ignore_ascii_case("development") || env.eq_ignore_ascii_case("dev") {
+            return false;
+        }
+    }
+
+    if let Ok(site_url) = std::env::var("SITE_URL") {
+        let lower = site_url.to_ascii_lowercase();
+        if lower.starts_with("http://localhost")
+            || lower.starts_with("http://127.0.0.1")
+            || lower.starts_with("http://0.0.0.0")
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+pub fn parse_auth_session_store(value: &str) -> std::result::Result<SessionStore, String> {
+    if value == "memory" || value.is_empty() {
+        return Ok(SessionStore::Memory);
+    }
+    if value.starts_with("sqlite:") {
+        let path = value.strip_prefix("sqlite:").unwrap_or("./sessions.db");
+        let path = if path.is_empty() {
+            "./sessions.db"
+        } else {
+            path
+        };
+        return Ok(SessionStore::Sqlite(path.to_string()));
+    }
+    if value.starts_with("postgres://") || value.starts_with("postgresql://") {
+        return Ok(SessionStore::Postgres(value.to_string()));
+    }
+    if value.starts_with("redis://") || value.starts_with("valkey://") {
+        return Ok(SessionStore::Redis(value.to_string()));
+    }
+
+    Err("session_store must be one of: memory, sqlite:PATH, postgres://..., postgresql://..., redis://..., valkey://...".to_string())
+}
+
 pub fn ensure_auth_session_store(config: &AuthConfig) -> std::result::Result<(), String> {
     initialize_session_store(&config.session_store)
 }
@@ -6208,7 +6251,7 @@ pub fn init() -> HashMap<String, Value> {
     //
     // Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url", or "redis://url".
     // @param providers Array of provider configs created by oauth() or oauth_discover()
-    // @param options Optional map with keys: session_secret, session_ttl, after_login, after_logout, session_store
+    // @param options Optional map with keys: session_secret, session_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, cookie_name, cookie_secure, session_store, store_tokens
     // @returns Unit
     // @see_also oauth, oauth_discover, auth_start
     // @since v0.3.11
@@ -6226,9 +6269,10 @@ pub fn init() -> HashMap<String, Value> {
             max_arity: 0,
             requires: Some(RuntimeCapability::HttpConfig),
             func: |args| {
-                if args.is_empty() {
+                if args.is_empty() || args.len() > 2 {
                     return Err(IntentError::type_error(
-                        "[auth] enable_auth() requires a providers array".to_string(),
+                        "[auth] enable_auth() requires 1 or 2 arguments (providers, optional config)"
+                            .to_string(),
                     ));
                 }
 
@@ -6276,92 +6320,100 @@ pub fn init() -> HashMap<String, Value> {
                     }
                 }
 
-                // Parse options
-                let session_secret = options
-                    .as_ref()
-                    .and_then(|o| o.get("session_secret"))
-                    .and_then(|v| match v {
-                        Value::String(s) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .unwrap_or_else(|| DEFAULT_SESSION_SECRET_SENTINEL.to_string());
+                let get_option = |keys: &[&str]| {
+                    options
+                        .as_ref()
+                        .and_then(|opts| keys.iter().find_map(|key| opts.get(*key)))
+                };
 
-                let session_ttl = options
-                    .as_ref()
-                    .and_then(|o| o.get("session_ttl"))
-                    .and_then(|v| match v {
-                        Value::Int(n) => Some(*n),
-                        _ => None,
-                    })
-                    .unwrap_or(86400);
+                let session_secret = match get_option(&["session_secret"]) {
+                    Some(Value::String(s)) => s.clone(),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"session_secret\" must be a string, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => DEFAULT_SESSION_SECRET_SENTINEL.to_string(),
+                };
 
-                let success_url = options
-                    .as_ref()
-                    .and_then(|o| o.get("after_login"))
-                    .and_then(|v| match v {
-                        Value::String(s) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .unwrap_or_else(|| "/".to_string());
+                let session_ttl = match get_option(&["session_ttl"]) {
+                    Some(Value::Int(n)) => *n,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"session_ttl\" must be an int, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => 86400,
+                };
 
-                let failure_url = options
-                    .as_ref()
-                    .and_then(|o| o.get("after_failure"))
-                    .and_then(|v| match v {
-                        Value::String(s) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .unwrap_or_else(|| "/".to_string());
+                let success_url = match get_option(&["success_url", "after_login"]) {
+                    Some(Value::String(s)) => s.clone(),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"success_url\"/\"after_login\" must be a string, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => "/".to_string(),
+                };
 
-                let logout_url = options
-                    .as_ref()
-                    .and_then(|o| o.get("after_logout"))
-                    .and_then(|v| match v {
-                        Value::String(s) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .unwrap_or_else(|| "/".to_string());
+                let failure_url = match get_option(&["failure_url", "after_failure"]) {
+                    Some(Value::String(s)) => s.clone(),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"failure_url\"/\"after_failure\" must be a string, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => "/".to_string(),
+                };
 
-                // Check if we should use secure cookies
-                // Default: true (HTTPS required) - must explicitly set NTNT_ENV=dev to allow HTTP
-                let is_dev = std::env::var("NTNT_ENV")
-                    .map(|v| v == "dev" || v == "development")
-                    .unwrap_or(false); // Default to secure (production) mode
+                let logout_url = match get_option(&["logout_url", "after_logout"]) {
+                    Some(Value::String(s)) => s.clone(),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"logout_url\"/\"after_logout\" must be a string, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => "/".to_string(),
+                };
 
-                let cookie_secure = options
-                    .as_ref()
-                    .and_then(|o| o.get("cookie_secure"))
-                    .and_then(|v| match v {
-                        Value::Bool(b) => Some(*b),
-                        _ => None,
-                    })
-                    .unwrap_or(!is_dev); // Secure by default unless explicitly in dev mode
+                let cookie_name = match get_option(&["cookie_name"]) {
+                    Some(Value::String(s)) => s.clone(),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"cookie_name\" must be a string, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => "ntnt_session".to_string(),
+                };
 
-                // Parse session storage backend
-                // Format: "memory" (default), "sqlite:./path.db", "postgres://...", "redis://..."
-                let session_store = options
-                    .as_ref()
-                    .and_then(|o| o.get("session_store"))
-                    .and_then(|v| match v {
-                        Value::String(s) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .map(|s| {
-                        if s == "memory" || s.is_empty() {
-                            SessionStore::Memory
-                        } else if s.starts_with("sqlite:") {
-                            let path = s.strip_prefix("sqlite:").unwrap_or("./sessions.db");
-                            SessionStore::Sqlite(path.to_string())
-                        } else if s.starts_with("postgres://") || s.starts_with("postgresql://") {
-                            SessionStore::Postgres(s)
-                        } else if s.starts_with("redis://") || s.starts_with("valkey://") {
-                            SessionStore::Redis(s)
-                        } else {
-                            eprintln!("[auth] Unknown session_store format '{}', using memory", s);
-                            SessionStore::Memory
-                        }
-                    })
-                    .unwrap_or(SessionStore::Memory);
+                let cookie_secure = match get_option(&["cookie_secure"]) {
+                    Some(Value::Bool(b)) => *b,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"cookie_secure\" must be a bool, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => default_auth_cookie_secure_env(),
+                };
+
+                let session_store = match get_option(&["session_store"]) {
+                    Some(Value::String(s)) => parse_auth_session_store(s)
+                        .map_err(IntentError::type_error)?,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"session_store\" must be a string, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => SessionStore::Memory,
+                };
 
                 // Initialize database/cache if needed
                 if let Err(e) = initialize_session_store(&session_store) {
@@ -6372,32 +6424,40 @@ pub fn init() -> HashMap<String, Value> {
                     )));
                 }
 
+                let store_tokens = match get_option(&["store_tokens"]) {
+                    Some(Value::Bool(b)) => *b,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"store_tokens\" must be a bool, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => false,
+                };
+
+                let refresh_ttl = match get_option(&["refresh_ttl"]) {
+                    Some(Value::Int(n)) => *n,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"refresh_ttl\" must be an int, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => 86400 * 30,
+                };
+
                 // Create auth config
                 let config = AuthConfig {
                     providers,
                     success_url,
                     failure_url,
                     logout_url,
-                    cookie_name: "ntnt_session".to_string(),
+                    cookie_name,
                     cookie_secure,
                     cookie_same_site: "Lax".to_string(),
                     session_ttl,
-                    store_tokens: options
-                        .as_ref()
-                        .and_then(|o| o.get("store_tokens"))
-                        .and_then(|v| match v {
-                            Value::Bool(b) => Some(*b),
-                            _ => None,
-                        })
-                        .unwrap_or(false),
-                    refresh_ttl: options
-                        .as_ref()
-                        .and_then(|o| o.get("refresh_ttl"))
-                        .and_then(|v| match v {
-                            Value::Int(n) => Some(*n),
-                            _ => None,
-                        })
-                        .unwrap_or(86400 * 30), // 30 days default
+                    store_tokens,
+                    refresh_ttl,
                     session_secret,
                     session_store,
                 };

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -1454,6 +1454,36 @@ pub fn ensure_auth_session_store(config: &AuthConfig) -> std::result::Result<(),
     initialize_session_store(&config.session_store)
 }
 
+fn auth_option_suggestion(key: &str) -> Option<String> {
+    let valid = [
+        "session_secret",
+        "session_ttl",
+        "refresh_ttl",
+        "success_url",
+        "after_login",
+        "failure_url",
+        "after_failure",
+        "logout_url",
+        "after_logout",
+        "cookie_name",
+        "cookie_secure",
+        "session_store",
+        "store_tokens",
+    ];
+
+    valid
+        .iter()
+        .map(|candidate| {
+            (
+                *candidate,
+                crate::error::levenshtein_distance(key, candidate),
+            )
+        })
+        .filter(|(_, distance)| *distance <= 4)
+        .min_by_key(|(_, distance)| *distance)
+        .map(|(candidate, _)| candidate.to_string())
+}
+
 /// Initialize auth with config
 pub fn init_auth(config: AuthConfig) {
     let is_prod = std::env::var("NTNT_ENV")
@@ -6251,7 +6281,7 @@ pub fn init() -> HashMap<String, Value> {
     //
     // Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url", or "redis://url".
     // @param providers Array of provider configs created by oauth() or oauth_discover()
-    // @param options Optional map with keys: session_secret, session_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, cookie_name, cookie_secure, session_store, store_tokens
+    // @param options Optional map with keys: session_secret, session_ttl, refresh_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, cookie_name, cookie_secure, session_store, store_tokens
     // @returns Unit
     // @see_also oauth, oauth_discover, auth_start
     // @since v0.3.11
@@ -6315,6 +6345,36 @@ pub fn init() -> HashMap<String, Value> {
                             return Err(IntentError::type_error(format!(
                                 "[auth] Provider at index {} must be a map (use oauth() to create)",
                                 idx
+                            )));
+                        }
+                    }
+                }
+
+                if let Some(opts) = &options {
+                    for key in opts.keys() {
+                        let known = matches!(
+                            key.as_str(),
+                            "session_secret"
+                                | "session_ttl"
+                                | "refresh_ttl"
+                                | "success_url"
+                                | "after_login"
+                                | "failure_url"
+                                | "after_failure"
+                                | "logout_url"
+                                | "after_logout"
+                                | "cookie_name"
+                                | "cookie_secure"
+                                | "session_store"
+                                | "store_tokens"
+                        );
+                        if !known {
+                            let suggestion = auth_option_suggestion(key)
+                                .map(|s| format!(" Did you mean \"{}\"?", s))
+                                .unwrap_or_default();
+                            return Err(IntentError::type_error(format!(
+                                "[auth] enable_auth() unknown option \"{}\".{}",
+                                key, suggestion
                             )));
                         }
                     }

--- a/src/stdlib/http_server.rs
+++ b/src/stdlib/http_server.rs
@@ -654,6 +654,13 @@ impl ServerState {
         self.add_route_with_source(method, pattern, handler, None, HashMap::new());
     }
 
+    /// Returns true if a route with the exact method and pattern is already registered.
+    pub fn has_route(&self, method: &str, pattern: &str) -> bool {
+        self.routes
+            .iter()
+            .any(|(route, _, _)| route.method == method && route.pattern == pattern)
+    }
+
     /// Detect if a new route would conflict with existing routes
     ///
     /// Two routes conflict if:


### PR DESCRIPTION
## Summary
- bump ntnt to 0.4.9
- rewrite DD-043 into a unified phased implementation plan and mark Phase 0 complete
- implement the first auth foundation improvements for Phase 1

## What changed
- `enable_auth(...)` now accepts the real 1-arg and 2-arg forms
- added stricter auth config validation with better type errors and unknown-key suggestions
- defaulted auth cookie security more safely based on env/site URL heuristics
- initialize configured auth session stores from the interpreter-side `enable_auth` path too
- added startup auth summary logging for enabled providers, routes, session TTL, and cookie posture
- added regression tests for config parsing and sqlite session-store edge cases
- regenerated docs and bumped version metadata to 0.4.9

## Verification
- `cargo test -q`
- `cargo build --release --locked`
- `./target/release/ntnt docs --generate`
- two review passes, including Codex review, with follow-up fixes for arity registration and session-store initialization

## Notes
This PR is the foundation slice, not the route-protection/session-helper/staged-auth phases yet. It is meant to make the auth entry point safer, clearer, and easier to debug before the heavier cleanup phases land.