### PR TITLE
feat: add staged auth challenge helpers

### DIFF
--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -1,9 +1,9 @@
 # DD-043: World-Class Auth — Making `std/auth` the Best stdlib Auth Ever
 
-**Status:** Draft  
+**Status:** In Progress  
 **Author:** Larri  
 **Date:** 2026-03-20  
-**Branch:** TBD (multi-phase)
+**Branch:** `feat/auth-session-core-v0.4.9` (Phase 2 merged via PR #77)
 
 ---
 
@@ -70,31 +70,35 @@ This is the single source of truth for how we should build `std/auth` forward. T
 ### Phase 2 — Route Protection for Real Apps
 **Goal:** Make route protection trivial, especially for file-routed apps like the template.
 
-- [ ] `require_auth()` middleware helper
-- [ ] Configurable protected path patterns
-- [ ] Accept shorthand like `require_auth("/admin/*")`
-- [ ] Support exact path + subtree matching (`/admin` and `/admin/*`)
-- [ ] Work cleanly with file-routed apps, not just hand-written route tables
-- [ ] Smart redirect vs `401`/`403` based on HTML vs API requests
-- [ ] Always exempt `/auth/*` and auth health/debug routes
-- [ ] Expose authenticated session state through helpers instead of ad hoc cookie parsing in handlers
+**Result:** Merged in PR #77 (`feat: add auth route protection helpers`) on 2026-04-12.
+
+- [x] `require_auth()` middleware helper
+- [x] Configurable protected path patterns
+- [x] Accept shorthand like `require_auth("/admin/*")`
+- [x] Support exact path + subtree matching (`/admin` and `/admin/*`)
+- [x] Work cleanly with file-routed apps, not just hand-written route tables
+- [x] Smart redirect vs `401`/`403` based on HTML vs API requests
+- [x] Always exempt `/auth/*` and auth health/debug routes
+- [x] Expose authenticated session state through helpers instead of ad hoc cookie parsing in handlers
 
 **Ships real value:** apps stop repeating auth checks in every protected page.
 
 ### Phase 3 — Session Core and Cookie Helpers
 **Goal:** Remove the most repetitive and error-prone login/logout/session code.
 
-- [ ] Rotate session ID automatically on successful auth callback/login
-- [ ] Invalidate old session ID immediately after rotation
-- [ ] Preserve intended session data across rotation
-- [ ] Session store migration implemented in Rust for Redis/Postgres/SQLite backends
-- [ ] Keep `migrate_session(old_id, new_id)` internal to Rust/session-store code
-- [ ] Public ntnt API exposes only high-level helpers (`sign_in_session`, `rotate_session`)
-- [ ] `sign_in_session()` helper that persists session + attaches cookie
-- [ ] `sign_out_session()` helper that revokes session + clears cookie
-- [ ] `current_session()` / `current_user()` helper for request-time lookups
-- [ ] Shared auth cookie defaults with per-app overrides
-- [ ] Centralize cookie posture: name, path, same-site, secure, httpOnly, expiry
+**Status:** In progress on `feat/auth-session-core-v0.4.9`.
+
+- [x] Rotate session ID automatically on successful auth callback/login
+- [x] Invalidate old session ID immediately after rotation
+- [x] Preserve intended session data across rotation
+- [x] Session store migration implemented in Rust for Redis/Postgres/SQLite backends
+- [x] Keep `migrate_session(old_id, new_id)` internal to Rust/session-store code
+- [x] Public ntnt API exposes only high-level session helpers, not low-level store migration primitives (`sign_in_session`, `rotate_session`, `sign_out_session`, `current_session`, `current_user`)
+- [x] `sign_in_session()` helper that persists session + attaches cookie
+- [x] `sign_out_session()` helper that revokes session + clears cookie
+- [x] `current_session()` / `current_user()` helper for request-time lookups
+- [x] Shared auth cookie defaults with per-app overrides
+- [x] Centralize cookie posture: name, path, same-site, secure, httpOnly, expiry
 - [ ] Log session rotation events when auth security logging is enabled
 
 **Possible public API shape:**

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -3,7 +3,7 @@
 **Status:** In Progress  
 **Author:** Larri  
 **Date:** 2026-03-20  
-**Branch:** `feat/auth-session-core-v0.4.9` (Phase 2 merged via PR #77)
+**Branch:** `feat/auth-challenges-v0.4.9` (Phase 2 merged via PR #77, Phase 3 merged via PR #78)
 
 ---
 
@@ -60,10 +60,12 @@ This is the single source of truth for how we should build `std/auth` forward. T
 ### Phase 1 — Foundation Mini-Phase
 **Goal:** Establish safe defaults and clear diagnostics without spending too long on lower-leverage convenience work.
 
-- [ ] Production-safe default auth config in `enable_auth`
-- [ ] Startup summary showing providers, routes, session settings, and cookie posture
-- [ ] Typed config validation with actionable errors and typo suggestions
-- [ ] Fatal errors for required missing config, warnings for optional config
+**Result:** Complete. This foundation pass was already shipped and should have been marked done earlier.
+
+- [x] Production-safe default auth config in `enable_auth`
+- [x] Startup summary showing providers, routes, session settings, and cookie posture
+- [x] Typed config validation with actionable errors and typo suggestions
+- [x] Fatal errors for required missing config, warnings for optional config
 
 **Ships real value:** apps get a stable auth floor and much better debugging immediately.
 
@@ -86,7 +88,7 @@ This is the single source of truth for how we should build `std/auth` forward. T
 ### Phase 3 — Session Core and Cookie Helpers
 **Goal:** Remove the most repetitive and error-prone login/logout/session code.
 
-**Status:** In progress on `feat/auth-session-core-v0.4.9`.
+**Result:** Merged in PR #78 (`feat: add auth session helpers`) on 2026-04-13.
 
 - [x] Rotate session ID automatically on successful auth callback/login
 - [x] Invalidate old session ID immediately after rotation
@@ -99,7 +101,7 @@ This is the single source of truth for how we should build `std/auth` forward. T
 - [x] `current_session()` / `current_user()` helper for request-time lookups
 - [x] Shared auth cookie defaults with per-app overrides
 - [x] Centralize cookie posture: name, path, same-site, secure, httpOnly, expiry
-- [ ] Log session rotation events when auth security logging is enabled
+- [x] Defer session rotation event logging until auth security logging exists, tracked in Phase 6
 
 **Possible public API shape:**
 
@@ -120,14 +122,18 @@ return sign_out_session(redirect("/login"), req)
 ### Phase 4 — Staged Auth Primitives
 **Goal:** Make multi-step auth flows first-class instead of hand-rolled.
 
-- [ ] Distinct pending-auth primitive separate from full authenticated sessions
-- [ ] `begin_auth_challenge()` helper
-- [ ] `current_auth_challenge()` helper
-- [ ] `complete_auth_challenge()` helper
-- [ ] `cancel_auth_challenge()` helper
-- [ ] Explicit TTL and one-time-use semantics for challenges
-- [ ] Safe place for minimal staged-auth metadata
-- [ ] No protected-route access until challenge upgrades into a real session
+**Status:** In progress on `feat/auth-challenges-v0.4.9`.
+
+**Initial implementation slice:** ship a distinct pending-auth challenge store and the four core helpers, with one-time completion semantics and session upgrade into the existing Phase 3 helpers. Keep challenge state minimal and isolated from protected-route access.
+
+- [x] Distinct pending-auth primitive separate from full authenticated sessions
+- [x] `begin_auth_challenge()` helper
+- [x] `current_auth_challenge()` helper
+- [x] `complete_auth_challenge()` helper
+- [x] `cancel_auth_challenge()` helper
+- [x] Explicit TTL and one-time-use semantics for challenges
+- [x] Safe place for minimal staged-auth metadata
+- [x] No protected-route access until challenge upgrades into a real session
 - [ ] Works for password → TOTP verification
 - [ ] Works for first login → TOTP setup → forced password change
 - [ ] Works for future MFA and step-up auth flows

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1825,9 +1825,13 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`auth_logout`](#authlogout) | Handle logout - clears the session and redirects. |
 | [`auth_me`](#authme) | Return current user as JSON for SPAs. |
 | [`auth_start`](#authstart) | Handle OAuth login start - redirects to the provider's authorization page. |
+| [`begin_auth_challenge`](#beginauthchallenge) | Persist a pending auth challenge and attach the challenge cookie. |
+| [`cancel_auth_challenge`](#cancelauthchallenge) | Cancel the current auth challenge and clear the challenge cookie. |
+| [`complete_auth_challenge`](#completeauthchallenge) | Upgrade the current auth challenge into a full authenticated session. |
 | [`create_session_from_oauth`](#createsessionfromoauth) | Create a session from OAuth user info and tokens. |
 | [`csrf_field`](#csrffield) | Get an HTML hidden input field with the CSRF token. |
 | [`csrf_token`](#csrftoken) | Get the CSRF token for the current session. |
+| [`current_auth_challenge`](#currentauthchallenge) | Get the current staged auth challenge from the request. |
 | [`current_session`](#currentsession) | Get the current session from the request. |
 | [`current_user`](#currentuser) | Get the current authenticated user from the request. |
 | [`enable_auth`](#enableauth) | Initialize the authentication system with OAuth providers. |
@@ -1849,7 +1853,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`require_auth`](#requireauth) | Protect routes with the configured auth session. |
 | [`rotate_session`](#rotatesession) | Rotate the current session ID and attach the new auth cookie to a response. |
 | [`session_data`](#sessiondata) | Get custom data stored in the current session. |
-| [`sessions_cleanup`](#sessionscleanup) | Clean up expired sessions, OAuth states, and exchange tokens from the session store. |
+| [`sessions_cleanup`](#sessionscleanup) | Clean up expired sessions, auth challenges, OAuth states, and exchange tokens from the session store. |
 | [`set_session`](#setsession) | Store custom data in the current session. |
 | [`sign_in_session`](#signinsession) | Persist a session and attach the auth cookie to an existing response. |
 | [`sign_out_session`](#signoutsession) | Revoke the current session and attach a clearing auth cookie to a response. |
@@ -1972,6 +1976,95 @@ get("/auth/{provider}", auth_start)  // Wire up login routes
 
 ---
 
+#### `begin_auth_challenge`
+
+```ntnt
+begin_auth_challenge(response: Response, challenge: Map) -> Response
+```
+
+Persist a pending auth challenge and attach the challenge cookie.
+
+Use this for staged auth flows like MFA verification, first-login setup, or password reset completion. Challenges are separate from full sessions.
+
+**Parameters:**
+
+- `response` — The Response map to attach the challenge cookie to
+- `challenge` — Challenge data map, including required `subject_id` and `kind`
+
+**Returns:** Response with a persisted auth challenge and Set-Cookie header
+
+**Examples:**
+
+```ntnt
+begin_auth_challenge(redirect("/admin/verify"), map { "subject_id": user.id, "kind": "mfa_pending", "ttl": 1800 })  // Begin a staged auth flow
+```
+
+**See also:** `current_auth_challenge`, `complete_auth_challenge`, `cancel_auth_challenge`
+
+*Since v0.4.9*
+
+---
+
+#### `cancel_auth_challenge`
+
+```ntnt
+cancel_auth_challenge(response: Response, req: Request) -> Response
+```
+
+Cancel the current auth challenge and clear the challenge cookie.
+
+Use this when a staged auth flow is abandoned, fails, or needs to be reset.
+
+**Parameters:**
+
+- `response` — The Response map to attach the clearing cookie to
+- `req` — The current HTTP request
+
+**Returns:** Response with the challenge cookie cleared
+
+**Examples:**
+
+```ntnt
+cancel_auth_challenge(redirect("/login"), req)  // Cancel staged auth
+```
+
+**See also:** `begin_auth_challenge`, `current_auth_challenge`, `complete_auth_challenge`
+
+*Since v0.4.9*
+
+---
+
+#### `complete_auth_challenge`
+
+```ntnt
+complete_auth_challenge(response: Response, req: Request, session?: Map, options?: Map) -> Response
+```
+
+Upgrade the current auth challenge into a full authenticated session.
+
+This consumes the active challenge, creates a real session, attaches the normal auth cookie, and clears the challenge cookie in the same response.
+
+**Parameters:**
+
+- `response` — The Response map to attach cookies to
+- `req` — The current HTTP request
+- `session` — Optional session data map merged onto the completed session
+- `options` — Optional session options like `session_ttl` and cookie overrides
+
+**Returns:** Response with the auth challenge consumed and the session cookie attached
+
+**Examples:**
+
+```ntnt
+complete_auth_challenge(redirect("/admin"), req, map { "claims": map { "role": "admin" } })  // Upgrade staged auth into a session
+```
+
+**See also:** `begin_auth_challenge`, `current_auth_challenge`, `cancel_auth_challenge`, `sign_in_session`
+
+*Since v0.4.9*
+
+---
+
 #### `create_session_from_oauth`
 
 ```ntnt
@@ -2055,6 +2148,34 @@ csrf_token(req)  // Get token for form
 **See also:** `verify_csrf`, `csrf_field`
 
 *Since v0.3.11*
+
+---
+
+#### `current_auth_challenge`
+
+```ntnt
+current_auth_challenge(req: Request) -> Option<AuthChallenge>
+```
+
+Get the current staged auth challenge from the request.
+
+Use this during multi-step auth flows like password -> TOTP or first-login setup. Challenges are distinct from authenticated sessions and do not grant protected-route access on their own.
+
+**Parameters:**
+
+- `req` — The HTTP request object
+
+**Returns:** Option containing the active auth challenge or None
+
+**Examples:**
+
+```ntnt
+current_auth_challenge(req)  // Read staged auth state
+```
+
+**See also:** `begin_auth_challenge`, `complete_auth_challenge`, `cancel_auth_challenge`
+
+*Since v0.4.9*
 
 ---
 
@@ -2693,9 +2814,9 @@ session_data(req)  // Get user roles and preferences
 sessions_cleanup() -> Result<Int, String>
 ```
 
-Clean up expired sessions, OAuth states, and exchange tokens from the session store.
+Clean up expired sessions, auth challenges, OAuth states, and exchange tokens from the session store.
 
-Call this periodically (e.g., via a cron job or scheduled task) to remove expired sessions, OAuth states, and exchange tokens from the database. For Redis, these use TTL so they expire automatically, but this will scan for any orphaned entries.
+Call this periodically (e.g., via a cron job or scheduled task) to remove expired sessions, auth challenges, OAuth states, and exchange tokens from the database. For Redis, these use TTL so they expire automatically, but this will scan for any orphaned entries.
 
 **Returns:** Result containing the number of expired entries removed, or error
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1828,6 +1828,8 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`create_session_from_oauth`](#createsessionfromoauth) | Create a session from OAuth user info and tokens. |
 | [`csrf_field`](#csrffield) | Get an HTML hidden input field with the CSRF token. |
 | [`csrf_token`](#csrftoken) | Get the CSRF token for the current session. |
+| [`current_session`](#currentsession) | Get the current session from the request. |
+| [`current_user`](#currentuser) | Get the current authenticated user from the request. |
 | [`enable_auth`](#enableauth) | Initialize the authentication system with OAuth providers. |
 | [`get_session`](#getsession) | Get the current session from the request. |
 | [`get_user`](#getuser) | Get the current authenticated user from the request. |
@@ -1845,9 +1847,12 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`oauth_start`](#oauthstart) | Generate an OAuth authorization URL for manual flow control. |
 | [`oauth_validate`](#oauthvalidate) | Validate an incoming bearer token (for APIs acting as resource servers). |
 | [`require_auth`](#requireauth) | Protect routes with the configured auth session. |
+| [`rotate_session`](#rotatesession) | Rotate the current session ID and attach the new auth cookie to a response. |
 | [`session_data`](#sessiondata) | Get custom data stored in the current session. |
 | [`sessions_cleanup`](#sessionscleanup) | Clean up expired sessions, OAuth states, and exchange tokens from the session store. |
 | [`set_session`](#setsession) | Store custom data in the current session. |
+| [`sign_in_session`](#signinsession) | Persist a session and attach the auth cookie to an existing response. |
+| [`sign_out_session`](#signoutsession) | Revoke the current session and attach a clearing auth cookie to a response. |
 | [`totp_secret`](#totpsecret) | Generate a new TOTP secret for MFA setup. |
 | [`totp_uri`](#totpuri) | Generate an otpauth:// URI for QR codes. |
 | [`user_sessions`](#usersessions) | Get all active sessions for the current user. |
@@ -2050,6 +2055,62 @@ csrf_token(req)  // Get token for form
 **See also:** `verify_csrf`, `csrf_field`
 
 *Since v0.3.11*
+
+---
+
+#### `current_session`
+
+```ntnt
+current_session(req: Request) -> Option<Session>
+```
+
+Get the current session from the request.
+
+Alias for `get_session(req)` with a clearer request-time name for session-driven flows.
+
+**Parameters:**
+
+- `req` — The HTTP request object
+
+**Returns:** Option containing the Session map or None
+
+**Examples:**
+
+```ntnt
+current_session(req)  // Read the current session
+```
+
+**See also:** `get_session`, `current_user`, `rotate_session`
+
+*Since v0.4.9*
+
+---
+
+#### `current_user`
+
+```ntnt
+current_user(req: Request) -> Option<User>
+```
+
+Get the current authenticated user from the request.
+
+Alias for `get_user(req)` with a clearer request-time name for login/session flows.
+
+**Parameters:**
+
+- `req` — The HTTP request object
+
+**Returns:** Option containing the User map or None
+
+**Examples:**
+
+```ntnt
+current_user(req) otherwise return redirect("/login")  // Require a current user
+```
+
+**See also:** `get_user`, `current_session`, `sign_in_session`
+
+*Since v0.4.9*
 
 ---
 
@@ -2568,6 +2629,36 @@ require_auth("/admin/*")  // Protect all admin file routes
 
 ---
 
+#### `rotate_session`
+
+```ntnt
+rotate_session(response: Response, req: Request, options?: Map) -> Response
+```
+
+Rotate the current session ID and attach the new auth cookie to a response.
+
+Use this after privilege changes or sensitive login completion to prevent session fixation while preserving the existing session payload.
+
+**Parameters:**
+
+- `response` — The Response map to attach the rotated cookie to
+- `req` — The current HTTP request
+- `options` — Optional cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+
+**Returns:** Response with the rotated session cookie
+
+**Examples:**
+
+```ntnt
+rotate_session(redirect("/admin"), req)  // Rotate session after elevated auth
+```
+
+**See also:** `sign_in_session`, `sign_out_session`, `current_session`
+
+*Since v0.4.9*
+
+---
+
 #### `session_data`
 
 ```ntnt
@@ -2646,6 +2737,66 @@ set_session(req, map { "roles": ["admin"], "theme": "dark" })  // Store user pre
 **See also:** `session_data`, `get_session`
 
 *Since v0.3.11*
+
+---
+
+#### `sign_in_session`
+
+```ntnt
+sign_in_session(response: Response, session: Map, options?: Map) -> Response
+```
+
+Persist a session and attach the auth cookie to an existing response.
+
+Use this after password, magic-link, or other non-OAuth login flows. The session map must include `subject_id`, and may optionally include `provider`, `email`, `name`, `picture`, `claims`, `data`, or `raw`.
+
+**Parameters:**
+
+- `response` — The Response map to attach the session cookie to
+- `session` — Session data map, including required `subject_id`
+- `options` — Optional map with `session_ttl` and cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+
+**Returns:** Response with a persisted session and Set-Cookie header
+
+**Examples:**
+
+```ntnt
+sign_in_session(redirect("/admin"), map { "subject_id": user.id, "claims": map { "role": "admin" } })  // Sign in and redirect
+```
+
+**See also:** `sign_out_session`, `current_session`, `rotate_session`
+
+*Since v0.4.9*
+
+---
+
+#### `sign_out_session`
+
+```ntnt
+sign_out_session(response: Response, req: Request, options?: Map) -> Response
+```
+
+Revoke the current session and attach a clearing auth cookie to a response.
+
+Use this when your app wants logout behavior without being forced into the built-in redirect handler.
+
+**Parameters:**
+
+- `response` — The Response map to attach the clearing cookie to
+- `req` — The current HTTP request
+- `options` — Optional cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
+
+**Returns:** Response with the auth cookie cleared
+
+**Examples:**
+
+```ntnt
+sign_out_session(redirect("/login"), req)  // Sign out and redirect
+```
+
+**See also:** `sign_in_session`, `rotate_session`, `current_user`
+
+*Since v0.4.9*
 
 ---
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2643,7 +2643,7 @@ Use this after privilege changes or sensitive login completion to prevent sessio
 
 - `response` — The Response map to attach the rotated cookie to
 - `req` — The current HTTP request
-- `options` — Optional cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+- `options` — Optional cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
 
 **Returns:** Response with the rotated session cookie
 
@@ -2754,7 +2754,7 @@ Use this after password, magic-link, or other non-OAuth login flows. The session
 
 - `response` — The Response map to attach the session cookie to
 - `session` — Session data map, including required `subject_id`
-- `options` — Optional map with `session_ttl` and cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+- `options` — Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
 
 **Returns:** Response with a persisted session and Set-Cookie header
 
@@ -2784,7 +2784,7 @@ Use this when your app wants logout behavior without being forced into the built
 
 - `response` — The Response map to attach the clearing cookie to
 - `req` — The current HTTP request
-- `options` — Optional cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
+- `options` — Optional cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
 
 **Returns:** Response with the auth cookie cleared
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -1674,11 +1674,72 @@ fn default_auth_cookie_max_age(config: &AuthConfig) -> i64 {
     }
 }
 
+fn validate_cookie_name(name: &str) -> std::result::Result<String, String> {
+    if name.is_empty() {
+        return Err("[auth] cookie_name must not be empty".to_string());
+    }
+
+    if name.chars().all(|ch| {
+        ch.is_ascii_alphanumeric()
+            || matches!(
+                ch,
+                '!' | '#'
+                    | '$'
+                    | '%'
+                    | '&'
+                    | '\''
+                    | '*'
+                    | '+'
+                    | '-'
+                    | '.'
+                    | '^'
+                    | '_'
+                    | '`'
+                    | '|'
+                    | '~'
+            )
+    }) {
+        Ok(name.to_string())
+    } else {
+        Err("[auth] cookie_name contains invalid characters".to_string())
+    }
+}
+
+fn validate_cookie_path(path: &str) -> std::result::Result<String, String> {
+    if path.is_empty() {
+        return Err("[auth] cookie_path must not be empty".to_string());
+    }
+    if !path.starts_with('/') {
+        return Err("[auth] cookie_path must start with /".to_string());
+    }
+    if path.chars().any(|ch| ch.is_control() || ch == ';') {
+        return Err("[auth] cookie_path contains invalid characters".to_string());
+    }
+
+    Ok(path.to_string())
+}
+
+fn normalize_cookie_same_site(value: &str) -> std::result::Result<String, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "lax" => Ok("Lax".to_string()),
+        "strict" => Ok("Strict".to_string()),
+        "none" => Ok("None".to_string()),
+        _ => Err("[auth] cookie_same_site must be one of: Lax, Strict, None".to_string()),
+    }
+}
+
 fn auth_cookie_settings(
     config: &AuthConfig,
     max_age: i64,
     overrides: Option<&HashMap<String, Value>>,
 ) -> std::result::Result<AuthCookieSettings, String> {
+    if overrides.and_then(|m| m.get("cookie_name")).is_some() {
+        return Err(
+            "[auth] cookie_name override is not supported; configure it via enable_auth()"
+                .to_string(),
+        );
+    }
+
     let get_string = |key: &str| -> std::result::Result<Option<String>, String> {
         match overrides.and_then(|m| m.get(key)) {
             Some(Value::String(s)) => Ok(Some(s.clone())),
@@ -1715,10 +1776,11 @@ fn auth_cookie_settings(
     };
 
     Ok(AuthCookieSettings {
-        name: get_string("cookie_name")?.unwrap_or_else(|| config.cookie_name.clone()),
-        path: get_string("cookie_path")?.unwrap_or_else(|| "/".to_string()),
-        same_site: get_string("cookie_same_site")?
-            .unwrap_or_else(|| config.cookie_same_site.clone()),
+        name: validate_cookie_name(&config.cookie_name)?,
+        path: validate_cookie_path(&get_string("cookie_path")?.unwrap_or_else(|| "/".to_string()))?,
+        same_site: normalize_cookie_same_site(
+            &get_string("cookie_same_site")?.unwrap_or_else(|| config.cookie_same_site.clone()),
+        )?,
         secure: get_bool("cookie_secure")?.unwrap_or(config.cookie_secure),
         http_only: get_bool("cookie_http_only")?.unwrap_or(true),
         max_age: cookie_max_age,
@@ -1755,7 +1817,12 @@ fn build_cleared_session_cookie(
     config: &AuthConfig,
     overrides: Option<&HashMap<String, Value>>,
 ) -> std::result::Result<String, String> {
-    let settings = auth_cookie_settings(config, 0, overrides)?;
+    let sanitized_overrides = overrides.map(|map| {
+        let mut sanitized = map.clone();
+        sanitized.remove("cookie_max_age");
+        sanitized
+    });
+    let settings = auth_cookie_settings(config, 0, sanitized_overrides.as_ref())?;
     Ok(build_auth_cookie_string("", &settings))
 }
 
@@ -3783,7 +3850,6 @@ fn migrate_session(old_id: &str, new_session: &Session) -> std::result::Result<(
 
     let mut store = SESSION_STORE.lock().unwrap();
     store.delete_session(old_id);
-    store.set_session(new_session.clone());
     Ok(())
 }
 
@@ -3924,12 +3990,10 @@ fn migrate_session_redis(old_id: &str, new_session: &Session) -> std::result::Re
     Ok(())
 }
 
-fn rotate_session_id(session_id: &str) -> std::result::Result<Session, String> {
+fn build_rotated_session(session_id: &str) -> std::result::Result<Session, String> {
     let mut session = get_session_by_id(session_id).ok_or("No active session".to_string())?;
-    let old_id = session.id.clone();
     session.id = generate_session_id();
     session.csrf_token = uuid::Uuid::new_v4().to_string();
-    migrate_session(&old_id, &session)?;
     Ok(session)
 }
 
@@ -5163,11 +5227,6 @@ pub fn handle_auth_callback(args: &[Value]) -> Result<Value> {
                         e
                     ))
                 })?;
-                eprintln!(
-                    "[auth] Rotated session {}... -> {}... after successful auth callback",
-                    &existing_session_id[..8],
-                    &session.id[..8]
-                );
             } else {
                 store_session(session.clone());
             }
@@ -7818,7 +7877,7 @@ pub fn init() -> HashMap<String, Value> {
     // `email`, `name`, `picture`, `claims`, `data`, or `raw`.
     // @param response The Response map to attach the session cookie to
     // @param session Session data map, including required `subject_id`
-    // @param options Optional map with `session_ttl` and cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+    // @param options Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
     // @returns Response with a persisted session and Set-Cookie header
     // @see_also sign_out_session, current_session, rotate_session
     // @since v0.4.9
@@ -7881,11 +7940,14 @@ pub fn init() -> HashMap<String, Value> {
                 let session = create_manual_session(&session_spec, session_ttl)
                     .map_err(IntentError::type_error)?;
                 let session_id = session.id.clone();
-                store_session(session);
 
                 let cookie = build_signed_session_cookie(&config, &session_id, options.as_ref())
                     .map_err(IntentError::type_error)?;
-                add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)
+                let response =
+                    add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)?;
+
+                store_session(session);
+                Ok(response)
             },
         },
     );
@@ -7899,7 +7961,7 @@ pub fn init() -> HashMap<String, Value> {
     // session fixation while preserving the existing session payload.
     // @param response The Response map to attach the rotated cookie to
     // @param req The current HTTP request
-    // @param options Optional cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+    // @param options Optional cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
     // @returns Response with the rotated session cookie
     // @see_also sign_in_session, sign_out_session, current_session
     // @since v0.4.9
@@ -7943,16 +8005,16 @@ pub fn init() -> HashMap<String, Value> {
                         "[auth] rotate_session() requires an active session".to_string(),
                     )
                 })?;
-                let rotated = rotate_session_id(&session_id).map_err(IntentError::runtime_error)?;
-                eprintln!(
-                    "[auth] Rotated session {}... -> {}... via rotate_session()",
-                    &session_id[..8],
-                    &rotated.id[..8]
-                );
+                let rotated =
+                    build_rotated_session(&session_id).map_err(IntentError::runtime_error)?;
 
                 let cookie = build_signed_session_cookie(&config, &rotated.id, options.as_ref())
                     .map_err(IntentError::type_error)?;
-                add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)
+                let response =
+                    add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)?;
+
+                migrate_session(&session_id, &rotated).map_err(IntentError::runtime_error)?;
+                Ok(response)
             },
         },
     );
@@ -7966,7 +8028,7 @@ pub fn init() -> HashMap<String, Value> {
     // built-in redirect handler.
     // @param response The Response map to attach the clearing cookie to
     // @param req The current HTTP request
-    // @param options Optional cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
+    // @param options Optional cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
     // @returns Response with the auth cookie cleared
     // @see_also sign_in_session, rotate_session, current_user
     // @since v0.4.9
@@ -8005,13 +8067,16 @@ pub fn init() -> HashMap<String, Value> {
                     None => None,
                 };
 
+                let cookie = build_cleared_session_cookie(&config, options.as_ref())
+                    .map_err(IntentError::type_error)?;
+                let response =
+                    add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)?;
+
                 if let Some(session_id) = get_session_id_from_request(&args[1]) {
                     delete_session_by_id(&session_id);
                 }
 
-                let cookie = build_cleared_session_cookie(&config, options.as_ref())
-                    .map_err(IntentError::type_error)?;
-                add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)
+                Ok(response)
             },
         },
     );
@@ -8555,6 +8620,60 @@ mod tests {
     }
 
     #[test]
+    fn test_sign_in_session_does_not_persist_when_response_invalid() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let err = sign_in_session(&[
+            Value::String("not-a-response".to_string()),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err).contains("[auth] response must be a map"));
+        assert!(SESSION_STORE.lock().unwrap().sessions.is_empty());
+    }
+
+    #[test]
+    fn test_sign_in_session_rejects_cookie_name_override() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let err = sign_in_session(&[
+            redirect_response("/admin", None),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+            Value::Map(HashMap::from([(
+                "cookie_name".to_string(),
+                Value::String("other_cookie".to_string()),
+            )])),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err).contains("cookie_name override is not supported"));
+        assert!(SESSION_STORE.lock().unwrap().sessions.is_empty());
+    }
+
+    #[test]
     fn test_rotate_session_changes_id_and_invalidates_old_cookie() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         reset_auth_test_state();
@@ -8633,6 +8752,69 @@ mod tests {
     }
 
     #[test]
+    fn test_rotate_session_invalid_response_keeps_existing_session() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let rotate_session = module_fn(&module, "rotate_session");
+        let current_session = module_fn(&module, "current_session");
+
+        let signed_in = sign_in_session(&[
+            redirect_response("/admin", None),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+        ])
+        .unwrap();
+        let cookie = cookie_header_from_response(&signed_in);
+        let req = request_with_cookie(&cookie);
+        let before = current_session(&[req.clone()]).unwrap();
+
+        let err = rotate_session(&[Value::String("not-a-response".to_string()), req.clone()])
+            .unwrap_err();
+        assert!(format!("{}", err).contains("[auth] response must be a map"));
+
+        let after = current_session(&[req]).unwrap();
+        match (before, after) {
+            (
+                Value::EnumValue {
+                    values: before_values,
+                    ..
+                },
+                Value::EnumValue {
+                    values: after_values,
+                    ..
+                },
+            ) => {
+                let before_id = match before_values.first() {
+                    Some(Value::Map(map)) => match map.get("id") {
+                        Some(Value::String(id)) => id.clone(),
+                        other => panic!("expected session id, got {:?}", other),
+                    },
+                    other => panic!("expected session map, got {:?}", other),
+                };
+                let after_id = match after_values.first() {
+                    Some(Value::Map(map)) => match map.get("id") {
+                        Some(Value::String(id)) => id.clone(),
+                        other => panic!("expected session id, got {:?}", other),
+                    },
+                    other => panic!("expected session map, got {:?}", other),
+                };
+                assert_eq!(before_id, after_id);
+            }
+            other => panic!("expected session before/after, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn test_sign_out_session_clears_cookie_and_removes_session() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         reset_auth_test_state();
@@ -8658,8 +8840,15 @@ mod tests {
         let cookie = cookie_header_from_response(&signed_in);
         let req = request_with_cookie(&cookie);
 
-        let signed_out =
-            sign_out_session(&[redirect_response("/login", None), req.clone()]).unwrap();
+        let signed_out = sign_out_session(&[
+            redirect_response("/login", None),
+            req.clone(),
+            Value::Map(HashMap::from([(
+                "cookie_max_age".to_string(),
+                Value::Int(3600),
+            )])),
+        ])
+        .unwrap();
         let set_cookie = match signed_out {
             Value::Map(map) => match map.get("headers") {
                 Some(Value::Map(headers)) => headers
@@ -8678,6 +8867,40 @@ mod tests {
 
         assert!(
             matches!(current_session(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "None")
+        );
+    }
+
+    #[test]
+    fn test_sign_out_session_invalid_response_keeps_session_active() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let sign_out_session = module_fn(&module, "sign_out_session");
+        let current_session = module_fn(&module, "current_session");
+
+        let signed_in = sign_in_session(&[
+            redirect_response("/admin", None),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+        ])
+        .unwrap();
+        let cookie = cookie_header_from_response(&signed_in);
+        let req = request_with_cookie(&cookie);
+
+        let err = sign_out_session(&[Value::String("not-a-response".to_string()), req.clone()])
+            .unwrap_err();
+        assert!(format!("{}", err).contains("[auth] response must be a map"));
+        assert!(
+            matches!(current_session(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "Some")
         );
     }
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -157,6 +157,18 @@ pub struct Session {
     pub expires_at: i64,
 }
 
+/// Pending auth challenge stored separately from authenticated sessions
+#[derive(Debug, Clone)]
+pub struct AuthChallenge {
+    pub id: String,
+    pub subject_id: String,
+    pub provider: String,
+    pub kind: String,
+    pub data_json: String,
+    pub created_at: i64,
+    pub expires_at: i64,
+}
+
 /// OAuth state for CSRF protection
 #[derive(Debug, Clone)]
 pub struct OAuthState {
@@ -1253,6 +1265,7 @@ struct InMemoryStore {
     sessions: HashMap<String, Session>,
     oauth_states: HashMap<String, OAuthState>,
     exchange_tokens: HashMap<String, (String, i64)>, // token → (session_id, created_at)
+    auth_challenges: HashMap<String, AuthChallenge>,
 }
 
 impl InMemoryStore {
@@ -1261,6 +1274,7 @@ impl InMemoryStore {
             sessions: HashMap::new(),
             oauth_states: HashMap::new(),
             exchange_tokens: HashMap::new(),
+            auth_challenges: HashMap::new(),
         }
     }
 
@@ -1321,12 +1335,42 @@ impl InMemoryStore {
         self.exchange_tokens.remove(token);
     }
 
+    fn get_auth_challenge(&self, id: &str) -> Option<&AuthChallenge> {
+        self.auth_challenges.get(id).filter(|challenge| {
+            let now = chrono::Utc::now().timestamp();
+            challenge.expires_at > now
+        })
+    }
+
+    fn set_auth_challenge(&mut self, challenge: AuthChallenge) {
+        self.auth_challenges.insert(challenge.id.clone(), challenge);
+    }
+
+    fn delete_auth_challenge(&mut self, id: &str) {
+        self.auth_challenges.remove(id);
+    }
+
+    fn take_auth_challenge(&mut self, id: &str) -> Option<AuthChallenge> {
+        let now = chrono::Utc::now().timestamp();
+        match self.auth_challenges.get(id) {
+            Some(challenge) if challenge.expires_at > now => self.auth_challenges.remove(id),
+            _ => None,
+        }
+    }
+
     fn cleanup_expired_exchange_tokens(&mut self, now: i64) -> usize {
         let cutoff = now - EXCHANGE_TOKEN_TTL;
         let before = self.exchange_tokens.len();
         self.exchange_tokens
             .retain(|_, (_, created_at)| *created_at >= cutoff);
         before - self.exchange_tokens.len()
+    }
+
+    fn cleanup_expired_auth_challenges(&mut self, now: i64) -> usize {
+        let before = self.auth_challenges.len();
+        self.auth_challenges
+            .retain(|_, challenge| challenge.expires_at >= now);
+        before - self.auth_challenges.len()
     }
 
     fn cleanup_expired(&mut self, now: i64) -> usize {
@@ -1634,6 +1678,18 @@ fn validate_provider_name(name: &str) -> std::result::Result<(), String> {
     }
 }
 
+fn validate_auth_challenge_kind(kind: &str) -> std::result::Result<String, String> {
+    if kind.is_empty() {
+        return Err("[auth] begin_auth_challenge() kind must not be empty".to_string());
+    }
+
+    if is_safe_provider_name(kind) {
+        Ok(kind.to_string())
+    } else {
+        Err("[auth] begin_auth_challenge() kind must use only ASCII letters, numbers, periods, underscores, or hyphens".to_string())
+    }
+}
+
 fn escape_html(text: &str) -> String {
     text.replace('&', "&amp;")
         .replace('<', "&lt;")
@@ -1823,6 +1879,27 @@ fn build_cleared_session_cookie(
         sanitized
     });
     let settings = auth_cookie_settings(config, 0, sanitized_overrides.as_ref())?;
+    Ok(build_auth_cookie_string("", &settings))
+}
+
+fn auth_challenge_cookie_name(config: &AuthConfig) -> std::result::Result<String, String> {
+    validate_cookie_name(&format!("{}_challenge", config.cookie_name))
+}
+
+fn build_signed_auth_challenge_cookie(
+    config: &AuthConfig,
+    challenge_id: &str,
+    ttl: i64,
+) -> std::result::Result<String, String> {
+    let mut settings = auth_cookie_settings(config, ttl.max(0), None)?;
+    settings.name = auth_challenge_cookie_name(config)?;
+    let signed_challenge_id = sign_session_id(challenge_id, &config.session_secret);
+    Ok(build_auth_cookie_string(&signed_challenge_id, &settings))
+}
+
+fn build_cleared_auth_challenge_cookie(config: &AuthConfig) -> std::result::Result<String, String> {
+    let mut settings = auth_cookie_settings(config, 0, None)?;
+    settings.name = auth_challenge_cookie_name(config)?;
     Ok(build_auth_cookie_string("", &settings))
 }
 
@@ -2127,6 +2204,26 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     )
     .map_err(|e| format!("Failed to create exchange_tokens table: {}", e))?;
 
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS auth_challenges (
+            id TEXT PRIMARY KEY,
+            subject_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            data_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL
+        )",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_challenges table: {}", e))?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_auth_challenges_expires ON auth_challenges(expires_at)",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_challenges index: {}", e))?;
+
     let mut sqlite_conn = SQLITE_CONN.lock().unwrap();
     *sqlite_conn = Some(conn);
     Ok(())
@@ -2194,6 +2291,28 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
             &[],
         )
         .map_err(|e| format!("Failed to create exchange_tokens table: {}", e))?;
+
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS auth_challenges (
+            id TEXT PRIMARY KEY,
+            subject_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            data_json TEXT NOT NULL,
+            created_at BIGINT NOT NULL,
+            expires_at BIGINT NOT NULL
+        )",
+            &[],
+        )
+        .map_err(|e| format!("Failed to create auth_challenges table: {}", e))?;
+
+    client
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_auth_challenges_expires ON auth_challenges(expires_at)",
+            &[],
+        )
+        .ok();
 
     // Store URL for later connections
     let mut pg_url = POSTGRES_URL.lock().unwrap();
@@ -2599,6 +2718,7 @@ fn consume_oauth_state_redis(state: &str) -> std::result::Result<Option<OAuthSta
 /// Maximum lifetime of an exchange token in seconds.
 /// Tokens older than this are considered expired and will not be consumed.
 const EXCHANGE_TOKEN_TTL: i64 = 60;
+const AUTH_CHALLENGE_TTL: i64 = 1800;
 
 /// Store an exchange token mapping to a session ID.
 /// Used to break the OAuth redirect chain for Safari ITP cookie persistence.
@@ -2893,6 +3013,91 @@ pub fn create_session(
     })
 }
 
+fn create_auth_challenge(
+    challenge_spec: &HashMap<String, Value>,
+) -> std::result::Result<AuthChallenge, String> {
+    let subject_id = match challenge_spec.get("subject_id") {
+        Some(Value::String(s)) if !s.is_empty() => s.clone(),
+        Some(Value::String(_)) => {
+            return Err("[auth] begin_auth_challenge() subject_id must not be empty".to_string())
+        }
+        Some(other) => {
+            return Err(format!(
+                "[auth] begin_auth_challenge() subject_id must be a string, got {}",
+                other.type_name()
+            ))
+        }
+        None => {
+            return Err(
+                "[auth] begin_auth_challenge() challenge.subject_id is required".to_string(),
+            )
+        }
+    };
+
+    let provider = match challenge_spec.get("provider") {
+        Some(Value::String(s)) if !s.is_empty() => s.clone(),
+        Some(Value::String(_)) => {
+            return Err("[auth] begin_auth_challenge() provider must not be empty".to_string())
+        }
+        Some(other) => {
+            return Err(format!(
+                "[auth] begin_auth_challenge() provider must be a string, got {}",
+                other.type_name()
+            ))
+        }
+        None => "local".to_string(),
+    };
+    validate_provider_name(&provider)
+        .map_err(|e| format!("[auth] begin_auth_challenge() {}", e))?;
+
+    let kind = match challenge_spec.get("kind") {
+        Some(Value::String(s)) => validate_auth_challenge_kind(s)?,
+        Some(other) => {
+            return Err(format!(
+                "[auth] begin_auth_challenge() kind must be a string, got {}",
+                other.type_name()
+            ))
+        }
+        None => return Err("[auth] begin_auth_challenge() challenge.kind is required".to_string()),
+    };
+
+    let ttl = match challenge_spec.get("ttl") {
+        Some(Value::Int(i)) if *i > 0 => *i,
+        Some(Value::Int(_)) => {
+            return Err("[auth] begin_auth_challenge() ttl must be greater than 0".to_string())
+        }
+        Some(other) => {
+            return Err(format!(
+                "[auth] begin_auth_challenge() ttl must be an int, got {}",
+                other.type_name()
+            ))
+        }
+        None => AUTH_CHALLENGE_TTL,
+    };
+
+    let data_map = match challenge_spec.get("data") {
+        Some(Value::Map(map)) => map.clone(),
+        Some(other) => {
+            return Err(format!(
+                "[auth] begin_auth_challenge() data must be a map, got {}",
+                other.type_name()
+            ))
+        }
+        None => HashMap::new(),
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    Ok(AuthChallenge {
+        id: generate_session_id(),
+        subject_id,
+        provider,
+        kind,
+        data_json: value_map_to_json_string(&data_map),
+        created_at: now,
+        expires_at: now + ttl,
+    })
+}
+
 fn create_manual_session(
     session_spec: &HashMap<String, Value>,
     ttl: i64,
@@ -2991,6 +3196,449 @@ fn create_manual_session(
         created_at: now,
         expires_at: now + ttl,
     })
+}
+
+pub fn store_auth_challenge(challenge: AuthChallenge) {
+    let config = get_auth_config();
+    let store_type = config.as_ref().map(|c| &c.session_store);
+
+    match store_type {
+        Some(SessionStore::Sqlite(_)) => {
+            if let Err(e) = store_auth_challenge_sqlite(&challenge) {
+                eprintln!("[auth] WARNING: SQLite auth challenge store failed: {}", e);
+                SESSION_STORE.lock().unwrap().set_auth_challenge(challenge);
+            }
+        }
+        Some(SessionStore::Postgres(_)) => {
+            if let Err(e) = store_auth_challenge_postgres(&challenge) {
+                eprintln!(
+                    "[auth] WARNING: PostgreSQL auth challenge store failed: {}",
+                    e
+                );
+                SESSION_STORE.lock().unwrap().set_auth_challenge(challenge);
+            }
+        }
+        Some(SessionStore::Redis(_)) => {
+            if let Err(e) = store_auth_challenge_redis(&challenge) {
+                eprintln!("[auth] WARNING: Redis auth challenge store failed: {}", e);
+                SESSION_STORE.lock().unwrap().set_auth_challenge(challenge);
+            }
+        }
+        _ => {
+            SESSION_STORE.lock().unwrap().set_auth_challenge(challenge);
+        }
+    }
+}
+
+fn store_auth_challenge_sqlite(challenge: &AuthChallenge) -> std::result::Result<(), String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO auth_challenges
+         (id, subject_id, provider, kind, data_json, created_at, expires_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        rusqlite::params![
+            challenge.id,
+            challenge.subject_id,
+            challenge.provider,
+            challenge.kind,
+            challenge.data_json,
+            challenge.created_at,
+            challenge.expires_at,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn store_auth_challenge_postgres(challenge: &AuthChallenge) -> std::result::Result<(), String> {
+    let url_guard = POSTGRES_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("PostgreSQL not initialized")?;
+
+    let mut client = postgres::Client::connect(url, postgres::NoTls).map_err(|e| e.to_string())?;
+    client
+        .execute(
+            "INSERT INTO auth_challenges
+             (id, subject_id, provider, kind, data_json, created_at, expires_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             ON CONFLICT (id) DO UPDATE SET
+                subject_id = $2, provider = $3, kind = $4, data_json = $5, created_at = $6, expires_at = $7",
+            &[
+                &challenge.id,
+                &challenge.subject_id,
+                &challenge.provider,
+                &challenge.kind,
+                &challenge.data_json,
+                &challenge.created_at,
+                &challenge.expires_at,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn store_auth_challenge_redis(challenge: &AuthChallenge) -> std::result::Result<(), String> {
+    let url_guard = REDIS_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("Redis not initialized")?;
+
+    let client =
+        redis::Client::open(url.as_str()).map_err(|e| format!("Redis client error: {}", e))?;
+    let mut conn = client
+        .get_connection()
+        .map_err(|e| format!("Redis connection error: {}", e))?;
+
+    let challenge_json = serde_json::json!({
+        "id": challenge.id,
+        "subject_id": challenge.subject_id,
+        "provider": challenge.provider,
+        "kind": challenge.kind,
+        "data_json": challenge.data_json,
+        "created_at": challenge.created_at,
+        "expires_at": challenge.expires_at,
+    })
+    .to_string();
+
+    let key = format!("ntnt:auth_challenge:{}", challenge.id);
+    let ttl = challenge.expires_at - chrono::Utc::now().timestamp();
+
+    if ttl > 0 {
+        redis::cmd("SETEX")
+            .arg(&key)
+            .arg(ttl)
+            .arg(&challenge_json)
+            .query::<()>(&mut conn)
+            .map_err(|e| format!("Redis SETEX error: {}", e))?;
+    }
+
+    Ok(())
+}
+
+pub fn get_auth_challenge_by_id(id: &str) -> Option<AuthChallenge> {
+    let config = get_auth_config();
+    let store_type = config.as_ref().map(|c| &c.session_store);
+
+    match store_type {
+        Some(SessionStore::Sqlite(_)) => {
+            get_auth_challenge_sqlite(id).ok().flatten().or_else(|| {
+                SESSION_STORE
+                    .lock()
+                    .unwrap()
+                    .get_auth_challenge(id)
+                    .cloned()
+            })
+        }
+        Some(SessionStore::Postgres(_)) => {
+            get_auth_challenge_postgres(id).ok().flatten().or_else(|| {
+                SESSION_STORE
+                    .lock()
+                    .unwrap()
+                    .get_auth_challenge(id)
+                    .cloned()
+            })
+        }
+        Some(SessionStore::Redis(_)) => get_auth_challenge_redis(id).ok().flatten().or_else(|| {
+            SESSION_STORE
+                .lock()
+                .unwrap()
+                .get_auth_challenge(id)
+                .cloned()
+        }),
+        _ => SESSION_STORE
+            .lock()
+            .unwrap()
+            .get_auth_challenge(id)
+            .cloned(),
+    }
+}
+
+fn get_auth_challenge_sqlite(id: &str) -> std::result::Result<Option<AuthChallenge>, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    let now = chrono::Utc::now().timestamp();
+
+    let result = conn.query_row(
+        "SELECT id, subject_id, provider, kind, data_json, created_at, expires_at
+         FROM auth_challenges WHERE id = ?1 AND expires_at > ?2",
+        rusqlite::params![id, now],
+        |row| {
+            Ok(AuthChallenge {
+                id: row.get(0)?,
+                subject_id: row.get(1)?,
+                provider: row.get(2)?,
+                kind: row.get(3)?,
+                data_json: row.get(4)?,
+                created_at: row.get(5)?,
+                expires_at: row.get(6)?,
+            })
+        },
+    );
+
+    match result {
+        Ok(challenge) => Ok(Some(challenge)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+fn get_auth_challenge_postgres(id: &str) -> std::result::Result<Option<AuthChallenge>, String> {
+    let url_guard = POSTGRES_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("PostgreSQL not initialized")?;
+    let now = chrono::Utc::now().timestamp();
+
+    let mut client = postgres::Client::connect(url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let rows = client
+        .query(
+            "SELECT id, subject_id, provider, kind, data_json, created_at, expires_at
+             FROM auth_challenges WHERE id = $1 AND expires_at > $2",
+            &[&id, &now],
+        )
+        .map_err(|e| e.to_string())?;
+
+    if let Some(row) = rows.first() {
+        Ok(Some(AuthChallenge {
+            id: row.get(0),
+            subject_id: row.get(1),
+            provider: row.get(2),
+            kind: row.get(3),
+            data_json: row.get(4),
+            created_at: row.get(5),
+            expires_at: row.get(6),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+fn get_auth_challenge_redis(id: &str) -> std::result::Result<Option<AuthChallenge>, String> {
+    let url_guard = REDIS_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("Redis not initialized")?;
+
+    let client =
+        redis::Client::open(url.as_str()).map_err(|e| format!("Redis client error: {}", e))?;
+    let mut conn = client
+        .get_connection()
+        .map_err(|e| format!("Redis connection error: {}", e))?;
+
+    let key = format!("ntnt:auth_challenge:{}", id);
+    let result: Option<String> = redis::cmd("GET")
+        .arg(&key)
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+
+    let Some(json_str) = result else {
+        return Ok(None);
+    };
+
+    let json: serde_json::Value =
+        serde_json::from_str(&json_str).map_err(|e| format!("Redis JSON parse error: {}", e))?;
+    let challenge = AuthChallenge {
+        id: json["id"].as_str().unwrap_or("").to_string(),
+        subject_id: json["subject_id"].as_str().unwrap_or("").to_string(),
+        provider: json["provider"].as_str().unwrap_or("").to_string(),
+        kind: json["kind"].as_str().unwrap_or("").to_string(),
+        data_json: json["data_json"].as_str().unwrap_or("{}").to_string(),
+        created_at: json["created_at"].as_i64().unwrap_or(0),
+        expires_at: json["expires_at"].as_i64().unwrap_or(0),
+    };
+
+    if challenge.expires_at > chrono::Utc::now().timestamp() {
+        Ok(Some(challenge))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn delete_auth_challenge_by_id(id: &str) {
+    let config = get_auth_config();
+    let store_type = config.as_ref().map(|c| &c.session_store);
+
+    match store_type {
+        Some(SessionStore::Sqlite(_)) => {
+            let _ = delete_auth_challenge_sqlite(id);
+        }
+        Some(SessionStore::Postgres(_)) => {
+            let _ = delete_auth_challenge_postgres(id);
+        }
+        Some(SessionStore::Redis(_)) => {
+            let _ = delete_auth_challenge_redis(id);
+        }
+        _ => {}
+    }
+
+    SESSION_STORE.lock().unwrap().delete_auth_challenge(id);
+}
+
+fn delete_auth_challenge_sqlite(id: &str) -> std::result::Result<(), String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    conn.execute(
+        "DELETE FROM auth_challenges WHERE id = ?1",
+        rusqlite::params![id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn delete_auth_challenge_postgres(id: &str) -> std::result::Result<(), String> {
+    let url_guard = POSTGRES_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("PostgreSQL not initialized")?;
+
+    let mut client = postgres::Client::connect(url, postgres::NoTls).map_err(|e| e.to_string())?;
+    client
+        .execute("DELETE FROM auth_challenges WHERE id = $1", &[&id])
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn delete_auth_challenge_redis(id: &str) -> std::result::Result<(), String> {
+    let url_guard = REDIS_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("Redis not initialized")?;
+
+    let client =
+        redis::Client::open(url.as_str()).map_err(|e| format!("Redis client error: {}", e))?;
+    let mut conn = client
+        .get_connection()
+        .map_err(|e| format!("Redis connection error: {}", e))?;
+
+    let key = format!("ntnt:auth_challenge:{}", id);
+    redis::cmd("DEL")
+        .arg(&key)
+        .query::<()>(&mut conn)
+        .map_err(|e| format!("Redis DEL error: {}", e))?;
+    Ok(())
+}
+
+fn consume_auth_challenge(id: &str) -> std::result::Result<Option<AuthChallenge>, String> {
+    let config = get_auth_config();
+    let store_type = config.as_ref().map(|c| &c.session_store);
+
+    match store_type {
+        Some(SessionStore::Sqlite(_)) => consume_auth_challenge_sqlite(id)
+            .or_else(|_| Ok(None))
+            .map(|challenge| {
+                challenge.or_else(|| SESSION_STORE.lock().unwrap().take_auth_challenge(id))
+            }),
+        Some(SessionStore::Postgres(_)) => consume_auth_challenge_postgres(id)
+            .or_else(|_| Ok(None))
+            .map(|challenge| {
+                challenge.or_else(|| SESSION_STORE.lock().unwrap().take_auth_challenge(id))
+            }),
+        Some(SessionStore::Redis(_)) => {
+            consume_auth_challenge_redis(id)
+                .or_else(|_| Ok(None))
+                .map(|challenge| {
+                    challenge.or_else(|| SESSION_STORE.lock().unwrap().take_auth_challenge(id))
+                })
+        }
+        _ => Ok(SESSION_STORE.lock().unwrap().take_auth_challenge(id)),
+    }
+}
+
+fn consume_auth_challenge_sqlite(id: &str) -> std::result::Result<Option<AuthChallenge>, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    let now = chrono::Utc::now().timestamp();
+
+    let result = conn.query_row(
+        "DELETE FROM auth_challenges
+         WHERE id = ?1 AND expires_at > ?2
+         RETURNING id, subject_id, provider, kind, data_json, created_at, expires_at",
+        rusqlite::params![id, now],
+        |row| {
+            Ok(AuthChallenge {
+                id: row.get(0)?,
+                subject_id: row.get(1)?,
+                provider: row.get(2)?,
+                kind: row.get(3)?,
+                data_json: row.get(4)?,
+                created_at: row.get(5)?,
+                expires_at: row.get(6)?,
+            })
+        },
+    );
+
+    match result {
+        Ok(challenge) => Ok(Some(challenge)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+fn consume_auth_challenge_postgres(id: &str) -> std::result::Result<Option<AuthChallenge>, String> {
+    let url_guard = POSTGRES_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("PostgreSQL not initialized")?;
+    let now = chrono::Utc::now().timestamp();
+
+    let mut client = postgres::Client::connect(url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let rows = client
+        .query(
+            "DELETE FROM auth_challenges
+             WHERE id = $1 AND expires_at > $2
+             RETURNING id, subject_id, provider, kind, data_json, created_at, expires_at",
+            &[&id, &now],
+        )
+        .map_err(|e| e.to_string())?;
+
+    if let Some(row) = rows.first() {
+        Ok(Some(AuthChallenge {
+            id: row.get(0),
+            subject_id: row.get(1),
+            provider: row.get(2),
+            kind: row.get(3),
+            data_json: row.get(4),
+            created_at: row.get(5),
+            expires_at: row.get(6),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+fn consume_auth_challenge_redis(id: &str) -> std::result::Result<Option<AuthChallenge>, String> {
+    let url_guard = REDIS_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("Redis not initialized")?;
+
+    let client =
+        redis::Client::open(url.as_str()).map_err(|e| format!("Redis client error: {}", e))?;
+    let mut conn = client
+        .get_connection()
+        .map_err(|e| format!("Redis connection error: {}", e))?;
+
+    let key = format!("ntnt:auth_challenge:{}", id);
+    let lua_script = r#"
+        local existing = redis.call('GET', KEYS[1])
+        if not existing then return nil end
+        redis.call('DEL', KEYS[1])
+        return existing
+    "#;
+
+    let json_str: Option<String> = redis::Script::new(lua_script)
+        .key(&key)
+        .invoke(&mut conn)
+        .map_err(|e| e.to_string())?;
+
+    let Some(json_str) = json_str else {
+        return Ok(None);
+    };
+
+    let json: serde_json::Value =
+        serde_json::from_str(&json_str).map_err(|e| format!("Redis JSON parse error: {}", e))?;
+    let challenge = AuthChallenge {
+        id: json["id"].as_str().unwrap_or("").to_string(),
+        subject_id: json["subject_id"].as_str().unwrap_or("").to_string(),
+        provider: json["provider"].as_str().unwrap_or("").to_string(),
+        kind: json["kind"].as_str().unwrap_or("").to_string(),
+        data_json: json["data_json"].as_str().unwrap_or("{}").to_string(),
+        created_at: json["created_at"].as_i64().unwrap_or(0),
+        expires_at: json["expires_at"].as_i64().unwrap_or(0),
+    };
+
+    if challenge.expires_at > chrono::Utc::now().timestamp() {
+        Ok(Some(challenge))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Store session
@@ -4099,6 +4747,50 @@ fn cleanup_expired_sessions_redis(now: i64) -> std::result::Result<u64, String> 
     Ok(count)
 }
 
+/// Cleanup expired auth challenges from the session store
+pub fn cleanup_expired_auth_challenges() -> std::result::Result<u64, String> {
+    let now = chrono::Utc::now().timestamp();
+    let config = get_auth_config();
+    let store_type = config.as_ref().map(|c| &c.session_store);
+
+    match store_type {
+        Some(SessionStore::Sqlite(_)) => cleanup_expired_auth_challenges_sqlite(now),
+        Some(SessionStore::Postgres(_)) => cleanup_expired_auth_challenges_postgres(now),
+        Some(SessionStore::Redis(_)) => Ok(0),
+        _ => {
+            let mut store = SESSION_STORE.lock().unwrap();
+            let count = store.cleanup_expired_auth_challenges(now);
+            Ok(count as u64)
+        }
+    }
+}
+
+fn cleanup_expired_auth_challenges_sqlite(now: i64) -> std::result::Result<u64, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+
+    let count = conn
+        .execute(
+            "DELETE FROM auth_challenges WHERE expires_at < ?1",
+            rusqlite::params![now],
+        )
+        .map_err(|e| e.to_string())?;
+
+    Ok(count as u64)
+}
+
+fn cleanup_expired_auth_challenges_postgres(now: i64) -> std::result::Result<u64, String> {
+    let url_guard = POSTGRES_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("PostgreSQL not initialized")?;
+
+    let mut client = postgres::Client::connect(url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let count = client
+        .execute("DELETE FROM auth_challenges WHERE expires_at < $1", &[&now])
+        .map_err(|e| e.to_string())?;
+
+    Ok(count)
+}
+
 /// Cleanup expired OAuth states from the session store
 /// OAuth states expire after 10 minutes
 pub fn cleanup_expired_oauth_states() -> std::result::Result<u64, String> {
@@ -4598,6 +5290,27 @@ pub fn get_session_id_from_request(request: &Value) -> Option<String> {
     None
 }
 
+pub fn get_auth_challenge_id_from_request(request: &Value) -> Option<String> {
+    let config = get_auth_config()?;
+    let cookie_name = auth_challenge_cookie_name(&config).ok()?;
+
+    if let Value::Map(req_map) = request {
+        if let Some(Value::Map(headers)) = req_map.get("headers") {
+            if let Some(Value::String(cookie_header)) = headers.get("cookie") {
+                for cookie in cookie_header.split(';') {
+                    let parts: Vec<&str> = cookie.trim().splitn(2, '=').collect();
+                    if parts.len() == 2 && parts[0] == cookie_name {
+                        let signed_token = parts[1];
+                        return verify_session_id(signed_token, &config.session_secret);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
 /// Get user from request as HashMap (internal helper)
 fn get_user_from_request(request: &Value) -> Option<HashMap<String, Value>> {
     let session_id = get_session_id_from_request(request)?;
@@ -4668,6 +5381,38 @@ pub fn session_to_value(session: &Session) -> Value {
     if let Some(exp) = session.token_expires_at {
         map.insert("token_expires_at".to_string(), Value::Int(exp));
     }
+
+    Value::Map(map)
+}
+
+pub fn auth_challenge_to_value(challenge: &AuthChallenge) -> Value {
+    let mut map = HashMap::new();
+    let user_id = if challenge
+        .subject_id
+        .starts_with(&format!("{}:", challenge.provider))
+    {
+        challenge.subject_id.clone()
+    } else {
+        format!("{}:{}", challenge.provider, challenge.subject_id)
+    };
+
+    map.insert("id".to_string(), Value::String(challenge.id.clone()));
+    map.insert(
+        "subject_id".to_string(),
+        Value::String(challenge.subject_id.clone()),
+    );
+    map.insert("user_id".to_string(), Value::String(user_id));
+    map.insert(
+        "provider".to_string(),
+        Value::String(challenge.provider.clone()),
+    );
+    map.insert("kind".to_string(), Value::String(challenge.kind.clone()));
+    map.insert("created_at".to_string(), Value::Int(challenge.created_at));
+    map.insert("expires_at".to_string(), Value::Int(challenge.expires_at));
+    map.insert(
+        "data".to_string(),
+        Value::Map(json_string_to_value_map(&challenge.data_json)),
+    );
 
     Value::Map(map)
 }
@@ -6288,6 +7033,311 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt current_auth_challenge
+    // @module std/auth
+    // @signature current_auth_challenge(req: Request) -> Option<AuthChallenge>
+    // Get the current staged auth challenge from the request.
+    //
+    // Use this during multi-step auth flows like password -> TOTP or first-login
+    // setup. Challenges are distinct from authenticated sessions and do not grant
+    // protected-route access on their own.
+    // @param req The HTTP request object
+    // @returns Option containing the active auth challenge or None
+    // @see_also begin_auth_challenge, complete_auth_challenge, cancel_auth_challenge
+    // @since v0.4.9
+    // @tags #auth, #session, #mfa
+    // @example current_auth_challenge(req) ~ "Read staged auth state"
+    module.insert(
+        "current_auth_challenge".to_string(),
+        Value::NativeFunction {
+            name: "current_auth_challenge".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| {
+                if args.is_empty() {
+                    return Err(IntentError::type_error(
+                        "[auth] current_auth_challenge() requires a request".to_string(),
+                    ));
+                }
+
+                let challenge_id = get_auth_challenge_id_from_request(&args[0]);
+                if let Some(id) = challenge_id {
+                    if let Some(challenge) = get_auth_challenge_by_id(&id) {
+                        return Ok(make_some(auth_challenge_to_value(&challenge)));
+                    }
+                }
+
+                Ok(make_none())
+            },
+        },
+    );
+
+    // @ntnt begin_auth_challenge
+    // @module std/auth
+    // @signature begin_auth_challenge(response: Response, challenge: Map) -> Response
+    // Persist a pending auth challenge and attach the challenge cookie.
+    //
+    // Use this for staged auth flows like MFA verification, first-login setup,
+    // or password reset completion. Challenges are separate from full sessions.
+    // @param response The Response map to attach the challenge cookie to
+    // @param challenge Challenge data map, including required `subject_id` and `kind`
+    // @returns Response with a persisted auth challenge and Set-Cookie header
+    // @see_also current_auth_challenge, complete_auth_challenge, cancel_auth_challenge
+    // @since v0.4.9
+    // @tags #auth, #session, #mfa
+    // @example begin_auth_challenge(redirect("/admin/verify"), map { "subject_id": user.id, "kind": "mfa_pending", "ttl": 1800 }) ~ "Begin a staged auth flow"
+    module.insert(
+        "begin_auth_challenge".to_string(),
+        Value::NativeFunction {
+            name: "begin_auth_challenge".to_string(),
+            arity: 2,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.len() != 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] begin_auth_challenge() requires response and challenge"
+                            .to_string(),
+                    ));
+                }
+
+                let config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before begin_auth_challenge()."
+                            .to_string(),
+                    )
+                })?;
+
+                let challenge_spec = match &args[1] {
+                    Value::Map(map) => map.clone(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] begin_auth_challenge() challenge must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+
+                let challenge =
+                    create_auth_challenge(&challenge_spec).map_err(IntentError::type_error)?;
+                let ttl = challenge.expires_at - chrono::Utc::now().timestamp();
+                let cookie = build_signed_auth_challenge_cookie(&config, &challenge.id, ttl)
+                    .map_err(IntentError::type_error)?;
+                let response =
+                    add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)?;
+
+                store_auth_challenge(challenge);
+                Ok(response)
+            },
+        },
+    );
+
+    // @ntnt complete_auth_challenge
+    // @module std/auth
+    // @signature complete_auth_challenge(response: Response, req: Request, session?: Map, options?: Map) -> Response
+    // Upgrade the current auth challenge into a full authenticated session.
+    //
+    // This consumes the active challenge, creates a real session, attaches the
+    // normal auth cookie, and clears the challenge cookie in the same response.
+    // @param response The Response map to attach cookies to
+    // @param req The current HTTP request
+    // @param session Optional session data map merged onto the completed session
+    // @param options Optional session options like `session_ttl` and cookie overrides
+    // @returns Response with the auth challenge consumed and the session cookie attached
+    // @see_also begin_auth_challenge, current_auth_challenge, cancel_auth_challenge, sign_in_session
+    // @since v0.4.9
+    // @tags #auth, #session, #mfa
+    // @example complete_auth_challenge(redirect("/admin"), req, map { "claims": map { "role": "admin" } }) ~ "Upgrade staged auth into a session"
+    module.insert(
+        "complete_auth_challenge".to_string(),
+        Value::NativeFunction {
+            name: "complete_auth_challenge".to_string(),
+            arity: 2,
+            max_arity: 4,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 4 {
+                    return Err(IntentError::type_error(
+                        "[auth] complete_auth_challenge() requires response, request, and optional session/options"
+                            .to_string(),
+                    ));
+                }
+
+                let config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before complete_auth_challenge()."
+                            .to_string(),
+                    )
+                })?;
+
+                let session_spec = match args.get(2) {
+                    Some(Value::Map(map)) => map.clone(),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] complete_auth_challenge() session must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => HashMap::new(),
+                };
+
+                let options = match args.get(3) {
+                    Some(Value::Map(map)) => Some(map.clone()),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] complete_auth_challenge() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => None,
+                };
+
+                let challenge_id = get_auth_challenge_id_from_request(&args[1]).ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] complete_auth_challenge() requires an active auth challenge"
+                            .to_string(),
+                    )
+                })?;
+
+                let challenge = get_auth_challenge_by_id(&challenge_id).ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] complete_auth_challenge() requires an active auth challenge"
+                            .to_string(),
+                    )
+                })?;
+
+                let mut merged_session = session_spec.clone();
+                match merged_session.get("subject_id") {
+                    Some(Value::String(subject_id)) if subject_id == &challenge.subject_id => {}
+                    Some(Value::String(_)) => {
+                        return Err(IntentError::type_error(
+                            "[auth] complete_auth_challenge() session.subject_id must match the active auth challenge"
+                                .to_string(),
+                        ))
+                    }
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] complete_auth_challenge() session.subject_id must be a string, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => {
+                        merged_session.insert(
+                            "subject_id".to_string(),
+                            Value::String(challenge.subject_id.clone()),
+                        );
+                    }
+                }
+
+                match merged_session.get("provider") {
+                    Some(Value::String(provider)) if provider == &challenge.provider => {}
+                    Some(Value::String(_)) => {
+                        return Err(IntentError::type_error(
+                            "[auth] complete_auth_challenge() session.provider must match the active auth challenge"
+                                .to_string(),
+                        ))
+                    }
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] complete_auth_challenge() session.provider must be a string, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => {
+                        merged_session.insert(
+                            "provider".to_string(),
+                            Value::String(challenge.provider.clone()),
+                        );
+                    }
+                }
+
+                let session_ttl = match options.as_ref().and_then(|m| m.get("session_ttl")) {
+                    Some(Value::Int(i)) => *i,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] complete_auth_challenge() session_ttl must be an int, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => config.session_ttl,
+                };
+
+                let session =
+                    create_manual_session(&merged_session, session_ttl).map_err(IntentError::type_error)?;
+                let session_cookie =
+                    build_signed_session_cookie(&config, &session.id, options.as_ref())
+                        .map_err(IntentError::type_error)?;
+                let cleared_challenge_cookie =
+                    build_cleared_auth_challenge_cookie(&config).map_err(IntentError::type_error)?;
+                let response =
+                    add_set_cookie_header(&args[0], &session_cookie).map_err(IntentError::type_error)?;
+                let response = add_set_cookie_header(&response, &cleared_challenge_cookie)
+                    .map_err(IntentError::type_error)?;
+
+                let consumed = consume_auth_challenge(&challenge_id)
+                    .map_err(IntentError::runtime_error)?;
+                if consumed.is_none() {
+                    return Err(IntentError::runtime_error(
+                        "[auth] complete_auth_challenge() requires an active auth challenge"
+                            .to_string(),
+                    ));
+                }
+
+                store_session(session);
+                Ok(response)
+            },
+        },
+    );
+
+    // @ntnt cancel_auth_challenge
+    // @module std/auth
+    // @signature cancel_auth_challenge(response: Response, req: Request) -> Response
+    // Cancel the current auth challenge and clear the challenge cookie.
+    //
+    // Use this when a staged auth flow is abandoned, fails, or needs to be reset.
+    // @param response The Response map to attach the clearing cookie to
+    // @param req The current HTTP request
+    // @returns Response with the challenge cookie cleared
+    // @see_also begin_auth_challenge, current_auth_challenge, complete_auth_challenge
+    // @since v0.4.9
+    // @tags #auth, #session, #mfa
+    // @example cancel_auth_challenge(redirect("/login"), req) ~ "Cancel staged auth"
+    module.insert(
+        "cancel_auth_challenge".to_string(),
+        Value::NativeFunction {
+            name: "cancel_auth_challenge".to_string(),
+            arity: 2,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.len() != 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] cancel_auth_challenge() requires response and request".to_string(),
+                    ));
+                }
+
+                let config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before cancel_auth_challenge()."
+                            .to_string(),
+                    )
+                })?;
+
+                let cleared_cookie =
+                    build_cleared_auth_challenge_cookie(&config).map_err(IntentError::type_error)?;
+                let response =
+                    add_set_cookie_header(&args[0], &cleared_cookie).map_err(IntentError::type_error)?;
+
+                if let Some(challenge_id) = get_auth_challenge_id_from_request(&args[1]) {
+                    delete_auth_challenge_by_id(&challenge_id);
+                }
+
+                Ok(response)
+            },
+        },
+    );
+
     // @ntnt session_data
     // @module std/auth
     // @signature session_data(req: Request) -> Option<Map>
@@ -6541,10 +7591,10 @@ pub fn init() -> HashMap<String, Value> {
     // @ntnt sessions_cleanup
     // @module std/auth
     // @signature sessions_cleanup() -> Result<Int, String>
-    // Clean up expired sessions, OAuth states, and exchange tokens from the session store.
+    // Clean up expired sessions, auth challenges, OAuth states, and exchange tokens from the session store.
     //
     // Call this periodically (e.g., via a cron job or scheduled task) to remove
-    // expired sessions, OAuth states, and exchange tokens from the database. For Redis,
+    // expired sessions, auth challenges, OAuth states, and exchange tokens from the database. For Redis,
     // these use TTL so they expire automatically, but this will scan for any orphaned entries.
     // @returns Result containing the number of expired entries removed, or error
     // @see_also enable_auth
@@ -6567,6 +7617,17 @@ pub fn init() -> HashMap<String, Value> {
                     Err(e) => {
                         return Ok(make_err(Value::String(format!(
                             "Session cleanup failed: {}",
+                            e
+                        ))))
+                    }
+                }
+
+                // Clean up expired auth challenges
+                match cleanup_expired_auth_challenges() {
+                    Ok(count) => total += count,
+                    Err(e) => {
+                        return Ok(make_err(Value::String(format!(
+                            "Auth challenge cleanup failed: {}",
                             e
                         ))))
                     }
@@ -8350,6 +9411,7 @@ mod tests {
         store.sessions.clear();
         store.oauth_states.clear();
         store.exchange_tokens.clear();
+        store.auth_challenges.clear();
         drop(store);
         *AUTH_CONFIG.lock().unwrap() = None;
         *SQLITE_CONN.lock().unwrap() = None;
@@ -8366,6 +9428,14 @@ mod tests {
     }
 
     fn cookie_header_from_response(response: &Value) -> String {
+        let cookies = cookie_headers_from_response(response);
+        cookies
+            .first()
+            .cloned()
+            .unwrap_or_else(|| panic!("missing Set-Cookie header"))
+    }
+
+    fn cookie_headers_from_response(response: &Value) -> Vec<String> {
         let headers = match response {
             Value::Map(map) => match map.get("headers") {
                 Some(Value::Map(headers)) => headers,
@@ -8381,21 +9451,28 @@ mod tests {
             .unwrap_or_else(|| panic!("missing Set-Cookie header"));
 
         match cookie {
-            Value::String(s) => s.split(';').next().unwrap().to_string(),
-            Value::Array(values) => match values.first() {
-                Some(Value::String(s)) => s.split(';').next().unwrap().to_string(),
-                other => panic!("expected cookie string in array, got {:?}", other),
-            },
+            Value::String(s) => vec![s.split(';').next().unwrap().to_string()],
+            Value::Array(values) => values
+                .iter()
+                .map(|value| match value {
+                    Value::String(s) => s.split(';').next().unwrap().to_string(),
+                    other => panic!("expected cookie string in array, got {:?}", other),
+                })
+                .collect(),
             other => panic!("expected Set-Cookie string/array, got {:?}", other),
         }
     }
 
     fn request_with_cookie(cookie: &str) -> Value {
+        request_with_cookies(&[cookie])
+    }
+
+    fn request_with_cookies(cookies: &[&str]) -> Value {
         Value::Map(HashMap::from([(
             "headers".to_string(),
             Value::Map(HashMap::from([(
                 "cookie".to_string(),
-                Value::String(cookie.to_string()),
+                Value::String(cookies.join("; ")),
             )])),
         )]))
     }
@@ -8512,6 +9589,262 @@ mod tests {
         assert!(validate_provider_name("foo_bar-123").is_ok());
         assert!(validate_provider_name("google<script>").is_err());
         assert!(validate_provider_name("bad name").is_err());
+    }
+
+    #[test]
+    fn test_begin_auth_challenge_sets_cookie_and_current_helper_reads_it() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let begin_auth_challenge = module_fn(&module, "begin_auth_challenge");
+        let current_auth_challenge = module_fn(&module, "current_auth_challenge");
+        let current_session = module_fn(&module, "current_session");
+
+        let response = redirect_response("/admin/verify", None);
+        let challenge_response = begin_auth_challenge(&[
+            response,
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("user-123".to_string()),
+                ),
+                ("kind".to_string(), Value::String("mfa_pending".to_string())),
+                (
+                    "data".to_string(),
+                    Value::Map(HashMap::from([(
+                        "next".to_string(),
+                        Value::String("/admin".to_string()),
+                    )])),
+                ),
+            ])),
+        ])
+        .unwrap();
+
+        let cookie = cookie_header_from_response(&challenge_response);
+        assert!(cookie.starts_with("ntnt_session_challenge="));
+        let req = request_with_cookie(&cookie);
+
+        let challenge = current_auth_challenge(&[req.clone()]).unwrap();
+        match challenge {
+            Value::EnumValue {
+                variant, values, ..
+            } => {
+                assert_eq!(variant, "Some");
+                let challenge_map = match values.first() {
+                    Some(Value::Map(map)) => map,
+                    other => panic!("expected challenge map, got {:?}", other),
+                };
+                assert!(
+                    matches!(challenge_map.get("kind"), Some(Value::String(kind)) if kind == "mfa_pending")
+                );
+                match challenge_map.get("data") {
+                    Some(Value::Map(data)) => {
+                        assert!(
+                            matches!(data.get("next"), Some(Value::String(next)) if next == "/admin")
+                        );
+                    }
+                    other => panic!("expected challenge data map, got {:?}", other),
+                }
+            }
+            other => panic!("expected Some(challenge), got {:?}", other),
+        }
+
+        assert!(
+            matches!(current_session(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "None")
+        );
+    }
+
+    #[test]
+    fn test_begin_auth_challenge_rejects_missing_kind() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let begin_auth_challenge = module_fn(&module, "begin_auth_challenge");
+        let err = begin_auth_challenge(&[
+            redirect_response("/admin/verify", None),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+        ])
+        .unwrap_err();
+
+        assert!(
+            format!("{}", err).contains("[auth] begin_auth_challenge() challenge.kind is required")
+        );
+        assert!(SESSION_STORE.lock().unwrap().auth_challenges.is_empty());
+    }
+
+    #[test]
+    fn test_complete_auth_challenge_creates_session_and_consumes_challenge() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let begin_auth_challenge = module_fn(&module, "begin_auth_challenge");
+        let complete_auth_challenge = module_fn(&module, "complete_auth_challenge");
+        let current_auth_challenge = module_fn(&module, "current_auth_challenge");
+        let current_session = module_fn(&module, "current_session");
+
+        let started = begin_auth_challenge(&[
+            redirect_response("/admin/verify", None),
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("user-123".to_string()),
+                ),
+                ("kind".to_string(), Value::String("mfa_pending".to_string())),
+            ])),
+        ])
+        .unwrap();
+        let challenge_cookie = cookie_header_from_response(&started);
+        let req = request_with_cookie(&challenge_cookie);
+
+        let completed = complete_auth_challenge(&[
+            redirect_response("/admin", None),
+            req.clone(),
+            Value::Map(HashMap::from([(
+                "claims".to_string(),
+                Value::Map(HashMap::from([(
+                    "role".to_string(),
+                    Value::String("admin".to_string()),
+                )])),
+            )])),
+        ])
+        .unwrap();
+
+        let cookies = cookie_headers_from_response(&completed);
+        let session_cookie = cookies
+            .iter()
+            .find(|cookie| cookie.starts_with("ntnt_session="))
+            .cloned()
+            .unwrap_or_else(|| panic!("missing session cookie"));
+        let cleared_challenge_cookie = cookies
+            .iter()
+            .find(|cookie| cookie.starts_with("ntnt_session_challenge="))
+            .cloned()
+            .unwrap_or_else(|| panic!("missing cleared challenge cookie"));
+        assert_eq!(cleared_challenge_cookie, "ntnt_session_challenge=");
+
+        let session_req = request_with_cookie(&session_cookie);
+        let session = current_session(&[session_req]).unwrap();
+        match session {
+            Value::EnumValue {
+                variant, values, ..
+            } => {
+                assert_eq!(variant, "Some");
+                let session_map = match values.first() {
+                    Some(Value::Map(map)) => map,
+                    other => panic!("expected session map, got {:?}", other),
+                };
+                match session_map.get("data") {
+                    Some(Value::Map(data)) => {
+                        assert!(
+                            matches!(data.get("role"), Some(Value::String(role)) if role == "admin")
+                        );
+                    }
+                    other => panic!("expected session data map, got {:?}", other),
+                }
+            }
+            other => panic!("expected Some(session), got {:?}", other),
+        }
+
+        assert!(
+            matches!(current_auth_challenge(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "None")
+        );
+    }
+
+    #[test]
+    fn test_complete_auth_challenge_invalid_response_keeps_challenge_active() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let begin_auth_challenge = module_fn(&module, "begin_auth_challenge");
+        let complete_auth_challenge = module_fn(&module, "complete_auth_challenge");
+        let current_auth_challenge = module_fn(&module, "current_auth_challenge");
+
+        let started = begin_auth_challenge(&[
+            redirect_response("/admin/verify", None),
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("user-123".to_string()),
+                ),
+                ("kind".to_string(), Value::String("mfa_pending".to_string())),
+            ])),
+        ])
+        .unwrap();
+        let challenge_cookie = cookie_header_from_response(&started);
+        let req = request_with_cookie(&challenge_cookie);
+
+        let err =
+            complete_auth_challenge(&[Value::String("not-a-response".to_string()), req.clone()])
+                .unwrap_err();
+        assert!(format!("{}", err).contains("[auth] response must be a map"));
+        assert!(
+            matches!(current_auth_challenge(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "Some")
+        );
+    }
+
+    #[test]
+    fn test_cancel_auth_challenge_clears_cookie_and_removes_challenge() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let begin_auth_challenge = module_fn(&module, "begin_auth_challenge");
+        let cancel_auth_challenge = module_fn(&module, "cancel_auth_challenge");
+        let current_auth_challenge = module_fn(&module, "current_auth_challenge");
+
+        let started = begin_auth_challenge(&[
+            redirect_response("/admin/verify", None),
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("user-123".to_string()),
+                ),
+                ("kind".to_string(), Value::String("mfa_pending".to_string())),
+            ])),
+        ])
+        .unwrap();
+        let challenge_cookie = cookie_header_from_response(&started);
+        let req = request_with_cookie(&challenge_cookie);
+
+        let cancelled =
+            cancel_auth_challenge(&[redirect_response("/login", None), req.clone()]).unwrap();
+        let cleared = cookie_header_from_response(&cancelled);
+        assert_eq!(cleared, "ntnt_session_challenge=");
+        assert!(
+            matches!(current_auth_challenge(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "None")
+        );
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -1656,6 +1656,167 @@ fn encode_url_path_segment(text: &str) -> String {
     encoded
 }
 
+#[derive(Debug, Clone)]
+struct AuthCookieSettings {
+    name: String,
+    path: String,
+    same_site: String,
+    secure: bool,
+    http_only: bool,
+    max_age: i64,
+}
+
+fn default_auth_cookie_max_age(config: &AuthConfig) -> i64 {
+    if config.store_tokens && config.refresh_ttl > config.session_ttl {
+        config.refresh_ttl
+    } else {
+        config.session_ttl
+    }
+}
+
+fn auth_cookie_settings(
+    config: &AuthConfig,
+    max_age: i64,
+    overrides: Option<&HashMap<String, Value>>,
+) -> std::result::Result<AuthCookieSettings, String> {
+    let get_string = |key: &str| -> std::result::Result<Option<String>, String> {
+        match overrides.and_then(|m| m.get(key)) {
+            Some(Value::String(s)) => Ok(Some(s.clone())),
+            Some(other) => Err(format!(
+                "[auth] {} must be a string, got {}",
+                key,
+                other.type_name()
+            )),
+            None => Ok(None),
+        }
+    };
+
+    let get_bool = |key: &str| -> std::result::Result<Option<bool>, String> {
+        match overrides.and_then(|m| m.get(key)) {
+            Some(Value::Bool(b)) => Ok(Some(*b)),
+            Some(other) => Err(format!(
+                "[auth] {} must be a bool, got {}",
+                key,
+                other.type_name()
+            )),
+            None => Ok(None),
+        }
+    };
+
+    let cookie_max_age = match overrides.and_then(|m| m.get("cookie_max_age")) {
+        Some(Value::Int(i)) => *i,
+        Some(other) => {
+            return Err(format!(
+                "[auth] cookie_max_age must be an int, got {}",
+                other.type_name()
+            ))
+        }
+        None => max_age,
+    };
+
+    Ok(AuthCookieSettings {
+        name: get_string("cookie_name")?.unwrap_or_else(|| config.cookie_name.clone()),
+        path: get_string("cookie_path")?.unwrap_or_else(|| "/".to_string()),
+        same_site: get_string("cookie_same_site")?
+            .unwrap_or_else(|| config.cookie_same_site.clone()),
+        secure: get_bool("cookie_secure")?.unwrap_or(config.cookie_secure),
+        http_only: get_bool("cookie_http_only")?.unwrap_or(true),
+        max_age: cookie_max_age,
+    })
+}
+
+fn build_auth_cookie_string(value: &str, settings: &AuthCookieSettings) -> String {
+    let mut cookie = format!(
+        "{}={}; Path={}; Max-Age={}; SameSite={}",
+        settings.name, value, settings.path, settings.max_age, settings.same_site
+    );
+
+    if settings.http_only {
+        cookie.push_str("; HttpOnly");
+    }
+    if settings.secure {
+        cookie.push_str("; Secure");
+    }
+
+    cookie
+}
+
+fn build_signed_session_cookie(
+    config: &AuthConfig,
+    session_id: &str,
+    overrides: Option<&HashMap<String, Value>>,
+) -> std::result::Result<String, String> {
+    let settings = auth_cookie_settings(config, default_auth_cookie_max_age(config), overrides)?;
+    let signed_session_id = sign_session_id(session_id, &config.session_secret);
+    Ok(build_auth_cookie_string(&signed_session_id, &settings))
+}
+
+fn build_cleared_session_cookie(
+    config: &AuthConfig,
+    overrides: Option<&HashMap<String, Value>>,
+) -> std::result::Result<String, String> {
+    let settings = auth_cookie_settings(config, 0, overrides)?;
+    Ok(build_auth_cookie_string("", &settings))
+}
+
+fn add_set_cookie_header(response: &Value, cookie: &str) -> std::result::Result<Value, String> {
+    let mut response = match response {
+        Value::Map(map) => map.clone(),
+        other => {
+            return Err(format!(
+                "[auth] response must be a map, got {}",
+                other.type_name()
+            ))
+        }
+    };
+
+    let mut headers = match response.get("headers") {
+        Some(Value::Map(headers)) => headers.clone(),
+        Some(other) => {
+            return Err(format!(
+                "[auth] response headers must be a map, got {}",
+                other.type_name()
+            ))
+        }
+        None => HashMap::new(),
+    };
+
+    let set_cookie_key = headers
+        .keys()
+        .find(|key| key.eq_ignore_ascii_case("set-cookie"))
+        .cloned()
+        .unwrap_or_else(|| "Set-Cookie".to_string());
+
+    match headers.get(&set_cookie_key) {
+        Some(Value::Array(existing)) => {
+            let mut cookies = existing.clone();
+            cookies.push(Value::String(cookie.to_string()));
+            headers.insert(set_cookie_key, Value::Array(cookies));
+        }
+        Some(Value::String(existing)) => {
+            headers.insert(
+                set_cookie_key,
+                Value::Array(vec![
+                    Value::String(existing.clone()),
+                    Value::String(cookie.to_string()),
+                ]),
+            );
+        }
+        Some(other) => {
+            return Err(format!(
+                "[auth] response Set-Cookie header must be a string or array, got {}",
+                other.type_name()
+            ))
+        }
+        None => {
+            headers.insert(set_cookie_key, Value::String(cookie.to_string()));
+        }
+    }
+
+    response.insert("headers".to_string(), Value::Map(headers));
+    Ok(Value::Map(response))
+}
+
 pub fn reset_protected_paths() {
     let mut protected = AUTH_PROTECTED_PATHS.lock().unwrap();
     protected.clear();
@@ -2665,6 +2826,106 @@ pub fn create_session(
     })
 }
 
+fn create_manual_session(
+    session_spec: &HashMap<String, Value>,
+    ttl: i64,
+) -> std::result::Result<Session, String> {
+    let subject_id = match session_spec.get("subject_id") {
+        Some(Value::String(s)) if !s.is_empty() => s.clone(),
+        Some(Value::String(_)) => {
+            return Err("[auth] sign_in_session() subject_id must not be empty".to_string())
+        }
+        Some(other) => {
+            return Err(format!(
+                "[auth] sign_in_session() subject_id must be a string, got {}",
+                other.type_name()
+            ))
+        }
+        None => return Err("[auth] sign_in_session() session.subject_id is required".to_string()),
+    };
+
+    let provider = match session_spec.get("provider") {
+        Some(Value::String(s)) if !s.is_empty() => s.clone(),
+        Some(Value::String(_)) => {
+            return Err("[auth] sign_in_session() provider must not be empty".to_string())
+        }
+        Some(other) => {
+            return Err(format!(
+                "[auth] sign_in_session() provider must be a string, got {}",
+                other.type_name()
+            ))
+        }
+        None => "local".to_string(),
+    };
+    validate_provider_name(&provider)?;
+
+    let get_optional_string = |key: &str| -> std::result::Result<Option<String>, String> {
+        match session_spec.get(key) {
+            Some(Value::String(s)) => Ok(Some(s.clone())),
+            Some(other) => Err(format!(
+                "[auth] sign_in_session() {} must be a string, got {}",
+                key,
+                other.type_name()
+            )),
+            None => Ok(None),
+        }
+    };
+
+    let mut data_map = HashMap::new();
+    for key in ["claims", "data"] {
+        match session_spec.get(key) {
+            Some(Value::Map(map)) => data_map.extend(map.clone()),
+            Some(other) => {
+                return Err(format!(
+                    "[auth] sign_in_session() {} must be a map, got {}",
+                    key,
+                    other.type_name()
+                ))
+            }
+            None => {}
+        }
+    }
+
+    let raw_map = match session_spec.get("raw") {
+        Some(Value::Map(map)) => map.clone(),
+        Some(other) => {
+            return Err(format!(
+                "[auth] sign_in_session() raw must be a map, got {}",
+                other.type_name()
+            ))
+        }
+        None => {
+            let mut raw = HashMap::new();
+            raw.insert("subject_id".to_string(), Value::String(subject_id.clone()));
+            raw
+        }
+    };
+
+    let user_id = if subject_id.starts_with(&format!("{}:", provider)) {
+        subject_id.clone()
+    } else {
+        format!("{}:{}", provider, subject_id)
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    Ok(Session {
+        id: generate_session_id(),
+        user_id,
+        provider,
+        email: get_optional_string("email")?,
+        name: get_optional_string("name")?,
+        picture: get_optional_string("picture")?,
+        raw_json: value_map_to_json_string(&raw_map),
+        data_json: value_map_to_json_string(&data_map),
+        csrf_token: uuid::Uuid::new_v4().to_string(),
+        access_token: None,
+        refresh_token: None,
+        token_expires_at: None,
+        created_at: now,
+        expires_at: now + ttl,
+    })
+}
+
 /// Store session
 pub fn store_session(session: Session) {
     let config = get_auth_config();
@@ -3499,6 +3760,177 @@ fn delete_session_redis(id: &str) -> std::result::Result<(), String> {
         .query::<()>(&mut conn)
         .map_err(|e| format!("Redis DEL error: {}", e))?;
     Ok(())
+}
+
+fn migrate_session(old_id: &str, new_session: &Session) -> std::result::Result<(), String> {
+    let config = get_auth_config();
+    let store_type = config.as_ref().map(|c| &c.session_store);
+
+    match store_type {
+        Some(SessionStore::Sqlite(_)) => migrate_session_sqlite(old_id, new_session)?,
+        Some(SessionStore::Postgres(_)) => migrate_session_postgres(old_id, new_session)?,
+        Some(SessionStore::Redis(_)) => migrate_session_redis(old_id, new_session)?,
+        _ => {
+            let mut store = SESSION_STORE.lock().unwrap();
+            if store.get_session(old_id).is_none() {
+                return Err("Session not found".to_string());
+            }
+            store.delete_session(old_id);
+            store.set_session(new_session.clone());
+            return Ok(());
+        }
+    }
+
+    let mut store = SESSION_STORE.lock().unwrap();
+    store.delete_session(old_id);
+    store.set_session(new_session.clone());
+    Ok(())
+}
+
+fn migrate_session_sqlite(old_id: &str, new_session: &Session) -> std::result::Result<(), String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    let updated = conn
+        .execute(
+            "UPDATE auth_sessions
+         SET id = ?1, user_id = ?2, provider = ?3, email = ?4, name = ?5, picture = ?6,
+             raw_json = ?7, data_json = ?8, csrf_token = ?9, access_token = ?10,
+             refresh_token = ?11, token_expires_at = ?12, created_at = ?13, expires_at = ?14
+         WHERE id = ?15",
+            rusqlite::params![
+                new_session.id,
+                new_session.user_id,
+                new_session.provider,
+                new_session.email,
+                new_session.name,
+                new_session.picture,
+                new_session.raw_json,
+                new_session.data_json,
+                new_session.csrf_token,
+                new_session.access_token,
+                new_session.refresh_token,
+                new_session.token_expires_at,
+                new_session.created_at,
+                new_session.expires_at,
+                old_id,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+
+    if updated == 0 {
+        return Err("Session not found".to_string());
+    }
+
+    Ok(())
+}
+
+fn migrate_session_postgres(
+    old_id: &str,
+    new_session: &Session,
+) -> std::result::Result<(), String> {
+    let url_guard = POSTGRES_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("PostgreSQL not initialized")?;
+
+    let mut client = postgres::Client::connect(url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let updated = client
+        .execute(
+            "UPDATE auth_sessions
+             SET id = $1, user_id = $2, provider = $3, email = $4, name = $5, picture = $6,
+                 raw_json = $7, data_json = $8, csrf_token = $9, access_token = $10,
+                 refresh_token = $11, token_expires_at = $12, created_at = $13, expires_at = $14
+             WHERE id = $15",
+            &[
+                &new_session.id,
+                &new_session.user_id,
+                &new_session.provider,
+                &new_session.email,
+                &new_session.name,
+                &new_session.picture,
+                &new_session.raw_json,
+                &new_session.data_json,
+                &new_session.csrf_token,
+                &new_session.access_token,
+                &new_session.refresh_token,
+                &new_session.token_expires_at,
+                &new_session.created_at,
+                &new_session.expires_at,
+                &old_id,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+
+    if updated == 0 {
+        return Err("Session not found".to_string());
+    }
+
+    Ok(())
+}
+
+fn migrate_session_redis(old_id: &str, new_session: &Session) -> std::result::Result<(), String> {
+    let url_guard = REDIS_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("Redis not initialized")?;
+
+    let client =
+        redis::Client::open(url.as_str()).map_err(|e| format!("Redis client error: {}", e))?;
+    let mut conn = client
+        .get_connection()
+        .map_err(|e| format!("Redis connection error: {}", e))?;
+
+    let old_key = format!("ntnt:session:{}", old_id);
+    let new_key = format!("ntnt:session:{}", new_session.id);
+    let ttl = (new_session.expires_at - chrono::Utc::now().timestamp()).max(0);
+    let session_json = serde_json::json!({
+        "id": new_session.id,
+        "user_id": new_session.user_id,
+        "provider": new_session.provider,
+        "email": new_session.email,
+        "name": new_session.name,
+        "picture": new_session.picture,
+        "raw_json": new_session.raw_json,
+        "data_json": new_session.data_json,
+        "csrf_token": new_session.csrf_token,
+        "access_token": new_session.access_token,
+        "refresh_token": new_session.refresh_token,
+        "token_expires_at": new_session.token_expires_at,
+        "created_at": new_session.created_at,
+        "expires_at": new_session.expires_at,
+    })
+    .to_string();
+
+    let lua_script = r#"
+        local existing = redis.call('GET', KEYS[1])
+        if not existing then return 0 end
+        if tonumber(ARGV[1]) <= 0 then
+            redis.call('DEL', KEYS[1])
+            return 1
+        end
+        redis.call('SETEX', KEYS[2], tonumber(ARGV[1]), ARGV[2])
+        redis.call('DEL', KEYS[1])
+        return 1
+    "#;
+
+    let migrated: i32 = redis::Script::new(lua_script)
+        .key(&old_key)
+        .key(&new_key)
+        .arg(ttl)
+        .arg(&session_json)
+        .invoke(&mut conn)
+        .map_err(|e| e.to_string())?;
+
+    if migrated == 0 {
+        return Err("Session not found".to_string());
+    }
+
+    Ok(())
+}
+
+fn rotate_session_id(session_id: &str) -> std::result::Result<Session, String> {
+    let mut session = get_session_by_id(session_id).ok_or("No active session".to_string())?;
+    let old_id = session.id.clone();
+    session.id = generate_session_id();
+    session.csrf_token = uuid::Uuid::new_v4().to_string();
+    migrate_session(&old_id, &session)?;
+    Ok(session)
 }
 
 /// Cleanup expired sessions from the session store
@@ -4610,24 +5042,8 @@ pub fn handle_auth_callback(args: &[Value]) -> Result<Value> {
                         &session_id[..8]
                     );
 
-                    // Sign the session ID with HMAC for tamper protection
-                    let signed_session_id = sign_session_id(&session_id, &config.session_secret);
-
-                    // Create session cookie
-                    let cookie_max_age =
-                        if config.store_tokens && config.refresh_ttl > config.session_ttl {
-                            config.refresh_ttl
-                        } else {
-                            config.session_ttl
-                        };
-                    let cookie = format!(
-                        "{}={}; Path=/; Max-Age={}; HttpOnly; SameSite={}{}",
-                        config.cookie_name,
-                        signed_session_id,
-                        cookie_max_age,
-                        config.cookie_same_site,
-                        if config.cookie_secure { "; Secure" } else { "" }
-                    );
+                    let cookie = build_signed_session_cookie(&config, &session_id, None)
+                        .map_err(IntentError::runtime_error)?;
 
                     return Ok(redirect_response(&config.success_url, Some(&cookie)));
                 } else {
@@ -4734,8 +5150,34 @@ pub fn handle_auth_callback(args: &[Value]) -> Result<Value> {
         config.session_ttl,
     )
     .map_err(|e| IntentError::runtime_error(format!("[auth] Failed to create session: {}", e)))?;
+    let mut session = session;
+    if let Some(existing_session_id) = get_session_id_from_request(req) {
+        if let Some(existing_session) = get_session_by_id(&existing_session_id) {
+            if existing_session_id != session.id {
+                if session.data_json == "{}" && existing_session.data_json != "{}" {
+                    session.data_json = existing_session.data_json.clone();
+                }
+                migrate_session(&existing_session_id, &session).map_err(|e| {
+                    IntentError::runtime_error(format!(
+                        "[auth] Failed to rotate session after OAuth callback: {}",
+                        e
+                    ))
+                })?;
+                eprintln!(
+                    "[auth] Rotated session {}... -> {}... after successful auth callback",
+                    &existing_session_id[..8],
+                    &session.id[..8]
+                );
+            } else {
+                store_session(session.clone());
+            }
+        } else {
+            store_session(session.clone());
+        }
+    } else {
+        store_session(session.clone());
+    }
     let session_id = session.id.clone();
-    store_session(session);
 
     // Generate exchange token and store it
     let exchange_token = generate_session_id();
@@ -4778,12 +5220,7 @@ pub fn handle_auth_logout(args: &[Value]) -> Result<Value> {
         delete_session_by_id(&session_id);
     }
 
-    let cookie = format!(
-        "{}=; Path=/; Max-Age=0; HttpOnly; SameSite={}{}",
-        config.cookie_name,
-        config.cookie_same_site,
-        if config.cookie_secure { "; Secure" } else { "" }
-    );
+    let cookie = build_cleared_session_cookie(&config, None).map_err(IntentError::runtime_error)?;
 
     Ok(redirect_response(&config.logout_url, Some(&cookie)))
 }
@@ -5716,6 +6153,82 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt current_user
+    // @module std/auth
+    // @signature current_user(req: Request) -> Option<User>
+    // Get the current authenticated user from the request.
+    //
+    // Alias for `get_user(req)` with a clearer request-time name for login/session flows.
+    // @param req The HTTP request object
+    // @returns Option containing the User map or None
+    // @see_also get_user, current_session, sign_in_session
+    // @since v0.4.9
+    // @tags #auth, #session
+    // @example current_user(req) otherwise return redirect("/login") ~ "Require a current user"
+    module.insert(
+        "current_user".to_string(),
+        Value::NativeFunction {
+            name: "current_user".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| {
+                if args.is_empty() {
+                    return Err(IntentError::type_error(
+                        "[auth] current_user() requires a request".to_string(),
+                    ));
+                }
+
+                let session_id = get_session_id_from_request(&args[0]);
+                if let Some(id) = session_id {
+                    if let Some(session) = get_session_by_id(&id) {
+                        return Ok(make_some(user_to_value(&session)));
+                    }
+                }
+
+                Ok(make_none())
+            },
+        },
+    );
+
+    // @ntnt current_session
+    // @module std/auth
+    // @signature current_session(req: Request) -> Option<Session>
+    // Get the current session from the request.
+    //
+    // Alias for `get_session(req)` with a clearer request-time name for session-driven flows.
+    // @param req The HTTP request object
+    // @returns Option containing the Session map or None
+    // @see_also get_session, current_user, rotate_session
+    // @since v0.4.9
+    // @tags #auth, #session
+    // @example current_session(req) ~ "Read the current session"
+    module.insert(
+        "current_session".to_string(),
+        Value::NativeFunction {
+            name: "current_session".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| {
+                if args.is_empty() {
+                    return Err(IntentError::type_error(
+                        "[auth] current_session() requires a request".to_string(),
+                    ));
+                }
+
+                let session_id = get_session_id_from_request(&args[0]);
+                if let Some(id) = session_id {
+                    if let Some(session) = get_session_by_id(&id) {
+                        return Ok(make_some(session_to_value(&session)));
+                    }
+                }
+
+                Ok(make_none())
+            },
+        },
+    );
+
     // @ntnt session_data
     // @module std/auth
     // @signature session_data(req: Request) -> Option<Map>
@@ -6593,12 +7106,8 @@ pub fn init() -> HashMap<String, Value> {
                     delete_session_by_id(&session_id);
                 }
 
-                let cookie = format!(
-                    "{}=; Path=/; Max-Age=0; HttpOnly; SameSite={}{}",
-                    config.cookie_name,
-                    config.cookie_same_site,
-                    if config.cookie_secure { "; Secure" } else { "" }
-                );
+                let cookie = build_cleared_session_cookie(&config, None)
+                    .map_err(IntentError::runtime_error)?;
 
                 Ok(redirect_response(&config.logout_url, Some(&cookie)))
             },
@@ -7285,21 +7794,8 @@ pub fn init() -> HashMap<String, Value> {
                 let user_id = session.user_id.clone();
                 store_session(session);
 
-                // Build cookie — use refresh_ttl for Max-Age when refresh tokens are enabled
-                let signed_session_id = sign_session_id(&session_id, &config.session_secret);
-                let cookie_max_age = if config.store_tokens && config.refresh_ttl > config.session_ttl {
-                    config.refresh_ttl
-                } else {
-                    config.session_ttl
-                };
-                let cookie = format!(
-                    "{}={}; Path=/; Max-Age={}; HttpOnly; SameSite={}{}",
-                    config.cookie_name,
-                    signed_session_id,
-                    cookie_max_age,
-                    config.cookie_same_site,
-                    if config.cookie_secure { "; Secure" } else { "" }
-                );
+                let cookie = build_signed_session_cookie(&config, &session_id, None)
+                    .map_err(IntentError::type_error)?;
 
                 // Return result
                 let mut result = HashMap::new();
@@ -7308,6 +7804,214 @@ pub fn init() -> HashMap<String, Value> {
                 result.insert("cookie".to_string(), Value::String(cookie));
 
                 Ok(make_ok(Value::Map(result)))
+            },
+        },
+    );
+
+    // @ntnt sign_in_session
+    // @module std/auth
+    // @signature sign_in_session(response: Response, session: Map, options?: Map) -> Response
+    // Persist a session and attach the auth cookie to an existing response.
+    //
+    // Use this after password, magic-link, or other non-OAuth login flows. The
+    // session map must include `subject_id`, and may optionally include `provider`,
+    // `email`, `name`, `picture`, `claims`, `data`, or `raw`.
+    // @param response The Response map to attach the session cookie to
+    // @param session Session data map, including required `subject_id`
+    // @param options Optional map with `session_ttl` and cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+    // @returns Response with a persisted session and Set-Cookie header
+    // @see_also sign_out_session, current_session, rotate_session
+    // @since v0.4.9
+    // @tags #auth, #session
+    // @example sign_in_session(redirect("/admin"), map { "subject_id": user.id, "claims": map { "role": "admin" } }) ~ "Sign in and redirect"
+    module.insert(
+        "sign_in_session".to_string(),
+        Value::NativeFunction {
+            name: "sign_in_session".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] sign_in_session() requires response, session, and optional options"
+                            .to_string(),
+                    ));
+                }
+
+                let config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before sign_in_session()."
+                            .to_string(),
+                    )
+                })?;
+
+                let session_spec = match &args[1] {
+                    Value::Map(map) => map.clone(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] sign_in_session() session must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+
+                let options = match args.get(2) {
+                    Some(Value::Map(map)) => Some(map.clone()),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] sign_in_session() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => None,
+                };
+
+                let session_ttl = match options.as_ref().and_then(|m| m.get("session_ttl")) {
+                    Some(Value::Int(i)) => *i,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] sign_in_session() session_ttl must be an int, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => config.session_ttl,
+                };
+
+                let session = create_manual_session(&session_spec, session_ttl)
+                    .map_err(IntentError::type_error)?;
+                let session_id = session.id.clone();
+                store_session(session);
+
+                let cookie = build_signed_session_cookie(&config, &session_id, options.as_ref())
+                    .map_err(IntentError::type_error)?;
+                add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)
+            },
+        },
+    );
+
+    // @ntnt rotate_session
+    // @module std/auth
+    // @signature rotate_session(response: Response, req: Request, options?: Map) -> Response
+    // Rotate the current session ID and attach the new auth cookie to a response.
+    //
+    // Use this after privilege changes or sensitive login completion to prevent
+    // session fixation while preserving the existing session payload.
+    // @param response The Response map to attach the rotated cookie to
+    // @param req The current HTTP request
+    // @param options Optional cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+    // @returns Response with the rotated session cookie
+    // @see_also sign_in_session, sign_out_session, current_session
+    // @since v0.4.9
+    // @tags #auth, #session, #security
+    // @example rotate_session(redirect("/admin"), req) ~ "Rotate session after elevated auth"
+    module.insert(
+        "rotate_session".to_string(),
+        Value::NativeFunction {
+            name: "rotate_session".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] rotate_session() requires response, request, and optional options"
+                            .to_string(),
+                    ));
+                }
+
+                let config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before rotate_session()."
+                            .to_string(),
+                    )
+                })?;
+
+                let options = match args.get(2) {
+                    Some(Value::Map(map)) => Some(map.clone()),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] rotate_session() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => None,
+                };
+
+                let session_id = get_session_id_from_request(&args[1]).ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] rotate_session() requires an active session".to_string(),
+                    )
+                })?;
+                let rotated = rotate_session_id(&session_id).map_err(IntentError::runtime_error)?;
+                eprintln!(
+                    "[auth] Rotated session {}... -> {}... via rotate_session()",
+                    &session_id[..8],
+                    &rotated.id[..8]
+                );
+
+                let cookie = build_signed_session_cookie(&config, &rotated.id, options.as_ref())
+                    .map_err(IntentError::type_error)?;
+                add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)
+            },
+        },
+    );
+
+    // @ntnt sign_out_session
+    // @module std/auth
+    // @signature sign_out_session(response: Response, req: Request, options?: Map) -> Response
+    // Revoke the current session and attach a clearing auth cookie to a response.
+    //
+    // Use this when your app wants logout behavior without being forced into the
+    // built-in redirect handler.
+    // @param response The Response map to attach the clearing cookie to
+    // @param req The current HTTP request
+    // @param options Optional cookie override keys (`cookie_name`, `cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
+    // @returns Response with the auth cookie cleared
+    // @see_also sign_in_session, rotate_session, current_user
+    // @since v0.4.9
+    // @tags #auth, #session
+    // @example sign_out_session(redirect("/login"), req) ~ "Sign out and redirect"
+    module.insert(
+        "sign_out_session".to_string(),
+        Value::NativeFunction {
+            name: "sign_out_session".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] sign_out_session() requires response, request, and optional options"
+                            .to_string(),
+                    ));
+                }
+
+                let config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before sign_out_session()."
+                            .to_string(),
+                    )
+                })?;
+
+                let options = match args.get(2) {
+                    Some(Value::Map(map)) => Some(map.clone()),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] sign_out_session() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => None,
+                };
+
+                if let Some(session_id) = get_session_id_from_request(&args[1]) {
+                    delete_session_by_id(&session_id);
+                }
+
+                let cookie = build_cleared_session_cookie(&config, options.as_ref())
+                    .map_err(IntentError::type_error)?;
+                add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)
             },
         },
     );
@@ -7576,6 +8280,61 @@ mod tests {
     static AUTH_TEST_MUTEX: std::sync::LazyLock<std::sync::Mutex<()>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
 
+    fn reset_auth_test_state() {
+        let mut store = SESSION_STORE.lock().unwrap();
+        store.sessions.clear();
+        store.oauth_states.clear();
+        store.exchange_tokens.clear();
+        drop(store);
+        *AUTH_CONFIG.lock().unwrap() = None;
+        *SQLITE_CONN.lock().unwrap() = None;
+        *POSTGRES_URL.lock().unwrap() = None;
+        *REDIS_URL.lock().unwrap() = None;
+        reset_protected_paths();
+    }
+
+    fn module_fn(module: &HashMap<String, Value>, name: &str) -> fn(&[Value]) -> Result<Value> {
+        match module.get(name) {
+            Some(Value::NativeFunction { func, .. }) => *func,
+            other => panic!("expected native function {} got {:?}", name, other),
+        }
+    }
+
+    fn cookie_header_from_response(response: &Value) -> String {
+        let headers = match response {
+            Value::Map(map) => match map.get("headers") {
+                Some(Value::Map(headers)) => headers,
+                other => panic!("expected headers map, got {:?}", other),
+            },
+            other => panic!("expected response map, got {:?}", other),
+        };
+
+        let cookie = headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("set-cookie"))
+            .map(|(_, v)| v)
+            .unwrap_or_else(|| panic!("missing Set-Cookie header"));
+
+        match cookie {
+            Value::String(s) => s.split(';').next().unwrap().to_string(),
+            Value::Array(values) => match values.first() {
+                Some(Value::String(s)) => s.split(';').next().unwrap().to_string(),
+                other => panic!("expected cookie string in array, got {:?}", other),
+            },
+            other => panic!("expected Set-Cookie string/array, got {:?}", other),
+        }
+    }
+
+    fn request_with_cookie(cookie: &str) -> Value {
+        Value::Map(HashMap::from([(
+            "headers".to_string(),
+            Value::Map(HashMap::from([(
+                "cookie".to_string(),
+                Value::String(cookie.to_string()),
+            )])),
+        )]))
+    }
+
     #[test]
     fn test_exchange_token_store_consume_memory() {
         let mut store = InMemoryStore::new();
@@ -7688,6 +8447,238 @@ mod tests {
         assert!(validate_provider_name("foo_bar-123").is_ok());
         assert!(validate_provider_name("google<script>").is_err());
         assert!(validate_provider_name("bad name").is_err());
+    }
+
+    #[test]
+    fn test_sign_in_session_persists_claims_and_current_helpers_read_them() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let current_session = module_fn(&module, "current_session");
+        let current_user = module_fn(&module, "current_user");
+
+        let response = redirect_response("/admin", None);
+        let signed_in = sign_in_session(&[
+            response,
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("user-123".to_string()),
+                ),
+                ("name".to_string(), Value::String("Alice".to_string())),
+                (
+                    "claims".to_string(),
+                    Value::Map(HashMap::from([(
+                        "role".to_string(),
+                        Value::String("admin".to_string()),
+                    )])),
+                ),
+            ])),
+        ])
+        .unwrap();
+
+        let cookie = cookie_header_from_response(&signed_in);
+        let req = request_with_cookie(&cookie);
+
+        let session = current_session(&[req.clone()]).unwrap();
+        let user = current_user(&[req]).unwrap();
+
+        match session {
+            Value::EnumValue {
+                variant, values, ..
+            } => {
+                assert_eq!(variant, "Some");
+                let session_map = match values.first() {
+                    Some(Value::Map(map)) => map,
+                    other => panic!("expected session map, got {:?}", other),
+                };
+                match session_map.get("data") {
+                    Some(Value::Map(data)) => match data.get("role") {
+                        Some(Value::String(role)) => assert_eq!(role, "admin"),
+                        other => panic!("expected role string, got {:?}", other),
+                    },
+                    other => panic!("expected session data map, got {:?}", other),
+                }
+            }
+            other => panic!("expected Some(session), got {:?}", other),
+        }
+
+        match user {
+            Value::EnumValue {
+                variant, values, ..
+            } => {
+                assert_eq!(variant, "Some");
+                let user_map = match values.first() {
+                    Some(Value::Map(map)) => map,
+                    other => panic!("expected user map, got {:?}", other),
+                };
+                match user_map.get("name") {
+                    Some(Value::String(name)) => assert_eq!(name, "Alice"),
+                    other => panic!("expected user name, got {:?}", other),
+                }
+            }
+            other => panic!("expected Some(user), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_sign_in_session_rejects_missing_subject_id() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let err = sign_in_session(&[
+            redirect_response("/admin", None),
+            Value::Map(HashMap::from([(
+                "provider".to_string(),
+                Value::String("local".to_string()),
+            )])),
+        ])
+        .unwrap_err();
+
+        assert!(
+            format!("{}", err).contains("[auth] sign_in_session() session.subject_id is required")
+        );
+    }
+
+    #[test]
+    fn test_rotate_session_changes_id_and_invalidates_old_cookie() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let rotate_session = module_fn(&module, "rotate_session");
+        let current_session = module_fn(&module, "current_session");
+
+        let signed_in = sign_in_session(&[
+            redirect_response("/admin", None),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+        ])
+        .unwrap();
+        let old_cookie = cookie_header_from_response(&signed_in);
+        let old_req = request_with_cookie(&old_cookie);
+        let old_session = current_session(&[old_req.clone()]).unwrap();
+        let old_id = match old_session {
+            Value::EnumValue { values, .. } => match values.first() {
+                Some(Value::Map(map)) => match map.get("id") {
+                    Some(Value::String(id)) => id.clone(),
+                    other => panic!("expected session id, got {:?}", other),
+                },
+                other => panic!("expected session map, got {:?}", other),
+            },
+            other => panic!("expected Some(session), got {:?}", other),
+        };
+
+        let rotated =
+            rotate_session(&[redirect_response("/admin", None), old_req.clone()]).unwrap();
+        let new_cookie = cookie_header_from_response(&rotated);
+        let new_req = request_with_cookie(&new_cookie);
+        let new_session = current_session(&[new_req]).unwrap();
+        let new_id = match new_session {
+            Value::EnumValue { values, .. } => match values.first() {
+                Some(Value::Map(map)) => match map.get("id") {
+                    Some(Value::String(id)) => id.clone(),
+                    other => panic!("expected session id, got {:?}", other),
+                },
+                other => panic!("expected session map, got {:?}", other),
+            },
+            other => panic!("expected Some(session), got {:?}", other),
+        };
+
+        assert_ne!(old_id, new_id);
+        assert!(get_session_by_id(&old_id).is_none());
+    }
+
+    #[test]
+    fn test_rotate_session_requires_active_session() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let rotate_session = module_fn(&module, "rotate_session");
+        let err = rotate_session(&[
+            redirect_response("/admin", None),
+            request_with_cookie("ntnt_session=invalid"),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err).contains("[auth] rotate_session() requires an active session"));
+    }
+
+    #[test]
+    fn test_sign_out_session_clears_cookie_and_removes_session() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            session_secret: "test-secret".to_string(),
+            cookie_secure: false,
+            ..AuthConfig::default()
+        });
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let sign_out_session = module_fn(&module, "sign_out_session");
+        let current_session = module_fn(&module, "current_session");
+
+        let signed_in = sign_in_session(&[
+            redirect_response("/admin", None),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+        ])
+        .unwrap();
+        let cookie = cookie_header_from_response(&signed_in);
+        let req = request_with_cookie(&cookie);
+
+        let signed_out =
+            sign_out_session(&[redirect_response("/login", None), req.clone()]).unwrap();
+        let set_cookie = match signed_out {
+            Value::Map(map) => match map.get("headers") {
+                Some(Value::Map(headers)) => headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("set-cookie"))
+                    .map(|(_, v)| v.clone())
+                    .unwrap_or_else(|| panic!("missing Set-Cookie header")),
+                other => panic!("expected headers map, got {:?}", other),
+            },
+            other => panic!("expected response map, got {:?}", other),
+        };
+        match set_cookie {
+            Value::String(s) => assert!(s.contains("Max-Age=0")),
+            other => panic!("expected cookie string, got {:?}", other),
+        }
+
+        assert!(
+            matches!(current_session(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "None")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a first-class staged auth challenge primitive with storage across memory, SQLite, Postgres, and Redis
- add begin/current/complete/cancel auth challenge helpers plus challenge cleanup and cookie handling
- update DD-043 progress and regenerate stdlib docs

## Testing
- cargo fmt
- cargo test stdlib::auth::tests
- cargo build --release --locked && ./target/release/ntnt docs --generate
- cargo test