### PR TITLE
fix: align is_some semantics with unwrap

### DIFF
--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -59,9 +59,9 @@ These functions are available everywhere without importing.
 | [`is_float(val: Any)`](#isfloat) | Returns true if the value is a Float. |
 | [`is_int(val: Any)`](#isint) | Returns true if the value is an integer. |
 | [`is_map(val: Any)`](#ismap) | Returns true if the value is a Map (dictionary/object). |
-| [`is_none(val: Any)`](#isnone) | Checks if a value is None. |
+| [`is_none(val: Any)`](#isnone) | Checks if a value is Option::None. |
 | [`is_ok(res: Result<Any, Any>)`](#isok) | Checks if a Result is Ok. |
-| [`is_some(val: Any)`](#issome) | Checks if a value is "present" (not None). |
+| [`is_some(val: Any)`](#issome) | Checks if a value is Option::Some. |
 | [`is_string(val: Any)`](#isstring) | Returns true if the value is a String. |
 | [`jobs(directory: String)`](#jobs) | Auto-discover and register job definitions from .tnt files in a directory. |
 | [`len(x: String \| Array \| Map)`](#len) | Returns the length of a string, array, or map. |
@@ -768,23 +768,23 @@ is_map(None)  // => false  // None is not a map
 is_none(val: Any) -> Bool
 ```
 
-Checks if a value is None.
+Checks if a value is Option::None.
 
-Returns true for Option::None, false for Option::Some and any non-Option value (Map, String, Int, etc.). This makes it safe to use after query_one() or any function that returns a value that might be None without wrapping in Option.
+Returns true only for Option::None. Returns false for Option::Some and for all non-Option values.
 
 **Parameters:**
 
 - `val` — The value to check
 
-**Returns:** true if None, false otherwise
+**Returns:** true if Option::None, false otherwise
 
 **Examples:**
 
 ```ntnt
 is_none(None)  // => true  // None is none
 is_none(Some(42))  // => false  // Some is not none
-is_none("hello")  // => false  // Non-Option values are not none
-is_none(map { "a": 1 })  // => false  // Maps are not none
+is_none("hello")  // => false  // Non-Option values are not None
+is_none(map { "a": 1 })  // => false  // Maps are not None
 ```
 
 **See also:** `is_some`, `Some`, `unwrap`, `unwrap_or`
@@ -832,23 +832,23 @@ is_ok(Err("fail"))  // => false  // Err is not ok
 is_some(val: Any) -> Bool
 ```
 
-Checks if a value is "present" (not None).
+Checks if a value is Option::Some.
 
-Returns true for Option::Some, and true for any non-Option value (Map, String, Int, etc.). Returns false only for Option::None. This makes it safe to use after query_one() or any function that returns a value that might be None.
+Returns true only for Option::Some. Returns false for Option::None and for all non-Option values. This keeps `is_some(x)` aligned with `unwrap(x)`, which only accepts real Option/Result values.
 
 **Parameters:**
 
 - `val` — The value to check
 
-**Returns:** true if the value is not None, false if None
+**Returns:** true if the value is Option::Some, false otherwise
 
 **Examples:**
 
 ```ntnt
 is_some(Some(42))  // => true  // Some is some
 is_some(None)  // => false  // None is not some
-is_some("hello")  // => true  // Non-Option values are considered present
-is_some(map { "a": 1 })  // => true  // Maps are considered present
+is_some("hello")  // => false  // Non-Option values are not Some
+is_some(map { "a": 1 })  // => false  // Maps are not Some
 ```
 
 **See also:** `is_none`, `Some`, `unwrap`, `unwrap_or`

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -834,7 +834,7 @@ is_some(val: Any) -> Bool
 
 Checks if a value is Option::Some.
 
-Returns true only for Option::Some. Returns false for Option::None and for all non-Option values. This keeps `is_some(x)` aligned with `unwrap(x)`, which only accepts real Option/Result values.
+Returns true only for Option::Some. Returns false for Option::None and for all non-Option values. This is a strict Option check; for `Result` values, use `is_ok` or `is_err` instead.
 
 **Parameters:**
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3004,21 +3004,20 @@ impl Interpreter {
 
         // @ntnt is_some
         // @signature is_some(val: Any) -> Bool
-        // Checks if a value is "present" (not None).
+        // Checks if a value is Option::Some.
         //
-        // Returns true for Option::Some, and true for any non-Option value
-        // (Map, String, Int, etc.). Returns false only for Option::None.
-        // This makes it safe to use after query_one() or any function that
-        // returns a value that might be None.
+        // Returns true only for Option::Some. Returns false for Option::None
+        // and for all non-Option values. This keeps `is_some(x)` aligned with
+        // `unwrap(x)`, which only accepts real Option/Result values.
         // @param val The value to check
-        // @returns true if the value is not None, false if None
+        // @returns true if the value is Option::Some, false otherwise
         // @tags #pure, #deterministic
         // @see_also is_none, Some, unwrap, unwrap_or
         // @since v0.1.0
         // @example is_some(Some(42)) => true ~ "Some is some"
         // @example is_some(None) => false ~ "None is not some"
-        // @example is_some("hello") => true ~ "Non-Option values are considered present"
-        // @example is_some(map { "a": 1 }) => true ~ "Maps are considered present"
+        // @example is_some("hello") => false ~ "Non-Option values are not Some"
+        // @example is_some(map { "a": 1 }) => false ~ "Maps are not Some"
         self.environment.borrow_mut().define(
             "is_some".to_string(),
             Value::NativeFunction {
@@ -3030,29 +3029,26 @@ impl Interpreter {
                     Value::EnumValue {
                         enum_name, variant, ..
                     } if enum_name == "Option" => Ok(Value::Bool(variant == "Some")),
-                    // Any non-Option value is considered "present" (not None)
-                    _ => Ok(Value::Bool(true)),
+                    _ => Ok(Value::Bool(false)),
                 },
             },
         );
 
         // @ntnt is_none
         // @signature is_none(val: Any) -> Bool
-        // Checks if a value is None.
+        // Checks if a value is Option::None.
         //
-        // Returns true for Option::None, false for Option::Some and any
-        // non-Option value (Map, String, Int, etc.). This makes it safe
-        // to use after query_one() or any function that returns a value
-        // that might be None without wrapping in Option.
+        // Returns true only for Option::None. Returns false for Option::Some
+        // and for all non-Option values.
         // @param val The value to check
-        // @returns true if None, false otherwise
+        // @returns true if Option::None, false otherwise
         // @tags #pure, #deterministic
         // @see_also is_some, Some, unwrap, unwrap_or
         // @since v0.1.0
         // @example is_none(None) => true ~ "None is none"
         // @example is_none(Some(42)) => false ~ "Some is not none"
-        // @example is_none("hello") => false ~ "Non-Option values are not none"
-        // @example is_none(map { "a": 1 }) => false ~ "Maps are not none"
+        // @example is_none("hello") => false ~ "Non-Option values are not None"
+        // @example is_none(map { "a": 1 }) => false ~ "Maps are not None"
         self.environment.borrow_mut().define(
             "is_none".to_string(),
             Value::NativeFunction {
@@ -10908,6 +10904,34 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(result, Value::Bool(true)));
+    }
+
+    #[test]
+    fn test_is_some_is_strict_for_non_option_values() {
+        let result = eval("is_some(map { \"a\": 1 })").unwrap();
+        assert!(matches!(result, Value::Bool(false)));
+
+        let result = eval("is_some([1, 2, 3])").unwrap();
+        assert!(matches!(result, Value::Bool(false)));
+
+        let result = eval("is_some(\"hello\")").unwrap();
+        assert!(matches!(result, Value::Bool(false)));
+    }
+
+    #[test]
+    fn test_is_some_does_not_make_unwrap_safe_for_raw_values() {
+        let result = eval(
+            r#"
+            let x = map { "a": 1 }
+            if is_some(x) {
+                unwrap(x)
+            } else {
+                "safe"
+            }
+        "#,
+        )
+        .unwrap();
+        assert!(matches!(result, Value::String(s) if s == "safe"));
     }
 
     #[test]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3007,8 +3007,8 @@ impl Interpreter {
         // Checks if a value is Option::Some.
         //
         // Returns true only for Option::Some. Returns false for Option::None
-        // and for all non-Option values. This keeps `is_some(x)` aligned with
-        // `unwrap(x)`, which only accepts real Option/Result values.
+        // and for all non-Option values. This is a strict Option check; for
+        // `Result` values, use `is_ok` or `is_err` instead.
         // @param val The value to check
         // @returns true if the value is Option::Some, false otherwise
         // @tags #pure, #deterministic
@@ -3060,7 +3060,6 @@ impl Interpreter {
                     Value::EnumValue {
                         enum_name, variant, ..
                     } if enum_name == "Option" => Ok(Value::Bool(variant == "None")),
-                    // Any non-Option value is considered "present" (not None)
                     _ => Ok(Value::Bool(false)),
                 },
             },


### PR DESCRIPTION
## Summary
- make `is_some` strict so it returns true only for `Option::Some`
- keep `unwrap` semantics unchanged
- add regression coverage for the `is_some(x)` plus `unwrap(x)` footgun on raw values
- regenerate stdlib docs

## Why
Previously, `is_some` returned true for any non-Option value, while `unwrap` only accepted actual `Option` or `Result` values.

That made patterns like `if is_some(x) { unwrap(x) }` unsafe by construction whenever `x` was a raw `Map`/`Array`, including values returned directly by helpers like `std/kv get_json(...)`.

This change aligns the semantics so `is_some` is a real Option check rather than a generic presence check.

## Validation
- `cargo fmt`
- `cargo test --lib`
- `cargo test --test language_features_tests --test type_checker_tests --test cli_tests`
- `cargo build --release --locked`
- `./target/release/ntnt docs --generate`
