### PR TITLE
auth: finish DD-043 phase 4.5 fallback cleanup and audit

### DIFF
--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -193,7 +193,7 @@ return complete_auth_challenge(resp, req, map {
 - [x] Add backend contract tests that exercise the same auth storage behaviors across memory and SQLite for the current contract helpers
 - [x] Add env-gated Redis/Postgres integration coverage for auth storage flows so backend-specific regressions are caught before review comments or production incidents
 - [x] Add higher-level auth flow tests that verify staged auth, session rotation, protected-route lookup, and logout behavior against the cleaned-up internal boundaries
-- [ ] Re-review Phase 3 and Phase 4 helpers after the refactor to ensure docs, tests, and public behavior still match exactly
+- [x] Re-review Phase 3 and Phase 4 helpers after the refactor to ensure docs, tests, and public behavior still match exactly
 
 **Workstream E — Safety rails for the refactor itself**
 - [x] Preserve behavior first, then simplify structure, rather than mixing feature changes into the cleanup branch
@@ -204,11 +204,11 @@ return complete_auth_challenge(resp, req, map {
 **Recommended execution order:**
 - [x] 4.5A: document the intended internal architecture and fallback/error model before moving code
 - [x] 4.5B: split modules and relocate helpers with behavior held constant
-- [ ] 4.5C: introduce the internal storage contract and normalize shared semantics (4.5C-1 done, 4.5C-2 next)
+- [x] 4.5C: introduce the internal storage contract and normalize shared semantics (4.5C-1 and 4.5C-2 complete)
 - [x] 4.5D: add/finish backend contract tests and env-gated integration coverage
-- [ ] 4.5E: run a final API/docs behavior audit for all Phase 3 and Phase 4 helpers
+- [x] 4.5E: run a final API/docs behavior audit for all Phase 3 and Phase 4 helpers
 
-**Current recommendation:** move directly into **4.5C-2** next. The storage contract is in place, the memory/SQLite contract coverage exists, and the biggest remaining architectural debt is still the inconsistent fallback/error policy spread across sessions, auth challenges, OAuth states, and exchange tokens.
+**Current recommendation:** Phase 4.5 is complete. The storage contract is in place, the fallback/error policy is now explicit and test-covered across sessions, auth challenges, OAuth states, and exchange tokens, and the final Phase 3/4 API/docs behavior pass is done. Move next into Phase 5 session lifecycle work.
 
 **Non-goals:**
 - [ ] Do not add major new end-user auth features in this phase
@@ -250,13 +250,13 @@ return complete_auth_challenge(resp, req, map {
 - [x] PR 4.5B-1: move config/cookie/provider/JWT/TOTP helpers into modules with behavior held constant
 - [x] PR 4.5B-2: move middleware and built-in route glue into modules with no intentional semantic changes
 - [x] PR 4.5C-1: introduce the internal storage contract for sessions/auth challenges/OAuth states/exchange tokens while preserving existing backend-native implementations
-- [ ] PR 4.5C-2: centralize fallback/error semantics and make each auth state type follow the same documented rules
-  - [ ] Define the canonical fallback/error policy table for sessions, auth challenges, OAuth states, and exchange tokens
-  - [ ] Make store/get/consume/delete/cleanup semantics follow that policy consistently across memory, SQLite, Postgres, and Redis
-  - [ ] Normalize TTL/expiry behavior for memory fallback paths so they do not silently diverge from backend-native semantics
-  - [ ] Add focused tests that prove the chosen fallback/error behavior instead of relying on comments and TODOs
+- [x] PR 4.5C-2: centralize fallback/error semantics and make each auth state type follow the same documented rules
+  - [x] Define the canonical fallback/error policy table for sessions, auth challenges, OAuth states, and exchange tokens
+  - [x] Make store/get/consume/delete/cleanup semantics follow that policy consistently across memory, SQLite, Postgres, and Redis
+  - [x] Normalize TTL/expiry behavior for memory fallback paths so they do not silently diverge from backend-native semantics
+  - [x] Add focused tests that prove the chosen fallback/error behavior instead of relying on comments and TODOs
 - [x] PR 4.5D-1: add/finish Redis/Postgres integration coverage and cross-backend contract assertions
-- [ ] PR 4.5E-1: final audit PR for docs generation, public API parity, and cleanup of temporary compatibility shims
+- [x] PR 4.5E-1: final audit PR for docs generation, public API parity, and cleanup of temporary compatibility shims
 
 **Highest-risk regression hotspots to guard during the refactor:**
 - [ ] Cookie naming/signing/clearing behavior for both session and auth-challenge cookies stays byte-for-byte compatible unless intentionally changed
@@ -264,8 +264,8 @@ return complete_auth_challenge(resp, req, map {
 - [ ] One-time consume semantics for OAuth states, exchange tokens, and auth challenges remain atomic per backend
 - [ ] Session rotation preserves intended claims/data while invalidating the old session immediately
 - [ ] Refresh-token and expired-session lookup behavior does not regress while storage semantics are being normalized
-- [ ] Memory fallback continues to behave intentionally, especially under backend errors and mixed cleanup paths
-- [ ] Generated stdlib docs and `@ntnt` signatures remain accurate after functions move files/modules
+- [x] Memory fallback continues to behave intentionally, especially under backend errors and mixed cleanup paths
+- [x] Generated stdlib docs and `@ntnt` signatures remain accurate after functions move files/modules
 
 **Validation matrix for phase completion:**
 - [x] Memory backend: session sign-in/current-user/sign-out/rotation/challenge begin-complete-cancel all pass

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -191,7 +191,7 @@ return complete_auth_challenge(resp, req, map {
 
 **Workstream D — Test architecture and verification matrix**
 - [x] Add backend contract tests that exercise the same auth storage behaviors across memory and SQLite for the current contract helpers
-- [ ] Add env-gated Redis/Postgres integration coverage for auth storage flows so backend-specific regressions are caught before review comments or production incidents
+- [x] Add env-gated Redis/Postgres integration coverage for auth storage flows so backend-specific regressions are caught before review comments or production incidents
 - [x] Add higher-level auth flow tests that verify staged auth, session rotation, protected-route lookup, and logout behavior against the cleaned-up internal boundaries
 - [ ] Re-review Phase 3 and Phase 4 helpers after the refactor to ensure docs, tests, and public behavior still match exactly
 
@@ -205,7 +205,7 @@ return complete_auth_challenge(resp, req, map {
 - [x] 4.5A: document the intended internal architecture and fallback/error model before moving code
 - [x] 4.5B: split modules and relocate helpers with behavior held constant
 - [ ] 4.5C: introduce the internal storage contract and normalize shared semantics (4.5C-1 done, 4.5C-2 next)
-- [ ] 4.5D: add/finish backend contract tests and env-gated integration coverage
+- [x] 4.5D: add/finish backend contract tests and env-gated integration coverage
 - [ ] 4.5E: run a final API/docs behavior audit for all Phase 3 and Phase 4 helpers
 
 **Current recommendation:** move directly into **4.5C-2** next. The storage contract is in place, the memory/SQLite contract coverage exists, and the biggest remaining architectural debt is still the inconsistent fallback/error policy spread across sessions, auth challenges, OAuth states, and exchange tokens.
@@ -246,7 +246,7 @@ return complete_auth_challenge(resp, req, map {
 
 **Recommended PR slicing plan:**
 - [x] PR 4.5A-1: add architecture notes, auth persistence/error/fallback invariants, and TODO anchors without moving behavior yet
-- [ ] PR 4.5A-2: add backend contract-test harness that can run against memory/SQLite immediately and Postgres/Redis when env-gated services are available
+- [x] PR 4.5A-2: add backend contract-test harness that can run against memory/SQLite immediately and Postgres/Redis when env-gated services are available
 - [x] PR 4.5B-1: move config/cookie/provider/JWT/TOTP helpers into modules with behavior held constant
 - [x] PR 4.5B-2: move middleware and built-in route glue into modules with no intentional semantic changes
 - [x] PR 4.5C-1: introduce the internal storage contract for sessions/auth challenges/OAuth states/exchange tokens while preserving existing backend-native implementations
@@ -255,7 +255,7 @@ return complete_auth_challenge(resp, req, map {
   - [ ] Make store/get/consume/delete/cleanup semantics follow that policy consistently across memory, SQLite, Postgres, and Redis
   - [ ] Normalize TTL/expiry behavior for memory fallback paths so they do not silently diverge from backend-native semantics
   - [ ] Add focused tests that prove the chosen fallback/error behavior instead of relying on comments and TODOs
-- [ ] PR 4.5D-1: add/finish Redis/Postgres integration coverage and cross-backend contract assertions
+- [x] PR 4.5D-1: add/finish Redis/Postgres integration coverage and cross-backend contract assertions
 - [ ] PR 4.5E-1: final audit PR for docs generation, public API parity, and cleanup of temporary compatibility shims
 
 **Highest-risk regression hotspots to guard during the refactor:**
@@ -270,8 +270,8 @@ return complete_auth_challenge(resp, req, map {
 **Validation matrix for phase completion:**
 - [x] Memory backend: session sign-in/current-user/sign-out/rotation/challenge begin-complete-cancel all pass
 - [x] SQLite backend: same core session + challenge flows pass with cleanup and consume behavior verified
-- [ ] Postgres backend: same core session + challenge flows pass in env-gated integration coverage
-- [ ] Redis/Valkey backend: same core session + challenge flows pass in env-gated integration coverage, including atomic consume paths
+- [x] Postgres backend: same core session + challenge flows pass in env-gated integration coverage
+- [x] Redis/Valkey backend: same core session + challenge flows pass in env-gated integration coverage, including atomic consume paths
 - [x] Protected-route behavior verified for HTML pages and API routes after module split
 - [x] OAuth state and exchange-token paths still pass, including Safari/redirect-chain-related flows already covered by current behavior
 - [x] `cargo test stdlib::auth::tests`, any relevant integration suites, `cargo build --release --locked`, and `./target/release/ntnt docs --generate` all pass at the end of each major slice

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -4054,11 +4054,44 @@ mod tests {
         store_oauth_state_record(&expired_oauth_state).unwrap_or_else(|e| {
             panic!("{} expired oauth state store should succeed: {}", label, e)
         });
-        assert_eq!(
-            cleanup_expired_oauth_state_records(now - OAUTH_STATE_TTL)
-                .unwrap_or_else(|e| panic!("{} oauth cleanup should succeed: {}", label, e)),
-            1
-        );
+        let cleaned_oauth_states = cleanup_expired_oauth_state_records(now - OAUTH_STATE_TTL)
+            .unwrap_or_else(|e| panic!("{} oauth cleanup should succeed: {}", label, e));
+        match store_kind {
+            SessionStore::Redis(_) => {
+                assert_eq!(
+                    cleaned_oauth_states, 0,
+                    "{} redis oauth cleanup should only scrub memory fallback entries",
+                    label
+                );
+                assert!(
+                    consume_oauth_state_record(&expired_oauth_state.state)
+                        .unwrap_or_else(|e| panic!(
+                            "{} expired oauth state consume should succeed: {}",
+                            label, e
+                        ))
+                        .is_some(),
+                    "{} redis oauth state should remain consumable until Redis TTL expires",
+                    label
+                );
+            }
+            _ => {
+                assert!(
+                    cleaned_oauth_states >= 1,
+                    "{} oauth cleanup should remove at least the expired state",
+                    label
+                );
+                assert!(
+                    consume_oauth_state_record(&expired_oauth_state.state)
+                        .unwrap_or_else(|e| panic!(
+                            "{} expired oauth state consume after cleanup should succeed: {}",
+                            label, e
+                        ))
+                        .is_none(),
+                    "{} expired oauth state should not be consumable after cleanup",
+                    label
+                );
+            }
+        }
 
         store_exchange_token_record(&format!("exchange-{}-active", label), &session.id)
             .unwrap_or_else(|e| panic!("{} exchange token store should succeed: {}", label, e));

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -3881,7 +3881,7 @@ mod tests {
 
     fn run_auth_storage_contract_round_trip(store_kind: SessionStore, label: &str) {
         reset_auth_test_state();
-        init_test_auth(store_kind);
+        init_test_auth(store_kind.clone());
 
         let now = chrono::Utc::now().timestamp();
         let session = Session {
@@ -3952,13 +3952,25 @@ mod tests {
         store_session_record(&refreshable_session).unwrap_or_else(|e| {
             panic!("{} refreshable session store should succeed: {}", label, e)
         });
-        assert_eq!(
-            get_refreshable_session_record(&refreshable_session.id, 3600)
-                .unwrap_or_else(|e| panic!("{} refreshable lookup should succeed: {}", label, e))
-                .unwrap_or_else(|| panic!("{} refreshable session should exist", label))
-                .id,
-            refreshable_session.id
-        );
+        let refreshable = get_refreshable_session_record(&refreshable_session.id, 3600)
+            .unwrap_or_else(|e| panic!("{} refreshable lookup should succeed: {}", label, e));
+        match store_kind {
+            SessionStore::Memory => {
+                assert!(
+                    refreshable.is_none(),
+                    "{} memory store should not surface expired sessions as refreshable",
+                    label
+                );
+            }
+            _ => {
+                assert_eq!(
+                    refreshable
+                        .unwrap_or_else(|| panic!("{} refreshable session should exist", label))
+                        .id,
+                    refreshable_session.id
+                );
+            }
+        }
 
         let rotated_session = Session {
             id: format!("session-{}-rotated", label),
@@ -4021,6 +4033,16 @@ mod tests {
                 .state,
             oauth_state.state
         );
+        assert!(
+            consume_oauth_state_record(&oauth_state.state)
+                .unwrap_or_else(|e| panic!(
+                    "{} oauth state second consume should succeed: {}",
+                    label, e
+                ))
+                .is_none(),
+            "{} oauth state should be one-time use",
+            label
+        );
         let expired_oauth_state = OAuthState {
             state: format!("oauth-{}-expired", label),
             nonce: None,
@@ -4040,14 +4062,25 @@ mod tests {
 
         store_exchange_token_record(&format!("exchange-{}-active", label), &session.id)
             .unwrap_or_else(|e| panic!("{} exchange token store should succeed: {}", label, e));
+        let active_exchange_token = format!("exchange-{}-active", label);
         assert_eq!(
-            consume_exchange_token_record(&format!("exchange-{}-active", label))
+            consume_exchange_token_record(&active_exchange_token)
                 .unwrap_or_else(|e| panic!(
                     "{} exchange token consume should succeed: {}",
                     label, e
                 ))
                 .as_deref(),
             Some(session.id.as_str())
+        );
+        assert!(
+            consume_exchange_token_record(&active_exchange_token)
+                .unwrap_or_else(|e| panic!(
+                    "{} exchange token second consume should succeed: {}",
+                    label, e
+                ))
+                .is_none(),
+            "{} exchange token should be one-time use",
+            label
         );
 
         let challenge = AuthChallenge {
@@ -4077,6 +4110,16 @@ mod tests {
                 .unwrap_or_else(|| panic!("{} auth challenge should exist", label))
                 .id,
             challenge.id
+        );
+        assert!(
+            consume_auth_challenge_record(&challenge.id)
+                .unwrap_or_else(|e| panic!(
+                    "{} auth challenge second consume should succeed: {}",
+                    label, e
+                ))
+                .is_none(),
+            "{} auth challenge should be one-time use",
+            label
         );
     }
 
@@ -4565,215 +4608,8 @@ mod tests {
 
     #[test]
     fn test_auth_storage_contract_memory_round_trip_all_record_types() {
-        use super::storage::{
-            cleanup_expired_auth_challenge_records, cleanup_expired_exchange_token_records,
-            cleanup_expired_oauth_state_records, delete_auth_challenge_record,
-            delete_session_record, get_auth_challenge_record, get_refreshable_session_record,
-            get_session_record, list_session_records_for_user, migrate_session_record,
-            store_auth_challenge_record, store_exchange_token_record, store_oauth_state_record,
-            store_session_record, update_session_record_data, update_session_record_tokens,
-        };
-
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
-        reset_auth_test_state();
-        init_test_auth(SessionStore::Memory);
-
-        let now = chrono::Utc::now().timestamp();
-        let session = Session {
-            id: "session-memory-1".to_string(),
-            user_id: "user-memory".to_string(),
-            provider: "local".to_string(),
-            email: Some("memory@example.com".to_string()),
-            name: Some("Memory User".to_string()),
-            picture: None,
-            raw_json: "{}".to_string(),
-            data_json: "{}".to_string(),
-            csrf_token: "csrf-memory-1".to_string(),
-            access_token: Some("access-memory-1".to_string()),
-            refresh_token: Some("refresh-memory-1".to_string()),
-            token_expires_at: Some(now + 60),
-            created_at: now,
-            expires_at: now + 300,
-        };
-
-        store_session_record(&session).expect("memory session store should succeed");
-        let fetched = get_session_record(&session.id)
-            .expect("memory session fetch should succeed")
-            .expect("memory session should exist");
-        assert_eq!(fetched.user_id, session.user_id);
-
-        update_session_record_data(&session.id, r#"{"role":"admin"}"#)
-            .expect("memory session data update should succeed");
-        update_session_record_tokens(
-            &session.id,
-            &TokenResponse {
-                access_token: "access-memory-2".to_string(),
-                token_type: "Bearer".to_string(),
-                expires_in: Some(120),
-                refresh_token: Some("refresh-memory-2".to_string()),
-                id_token: None,
-                scope: None,
-            },
-            now,
-        )
-        .expect("memory session token update should succeed");
-
-        let updated = get_session_record(&session.id)
-            .expect("memory updated session fetch should succeed")
-            .expect("memory updated session should exist");
-        assert_eq!(updated.data_json, r#"{"role":"admin"}"#);
-        assert_eq!(updated.access_token.as_deref(), Some("access-memory-2"));
-        assert_eq!(updated.refresh_token.as_deref(), Some("refresh-memory-2"));
-        assert_eq!(updated.token_expires_at, Some(now + 120));
-        assert!(get_refreshable_session_record(&session.id, 3600)
-            .expect("memory refreshable lookup should succeed")
-            .is_none());
-
-        let rotated = Session {
-            id: "session-memory-2".to_string(),
-            csrf_token: "csrf-memory-2".to_string(),
-            ..updated.clone()
-        };
-        migrate_session_record(&session.id, &rotated)
-            .expect("memory session migration should succeed");
-        assert!(get_session_record(&session.id)
-            .expect("old memory session lookup should succeed")
-            .is_none());
-        assert_eq!(
-            get_session_record(&rotated.id)
-                .expect("rotated memory session lookup should succeed")
-                .expect("rotated memory session should exist")
-                .csrf_token,
-            "csrf-memory-2"
-        );
-        assert_eq!(
-            list_session_records_for_user("user-memory", Some(&rotated.id), now)
-                .expect("memory session listing should succeed")
-                .len(),
-            1
-        );
-        delete_session_record(&rotated.id).expect("memory session delete should succeed");
-        assert!(get_session_record(&rotated.id)
-            .expect("deleted memory session lookup should succeed")
-            .is_none());
-
-        let oauth_state = OAuthState {
-            state: "oauth-memory-active".to_string(),
-            nonce: Some("nonce-memory".to_string()),
-            pkce_verifier: Some("pkce-memory".to_string()),
-            provider: "github".to_string(),
-            redirect_url: "/auth/callback".to_string(),
-            created_at: now,
-        };
-        store_oauth_state_record(&oauth_state).expect("memory oauth state store should succeed");
-        let consumed_oauth = super::storage::consume_oauth_state_record(&oauth_state.state)
-            .expect("memory oauth state consume should succeed")
-            .expect("memory oauth state should exist");
-        assert_eq!(consumed_oauth.state, oauth_state.state);
-        assert!(
-            super::storage::consume_oauth_state_record(&oauth_state.state)
-                .expect("memory oauth state second consume should succeed")
-                .is_none()
-        );
-
-        let expired_oauth_state = OAuthState {
-            state: "oauth-memory-expired".to_string(),
-            nonce: None,
-            pkce_verifier: None,
-            provider: "github".to_string(),
-            redirect_url: "/auth/callback".to_string(),
-            created_at: now - 700,
-        };
-        store_oauth_state_record(&expired_oauth_state)
-            .expect("expired memory oauth state store should succeed");
-        assert_eq!(
-            cleanup_expired_oauth_state_records(now - 600)
-                .expect("memory oauth cleanup should succeed"),
-            1
-        );
-
-        store_exchange_token_record("exchange-memory-active", "session-memory-final")
-            .expect("memory exchange token store should succeed");
-        assert_eq!(
-            super::storage::consume_exchange_token_record("exchange-memory-active")
-                .expect("memory exchange token consume should succeed")
-                .as_deref(),
-            Some("session-memory-final")
-        );
-        assert!(
-            super::storage::consume_exchange_token_record("exchange-memory-active")
-                .expect("memory exchange token second consume should succeed")
-                .is_none()
-        );
-        SESSION_STORE.lock().unwrap().exchange_tokens.insert(
-            "exchange-memory-expired".to_string(),
-            (
-                "session-memory-stale".to_string(),
-                now - EXCHANGE_TOKEN_TTL - 1,
-            ),
-        );
-        assert_eq!(
-            cleanup_expired_exchange_token_records(now)
-                .expect("memory exchange token cleanup should succeed"),
-            1
-        );
-
-        let active_challenge = AuthChallenge {
-            id: "challenge-memory-active".to_string(),
-            subject_id: "user-memory".to_string(),
-            provider: "local".to_string(),
-            kind: "mfa_pending".to_string(),
-            data_json: "{}".to_string(),
-            created_at: now,
-            expires_at: now + 60,
-        };
-        store_auth_challenge_record(&active_challenge)
-            .expect("memory auth challenge store should succeed");
-        let fetched_challenge = get_auth_challenge_record(&active_challenge.id)
-            .expect("memory auth challenge fetch should succeed")
-            .expect("memory auth challenge should exist");
-        assert_eq!(fetched_challenge.id, active_challenge.id);
-        delete_auth_challenge_record(&active_challenge.id)
-            .expect("memory auth challenge delete should succeed");
-        assert!(get_auth_challenge_record(&active_challenge.id)
-            .expect("deleted memory auth challenge lookup should succeed")
-            .is_none());
-
-        let consumable_challenge = AuthChallenge {
-            id: "challenge-memory-consume".to_string(),
-            subject_id: "user-memory".to_string(),
-            provider: "local".to_string(),
-            kind: "mfa_pending".to_string(),
-            data_json: "{}".to_string(),
-            created_at: now,
-            expires_at: now + 60,
-        };
-        store_auth_challenge_record(&consumable_challenge)
-            .expect("memory consumable auth challenge store should succeed");
-        assert_eq!(
-            super::storage::consume_auth_challenge_record(&consumable_challenge.id)
-                .expect("memory auth challenge consume should succeed")
-                .expect("memory auth challenge should be consumable")
-                .id,
-            consumable_challenge.id
-        );
-
-        let expired_challenge = AuthChallenge {
-            id: "challenge-memory-expired".to_string(),
-            subject_id: "user-memory".to_string(),
-            provider: "local".to_string(),
-            kind: "password_reset".to_string(),
-            data_json: "{}".to_string(),
-            created_at: now - 120,
-            expires_at: now - 60,
-        };
-        store_auth_challenge_record(&expired_challenge)
-            .expect("expired memory auth challenge store should succeed");
-        assert_eq!(
-            cleanup_expired_auth_challenge_records(now)
-                .expect("memory auth challenge cleanup should succeed"),
-            1
-        );
+        run_auth_storage_contract_round_trip(SessionStore::Memory, "memory");
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -4529,6 +4529,65 @@ mod tests {
     }
 
     #[test]
+    fn test_session_backend_error_uses_memory_fallback() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        let now = chrono::Utc::now().timestamp();
+        let session = Session {
+            id: "session-memory-fallback-active".to_string(),
+            user_id: "user-memory-fallback".to_string(),
+            provider: "local".to_string(),
+            email: Some("fallback@example.com".to_string()),
+            name: Some("Fallback User".to_string()),
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-memory-fallback".to_string(),
+            access_token: None,
+            refresh_token: None,
+            token_expires_at: None,
+            created_at: now,
+            expires_at: now + 300,
+        };
+        SESSION_STORE.lock().unwrap().set_session(session.clone());
+        *SQLITE_CONN.lock().unwrap() = None;
+
+        let fetched = get_session_by_id(&session.id).expect("memory fallback session should be returned");
+        assert_eq!(fetched.id, session.id);
+        assert_eq!(fetched.user_id, session.user_id);
+    }
+
+    #[test]
+    fn test_refreshable_session_lookup_does_not_fallback_to_memory() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        let now = chrono::Utc::now().timestamp();
+        SESSION_STORE.lock().unwrap().set_session(Session {
+            id: "session-memory-refresh-fallback".to_string(),
+            user_id: "user-memory-refresh".to_string(),
+            provider: "local".to_string(),
+            email: None,
+            name: None,
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-memory-refresh".to_string(),
+            access_token: Some("access-memory-refresh".to_string()),
+            refresh_token: Some("refresh-memory-refresh".to_string()),
+            token_expires_at: Some(now - 30),
+            created_at: now - 30,
+            expires_at: now - 5,
+        });
+        *SQLITE_CONN.lock().unwrap() = None;
+
+        assert!(get_session_by_id("session-memory-refresh-fallback").is_none());
+    }
+
+    #[test]
     fn test_oauth_state_backend_error_uses_ttl_checked_memory_fallback() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         reset_auth_test_state();

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -3769,6 +3769,15 @@ pub fn init() -> HashMap<String, Value> {
 
 #[cfg(test)]
 mod tests {
+    use super::storage::{
+        cleanup_expired_oauth_state_records, consume_auth_challenge_record,
+        consume_exchange_token_record, consume_oauth_state_record,
+        delete_all_session_records_for_user, delete_session_record, extend_session_record_expiry,
+        get_auth_challenge_record, get_refreshable_session_record, get_session_record,
+        list_session_records_for_user, migrate_session_record, store_auth_challenge_record,
+        store_exchange_token_record, store_oauth_state_record, store_session_record,
+        update_session_record_data, update_session_record_tokens, OAUTH_STATE_TTL,
+    };
     use super::*;
 
     static AUTH_TEST_MUTEX: std::sync::LazyLock<std::sync::Mutex<()>> =
@@ -3854,6 +3863,221 @@ mod tests {
         };
         ensure_auth_session_store(&config).unwrap();
         init_auth(config);
+    }
+
+    fn auth_test_postgres_store() -> Option<SessionStore> {
+        std::env::var("NTNT_AUTH_TEST_POSTGRES_URL")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(SessionStore::Postgres)
+    }
+
+    fn auth_test_redis_store() -> Option<SessionStore> {
+        std::env::var("NTNT_AUTH_TEST_REDIS_URL")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(SessionStore::Redis)
+    }
+
+    fn run_auth_storage_contract_round_trip(store_kind: SessionStore, label: &str) {
+        reset_auth_test_state();
+        init_test_auth(store_kind);
+
+        let now = chrono::Utc::now().timestamp();
+        let session = Session {
+            id: format!("session-{}-1", label),
+            user_id: format!("user-{}", label),
+            provider: "local".to_string(),
+            email: Some(format!("{}@example.com", label)),
+            name: Some(format!("{} User", label)),
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: format!("csrf-{}-1", label),
+            access_token: Some(format!("access-{}-1", label)),
+            refresh_token: Some(format!("refresh-{}-1", label)),
+            token_expires_at: Some(now + 60),
+            created_at: now,
+            expires_at: now + 300,
+        };
+        store_session_record(&session)
+            .unwrap_or_else(|e| panic!("{} session store should succeed: {}", label, e));
+        assert_eq!(
+            get_session_record(&session.id)
+                .unwrap_or_else(|e| panic!("{} session lookup should succeed: {}", label, e))
+                .unwrap_or_else(|| panic!("{} session should exist", label))
+                .id,
+            session.id
+        );
+        update_session_record_data(&session.id, r#"{"role":"admin"}"#)
+            .unwrap_or_else(|e| panic!("{} session data update should succeed: {}", label, e));
+        update_session_record_tokens(
+            &session.id,
+            &TokenResponse {
+                access_token: format!("access-{}-2", label),
+                token_type: "Bearer".to_string(),
+                expires_in: Some(120),
+                refresh_token: Some(format!("refresh-{}-2", label)),
+                id_token: None,
+                scope: None,
+            },
+            now,
+        )
+        .unwrap_or_else(|e| panic!("{} session token update should succeed: {}", label, e));
+        extend_session_record_expiry(&session.id, now + 600)
+            .unwrap_or_else(|e| panic!("{} session expiry extension should succeed: {}", label, e));
+        let updated_session = get_session_record(&session.id)
+            .unwrap_or_else(|e| panic!("{} updated session lookup should succeed: {}", label, e))
+            .unwrap_or_else(|| panic!("{} updated session should exist", label));
+        assert_eq!(updated_session.data_json, r#"{"role":"admin"}"#);
+        assert_eq!(updated_session.token_expires_at, Some(now + 120));
+        assert_eq!(updated_session.expires_at, now + 600);
+
+        let refreshable_session = Session {
+            id: format!("session-{}-refreshable", label),
+            user_id: format!("user-{}", label),
+            provider: "local".to_string(),
+            email: None,
+            name: None,
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: format!("csrf-{}-refreshable", label),
+            access_token: Some(format!("access-{}-refreshable", label)),
+            refresh_token: Some(format!("refresh-{}-refreshable", label)),
+            token_expires_at: Some(now - 30),
+            created_at: now - 30,
+            expires_at: now - 5,
+        };
+        store_session_record(&refreshable_session).unwrap_or_else(|e| {
+            panic!("{} refreshable session store should succeed: {}", label, e)
+        });
+        assert_eq!(
+            get_refreshable_session_record(&refreshable_session.id, 3600)
+                .unwrap_or_else(|e| panic!("{} refreshable lookup should succeed: {}", label, e))
+                .unwrap_or_else(|| panic!("{} refreshable session should exist", label))
+                .id,
+            refreshable_session.id
+        );
+
+        let rotated_session = Session {
+            id: format!("session-{}-rotated", label),
+            csrf_token: format!("csrf-{}-rotated", label),
+            ..updated_session.clone()
+        };
+        migrate_session_record(&session.id, &rotated_session)
+            .unwrap_or_else(|e| panic!("{} session migration should succeed: {}", label, e));
+        assert!(get_session_record(&session.id)
+            .unwrap_or_else(|e| panic!("{} old session lookup should succeed: {}", label, e))
+            .is_none());
+        assert_eq!(
+            get_session_record(&rotated_session.id)
+                .unwrap_or_else(|e| panic!(
+                    "{} rotated session lookup should succeed: {}",
+                    label, e
+                ))
+                .unwrap_or_else(|| panic!("{} rotated session should exist", label))
+                .csrf_token,
+            format!("csrf-{}-rotated", label)
+        );
+        let listed_sessions = list_session_records_for_user(
+            &format!("user-{}", label),
+            Some(&rotated_session.id),
+            now,
+        )
+        .unwrap_or_else(|e| panic!("{} session listing should succeed: {}", label, e));
+        assert_eq!(listed_sessions.len(), 1);
+        assert!(listed_sessions
+            .iter()
+            .any(|session| session.id == rotated_session.id && session.is_current));
+        assert_eq!(
+            delete_all_session_records_for_user(
+                &format!("user-{}", label),
+                Some(&rotated_session.id),
+            )
+            .unwrap_or_else(|e| panic!("{} delete-all sessions should succeed: {}", label, e)),
+            1
+        );
+        delete_session_record(&rotated_session.id)
+            .unwrap_or_else(|e| panic!("{} session delete should succeed: {}", label, e));
+        assert!(get_session_record(&rotated_session.id)
+            .unwrap_or_else(|e| panic!("{} deleted session lookup should succeed: {}", label, e))
+            .is_none());
+
+        let oauth_state = OAuthState {
+            state: format!("oauth-{}-active", label),
+            nonce: Some(format!("nonce-{}", label)),
+            pkce_verifier: Some(format!("pkce-{}", label)),
+            provider: "github".to_string(),
+            redirect_url: "/auth/callback".to_string(),
+            created_at: now,
+        };
+        store_oauth_state_record(&oauth_state)
+            .unwrap_or_else(|e| panic!("{} oauth state store should succeed: {}", label, e));
+        assert_eq!(
+            consume_oauth_state_record(&oauth_state.state)
+                .unwrap_or_else(|e| panic!("{} oauth state consume should succeed: {}", label, e))
+                .unwrap_or_else(|| panic!("{} oauth state should exist", label))
+                .state,
+            oauth_state.state
+        );
+        let expired_oauth_state = OAuthState {
+            state: format!("oauth-{}-expired", label),
+            nonce: None,
+            pkce_verifier: None,
+            provider: "github".to_string(),
+            redirect_url: "/auth/callback".to_string(),
+            created_at: now - OAUTH_STATE_TTL - 100,
+        };
+        store_oauth_state_record(&expired_oauth_state).unwrap_or_else(|e| {
+            panic!("{} expired oauth state store should succeed: {}", label, e)
+        });
+        assert_eq!(
+            cleanup_expired_oauth_state_records(now - OAUTH_STATE_TTL)
+                .unwrap_or_else(|e| panic!("{} oauth cleanup should succeed: {}", label, e)),
+            1
+        );
+
+        store_exchange_token_record(&format!("exchange-{}-active", label), &session.id)
+            .unwrap_or_else(|e| panic!("{} exchange token store should succeed: {}", label, e));
+        assert_eq!(
+            consume_exchange_token_record(&format!("exchange-{}-active", label))
+                .unwrap_or_else(|e| panic!(
+                    "{} exchange token consume should succeed: {}",
+                    label, e
+                ))
+                .as_deref(),
+            Some(session.id.as_str())
+        );
+
+        let challenge = AuthChallenge {
+            id: format!("challenge-{}-active", label),
+            subject_id: format!("user-{}", label),
+            provider: "local".to_string(),
+            kind: "mfa_pending".to_string(),
+            data_json: "{}".to_string(),
+            created_at: now,
+            expires_at: now + 60,
+        };
+        store_auth_challenge_record(&challenge)
+            .unwrap_or_else(|e| panic!("{} auth challenge store should succeed: {}", label, e));
+        assert_eq!(
+            get_auth_challenge_record(&challenge.id)
+                .unwrap_or_else(|e| panic!("{} auth challenge lookup should succeed: {}", label, e))
+                .unwrap_or_else(|| panic!("{} auth challenge should exist", label))
+                .id,
+            challenge.id
+        );
+        assert_eq!(
+            consume_auth_challenge_record(&challenge.id)
+                .unwrap_or_else(|e| panic!(
+                    "{} auth challenge consume should succeed: {}",
+                    label, e
+                ))
+                .unwrap_or_else(|| panic!("{} auth challenge should exist", label))
+                .id,
+            challenge.id
+        );
     }
 
     #[test]
@@ -4550,6 +4774,28 @@ mod tests {
                 .expect("memory auth challenge cleanup should succeed"),
             1
         );
+    }
+
+    #[test]
+    fn test_auth_storage_contract_postgres_round_trip_all_record_types() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let Some(store) = auth_test_postgres_store() else {
+            eprintln!("[auth-test] skipping Postgres auth contract test — set NTNT_AUTH_TEST_POSTGRES_URL");
+            return;
+        };
+        run_auth_storage_contract_round_trip(store, "postgres");
+    }
+
+    #[test]
+    fn test_auth_storage_contract_redis_round_trip_all_record_types() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let Some(store) = auth_test_redis_store() else {
+            eprintln!(
+                "[auth-test] skipping Redis auth contract test — set NTNT_AUTH_TEST_REDIS_URL"
+            );
+            return;
+        };
+        run_auth_storage_contract_round_trip(store, "redis");
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -3930,6 +3930,14 @@ mod tests {
             .unwrap_or_else(|e| panic!("{} updated session lookup should succeed: {}", label, e))
             .unwrap_or_else(|| panic!("{} updated session should exist", label));
         assert_eq!(updated_session.data_json, r#"{"role":"admin"}"#);
+        assert_eq!(
+            updated_session.access_token.as_deref(),
+            Some(format!("access-{}-2", label).as_str())
+        );
+        assert_eq!(
+            updated_session.refresh_token.as_deref(),
+            Some(format!("refresh-{}-2", label).as_str())
+        );
         assert_eq!(updated_session.token_expires_at, Some(now + 120));
         assert_eq!(updated_session.expires_at, now + 600);
 

--- a/src/stdlib/auth/sessions.rs
+++ b/src/stdlib/auth/sessions.rs
@@ -1,9 +1,9 @@
 use super::storage::{
     active_auth_storage_backend, cleanup_expired_session_records,
     delete_all_session_records_for_user, delete_session_record, extend_session_record_expiry,
-    get_refreshable_session_record, get_session_record, list_session_records_for_user,
-    migrate_session_record, store_session_record, update_session_record_data,
-    update_session_record_tokens, AuthStorageBackend,
+    get_refreshable_session_record_without_fallback, get_session_record_with_fallback,
+    list_session_records_for_user, migrate_session_record, store_session_record,
+    update_session_record_data, update_session_record_tokens, AuthStorageBackend,
 };
 use super::*;
 
@@ -34,16 +34,7 @@ pub fn store_session(session: Session) {
 /// Get session by ID
 pub fn get_session_by_id(id: &str) -> Option<Session> {
     let config = get_auth_config();
-    let backend = active_auth_storage_backend();
-
-    let session = match backend {
-        AuthStorageBackend::Memory => get_session_record(id).ok().flatten(),
-        _ => match get_session_record(id) {
-            Ok(Some(session)) => Some(session),
-            Ok(None) => SESSION_STORE.lock().unwrap().get_session(id).cloned(),
-            Err(_) => SESSION_STORE.lock().unwrap().get_session(id).cloned(),
-        },
-    };
+    let session = get_session_record_with_fallback(id);
 
     if session.is_some() {
         return session;
@@ -51,12 +42,8 @@ pub fn get_session_by_id(id: &str) -> Option<Session> {
 
     if let Some(config) = &config {
         if config.store_tokens {
-            let expired_session = match backend {
-                AuthStorageBackend::Memory => None,
-                _ => get_refreshable_session_record(id, config.refresh_ttl)
-                    .ok()
-                    .flatten(),
-            };
+            let expired_session =
+                get_refreshable_session_record_without_fallback(id, config.refresh_ttl);
 
             if let Some(expired) = expired_session {
                 if let Some(ref refresh_token) = expired.refresh_token {

--- a/src/stdlib/auth/storage.rs
+++ b/src/stdlib/auth/storage.rs
@@ -66,21 +66,32 @@ fn take_exchange_token_memory(token: &str) -> Option<String> {
 // - OAuth states
 // - session exchange tokens
 //
-// Higher-level helpers still own fallback/error behavior for now. This layer is
-// responsible only for routing each operation through a consistent per-record
-// contract while preserving backend-native atomicity and query shape.
+// This layer owns the canonical fallback/error contract for auth persistence.
+// Backend-native helpers preserve atomicity/query shape, while these public-ish
+// storage entrypoints decide whether failures should degrade to memory, return
+// None, or propagate.
 //
 // Canonical fallback/error policy (Phase 4.5C-2):
-// - sessions: fallback to memory on store/get backend failures; list/delete-all propagate
-//   backend errors; do not silently mask explicit mutation or migration failures
-// - auth challenges: fallback to memory on store/get/consume backend failures and always
-//   scrub memory fallback entries during cleanup
-// - OAuth states: fallback to memory on store/consume backend failures and always scrub
-//   memory fallback entries during cleanup; fallback consume must enforce the same TTL as
-//   backend-native consume paths
-// - exchange tokens: fallback to memory on store/consume backend failures and always scrub
-//   memory fallback entries during cleanup; fallback consume must enforce the same TTL as
-//   backend-native consume paths
+// - sessions:
+//   - store/get may fall back to the in-memory store
+//   - refreshable lookup never falls back to memory because memory does not keep
+//     expired sessions available for token refresh
+//   - update/migrate/list/delete-all propagate backend errors
+//   - cleanup is backend-native only (memory backend cleans its own store)
+// - auth challenges:
+//   - store/get/consume may fall back to the in-memory store
+//   - delete ignores missing backend state but still scrubs memory fallback
+//   - cleanup always scrubs memory fallback entries in addition to any backend cleanup
+// - OAuth states:
+//   - store/consume may fall back to the in-memory store
+//   - fallback consume enforces the same TTL window as backend-native consume paths
+//   - cleanup always scrubs memory fallback entries; Redis backend cleanup only affects
+//     fallback memory because Redis native expiry is TTL-driven
+// - exchange tokens:
+//   - store/consume may fall back to the in-memory store
+//   - fallback consume enforces the same TTL window as backend-native consume paths
+//   - cleanup always scrubs memory fallback entries; Redis backend cleanup only affects
+//     fallback memory because Redis native expiry is TTL-driven
 
 pub(super) fn store_oauth_state_record(state: &OAuthState) -> std::result::Result<(), String> {
     match active_auth_storage_backend() {
@@ -1544,6 +1555,27 @@ pub(super) fn get_session_record(id: &str) -> std::result::Result<Option<Session
         AuthStorageBackend::Postgres => get_session_postgres(id),
         AuthStorageBackend::Redis => get_session_redis(id),
         AuthStorageBackend::Memory => Ok(SESSION_STORE.lock().unwrap().get_session(id).cloned()),
+    }
+}
+
+pub(super) fn get_session_record_with_fallback(id: &str) -> Option<Session> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => get_session_record(id).ok().flatten(),
+        _ => match get_session_record(id) {
+            Ok(Some(session)) => Some(session),
+            Ok(None) => SESSION_STORE.lock().unwrap().get_session(id).cloned(),
+            Err(_) => SESSION_STORE.lock().unwrap().get_session(id).cloned(),
+        },
+    }
+}
+
+pub(super) fn get_refreshable_session_record_without_fallback(
+    id: &str,
+    refresh_ttl: i64,
+) -> Option<Session> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => None,
+        _ => get_refreshable_session_record(id, refresh_ttl).ok().flatten(),
     }
 }
 


### PR DESCRIPTION
## Summary
- finish DD-043 Phase 4.5C-2 fallback/error cleanup across auth storage and session lookup paths
- add focused session fallback tests alongside the existing auth-challenge / oauth-state / exchange-token policy coverage
- mark DD-043 Phase 4.5C, 4.5D, and 4.5E complete after the final auth/docs audit pass

## What changed
- add explicit storage helpers for session fallback semantics:
  - `get_session_record_with_fallback(...)`
  - `get_refreshable_session_record_without_fallback(...)`
- update `auth/sessions.rs` to use the canonical storage-level fallback contract instead of inlining session fallback policy
- add tests proving:
  - ordinary session lookup may fall back to memory on backend failure
  - refreshable expired-session lookup does not fall back to memory
- update DD-043 to reflect completed 4.5 cleanup/audit work

## Validation
- `cargo build --release --locked`
- `./target/release/ntnt docs --generate`
- `cargo test --release --locked auth -- --nocapture`

## Context
PR #88 already covered the backend contract harness and env-gated Postgres/Redis auth coverage. This PR is the follow-on final 4.5 cleanup pass after that merge, focused on centralizing fallback/error semantics and closing the remaining DD-043 4.5C/4.5E items.
