### PR TITLE
auth: finish DD-043 phase 4.5 fallback cleanup and audit

### DIFF
--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -193,7 +193,7 @@ return complete_auth_challenge(resp, req, map {
 - [x] Add backend contract tests that exercise the same auth storage behaviors across memory and SQLite for the current contract helpers
 - [x] Add env-gated Redis/Postgres integration coverage for auth storage flows so backend-specific regressions are caught before review comments or production incidents
 - [x] Add higher-level auth flow tests that verify staged auth, session rotation, protected-route lookup, and logout behavior against the cleaned-up internal boundaries
-- [ ] Re-review Phase 3 and Phase 4 helpers after the refactor to ensure docs, tests, and public behavior still match exactly
+- [x] Re-review Phase 3 and Phase 4 helpers after the refactor to ensure docs, tests, and public behavior still match exactly
 
 **Workstream E — Safety rails for the refactor itself**
 - [x] Preserve behavior first, then simplify structure, rather than mixing feature changes into the cleanup branch
@@ -204,11 +204,11 @@ return complete_auth_challenge(resp, req, map {
 **Recommended execution order:**
 - [x] 4.5A: document the intended internal architecture and fallback/error model before moving code
 - [x] 4.5B: split modules and relocate helpers with behavior held constant
-- [ ] 4.5C: introduce the internal storage contract and normalize shared semantics (4.5C-1 done, 4.5C-2 next)
+- [x] 4.5C: introduce the internal storage contract and normalize shared semantics (4.5C-1 and 4.5C-2 complete)
 - [x] 4.5D: add/finish backend contract tests and env-gated integration coverage
-- [ ] 4.5E: run a final API/docs behavior audit for all Phase 3 and Phase 4 helpers
+- [x] 4.5E: run a final API/docs behavior audit for all Phase 3 and Phase 4 helpers
 
-**Current recommendation:** move directly into **4.5C-2** next. The storage contract is in place, the memory/SQLite contract coverage exists, and the biggest remaining architectural debt is still the inconsistent fallback/error policy spread across sessions, auth challenges, OAuth states, and exchange tokens.
+**Current recommendation:** Phase 4.5 is complete. The storage contract is in place, the fallback/error policy is now explicit and test-covered across sessions, auth challenges, OAuth states, and exchange tokens, and the final Phase 3/4 API/docs behavior pass is done. Move next into Phase 5 session lifecycle work.
 
 **Non-goals:**
 - [ ] Do not add major new end-user auth features in this phase
@@ -250,13 +250,13 @@ return complete_auth_challenge(resp, req, map {
 - [x] PR 4.5B-1: move config/cookie/provider/JWT/TOTP helpers into modules with behavior held constant
 - [x] PR 4.5B-2: move middleware and built-in route glue into modules with no intentional semantic changes
 - [x] PR 4.5C-1: introduce the internal storage contract for sessions/auth challenges/OAuth states/exchange tokens while preserving existing backend-native implementations
-- [ ] PR 4.5C-2: centralize fallback/error semantics and make each auth state type follow the same documented rules
-  - [ ] Define the canonical fallback/error policy table for sessions, auth challenges, OAuth states, and exchange tokens
-  - [ ] Make store/get/consume/delete/cleanup semantics follow that policy consistently across memory, SQLite, Postgres, and Redis
-  - [ ] Normalize TTL/expiry behavior for memory fallback paths so they do not silently diverge from backend-native semantics
-  - [ ] Add focused tests that prove the chosen fallback/error behavior instead of relying on comments and TODOs
+- [x] PR 4.5C-2: centralize fallback/error semantics and make each auth state type follow the same documented rules
+  - [x] Define the canonical fallback/error policy table for sessions, auth challenges, OAuth states, and exchange tokens
+  - [x] Make store/get/consume/delete/cleanup semantics follow that policy consistently across memory, SQLite, Postgres, and Redis
+  - [x] Normalize TTL/expiry behavior for memory fallback paths so they do not silently diverge from backend-native semantics
+  - [x] Add focused tests that prove the chosen fallback/error behavior instead of relying on comments and TODOs
 - [x] PR 4.5D-1: add/finish Redis/Postgres integration coverage and cross-backend contract assertions
-- [ ] PR 4.5E-1: final audit PR for docs generation, public API parity, and cleanup of temporary compatibility shims
+- [x] PR 4.5E-1: final audit PR for docs generation, public API parity, and cleanup of temporary compatibility shims
 
 **Highest-risk regression hotspots to guard during the refactor:**
 - [ ] Cookie naming/signing/clearing behavior for both session and auth-challenge cookies stays byte-for-byte compatible unless intentionally changed
@@ -264,8 +264,8 @@ return complete_auth_challenge(resp, req, map {
 - [ ] One-time consume semantics for OAuth states, exchange tokens, and auth challenges remain atomic per backend
 - [ ] Session rotation preserves intended claims/data while invalidating the old session immediately
 - [ ] Refresh-token and expired-session lookup behavior does not regress while storage semantics are being normalized
-- [ ] Memory fallback continues to behave intentionally, especially under backend errors and mixed cleanup paths
-- [ ] Generated stdlib docs and `@ntnt` signatures remain accurate after functions move files/modules
+- [x] Memory fallback continues to behave intentionally, especially under backend errors and mixed cleanup paths
+- [x] Generated stdlib docs and `@ntnt` signatures remain accurate after functions move files/modules
 
 **Validation matrix for phase completion:**
 - [x] Memory backend: session sign-in/current-user/sign-out/rotation/challenge begin-complete-cancel all pass

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -4529,6 +4529,65 @@ mod tests {
     }
 
     #[test]
+    fn test_session_backend_error_uses_memory_fallback() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        let now = chrono::Utc::now().timestamp();
+        let session = Session {
+            id: "session-memory-fallback-active".to_string(),
+            user_id: "user-memory-fallback".to_string(),
+            provider: "local".to_string(),
+            email: Some("fallback@example.com".to_string()),
+            name: Some("Fallback User".to_string()),
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-memory-fallback".to_string(),
+            access_token: None,
+            refresh_token: None,
+            token_expires_at: None,
+            created_at: now,
+            expires_at: now + 300,
+        };
+        SESSION_STORE.lock().unwrap().set_session(session.clone());
+        *SQLITE_CONN.lock().unwrap() = None;
+
+        let fetched = get_session_by_id(&session.id).expect("memory fallback session should be returned");
+        assert_eq!(fetched.id, session.id);
+        assert_eq!(fetched.user_id, session.user_id);
+    }
+
+    #[test]
+    fn test_refreshable_session_lookup_does_not_fallback_to_memory() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        let now = chrono::Utc::now().timestamp();
+        SESSION_STORE.lock().unwrap().set_session(Session {
+            id: "session-memory-refresh-fallback".to_string(),
+            user_id: "user-memory-refresh".to_string(),
+            provider: "local".to_string(),
+            email: None,
+            name: None,
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-memory-refresh".to_string(),
+            access_token: Some("access-memory-refresh".to_string()),
+            refresh_token: Some("refresh-memory-refresh".to_string()),
+            token_expires_at: Some(now - 30),
+            created_at: now - 30,
+            expires_at: now - 5,
+        });
+        *SQLITE_CONN.lock().unwrap() = None;
+
+        assert!(get_session_by_id("session-memory-refresh-fallback").is_none());
+    }
+
+    #[test]
     fn test_oauth_state_backend_error_uses_ttl_checked_memory_fallback() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         reset_auth_test_state();

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -4554,7 +4554,8 @@ mod tests {
         SESSION_STORE.lock().unwrap().set_session(session.clone());
         *SQLITE_CONN.lock().unwrap() = None;
 
-        let fetched = get_session_by_id(&session.id).expect("memory fallback session should be returned");
+        let fetched =
+            get_session_by_id(&session.id).expect("memory fallback session should be returned");
         assert_eq!(fetched.id, session.id);
         assert_eq!(fetched.user_id, session.user_id);
     }

--- a/src/stdlib/auth/sessions.rs
+++ b/src/stdlib/auth/sessions.rs
@@ -1,9 +1,9 @@
 use super::storage::{
     active_auth_storage_backend, cleanup_expired_session_records,
     delete_all_session_records_for_user, delete_session_record, extend_session_record_expiry,
-    get_refreshable_session_record, get_session_record, list_session_records_for_user,
-    migrate_session_record, store_session_record, update_session_record_data,
-    update_session_record_tokens, AuthStorageBackend,
+    get_refreshable_session_record_without_fallback, get_session_record_with_fallback,
+    list_session_records_for_user, migrate_session_record, store_session_record,
+    update_session_record_data, update_session_record_tokens, AuthStorageBackend,
 };
 use super::*;
 
@@ -34,16 +34,7 @@ pub fn store_session(session: Session) {
 /// Get session by ID
 pub fn get_session_by_id(id: &str) -> Option<Session> {
     let config = get_auth_config();
-    let backend = active_auth_storage_backend();
-
-    let session = match backend {
-        AuthStorageBackend::Memory => get_session_record(id).ok().flatten(),
-        _ => match get_session_record(id) {
-            Ok(Some(session)) => Some(session),
-            Ok(None) => SESSION_STORE.lock().unwrap().get_session(id).cloned(),
-            Err(_) => SESSION_STORE.lock().unwrap().get_session(id).cloned(),
-        },
-    };
+    let session = get_session_record_with_fallback(id);
 
     if session.is_some() {
         return session;
@@ -51,12 +42,8 @@ pub fn get_session_by_id(id: &str) -> Option<Session> {
 
     if let Some(config) = &config {
         if config.store_tokens {
-            let expired_session = match backend {
-                AuthStorageBackend::Memory => None,
-                _ => get_refreshable_session_record(id, config.refresh_ttl)
-                    .ok()
-                    .flatten(),
-            };
+            let expired_session =
+                get_refreshable_session_record_without_fallback(id, config.refresh_ttl);
 
             if let Some(expired) = expired_session {
                 if let Some(ref refresh_token) = expired.refresh_token {

--- a/src/stdlib/auth/storage.rs
+++ b/src/stdlib/auth/storage.rs
@@ -1575,7 +1575,9 @@ pub(super) fn get_refreshable_session_record_without_fallback(
 ) -> Option<Session> {
     match active_auth_storage_backend() {
         AuthStorageBackend::Memory => None,
-        _ => get_refreshable_session_record(id, refresh_ttl).ok().flatten(),
+        _ => get_refreshable_session_record(id, refresh_ttl)
+            .ok()
+            .flatten(),
     }
 }
 

--- a/src/stdlib/auth/storage.rs
+++ b/src/stdlib/auth/storage.rs
@@ -66,21 +66,32 @@ fn take_exchange_token_memory(token: &str) -> Option<String> {
 // - OAuth states
 // - session exchange tokens
 //
-// Higher-level helpers still own fallback/error behavior for now. This layer is
-// responsible only for routing each operation through a consistent per-record
-// contract while preserving backend-native atomicity and query shape.
+// This layer owns the canonical fallback/error contract for auth persistence.
+// Backend-native helpers preserve atomicity/query shape, while these public-ish
+// storage entrypoints decide whether failures should degrade to memory, return
+// None, or propagate.
 //
 // Canonical fallback/error policy (Phase 4.5C-2):
-// - sessions: fallback to memory on store/get backend failures; list/delete-all propagate
-//   backend errors; do not silently mask explicit mutation or migration failures
-// - auth challenges: fallback to memory on store/get/consume backend failures and always
-//   scrub memory fallback entries during cleanup
-// - OAuth states: fallback to memory on store/consume backend failures and always scrub
-//   memory fallback entries during cleanup; fallback consume must enforce the same TTL as
-//   backend-native consume paths
-// - exchange tokens: fallback to memory on store/consume backend failures and always scrub
-//   memory fallback entries during cleanup; fallback consume must enforce the same TTL as
-//   backend-native consume paths
+// - sessions:
+//   - store/get may fall back to the in-memory store
+//   - refreshable lookup never falls back to memory because memory does not keep
+//     expired sessions available for token refresh
+//   - update/migrate/list/delete-all propagate backend errors
+//   - cleanup is backend-native only (memory backend cleans its own store)
+// - auth challenges:
+//   - store/get/consume may fall back to the in-memory store
+//   - delete ignores missing backend state but still scrubs memory fallback
+//   - cleanup always scrubs memory fallback entries in addition to any backend cleanup
+// - OAuth states:
+//   - store/consume may fall back to the in-memory store
+//   - fallback consume enforces the same TTL window as backend-native consume paths
+//   - cleanup always scrubs memory fallback entries; Redis backend cleanup only affects
+//     fallback memory because Redis native expiry is TTL-driven
+// - exchange tokens:
+//   - store/consume may fall back to the in-memory store
+//   - fallback consume enforces the same TTL window as backend-native consume paths
+//   - cleanup always scrubs memory fallback entries; Redis backend cleanup only affects
+//     fallback memory because Redis native expiry is TTL-driven
 
 pub(super) fn store_oauth_state_record(state: &OAuthState) -> std::result::Result<(), String> {
     match active_auth_storage_backend() {
@@ -1544,6 +1555,27 @@ pub(super) fn get_session_record(id: &str) -> std::result::Result<Option<Session
         AuthStorageBackend::Postgres => get_session_postgres(id),
         AuthStorageBackend::Redis => get_session_redis(id),
         AuthStorageBackend::Memory => Ok(SESSION_STORE.lock().unwrap().get_session(id).cloned()),
+    }
+}
+
+pub(super) fn get_session_record_with_fallback(id: &str) -> Option<Session> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => get_session_record(id).ok().flatten(),
+        _ => match get_session_record(id) {
+            Ok(Some(session)) => Some(session),
+            Ok(None) => SESSION_STORE.lock().unwrap().get_session(id).cloned(),
+            Err(_) => SESSION_STORE.lock().unwrap().get_session(id).cloned(),
+        },
+    }
+}
+
+pub(super) fn get_refreshable_session_record_without_fallback(
+    id: &str,
+    refresh_ttl: i64,
+) -> Option<Session> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => None,
+        _ => get_refreshable_session_record(id, refresh_ttl).ok().flatten(),
     }
 }
 


### PR DESCRIPTION
## Summary
- finish DD-043 Phase 4.5C-2 fallback/error cleanup across auth storage and session lookup paths
- add focused session fallback tests alongside the existing auth-challenge / oauth-state / exchange-token policy coverage
- mark DD-043 Phase 4.5C, 4.5D, and 4.5E complete after the final auth/docs audit pass

## What changed
- add explicit storage helpers for session fallback semantics:
  - `get_session_record_with_fallback(...)`
  - `get_refreshable_session_record_without_fallback(...)`
- update `auth/sessions.rs` to use the canonical storage-level fallback contract instead of inlining session fallback policy
- add tests proving:
  - ordinary session lookup may fall back to memory on backend failure
  - refreshable expired-session lookup does not fall back to memory
- update DD-043 to reflect completed 4.5 cleanup/audit work

## Validation
- `cargo build --release --locked`
- `./target/release/ntnt docs --generate`
- `cargo test --release --locked auth -- --nocapture`

## Context
PR #88 already covered the backend contract harness and env-gated Postgres/Redis auth coverage. This PR is the follow-on final 4.5 cleanup pass after that merge, focused on centralizing fallback/error semantics and closing the remaining DD-043 4.5C/4.5E items.
