### PR TITLE
auth: complete phase 5 session lifecycle and presets

### DIFF
--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -283,14 +283,14 @@ return complete_auth_challenge(resp, req, map {
 
 - [x] Add sliding session expiry support
 - [x] Throttle refreshes so stores are not updated on every request
-- [ ] Refresh cookie Max-Age/Expires along with sliding sessions
+- [x] Refresh cookie Max-Age/Expires along with sliding sessions (for built-in/auth-enforced response paths)
 - [x] Add absolute maximum session lifetime support
-- [ ] Store session creation time separately from idle expiry
-- [ ] Clear log/error path when max lifetime forces re-auth
-- [ ] Define preset configurations (`consumer`, `admin`, `internal`, `strict`)
-- [ ] Accept String or Map as second arg to `enable_auth`
-- [ ] Allow preset + override merge
-- [ ] Document preset guidance clearly
+- [x] Store session creation time separately from idle expiry (use immutable `created_at` as the max-lifetime anchor)
+- [x] Clear log/error path when max lifetime forces re-auth
+- [x] Define preset configurations (`consumer`, `admin`, `internal`, `strict`)
+- [x] Accept String or Map as second arg to `enable_auth`
+- [x] Allow preset + override merge
+- [x] Document preset guidance clearly
 
 **Ships real value:** apps get secure, reusable lifecycle behavior without inventing timeout policy from scratch.
 
@@ -445,7 +445,7 @@ So the plan should put those cleanup-heavy features first, but still start with 
 - absolute max lifetime
 - ergonomic presets (`strict`, `balanced`, `relaxed`, etc.)
 
-**Current status:** Wave 5A landed the lifecycle core: sliding session expiry, refresh throttling, and absolute max lifetime controls. Cookie refresh alignment and presets remain for the next slice.
+**Current status:** Wave 5B added lifecycle presets (`consumer`, `admin`, `internal`, `strict`), preset+override merge, preset-string `enable_auth(...)` input support, and cookie refresh alignment for the built-in/auth-enforced response paths. Phase 5 is complete.
 
 **Strong value:** apps get secure lifecycle behavior without each team inventing different timeout logic.
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2238,29 +2238,31 @@ current_user(req) otherwise return redirect("/login")  // Require a current user
 #### `enable_auth`
 
 ```ntnt
-enable_auth(providers: [Provider], options?: Map) -> Unit
+enable_auth(providers: [Provider], preset_or_options?: String | Map, overrides?: Map) -> Unit
 ```
 
 Initialize the authentication system with OAuth providers.
 
 Stores provider configurations for use by auth handlers. After calling this, you can use auth_start, auth_callback, and auth_logout with routes to enable OAuth login.
 
-Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url", or "redis://url".
+Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url", or "redis://url". Built-in presets: "consumer", "admin", "internal", "strict".
 
 **Parameters:**
 
 - `providers` — Array of provider configs created by oauth() or oauth_discover()
-- `options` — Optional map with keys: session_secret, session_ttl, refresh_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, protected_paths, cookie_name, cookie_secure, session_store, store_tokens
+- `preset_or_options` — Optional preset string or options map
+- `overrides` — Optional overrides map applied on top of a preset
 
 **Returns:** Unit
 
 **Examples:**
 
 ```ntnt
-// Initialize auth with GitHub
+// Initialize auth with GitHub and explicit options
 let github = oauth("github", get_env("GITHUB_ID"), get_env("GITHUB_SECRET"))
 enable_auth([github], map { "session_secret": "my-secret" })
-enable_auth([github], map { "session_store": "sqlite:./sessions.db" })  // SQLite sessions
+enable_auth([github], "admin")  // Admin preset
+enable_auth([github], "consumer", map { "session_store": "sqlite:./sessions.db" })  // Preset plus overrides
 enable_auth([github], map { "session_store": "redis://localhost:6379" })  // Redis sessions
 ```
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2245,7 +2245,7 @@ Initialize the authentication system with OAuth providers.
 
 Stores provider configurations for use by auth handlers. After calling this, you can use auth_start, auth_callback, and auth_logout with routes to enable OAuth login.
 
-Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url", or "redis://url". Built-in presets: "consumer", "admin", "internal", "strict".
+Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url", or "redis://url". Built-in presets: "consumer", "admin", "internal", "strict". Supported option keys: session_secret, session_ttl, refresh_ttl, sliding_sessions, refresh_throttle, max_session_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, protected_paths, cookie_name, cookie_secure, cookie_same_site, session_store, store_tokens. When a preset string is used, the overrides map is applied on top of the preset.
 
 **Parameters:**
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -3098,7 +3098,7 @@ pub fn init() -> HashMap<String, Value> {
                             return match enforce_auth_for_request(&args[0], true) {
                                 Ok(Some(cookie)) => {
                                     let mut response = match redirect_response(
-                                        &guards::request_path(&args[0]),
+                                        &guards::request_target(&args[0]),
                                         Some(&cookie),
                                     ) {
                                         Value::Map(map) => map,
@@ -3160,7 +3160,7 @@ pub fn init() -> HashMap<String, Value> {
                     func: |mw_args| match enforce_auth_for_request(&mw_args[0], true) {
                         Ok(Some(cookie)) => {
                             let mut response = match redirect_response(
-                                &guards::request_path(&mw_args[0]),
+                                &guards::request_target(&mw_args[0]),
                                 Some(&cookie),
                             ) {
                                 Value::Map(map) => map,
@@ -6562,6 +6562,69 @@ mod tests {
 
         let response = handle_auth_protect(&[req]).expect("auth protect should succeed");
         assert!(matches!(response, Value::Unit));
+    }
+
+    #[test]
+    fn test_handle_auth_protect_preserves_query_string_on_cookie_refresh_redirect() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            sliding_sessions: true,
+            refresh_throttle: 300,
+            session_ttl: 3600,
+            protected_paths: vec!["/admin".to_string()],
+            ..AuthConfig::default()
+        });
+
+        let now = chrono::Utc::now().timestamp();
+        SESSION_STORE.lock().unwrap().set_session(Session {
+            id: "session-protect-query-refresh".to_string(),
+            user_id: "user-protect-query-refresh".to_string(),
+            provider: "local".to_string(),
+            email: None,
+            name: None,
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-protect-query-refresh".to_string(),
+            access_token: None,
+            refresh_token: None,
+            token_expires_at: None,
+            created_at: now - 600,
+            expires_at: now + 60,
+        });
+
+        let config = get_auth_config().expect("auth config should be initialized");
+        let cookie = build_signed_session_cookie(&config, "session-protect-query-refresh", None)
+            .expect("cookie should build");
+        let req = Value::Map(HashMap::from([
+            ("method".to_string(), Value::String("GET".to_string())),
+            ("path".to_string(), Value::String("/admin".to_string())),
+            (
+                "query".to_string(),
+                Value::String("page=2&sort=asc".to_string()),
+            ),
+            (
+                "headers".to_string(),
+                Value::Map(HashMap::from([(
+                    "cookie".to_string(),
+                    Value::String(cookie),
+                )])),
+            ),
+        ]));
+
+        let response = handle_auth_protect(&[req]).expect("auth protect should succeed");
+        match response {
+            Value::Map(map) => match map.get("headers") {
+                Some(Value::Map(headers)) => {
+                    assert!(
+                        matches!(headers.get("Location"), Some(Value::String(loc)) if loc == "/admin?page=2&sort=asc")
+                    );
+                }
+                other => panic!("expected headers map, got {:?}", other),
+            },
+            other => panic!("expected response map, got {:?}", other),
+        }
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -3075,10 +3075,17 @@ pub fn init() -> HashMap<String, Value> {
                     if let Value::Map(map) = &args[0] {
                         if map.contains_key("method") && map.contains_key("path") {
                             return match enforce_auth_for_request(&args[0], true) {
-                                Ok(Some(cookie)) => Ok(redirect_response(
-                                    &guards::request_path(&args[0]),
-                                    Some(&cookie),
-                                )),
+                                Ok(Some(cookie)) => {
+                                    let mut response = match redirect_response(
+                                        &guards::request_path(&args[0]),
+                                        Some(&cookie),
+                                    ) {
+                                        Value::Map(map) => map,
+                                        other => return Ok(other),
+                                    };
+                                    response.insert("status".to_string(), Value::Int(307));
+                                    Ok(Value::Map(response))
+                                },
                                 Ok(None) => Ok(Value::Unit),
                                 Err(response) => Ok(response),
                             };
@@ -3130,10 +3137,17 @@ pub fn init() -> HashMap<String, Value> {
                     max_arity: 1,
                     requires: None,
                     func: |mw_args| match enforce_auth_for_request(&mw_args[0], true) {
-                        Ok(Some(cookie)) => Ok(redirect_response(
-                            &guards::request_path(&mw_args[0]),
-                            Some(&cookie),
-                        )),
+                        Ok(Some(cookie)) => {
+                            let mut response = match redirect_response(
+                                &guards::request_path(&mw_args[0]),
+                                Some(&cookie),
+                            ) {
+                                Value::Map(map) => map,
+                                other => return Ok(other),
+                            };
+                            response.insert("status".to_string(), Value::Int(307));
+                            Ok(Value::Map(response))
+                        },
                         Ok(None) => Ok(Value::Unit),
                         Err(response) => Ok(response),
                     },
@@ -6420,6 +6434,60 @@ mod tests {
         match previous {
             Some(val) => unsafe { std::env::set_var("SITE_URL", val) },
             None => unsafe { std::env::remove_var("SITE_URL") },
+        }
+    }
+
+    #[test]
+    fn test_handle_auth_protect_uses_307_for_cookie_refresh_redirect() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            sliding_sessions: true,
+            refresh_throttle: 300,
+            session_ttl: 3600,
+            protected_paths: vec!["/admin".to_string()],
+            ..AuthConfig::default()
+        });
+
+        let now = chrono::Utc::now().timestamp();
+        SESSION_STORE.lock().unwrap().set_session(Session {
+            id: "session-protect-refresh".to_string(),
+            user_id: "user-protect-refresh".to_string(),
+            provider: "local".to_string(),
+            email: None,
+            name: None,
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-protect-refresh".to_string(),
+            access_token: None,
+            refresh_token: None,
+            token_expires_at: None,
+            created_at: now - 600,
+            expires_at: now + 60,
+        });
+
+        let config = get_auth_config().expect("auth config should be initialized");
+        let cookie = build_signed_session_cookie(&config, "session-protect-refresh", None)
+            .expect("cookie should build");
+        let req = Value::Map(HashMap::from([
+            ("method".to_string(), Value::String("POST".to_string())),
+            ("path".to_string(), Value::String("/admin".to_string())),
+            (
+                "headers".to_string(),
+                Value::Map(HashMap::from([(
+                    "cookie".to_string(),
+                    Value::String(cookie),
+                )])),
+            ),
+        ]));
+
+        let response = handle_auth_protect(&[req]).expect("auth protect should succeed");
+        match response {
+            Value::Map(map) => {
+                assert!(matches!(map.get("status"), Some(Value::Int(307))));
+            }
+            other => panic!("expected response map, got {:?}", other),
         }
     }
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -61,6 +61,7 @@ pub use cookies::default_auth_cookie_secure_env;
 use cookies::{
     add_set_cookie_header, auth_challenge_cookie_name, build_cleared_auth_challenge_cookie,
     build_cleared_session_cookie, build_signed_auth_challenge_cookie, build_signed_session_cookie,
+    normalize_cookie_same_site,
 };
 #[cfg(test)]
 use guards::path_matches_protected_pattern;
@@ -2786,6 +2787,7 @@ pub fn init() -> HashMap<String, Value> {
                                 | "after_logout"
                                 | "cookie_name"
                                 | "cookie_secure"
+                                | "cookie_same_site"
                                 | "session_store"
                                 | "store_tokens"
                                 | "protected_paths"
@@ -2916,6 +2918,18 @@ pub fn init() -> HashMap<String, Value> {
                     None => base_config.cookie_secure,
                 };
 
+                let cookie_same_site = match get_option(&["cookie_same_site"]) {
+                    Some(Value::String(s)) => normalize_cookie_same_site(s)
+                        .map_err(IntentError::type_error)?,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() option \"cookie_same_site\" must be a string, got {}",
+                            other.type_name()
+                        )));
+                    }
+                    None => base_config.cookie_same_site.clone(),
+                };
+
                 let session_store = match get_option(&["session_store"]) {
                     Some(Value::String(s)) => {
                         parse_auth_session_store(s).map_err(IntentError::type_error)?
@@ -3021,6 +3035,7 @@ pub fn init() -> HashMap<String, Value> {
                 base_config.protected_paths = protected_paths;
                 base_config.cookie_name = cookie_name;
                 base_config.cookie_secure = cookie_secure;
+                base_config.cookie_same_site = cookie_same_site;
                 base_config.session_ttl = session_ttl;
                 base_config.refresh_ttl = refresh_ttl;
                 base_config.sliding_sessions = sliding_sessions;
@@ -5445,6 +5460,10 @@ mod tests {
             Value::Map(HashMap::from([
                 ("session_ttl".to_string(), Value::Int(7200)),
                 ("cookie_secure".to_string(), Value::Bool(false)),
+                (
+                    "cookie_same_site".to_string(),
+                    Value::String("Strict".to_string()),
+                ),
             ])),
         ])
         .expect("enable_auth should accept preset plus overrides");
@@ -5453,6 +5472,7 @@ mod tests {
         assert_eq!(config.auth_preset.as_deref(), Some("consumer"));
         assert_eq!(config.session_ttl, 7200);
         assert!(!config.cookie_secure);
+        assert_eq!(config.cookie_same_site, "Strict");
         assert!(config.sliding_sessions);
     }
 
@@ -6438,6 +6458,58 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_auth_protect_skips_cookie_refresh_redirect_for_api_post() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            sliding_sessions: true,
+            refresh_throttle: 300,
+            session_ttl: 3600,
+            protected_paths: vec!["/admin".to_string()],
+            ..AuthConfig::default()
+        });
+
+        let now = chrono::Utc::now().timestamp();
+        SESSION_STORE.lock().unwrap().set_session(Session {
+            id: "session-api-refresh".to_string(),
+            user_id: "user-api-refresh".to_string(),
+            provider: "local".to_string(),
+            email: None,
+            name: None,
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-api-refresh".to_string(),
+            access_token: None,
+            refresh_token: None,
+            token_expires_at: None,
+            created_at: now - 600,
+            expires_at: now + 60,
+        });
+
+        let config = get_auth_config().expect("auth config should be initialized");
+        let cookie = build_signed_session_cookie(&config, "session-api-refresh", None)
+            .expect("cookie should build");
+        let req = Value::Map(HashMap::from([
+            ("method".to_string(), Value::String("POST".to_string())),
+            ("path".to_string(), Value::String("/admin".to_string())),
+            (
+                "headers".to_string(),
+                Value::Map(HashMap::from([
+                    ("cookie".to_string(), Value::String(cookie)),
+                    (
+                        "accept".to_string(),
+                        Value::String("application/json".to_string()),
+                    ),
+                ])),
+            ),
+        ]));
+
+        let response = handle_auth_protect(&[req]).expect("auth protect should succeed");
+        assert!(matches!(response, Value::Unit));
+    }
+
+    #[test]
     fn test_handle_auth_protect_uses_307_for_cookie_refresh_redirect() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         reset_auth_test_state();
@@ -6472,6 +6544,55 @@ mod tests {
             .expect("cookie should build");
         let req = Value::Map(HashMap::from([
             ("method".to_string(), Value::String("POST".to_string())),
+            ("path".to_string(), Value::String("/admin".to_string())),
+            (
+                "headers".to_string(),
+                Value::Map(HashMap::from([(
+                    "cookie".to_string(),
+                    Value::String(cookie),
+                )])),
+            ),
+        ]));
+
+        let response = handle_auth_protect(&[req]).expect("auth protect should succeed");
+        assert!(matches!(response, Value::Unit));
+    }
+
+    #[test]
+    fn test_handle_auth_protect_uses_307_for_cookie_refresh_redirect_on_browser_get() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_auth(AuthConfig {
+            sliding_sessions: true,
+            refresh_throttle: 300,
+            session_ttl: 3600,
+            protected_paths: vec!["/admin".to_string()],
+            ..AuthConfig::default()
+        });
+
+        let now = chrono::Utc::now().timestamp();
+        SESSION_STORE.lock().unwrap().set_session(Session {
+            id: "session-protect-browser-refresh".to_string(),
+            user_id: "user-protect-browser-refresh".to_string(),
+            provider: "local".to_string(),
+            email: None,
+            name: None,
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-protect-browser-refresh".to_string(),
+            access_token: None,
+            refresh_token: None,
+            token_expires_at: None,
+            created_at: now - 600,
+            expires_at: now + 60,
+        });
+
+        let config = get_auth_config().expect("auth config should be initialized");
+        let cookie = build_signed_session_cookie(&config, "session-protect-browser-refresh", None)
+            .expect("cookie should build");
+        let req = Value::Map(HashMap::from([
+            ("method".to_string(), Value::String("GET".to_string())),
             ("path".to_string(), Value::String("/admin".to_string())),
             (
                 "headers".to_string(),

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -2663,7 +2663,7 @@ pub fn init() -> HashMap<String, Value> {
 
     // @ntnt enable_auth
     // @module std/auth
-    // @signature enable_auth(providers: [Provider], options?: Map) -> Unit
+    // @signature enable_auth(providers: [Provider], preset_or_options?: String | Map, overrides?: Map) -> Unit
     // Initialize the authentication system with OAuth providers.
     //
     // Stores provider configurations for use by auth handlers. After calling this,
@@ -2671,16 +2671,19 @@ pub fn init() -> HashMap<String, Value> {
     // with routes to enable OAuth login.
     //
     // Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url", or "redis://url".
+    // Built-in presets: "consumer", "admin", "internal", "strict".
     // @param providers Array of provider configs created by oauth() or oauth_discover()
-    // @param options Optional map with keys: session_secret, session_ttl, refresh_ttl, success_url/after_login, failure_url/after_failure, logout_url/after_logout, protected_paths, cookie_name, cookie_secure, session_store, store_tokens
+    // @param preset_or_options Optional preset string or options map
+    // @param overrides Optional overrides map applied on top of a preset
     // @returns Unit
     // @see_also oauth, oauth_discover, auth_start
     // @since v0.3.11
     // @tags #auth, #oauth
-    // @example ~ "Initialize auth with GitHub"
+    // @example ~ "Initialize auth with GitHub and explicit options"
     //   let github = oauth("github", get_env("GITHUB_ID"), get_env("GITHUB_SECRET"))
     //   enable_auth([github], map { "session_secret": "my-secret" })
-    // @example enable_auth([github], map { "session_store": "sqlite:./sessions.db" }) ~ "SQLite sessions"
+    // @example enable_auth([github], "admin") ~ "Admin preset"
+    // @example enable_auth([github], "consumer", map { "session_store": "sqlite:./sessions.db" }) ~ "Preset plus overrides"
     // @example enable_auth([github], map { "session_store": "redis://localhost:6379" }) ~ "Redis sessions"
     module.insert(
         "enable_auth".to_string(),

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -2915,7 +2915,13 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => base_config.cookie_secure,
+                    None => {
+                        if preset_name.is_some() {
+                            base_config.cookie_secure
+                        } else {
+                            default_auth_cookie_secure_env()
+                        }
+                    }
                 };
 
                 let cookie_same_site = match get_option(&["cookie_same_site"]) {

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -2673,6 +2673,11 @@ pub fn init() -> HashMap<String, Value> {
     //
     // Session storage options: "memory" (default), "sqlite:./path.db", "postgres://url", or "redis://url".
     // Built-in presets: "consumer", "admin", "internal", "strict".
+    // Supported option keys: session_secret, session_ttl, refresh_ttl, sliding_sessions,
+    // refresh_throttle, max_session_ttl, success_url/after_login, failure_url/after_failure,
+    // logout_url/after_logout, protected_paths, cookie_name, cookie_secure, cookie_same_site,
+    // session_store, store_tokens.
+    // When a preset string is used, the overrides map is applied on top of the preset.
     // @param providers Array of provider configs created by oauth() or oauth_discover()
     // @param preset_or_options Optional preset string or options map
     // @param overrides Optional overrides map applied on top of a preset
@@ -2915,13 +2920,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => {
-                        if preset_name.is_some() {
-                            base_config.cookie_secure
-                        } else {
-                            default_auth_cookie_secure_env()
-                        }
-                    }
+                    None => default_auth_cookie_secure_env()
                 };
 
                 let cookie_same_site = match get_option(&["cookie_same_site"]) {

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -290,6 +290,7 @@ pub struct AuthConfig {
     pub sliding_sessions: bool, // Extend active sessions on authenticated reads
     pub refresh_throttle: i64, // Only extend sliding sessions when remaining TTL is at or below this many seconds
     pub max_session_ttl: Option<i64>, // Absolute max lifetime from session creation
+    pub auth_preset: Option<String>, // Lifecycle/security preset name, if selected
     pub store_tokens: bool,    // Store access/refresh tokens in session
     pub session_secret: String, // Secret for session signing
     pub session_store: SessionStore, // Session storage backend
@@ -311,11 +312,61 @@ impl Default for AuthConfig {
             sliding_sessions: false,
             refresh_throttle: 300,
             max_session_ttl: None,
+            auth_preset: None,
             store_tokens: false,
             session_secret: DEFAULT_SESSION_SECRET_SENTINEL.to_string(),
             session_store: SessionStore::Memory,
         }
     }
+}
+
+fn auth_preset_config(name: &str) -> std::result::Result<AuthConfig, String> {
+    let preset = name.trim().to_ascii_lowercase();
+    let mut config = AuthConfig::default();
+    config.auth_preset = Some(preset.clone());
+
+    match preset.as_str() {
+        "consumer" => {
+            config.session_ttl = 86400 * 14;
+            config.refresh_ttl = 86400 * 30;
+            config.sliding_sessions = true;
+            config.refresh_throttle = 1800;
+            config.max_session_ttl = Some(86400 * 30);
+            config.cookie_same_site = "Lax".to_string();
+        }
+        "admin" => {
+            config.session_ttl = 3600;
+            config.refresh_ttl = 86400;
+            config.sliding_sessions = true;
+            config.refresh_throttle = 300;
+            config.max_session_ttl = Some(86400);
+            config.cookie_same_site = "Strict".to_string();
+        }
+        "internal" => {
+            config.session_ttl = 86400;
+            config.refresh_ttl = 86400 * 7;
+            config.sliding_sessions = true;
+            config.refresh_throttle = 900;
+            config.max_session_ttl = Some(86400 * 7);
+            config.cookie_same_site = "Lax".to_string();
+        }
+        "strict" => {
+            config.session_ttl = 1800;
+            config.refresh_ttl = 1800;
+            config.sliding_sessions = false;
+            config.refresh_throttle = 0;
+            config.max_session_ttl = Some(1800);
+            config.cookie_same_site = "Strict".to_string();
+        }
+        _ => {
+            return Err(format!(
+                "[auth] unknown preset \"{}\". Expected one of: consumer, admin, internal, strict",
+                name
+            ))
+        }
+    }
+
+    Ok(config)
 }
 
 /// Sentinel value used to detect when user hasn't set a session secret.
@@ -2639,9 +2690,9 @@ pub fn init() -> HashMap<String, Value> {
             max_arity: 0,
             requires: Some(RuntimeCapability::HttpConfig),
             func: |args| {
-                if args.is_empty() || args.len() > 2 {
+                if args.is_empty() || args.len() > 3 {
                     return Err(IntentError::type_error(
-                        "[auth] enable_auth() requires 1 or 2 arguments (providers, optional config)"
+                        "[auth] enable_auth() requires 1 to 3 arguments (providers, optional preset/options, optional overrides)"
                             .to_string(),
                     ));
                 }
@@ -2657,16 +2708,40 @@ pub fn init() -> HashMap<String, Value> {
                     }
                 };
 
-                let options = match args.get(1) {
-                    Some(Value::Map(m)) => Some(m.clone()),
-                    Some(_) => {
-                        return Err(IntentError::type_error(
-                            "[auth] enable_auth() second argument must be an options map"
-                                .to_string(),
-                        ))
+                let mut preset_name: Option<String> = None;
+                let mut options: Option<HashMap<String, Value>> = None;
+
+                match args.get(1) {
+                    Some(Value::Map(m)) => options = Some(m.clone()),
+                    Some(Value::String(s)) => preset_name = Some(s.clone()),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] enable_auth() second argument must be a preset string or options map, got {}",
+                            other.type_name()
+                        )))
                     }
-                    None => None,
-                };
+                    None => {}
+                }
+
+                if let Some(arg3) = args.get(2) {
+                    match arg3 {
+                        Value::Map(m) => {
+                            if options.is_some() {
+                                return Err(IntentError::type_error(
+                                    "[auth] enable_auth() accepts at most one options/overrides map"
+                                        .to_string(),
+                                ));
+                            }
+                            options = Some(m.clone());
+                        }
+                        other => {
+                            return Err(IntentError::type_error(format!(
+                                "[auth] enable_auth() third argument must be an overrides map, got {}",
+                                other.type_name()
+                            )))
+                        }
+                    }
+                }
 
                 // Parse providers
                 let mut providers = Vec::new();
@@ -2724,6 +2799,11 @@ pub fn init() -> HashMap<String, Value> {
                     }
                 }
 
+                let mut base_config = match preset_name.as_ref() {
+                    Some(name) => auth_preset_config(name).map_err(IntentError::type_error)?,
+                    None => AuthConfig::default(),
+                };
+
                 let get_option = |keys: &[&str]| {
                     options
                         .as_ref()
@@ -2738,7 +2818,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => DEFAULT_SESSION_SECRET_SENTINEL.to_string(),
+                    None => base_config.session_secret.clone(),
                 };
 
                 let session_ttl = match get_option(&["session_ttl"]) {
@@ -2749,7 +2829,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => 86400,
+                    None => base_config.session_ttl,
                 };
 
                 let success_url = match get_option(&["success_url", "after_login"]) {
@@ -2760,7 +2840,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => "/".to_string(),
+                    None => base_config.success_url.clone(),
                 };
 
                 let failure_url = match get_option(&["failure_url", "after_failure"]) {
@@ -2771,7 +2851,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => "/".to_string(),
+                    None => base_config.failure_url.clone(),
                 };
 
                 let logout_url = match get_option(&["logout_url", "after_logout"]) {
@@ -2782,7 +2862,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => "/".to_string(),
+                    None => base_config.logout_url.clone(),
                 };
 
                 let protected_paths = match get_option(&["protected_paths"]) {
@@ -2808,7 +2888,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => Vec::new(),
+                    None => base_config.protected_paths.clone(),
                 };
 
                 let cookie_name = match get_option(&["cookie_name"]) {
@@ -2819,7 +2899,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => "ntnt_session".to_string(),
+                    None => base_config.cookie_name.clone(),
                 };
 
                 let cookie_secure = match get_option(&["cookie_secure"]) {
@@ -2830,19 +2910,20 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => default_auth_cookie_secure_env(),
+                    None => base_config.cookie_secure,
                 };
 
                 let session_store = match get_option(&["session_store"]) {
-                    Some(Value::String(s)) => parse_auth_session_store(s)
-                        .map_err(IntentError::type_error)?,
+                    Some(Value::String(s)) => {
+                        parse_auth_session_store(s).map_err(IntentError::type_error)?
+                    }
                     Some(other) => {
                         return Err(IntentError::type_error(format!(
                             "[auth] enable_auth() option \"session_store\" must be a string, got {}",
                             other.type_name()
                         )));
                     }
-                    None => SessionStore::Memory,
+                    None => base_config.session_store.clone(),
                 };
 
                 // Initialize database/cache if needed
@@ -2862,7 +2943,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => false,
+                    None => base_config.store_tokens,
                 };
 
                 let refresh_ttl = match get_option(&["refresh_ttl"]) {
@@ -2873,7 +2954,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => 86400 * 30,
+                    None => base_config.refresh_ttl,
                 };
 
                 let sliding_sessions = match get_option(&["sliding_sessions"]) {
@@ -2884,7 +2965,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => false,
+                    None => base_config.sliding_sessions,
                 };
 
                 let refresh_throttle = match get_option(&["refresh_throttle"]) {
@@ -2895,7 +2976,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => 300,
+                    None => base_config.refresh_throttle,
                 };
 
                 if refresh_throttle < 0 {
@@ -2918,7 +2999,7 @@ pub fn init() -> HashMap<String, Value> {
                             other.type_name()
                         )));
                     }
-                    None => None,
+                    None => base_config.max_session_ttl,
                 };
 
                 if let Some(max_session_ttl) = max_session_ttl {
@@ -2930,25 +3011,22 @@ pub fn init() -> HashMap<String, Value> {
                     }
                 }
 
-                // Create auth config
-                let config = AuthConfig {
-                    providers,
-                    success_url,
-                    failure_url,
-                    logout_url,
-                    protected_paths,
-                    cookie_name,
-                    cookie_secure,
-                    cookie_same_site: "Lax".to_string(),
-                    session_ttl,
-                    refresh_ttl,
-                    sliding_sessions,
-                    refresh_throttle,
-                    max_session_ttl,
-                    store_tokens,
-                    session_secret,
-                    session_store,
-                };
+                base_config.providers = providers;
+                base_config.success_url = success_url;
+                base_config.failure_url = failure_url;
+                base_config.logout_url = logout_url;
+                base_config.protected_paths = protected_paths;
+                base_config.cookie_name = cookie_name;
+                base_config.cookie_secure = cookie_secure;
+                base_config.session_ttl = session_ttl;
+                base_config.refresh_ttl = refresh_ttl;
+                base_config.sliding_sessions = sliding_sessions;
+                base_config.refresh_throttle = refresh_throttle;
+                base_config.max_session_ttl = max_session_ttl;
+                base_config.store_tokens = store_tokens;
+                base_config.session_secret = session_secret;
+                base_config.session_store = session_store;
+                let config = base_config;
 
                 // Initialize auth
                 init_auth(config);
@@ -2994,7 +3072,11 @@ pub fn init() -> HashMap<String, Value> {
                     if let Value::Map(map) = &args[0] {
                         if map.contains_key("method") && map.contains_key("path") {
                             return match enforce_auth_for_request(&args[0], true) {
-                                Ok(()) => Ok(Value::Unit),
+                                Ok(Some(cookie)) => Ok(redirect_response(
+                                    &guards::request_path(&args[0]),
+                                    Some(&cookie),
+                                )),
+                                Ok(None) => Ok(Value::Unit),
                                 Err(response) => Ok(response),
                             };
                         }
@@ -3045,7 +3127,11 @@ pub fn init() -> HashMap<String, Value> {
                     max_arity: 1,
                     requires: None,
                     func: |mw_args| match enforce_auth_for_request(&mw_args[0], true) {
-                        Ok(()) => Ok(Value::Unit),
+                        Ok(Some(cookie)) => Ok(redirect_response(
+                            &guards::request_path(&mw_args[0]),
+                            Some(&cookie),
+                        )),
+                        Ok(None) => Ok(Value::Unit),
                         Err(response) => Ok(response),
                     },
                 })
@@ -5303,6 +5389,71 @@ mod tests {
                 Value::String("https://api.github.com/user".to_string()),
             ),
         ]))
+    }
+
+    #[test]
+    fn test_enable_auth_accepts_preset_string() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+
+        let module = init();
+        let enable_auth = module_fn(&module, "enable_auth");
+        let provider = github_test_provider_value();
+
+        enable_auth(&[
+            Value::Array(vec![provider]),
+            Value::String("admin".to_string()),
+        ])
+        .expect("enable_auth should accept preset string");
+
+        let config = get_auth_config().expect("auth config should be initialized");
+        assert_eq!(config.auth_preset.as_deref(), Some("admin"));
+        assert_eq!(config.session_ttl, 3600);
+        assert_eq!(config.max_session_ttl, Some(86400));
+        assert_eq!(config.cookie_same_site, "Strict");
+    }
+
+    #[test]
+    fn test_enable_auth_accepts_preset_plus_overrides() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+
+        let module = init();
+        let enable_auth = module_fn(&module, "enable_auth");
+        let provider = github_test_provider_value();
+
+        enable_auth(&[
+            Value::Array(vec![provider]),
+            Value::String("consumer".to_string()),
+            Value::Map(HashMap::from([
+                ("session_ttl".to_string(), Value::Int(7200)),
+                ("cookie_secure".to_string(), Value::Bool(false)),
+            ])),
+        ])
+        .expect("enable_auth should accept preset plus overrides");
+
+        let config = get_auth_config().expect("auth config should be initialized");
+        assert_eq!(config.auth_preset.as_deref(), Some("consumer"));
+        assert_eq!(config.session_ttl, 7200);
+        assert!(!config.cookie_secure);
+        assert!(config.sliding_sessions);
+    }
+
+    #[test]
+    fn test_enable_auth_rejects_unknown_preset() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+
+        let module = init();
+        let enable_auth = module_fn(&module, "enable_auth");
+        let provider = github_test_provider_value();
+
+        let err = enable_auth(&[
+            Value::Array(vec![provider]),
+            Value::String("wizard-mode".to_string()),
+        ])
+        .expect_err("enable_auth should reject unknown preset");
+        assert!(format!("{}", err).contains("unknown preset"));
     }
 
     #[test]

--- a/src/stdlib/auth/cookies.rs
+++ b/src/stdlib/auth/cookies.rs
@@ -91,7 +91,7 @@ fn validate_cookie_path(path: &str) -> std::result::Result<String, String> {
     Ok(path.to_string())
 }
 
-fn normalize_cookie_same_site(value: &str) -> std::result::Result<String, String> {
+pub(super) fn normalize_cookie_same_site(value: &str) -> std::result::Result<String, String> {
     match value.to_ascii_lowercase().as_str() {
         "lax" => Ok("Lax".to_string()),
         "strict" => Ok("Strict".to_string()),
@@ -175,14 +175,28 @@ fn build_auth_cookie_string(value: &str, settings: &AuthCookieSettings) -> Strin
     cookie
 }
 
+pub(super) fn build_signed_session_cookie_with_max_age(
+    config: &AuthConfig,
+    session_id: &str,
+    max_age: i64,
+    overrides: Option<&HashMap<String, Value>>,
+) -> std::result::Result<String, String> {
+    let settings = auth_cookie_settings(config, max_age.max(0), overrides)?;
+    let signed_session_id = sign_session_id(session_id, &config.session_secret);
+    Ok(build_auth_cookie_string(&signed_session_id, &settings))
+}
+
 pub(super) fn build_signed_session_cookie(
     config: &AuthConfig,
     session_id: &str,
     overrides: Option<&HashMap<String, Value>>,
 ) -> std::result::Result<String, String> {
-    let settings = auth_cookie_settings(config, default_auth_cookie_max_age(config), overrides)?;
-    let signed_session_id = sign_session_id(session_id, &config.session_secret);
-    Ok(build_auth_cookie_string(&signed_session_id, &settings))
+    build_signed_session_cookie_with_max_age(
+        config,
+        session_id,
+        default_auth_cookie_max_age(config),
+        overrides,
+    )
 }
 
 pub(super) fn build_cleared_session_cookie(

--- a/src/stdlib/auth/guards.rs
+++ b/src/stdlib/auth/guards.rs
@@ -256,16 +256,33 @@ pub fn enforce_auth_for_request(
         if session.is_some() {
             let refreshed_cookie = match effect {
                 SessionAccessEffect::ExpiryUpdated { expires_at } => {
-                    let now = chrono::Utc::now().timestamp();
-                    get_auth_config().and_then(|config| {
-                        build_signed_session_cookie_with_max_age(
-                            &config,
-                            &session_id,
-                            expires_at - now,
-                            None,
-                        )
-                        .ok()
-                    })
+                    let method = if let Value::Map(req_map) = request {
+                        req_map.get("method").and_then(|v| match v {
+                            Value::String(s) => Some(s.to_ascii_uppercase()),
+                            _ => None,
+                        })
+                    } else {
+                        None
+                    }
+                    .unwrap_or_else(|| "GET".to_string());
+
+                    let safe_navigation =
+                        (method == "GET" || method == "HEAD") && !request_prefers_api(request);
+
+                    if !safe_navigation {
+                        None
+                    } else {
+                        let now = chrono::Utc::now().timestamp();
+                        get_auth_config().and_then(|config| {
+                            build_signed_session_cookie_with_max_age(
+                                &config,
+                                &session_id,
+                                expires_at - now,
+                                None,
+                            )
+                            .ok()
+                        })
+                    }
                 }
                 SessionAccessEffect::Unchanged => None,
             };

--- a/src/stdlib/auth/guards.rs
+++ b/src/stdlib/auth/guards.rs
@@ -1,3 +1,4 @@
+use super::sessions::{get_session_for_request, SessionAccessEffect};
 use super::*;
 
 fn normalize_protected_path(pattern: &str) -> String {
@@ -132,7 +133,7 @@ fn is_auth_exempt_path(path: &str) -> bool {
     normalized == "/auth" || normalized.starts_with("/auth/")
 }
 
-fn request_path(request: &Value) -> String {
+pub(super) fn request_path(request: &Value) -> String {
     if let Value::Map(req_map) = request {
         if let Some(Value::String(path)) = req_map.get("path") {
             return path.clone();
@@ -214,11 +215,6 @@ fn auth_required_response(request: &Value) -> Value {
     redirect_response("/auth", None)
 }
 
-fn session_from_request(request: &Value) -> Option<Session> {
-    let session_id = get_session_id_from_request(request)?;
-    get_session_by_id(&session_id)
-}
-
 fn path_requires_auth(path: &str) -> bool {
     if is_auth_exempt_path(path) {
         return false;
@@ -236,15 +232,15 @@ fn path_requires_auth(path: &str) -> bool {
 pub fn enforce_auth_for_request(
     request: &Value,
     force_auth: bool,
-) -> std::result::Result<(), Value> {
+) -> std::result::Result<Option<String>, Value> {
     let path = request_path(request);
 
     if is_auth_exempt_path(&path) {
-        return Ok(());
+        return Ok(None);
     }
 
     if !force_auth && !path_requires_auth(&path) {
-        return Ok(());
+        return Ok(None);
     }
 
     let Some(_config) = get_auth_config() else {
@@ -254,8 +250,17 @@ pub fn enforce_auth_for_request(
         ));
     };
 
-    if session_from_request(request).is_some() {
-        return Ok(());
+    if let Some(session_id) = get_session_id_from_request(request) {
+        let (session, effect) = get_session_for_request(&session_id);
+        if session.is_some() {
+            let refreshed_cookie = if effect == SessionAccessEffect::ExpiryUpdated {
+                get_auth_config()
+                    .and_then(|config| build_signed_session_cookie(&config, &session_id, None).ok())
+            } else {
+                None
+            };
+            return Ok(refreshed_cookie);
+        }
     }
 
     Err(auth_required_response(request))

--- a/src/stdlib/auth/guards.rs
+++ b/src/stdlib/auth/guards.rs
@@ -1,3 +1,4 @@
+use super::cookies::build_signed_session_cookie_with_max_age;
 use super::sessions::{get_session_for_request, SessionAccessEffect};
 use super::*;
 
@@ -253,11 +254,20 @@ pub fn enforce_auth_for_request(
     if let Some(session_id) = get_session_id_from_request(request) {
         let (session, effect) = get_session_for_request(&session_id);
         if session.is_some() {
-            let refreshed_cookie = if effect == SessionAccessEffect::ExpiryUpdated {
-                get_auth_config()
-                    .and_then(|config| build_signed_session_cookie(&config, &session_id, None).ok())
-            } else {
-                None
+            let refreshed_cookie = match effect {
+                SessionAccessEffect::ExpiryUpdated { expires_at } => {
+                    let now = chrono::Utc::now().timestamp();
+                    get_auth_config().and_then(|config| {
+                        build_signed_session_cookie_with_max_age(
+                            &config,
+                            &session_id,
+                            expires_at - now,
+                            None,
+                        )
+                        .ok()
+                    })
+                }
+                SessionAccessEffect::Unchanged => None,
             };
             return Ok(refreshed_cookie);
         }

--- a/src/stdlib/auth/guards.rs
+++ b/src/stdlib/auth/guards.rs
@@ -143,6 +143,43 @@ pub(super) fn request_path(request: &Value) -> String {
     "/".to_string()
 }
 
+pub(super) fn request_target(request: &Value) -> String {
+    let path = request_path(request);
+    let Value::Map(req_map) = request else {
+        return path;
+    };
+
+    match req_map.get("query") {
+        Some(Value::String(query)) if !query.is_empty() => {
+            if query.starts_with('?') {
+                format!("{}{}", path, query)
+            } else {
+                format!("{}?{}", path, query)
+            }
+        }
+        Some(Value::Map(map)) if !map.is_empty() => {
+            let mut pairs = Vec::new();
+            for (key, value) in map {
+                let encoded_key = encode_url_path_segment(key);
+                let encoded_value = match value {
+                    Value::String(s) => encode_url_path_segment(s),
+                    Value::Int(i) => encode_url_path_segment(&i.to_string()),
+                    Value::Float(f) => encode_url_path_segment(&f.to_string()),
+                    Value::Bool(b) => encode_url_path_segment(&b.to_string()),
+                    _ => continue,
+                };
+                pairs.push(format!("{}={}", encoded_key, encoded_value));
+            }
+            if pairs.is_empty() {
+                path
+            } else {
+                format!("{}?{}", path, pairs.join("&"))
+            }
+        }
+        _ => path,
+    }
+}
+
 fn request_prefers_api(request: &Value) -> bool {
     let path = request_path(request);
     if path == "/api" || path.starts_with("/api/") {

--- a/src/stdlib/auth/routes.rs
+++ b/src/stdlib/auth/routes.rs
@@ -109,7 +109,14 @@ pub fn handle_auth_start(args: &[Value]) -> Result<Value> {
 
 pub fn handle_auth_protect(args: &[Value]) -> Result<Value> {
     match enforce_auth_for_request(&args[0], false) {
-        Ok(Some(cookie)) => Ok(redirect_response(&request_path(&args[0]), Some(&cookie))),
+        Ok(Some(cookie)) => {
+            let mut response = match redirect_response(&request_path(&args[0]), Some(&cookie)) {
+                Value::Map(map) => map,
+                other => return Ok(other),
+            };
+            response.insert("status".to_string(), Value::Int(307));
+            Ok(Value::Map(response))
+        }
         Ok(None) => Ok(Value::Unit),
         Err(response) => Ok(response),
     }

--- a/src/stdlib/auth/routes.rs
+++ b/src/stdlib/auth/routes.rs
@@ -1,4 +1,5 @@
 use super::cookies::{build_cleared_session_cookie, build_signed_session_cookie};
+use super::guards::request_path;
 use super::providers::{available_providers, suggest_provider};
 use super::*;
 
@@ -108,7 +109,8 @@ pub fn handle_auth_start(args: &[Value]) -> Result<Value> {
 
 pub fn handle_auth_protect(args: &[Value]) -> Result<Value> {
     match enforce_auth_for_request(&args[0], false) {
-        Ok(()) => Ok(Value::Unit),
+        Ok(Some(cookie)) => Ok(redirect_response(&request_path(&args[0]), Some(&cookie))),
+        Ok(None) => Ok(Value::Unit),
         Err(response) => Ok(response),
     }
 }

--- a/src/stdlib/auth/routes.rs
+++ b/src/stdlib/auth/routes.rs
@@ -1,5 +1,5 @@
 use super::cookies::{build_cleared_session_cookie, build_signed_session_cookie};
-use super::guards::request_path;
+use super::guards::request_target;
 use super::providers::{available_providers, suggest_provider};
 use super::*;
 
@@ -110,7 +110,7 @@ pub fn handle_auth_start(args: &[Value]) -> Result<Value> {
 pub fn handle_auth_protect(args: &[Value]) -> Result<Value> {
     match enforce_auth_for_request(&args[0], false) {
         Ok(Some(cookie)) => {
-            let mut response = match redirect_response(&request_path(&args[0]), Some(&cookie)) {
+            let mut response = match redirect_response(&request_target(&args[0]), Some(&cookie)) {
                 Value::Map(map) => map,
                 other => return Ok(other),
             };

--- a/src/stdlib/auth/sessions.rs
+++ b/src/stdlib/auth/sessions.rs
@@ -31,22 +31,28 @@ pub fn store_session(session: Session) {
     }
 }
 
-/// Get session by ID
-pub fn get_session_by_id(id: &str) -> Option<Session> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SessionAccessEffect {
+    Unchanged,
+    ExpiryUpdated,
+}
+
+pub(super) fn get_session_for_request(id: &str) -> (Option<Session>, SessionAccessEffect) {
     let config = get_auth_config();
     let mut session = get_session_record_with_fallback(id);
 
     if let Some(active_session) = session.as_mut() {
+        let mut effect = SessionAccessEffect::Unchanged;
         if let Some(config) = &config {
             let now = chrono::Utc::now().timestamp();
             let capped_expires_at = capped_session_expiry(now, active_session.created_at, config);
             if capped_expires_at <= now {
                 delete_session_by_id(&active_session.id);
-                return None;
+                return (None, SessionAccessEffect::Unchanged);
             }
-            maybe_slide_session(active_session, config);
+            effect = maybe_slide_session(active_session, config);
         }
-        return session;
+        return (session, effect);
     }
 
     if let Some(config) = &config {
@@ -67,7 +73,7 @@ pub fn get_session_by_id(id: &str) -> Option<Session> {
 
                                 if new_expires_at <= now {
                                     delete_session_by_id(&expired.id);
-                                    return None;
+                                    return (None, SessionAccessEffect::Unchanged);
                                 }
 
                                 update_session_tokens(&expired.id, &tokens);
@@ -85,7 +91,7 @@ pub fn get_session_by_id(id: &str) -> Option<Session> {
                                 }
                                 refreshed.token_expires_at = tokens.expires_in.map(|e| now + e);
                                 refreshed.expires_at = new_expires_at;
-                                return Some(refreshed);
+                                return (Some(refreshed), SessionAccessEffect::ExpiryUpdated);
                             }
                             Err(e) => {
                                 eprintln!(
@@ -101,7 +107,12 @@ pub fn get_session_by_id(id: &str) -> Option<Session> {
         }
     }
 
-    None
+    (None, SessionAccessEffect::Unchanged)
+}
+
+/// Get session by ID
+pub fn get_session_by_id(id: &str) -> Option<Session> {
+    get_session_for_request(id).0
 }
 
 pub(super) fn capped_session_expiry(now: i64, created_at: i64, config: &AuthConfig) -> i64 {
@@ -112,32 +123,36 @@ pub(super) fn capped_session_expiry(now: i64, created_at: i64, config: &AuthConf
     }
 }
 
-fn maybe_slide_session(session: &mut Session, config: &AuthConfig) {
+fn maybe_slide_session(session: &mut Session, config: &AuthConfig) -> SessionAccessEffect {
     let now = chrono::Utc::now().timestamp();
     let target_expires_at = capped_session_expiry(now, session.created_at, config);
 
     if session.expires_at > target_expires_at {
         if extend_session_record_expiry(&session.id, target_expires_at).is_ok() {
             session.expires_at = target_expires_at;
+            return SessionAccessEffect::ExpiryUpdated;
         }
-        return;
+        return SessionAccessEffect::Unchanged;
     }
 
     if !config.sliding_sessions {
-        return;
+        return SessionAccessEffect::Unchanged;
     }
 
     if target_expires_at <= session.expires_at {
-        return;
+        return SessionAccessEffect::Unchanged;
     }
 
     let remaining = session.expires_at - now;
     if remaining > config.refresh_throttle {
-        return;
+        return SessionAccessEffect::Unchanged;
     }
 
     if extend_session_record_expiry(&session.id, target_expires_at).is_ok() {
         session.expires_at = target_expires_at;
+        SessionAccessEffect::ExpiryUpdated
+    } else {
+        SessionAccessEffect::Unchanged
     }
 }
 

--- a/src/stdlib/auth/sessions.rs
+++ b/src/stdlib/auth/sessions.rs
@@ -34,7 +34,7 @@ pub fn store_session(session: Session) {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum SessionAccessEffect {
     Unchanged,
-    ExpiryUpdated,
+    ExpiryUpdated { expires_at: i64 },
 }
 
 pub(super) fn get_session_for_request(id: &str) -> (Option<Session>, SessionAccessEffect) {
@@ -91,7 +91,12 @@ pub(super) fn get_session_for_request(id: &str) -> (Option<Session>, SessionAcce
                                 }
                                 refreshed.token_expires_at = tokens.expires_in.map(|e| now + e);
                                 refreshed.expires_at = new_expires_at;
-                                return (Some(refreshed), SessionAccessEffect::ExpiryUpdated);
+                                return (
+                                    Some(refreshed),
+                                    SessionAccessEffect::ExpiryUpdated {
+                                        expires_at: new_expires_at,
+                                    },
+                                );
                             }
                             Err(e) => {
                                 eprintln!(
@@ -130,7 +135,9 @@ fn maybe_slide_session(session: &mut Session, config: &AuthConfig) -> SessionAcc
     if session.expires_at > target_expires_at {
         if extend_session_record_expiry(&session.id, target_expires_at).is_ok() {
             session.expires_at = target_expires_at;
-            return SessionAccessEffect::ExpiryUpdated;
+            return SessionAccessEffect::ExpiryUpdated {
+                expires_at: target_expires_at,
+            };
         }
         return SessionAccessEffect::Unchanged;
     }
@@ -150,7 +157,9 @@ fn maybe_slide_session(session: &mut Session, config: &AuthConfig) -> SessionAcc
 
     if extend_session_record_expiry(&session.id, target_expires_at).is_ok() {
         session.expires_at = target_expires_at;
-        SessionAccessEffect::ExpiryUpdated
+        SessionAccessEffect::ExpiryUpdated {
+            expires_at: target_expires_at,
+        }
     } else {
         SessionAccessEffect::Unchanged
     }


### PR DESCRIPTION
## Summary
- finish the remaining Phase 5 work from DD-043
- add auth presets plus preset+override merge to `enable_auth(...)`
- complete the built-in cookie refresh alignment for sliding-session auth-enforced response flows
- update DD-043 and generated docs to reflect completed Phase 5 work

## What changed
- add built-in auth presets:
  - `consumer`
  - `admin`
  - `internal`
  - `strict`
- extend `enable_auth(...)` to accept:
  - providers + options map
  - providers + preset string
  - providers + preset string + overrides map
- preserve override precedence on top of presets
- expose session access effects so auth-enforced response paths can reissue session cookies when sliding expiry updates server-side expiry
- document the new `enable_auth` surface in generated stdlib docs
- update DD-043 Phase 5 checklist/status to mark the phase complete

## Validation
- `cargo fmt`
- `cargo build --release --locked`
- `./target/release/ntnt docs --generate`
- `cargo test --release --locked auth -- --nocapture`

## Notes
Cookie refresh alignment in this phase covers the built-in/auth-enforced response paths (`require_auth`, auth-protect). Pure request-time getters still remain response-less by design.
