### PR TITLE
feat: complete DD-043 auth phase 6 hardening

### DIFF
--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -297,13 +297,17 @@ return complete_auth_challenge(resp, req, map {
 ### Phase 6 — OAuth Hardening and Observability
 **Goal:** Improve security posture and make auth easier to inspect in production.
 
-- [ ] Refresh token rotation when providers issue a new refresh token
-- [ ] Invalidate old refresh token references where feasible
-- [ ] Log refresh token rotation events
-- [ ] Document provider differences clearly
-- [ ] `/auth/health` endpoint (dev-only by default)
-- [ ] Health output shows config state without leaking secrets
-- [ ] Diagnose common issues like redirect mismatch, missing env, wrong store
+- [x] Refresh token rotation when providers issue a new refresh token
+- [x] Invalidate old refresh token references where feasible
+- [x] Log refresh token rotation events
+- [x] Document provider differences clearly
+- [x] `/auth/health` endpoint (dev-only by default)
+- [x] Health output shows config state without leaking secrets
+- [x] Diagnose common issues like redirect mismatch, missing env, wrong store
+
+**Implementation note (2026-04-21 / PR pending):** Phase 6 now preserves provider-specific refresh-token behavior correctly (including rotation only when a provider actually returns a new refresh token), logs rotation events without exposing token material, and adds a built-in `/auth/health` diagnostics route that is dev-only by default and can be explicitly enabled in production.
+
+**Provider differences:** some providers return a fresh refresh token on every refresh, while others omit `refresh_token` unless rotation occurs. `std/auth` now preserves the stored token when providers omit it, replaces the stored token when they rotate it, and surfaces the distinction through safe auth logs and diagnostics rather than pretending all providers behave the same.
 
 **Ships real value:** better production safety and far easier troubleshooting.
 

--- a/design-docs/dd-043-phase-6-plan.md
+++ b/design-docs/dd-043-phase-6-plan.md
@@ -1,0 +1,95 @@
+# DD-043 Phase 6 Implementation Plan
+
+## Scope
+Implement the full Phase 6 slice from DD-043:
+1. Refresh token rotation handling when providers issue a new refresh token
+2. Invalidate old refresh token references where feasible
+3. Log refresh token rotation events
+4. Add `/auth/health` endpoint (dev-only by default)
+5. Health output shows config state without leaking secrets
+6. Diagnose common issues like redirect mismatch, missing env, wrong store
+7. Document provider differences clearly
+
+## Likely code areas
+- `src/stdlib/auth/oauth.rs`
+  - tighten refresh response parsing to preserve whether provider returned a new refresh token vs reused prior token
+- `src/stdlib/auth/sessions.rs`
+  - centralize auto-refresh handling and emit rotation/security logs
+- `src/stdlib/auth/storage.rs`
+  - add a helper to clear/replace stale session rows by refresh-token rotation semantics where backend support allows it
+- `src/stdlib/auth/routes.rs`
+  - implement `/auth/health`
+  - include auth diagnostics payload + dev/prod gating
+- `src/stdlib/auth/guards.rs` or request helpers
+  - exempt `/auth/health` consistently from auth enforcement if needed
+- `src/stdlib/auth.rs`
+  - wire built-in route and any public-facing helpers/docs
+  - add tests near existing auth tests for refresh rotation + health route behavior
+- `docs/STDLIB_REFERENCE.md` / generated docs
+  - regenerated if docstrings or exported behavior text changes
+- `design-docs/dd-043-auth-excellence.md`
+  - mark Phase 6 items complete once shipped
+
+## Design approach
+### Refresh-token rotation semantics
+- Distinguish between:
+  - provider returned a new refresh token (real rotation)
+  - provider omitted refresh token (keep existing one)
+- When a new refresh token is returned, treat it as rotation and overwrite the stored token atomically with the new access token + expiry.
+- "Invalidate old refresh token references where feasible" likely means:
+  - ensure current session storage no longer retains the prior token after update
+  - log rotation occurrence for observability
+  - document that upstream provider invalidation is provider-defined and not always app-enforceable
+- Avoid pretending we can revoke provider-side old tokens unless the provider exposes a revocation endpoint and we already support it.
+
+### Observability / security logging
+- Emit structured-ish stderr logs with stable `[auth]` prefixes for:
+  - refresh success without rotation
+  - refresh success with rotation
+  - refresh failure
+- Keep logs secret-safe: never print token values.
+
+### `/auth/health`
+- Built-in route under `/auth/health`
+- Dev-only by default: in production, return 404/disabled unless explicit config opt-in exists; if no opt-in exists today, implement strict dev-only behavior for this phase.
+- Return JSON or HTML? Prefer JSON map-like HTTP response since this is diagnostics.
+- Include:
+  - auth configured or not
+  - provider names
+  - route URLs
+  - cookie posture (`secure`, same-site, cookie name)
+  - session store backend kind
+  - token storage enabled flag
+  - protected paths count/list (safe)
+  - warnings/diagnostics array for likely misconfigurations:
+    - default/dev session secret in production
+    - missing provider env values / blank client id or secret
+    - likely redirect-uri mismatch hints based on `SITE_URL` / request host / provider callback shape
+    - memory store in production warning
+- Exclude secrets, tokens, raw URLs with embedded credentials.
+
+## Tests
+- Unit tests for refresh response parsing:
+  - new refresh token returned => rotation detected
+  - no refresh token returned => keep old token, no rotation event
+- Session refresh tests across memory/sqlite existing helpers:
+  - expired session auto-refresh updates access token
+  - rotated refresh token replaces stored token
+- Health route tests:
+  - enabled in dev
+  - hidden/disabled in prod
+  - output contains safe config summary and warnings
+  - output does not contain client_secret / session_secret
+- If practical, tests for provider-diagnostics text on missing config
+
+## Risks / review focus
+- Do not break existing refresh behavior for providers that never resend refresh tokens.
+- Keep storage updates aligned across backends; existing `update_session_record_tokens` may already be sufficient if it overwrites refresh token when provided.
+- Avoid leaking secrets in health output or logs.
+- Match existing built-in route patterns instead of inventing a new response shape.
+
+## Self-review notes
+- Existing `refresh_access_token()` currently always returns some refresh token by falling back to the old one. That hides whether rotation happened; fix by preserving provider response distinction.
+- Existing `update_session_record_tokens()` already uses `COALESCE` semantics, which is good for providers that omit refresh tokens.
+- Need to inspect route registration before implementing `/auth/health` to ensure built-in dispatch exists.
+- Need to inspect current tests around auth routes and refresh flows to extend, not duplicate.

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1822,6 +1822,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | Function | Description |
 |----------|-------------|
 | [`auth_callback`](#authcallback) | Handle OAuth callback - exchanges code for tokens, creates session. |
+| [`auth_health`](#authhealth) | Return auth diagnostics for the built-in `/auth/health` route. |
 | [`auth_logout`](#authlogout) | Handle logout - clears the session and redirects. |
 | [`auth_me`](#authme) | Return current user as JSON for SPAs. |
 | [`auth_start`](#authstart) | Handle OAuth login start - redirects to the provider's authorization page. |
@@ -1889,6 +1890,34 @@ get("/auth/{provider}/callback", auth_callback)  // Wire up callback route
 **See also:** `enable_auth`, `auth_start`
 
 *Since v0.3.11*
+
+---
+
+#### `auth_health`
+
+```ntnt
+auth_health(req: Request) -> Response
+```
+
+Return auth diagnostics for the built-in `/auth/health` route.
+
+The response includes safe config state, provider posture, cookie/session settings, and warnings for common auth misconfigurations without leaking secrets. In production, this route is disabled unless `health_endpoint: true` is set.
+
+**Parameters:**
+
+- `req` — The current HTTP request object
+
+**Returns:** JSON response with auth diagnostics
+
+**Examples:**
+
+```ntnt
+get("/auth/health", auth_health)  // Wire up auth diagnostics
+```
+
+**See also:** `enable_auth`, `auth_start`, `auth_callback`
+
+*Since v0.4.9*
 
 ---
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -90,8 +90,8 @@ pub use request_helpers::{
 };
 use request_helpers::{get_host_and_proto, get_user_from_request};
 pub use routes::{
-    handle_auth_callback, handle_auth_index, handle_auth_logout, handle_auth_protect,
-    handle_auth_start,
+    handle_auth_callback, handle_auth_health, handle_auth_index, handle_auth_logout,
+    handle_auth_protect, handle_auth_start,
 };
 use sessions::{
     build_rotated_session, get_session_by_id, migrate_session, update_session_data,
@@ -293,6 +293,7 @@ pub struct AuthConfig {
     pub max_session_ttl: Option<i64>, // Absolute max lifetime from session creation
     pub auth_preset: Option<String>, // Lifecycle/security preset name, if selected
     pub store_tokens: bool,    // Store access/refresh tokens in session
+    pub health_endpoint: bool, // Expose /auth/health diagnostics (dev-only default unless explicitly enabled)
     pub session_secret: String, // Secret for session signing
     pub session_store: SessionStore, // Session storage backend
 }
@@ -315,6 +316,7 @@ impl Default for AuthConfig {
             max_session_ttl: None,
             auth_preset: None,
             store_tokens: false,
+            health_endpoint: false,
             session_secret: DEFAULT_SESSION_SECRET_SENTINEL.to_string(),
             session_store: SessionStore::Memory,
         }
@@ -3736,6 +3738,31 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt auth_health
+    // @module std/auth
+    // @signature auth_health(req: Request) -> Response
+    // Return auth diagnostics for the built-in `/auth/health` route.
+    //
+    // The response includes safe config state, provider posture, cookie/session settings,
+    // and warnings for common auth misconfigurations without leaking secrets.
+    // In production, this route is disabled unless `health_endpoint: true` is set.
+    // @param req The current HTTP request object
+    // @returns JSON response with auth diagnostics
+    // @see_also enable_auth, auth_start, auth_callback
+    // @since v0.4.9
+    // @tags #auth, #observability
+    // @example get("/auth/health", auth_health) ~ "Wire up auth diagnostics"
+    module.insert(
+        "auth_health".to_string(),
+        Value::NativeFunction {
+            name: "auth_health".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| handle_auth_health(args),
+        },
+    );
+
     // @ntnt auth_callback
     // @module std/auth
     // @signature auth_callback(req: Request) -> Response
@@ -6258,6 +6285,198 @@ mod tests {
         assert!(
             matches!(current_session(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "Some")
         );
+    }
+
+    #[test]
+    fn test_refresh_access_token_does_not_force_old_refresh_token_into_response() {
+        let parsed = serde_json::json!({
+            "access_token": "new-access",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        });
+
+        let tokens = TokenResponse {
+            access_token: parsed["access_token"].as_str().unwrap().to_string(),
+            token_type: parsed["token_type"].as_str().unwrap().to_string(),
+            expires_in: parsed["expires_in"].as_i64(),
+            refresh_token: parsed
+                .get("refresh_token")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            id_token: None,
+            scope: None,
+        };
+
+        assert_eq!(tokens.refresh_token, None);
+    }
+
+    #[test]
+    fn test_update_session_record_tokens_preserves_refresh_token_when_provider_omits_one() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let now = chrono::Utc::now().timestamp();
+        let session = Session {
+            id: "session-refresh-preserve".to_string(),
+            user_id: "user-refresh-preserve".to_string(),
+            provider: "local".to_string(),
+            email: None,
+            name: None,
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-refresh-preserve".to_string(),
+            access_token: Some("access-old".to_string()),
+            refresh_token: Some("refresh-old".to_string()),
+            token_expires_at: Some(now + 60),
+            created_at: now,
+            expires_at: now + 600,
+        };
+        store_session_record(&session).expect("session should store");
+
+        update_session_record_tokens(
+            &session.id,
+            &TokenResponse {
+                access_token: "access-new".to_string(),
+                token_type: "Bearer".to_string(),
+                expires_in: Some(120),
+                refresh_token: None,
+                id_token: None,
+                scope: None,
+            },
+            now,
+        )
+        .expect("token update should succeed");
+
+        let updated = get_session_record(&session.id)
+            .expect("lookup should succeed")
+            .expect("session should exist");
+        assert_eq!(updated.access_token.as_deref(), Some("access-new"));
+        assert_eq!(updated.refresh_token.as_deref(), Some("refresh-old"));
+    }
+
+    #[test]
+    fn test_handle_auth_health_reports_safe_diagnostics_in_dev() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        let previous_env = std::env::var("NTNT_ENV").ok();
+        let previous_site = std::env::var("SITE_URL").ok();
+        unsafe {
+            std::env::remove_var("SITE_URL");
+            std::env::set_var("NTNT_ENV", "development");
+        }
+
+        init_auth(AuthConfig {
+            providers: vec![ProviderConfig {
+                name: "google".to_string(),
+                client_id: "client-id".to_string(),
+                client_secret: "super-secret".to_string(),
+                authorize_url: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
+                token_url: "https://oauth2.googleapis.com/token".to_string(),
+                userinfo_url: "https://openidconnect.googleapis.com/v1/userinfo".to_string(),
+                supports_oidc: true,
+                use_pkce: true,
+                ..ProviderConfig::default()
+            }],
+            protected_paths: vec!["/admin/*".to_string()],
+            store_tokens: true,
+            session_secret: "dev-secret-value".to_string(),
+            ..AuthConfig::default()
+        });
+
+        let req = Value::Map(HashMap::from([(
+            "headers".to_string(),
+            Value::Map(HashMap::from([(
+                "host".to_string(),
+                Value::String("example.com".to_string()),
+            )])),
+        )]));
+
+        let response = handle_auth_health(&[req]).expect("health should succeed");
+        let body = match response {
+            Value::Map(map) => match map.get("body") {
+                Some(Value::String(body)) => body.clone(),
+                other => panic!("expected body string, got {:?}", other),
+            },
+            other => panic!("expected response map, got {:?}", other),
+        };
+
+        assert!(body.contains("\"providers\""));
+        assert!(body.contains("\"google\""));
+        assert!(body.contains("\"warnings\""));
+        assert!(body.contains("SITE_URL is not set"));
+        assert!(!body.contains("super-secret"));
+        assert!(!body.contains("dev-secret-value"));
+
+        match previous_env {
+            Some(val) => unsafe { std::env::set_var("NTNT_ENV", val) },
+            None => unsafe { std::env::remove_var("NTNT_ENV") },
+        }
+        match previous_site {
+            Some(val) => unsafe { std::env::set_var("SITE_URL", val) },
+            None => unsafe { std::env::remove_var("SITE_URL") },
+        }
+    }
+
+    #[test]
+    fn test_handle_auth_health_disabled_in_production_without_opt_in() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        let previous_env = std::env::var("NTNT_ENV").ok();
+        unsafe {
+            std::env::set_var("NTNT_ENV", "production");
+        }
+
+        init_auth(AuthConfig {
+            session_secret: "prod-secret-value".to_string(),
+            ..AuthConfig::default()
+        });
+
+        let response = handle_auth_health(&[]).expect("health should return response");
+        match response {
+            Value::Map(map) => {
+                assert!(matches!(map.get("status"), Some(Value::Int(404))));
+            }
+            other => panic!("expected response map, got {:?}", other),
+        }
+
+        match previous_env {
+            Some(val) => unsafe { std::env::set_var("NTNT_ENV", val) },
+            None => unsafe { std::env::remove_var("NTNT_ENV") },
+        }
+    }
+
+    #[test]
+    fn test_handle_auth_health_enabled_in_production_with_opt_in() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        let previous_env = std::env::var("NTNT_ENV").ok();
+        unsafe {
+            std::env::set_var("NTNT_ENV", "production");
+        }
+
+        init_auth(AuthConfig {
+            health_endpoint: true,
+            session_secret: "prod-secret-value".to_string(),
+            session_store: SessionStore::Memory,
+            ..AuthConfig::default()
+        });
+
+        let response = handle_auth_health(&[]).expect("health should succeed");
+        let body = match response {
+            Value::Map(map) => match map.get("body") {
+                Some(Value::String(body)) => body.clone(),
+                other => panic!("expected body string, got {:?}", other),
+            },
+            other => panic!("expected response map, got {:?}", other),
+        };
+        assert!(body.contains("Production is using in-memory session storage"));
+
+        match previous_env {
+            Some(val) => unsafe { std::env::set_var("NTNT_ENV", val) },
+            None => unsafe { std::env::remove_var("NTNT_ENV") },
+        }
     }
 
     #[test]

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -54,6 +54,7 @@ pub(super) fn auth_option_suggestion(key: &str) -> Option<String> {
         "cookie_secure",
         "session_store",
         "store_tokens",
+        "health_endpoint",
         "protected_paths",
     ];
 

--- a/src/stdlib/auth/guards.rs
+++ b/src/stdlib/auth/guards.rs
@@ -321,6 +321,47 @@ pub fn enforce_auth_for_request(
                         })
                     }
                 }
+                SessionAccessEffect::TokensRefreshed {
+                    expires_at,
+                    refresh_rotated,
+                } => {
+                    let method = if let Value::Map(req_map) = request {
+                        req_map.get("method").and_then(|v| match v {
+                            Value::String(s) => Some(s.to_ascii_uppercase()),
+                            _ => None,
+                        })
+                    } else {
+                        None
+                    }
+                    .unwrap_or_else(|| "GET".to_string());
+
+                    let safe_navigation =
+                        (method == "GET" || method == "HEAD") && !request_prefers_api(request);
+
+                    if !safe_navigation {
+                        None
+                    } else {
+                        let now = chrono::Utc::now().timestamp();
+                        let cookie = get_auth_config().and_then(|config| {
+                            build_signed_session_cookie_with_max_age(
+                                &config,
+                                &session_id,
+                                expires_at - now,
+                                None,
+                            )
+                            .ok()
+                        });
+
+                        if refresh_rotated {
+                            eprintln!(
+                                "[auth] Refreshed session cookie after refresh-token rotation for session {}",
+                                &session_id[..8]
+                            );
+                        }
+
+                        cookie
+                    }
+                }
                 SessionAccessEffect::Unchanged => None,
             };
             return Ok(refreshed_cookie);

--- a/src/stdlib/auth/oauth.rs
+++ b/src/stdlib/auth/oauth.rs
@@ -454,8 +454,7 @@ pub fn refresh_access_token(
         refresh_token: json
             .get("refresh_token")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .or_else(|| Some(refresh_token.to_string())), // Keep old refresh token if not returned
+            .map(|s| s.to_string()),
         id_token: json
             .get("id_token")
             .and_then(|v| v.as_str())

--- a/src/stdlib/auth/routes.rs
+++ b/src/stdlib/auth/routes.rs
@@ -393,7 +393,7 @@ fn auth_health_enabled(config: &AuthConfig) -> bool {
 fn sanitize_session_store_label(store: &SessionStore) -> String {
     match store {
         SessionStore::Memory => "memory".to_string(),
-        SessionStore::Sqlite(path) => format!("sqlite:{}", path),
+        SessionStore::Sqlite(_) => "sqlite".to_string(),
         SessionStore::Postgres(_) => "postgres".to_string(),
         SessionStore::Redis(url) => {
             if url.starts_with("valkey://") {
@@ -423,6 +423,14 @@ fn auth_health_warnings(config: &AuthConfig, request: Option<&Value>) -> Vec<Str
         warnings.push("No OAuth providers configured.".to_string());
     }
 
+    let site_url_missing = std::env::var("SITE_URL").is_err();
+    let callback_example = request.map(get_host_and_proto).and_then(|(host, proto)| {
+        config
+            .providers
+            .first()
+            .map(|provider| format!("{}://{}/auth/{}/callback", proto, host, provider.name))
+    });
+
     for provider in &config.providers {
         if provider.client_id.trim().is_empty() {
             warnings.push(format!(
@@ -436,18 +444,14 @@ fn auth_health_warnings(config: &AuthConfig, request: Option<&Value>) -> Vec<Str
                 provider.name
             ));
         }
+    }
 
-        let callback_host = request
-            .map(get_host_and_proto)
-            .map(|(host, proto)| format!("{}://{}/auth/{}/callback", proto, host, provider.name));
-        if std::env::var("SITE_URL").is_err() {
-            if let Some(callback) = callback_host {
-                warnings.push(format!(
-                    "SITE_URL is not set; OAuth callback URLs currently depend on request host headers (example callback: {}).",
-                    callback
-                ));
-                break;
-            }
+    if site_url_missing {
+        if let Some(callback) = callback_example {
+            warnings.push(format!(
+                "SITE_URL is not set; OAuth callback URLs currently depend on request host headers (example callback: {}).",
+                callback
+            ));
         }
     }
 

--- a/src/stdlib/auth/routes.rs
+++ b/src/stdlib/auth/routes.rs
@@ -380,6 +380,192 @@ pub fn handle_auth_callback(args: &[Value]) -> Result<Value> {
     Ok(html_response(&html))
 }
 
+fn auth_health_enabled(config: &AuthConfig) -> bool {
+    if config.health_endpoint {
+        return true;
+    }
+
+    std::env::var("NTNT_ENV")
+        .map(|v| v != "production" && v != "prod")
+        .unwrap_or(true)
+}
+
+fn sanitize_session_store_label(store: &SessionStore) -> String {
+    match store {
+        SessionStore::Memory => "memory".to_string(),
+        SessionStore::Sqlite(path) => format!("sqlite:{}", path),
+        SessionStore::Postgres(_) => "postgres".to_string(),
+        SessionStore::Redis(url) => {
+            if url.starts_with("valkey://") {
+                "valkey".to_string()
+            } else {
+                "redis".to_string()
+            }
+        }
+    }
+}
+
+fn auth_health_warnings(config: &AuthConfig, request: Option<&Value>) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let is_prod = std::env::var("NTNT_ENV")
+        .map(|v| v == "production" || v == "prod")
+        .unwrap_or(false);
+
+    if matches!(config.session_store, SessionStore::Memory) && is_prod {
+        warnings.push("Production is using in-memory session storage; sessions will be lost on restart and are not shared across instances.".to_string());
+    }
+
+    if is_prod && config.session_secret == DEFAULT_SESSION_SECRET_SENTINEL {
+        warnings.push("Production is using the default session secret sentinel; auth should fail closed before this is reachable.".to_string());
+    }
+
+    if config.providers.is_empty() {
+        warnings.push("No OAuth providers configured.".to_string());
+    }
+
+    for provider in &config.providers {
+        if provider.client_id.trim().is_empty() {
+            warnings.push(format!(
+                "Provider '{}' is missing client_id.",
+                provider.name
+            ));
+        }
+        if provider.client_secret.trim().is_empty() {
+            warnings.push(format!(
+                "Provider '{}' is missing client_secret.",
+                provider.name
+            ));
+        }
+
+        let callback_host = request
+            .map(get_host_and_proto)
+            .map(|(host, proto)| format!("{}://{}/auth/{}/callback", proto, host, provider.name));
+        if std::env::var("SITE_URL").is_err() {
+            if let Some(callback) = callback_host {
+                warnings.push(format!(
+                    "SITE_URL is not set; OAuth callback URLs currently depend on request host headers (example callback: {}).",
+                    callback
+                ));
+                break;
+            }
+        }
+    }
+
+    warnings
+}
+
+pub fn handle_auth_health(args: &[Value]) -> Result<Value> {
+    let config = get_auth_config()
+        .ok_or_else(|| IntentError::runtime_error("[auth] Auth not configured".to_string()))?;
+
+    if !auth_health_enabled(&config) {
+        return Ok(crate::stdlib::http_server::create_error_response(
+            404,
+            "Auth health endpoint is disabled in production.",
+        ));
+    }
+
+    let request = args.first();
+    let mut response = HashMap::new();
+    response.insert("ok".to_string(), serde_json::Value::Bool(true));
+    response.insert(
+        "environment".to_string(),
+        serde_json::Value::String(
+            std::env::var("NTNT_ENV").unwrap_or_else(|_| "development".to_string()),
+        ),
+    );
+    response.insert(
+        "health_endpoint".to_string(),
+        serde_json::Value::Bool(config.health_endpoint),
+    );
+    response.insert(
+        "providers".to_string(),
+        serde_json::Value::Array(
+            config
+                .providers
+                .iter()
+                .map(|provider| {
+                    serde_json::json!({
+                        "name": provider.name,
+                        "supports_oidc": provider.supports_oidc,
+                        "use_pkce": provider.use_pkce,
+                        "has_client_id": !provider.client_id.trim().is_empty(),
+                        "has_client_secret": !provider.client_secret.trim().is_empty(),
+                        "authorize_url": provider.authorize_url,
+                        "token_url": provider.token_url,
+                    })
+                })
+                .collect(),
+        ),
+    );
+    response.insert(
+        "routes".to_string(),
+        serde_json::json!({
+            "index": "/auth",
+            "start": "/auth/{provider}",
+            "callback": "/auth/{provider}/callback",
+            "logout": "/auth/logout",
+            "health": "/auth/health",
+            "success_url": config.success_url,
+            "failure_url": config.failure_url,
+            "logout_url": config.logout_url,
+        }),
+    );
+    response.insert(
+        "cookie".to_string(),
+        serde_json::json!({
+            "name": config.cookie_name,
+            "secure": config.cookie_secure,
+            "same_site": config.cookie_same_site,
+            "http_only": true,
+        }),
+    );
+    response.insert(
+        "session".to_string(),
+        serde_json::json!({
+            "store": sanitize_session_store_label(&config.session_store),
+            "store_tokens": config.store_tokens,
+            "session_ttl": config.session_ttl,
+            "refresh_ttl": config.refresh_ttl,
+            "sliding_sessions": config.sliding_sessions,
+            "refresh_throttle": config.refresh_throttle,
+            "max_session_ttl": config.max_session_ttl,
+            "preset": config.auth_preset,
+        }),
+    );
+    response.insert(
+        "protected_paths".to_string(),
+        serde_json::Value::Array(
+            get_protected_paths()
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect(),
+        ),
+    );
+    if let Some(req) = request {
+        let (host, proto) = get_host_and_proto(req);
+        response.insert(
+            "request_context".to_string(),
+            serde_json::json!({
+                "host": host,
+                "proto": proto,
+            }),
+        );
+    }
+    response.insert(
+        "warnings".to_string(),
+        serde_json::Value::Array(
+            auth_health_warnings(&config, request)
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect(),
+        ),
+    );
+
+    let value_map = json_map_to_value_map(&response.into_iter().collect());
+    Ok(json_response(Value::Map(value_map), 200))
+}
+
 pub fn handle_auth_logout(args: &[Value]) -> Result<Value> {
     let req = &args[0];
     let config = get_auth_config().unwrap_or_default();

--- a/src/stdlib/auth/sessions.rs
+++ b/src/stdlib/auth/sessions.rs
@@ -31,10 +31,16 @@ pub fn store_session(session: Session) {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum SessionAccessEffect {
     Unchanged,
-    ExpiryUpdated { expires_at: i64 },
+    ExpiryUpdated {
+        expires_at: i64,
+    },
+    TokensRefreshed {
+        expires_at: i64,
+        refresh_rotated: bool,
+    },
 }
 
 pub(super) fn get_session_for_request(id: &str) -> (Option<Session>, SessionAccessEffect) {
@@ -76,25 +82,39 @@ pub(super) fn get_session_for_request(id: &str) -> (Option<Session>, SessionAcce
                                     return (None, SessionAccessEffect::Unchanged);
                                 }
 
+                                let rotated_refresh_token =
+                                    tokens.refresh_token.as_ref().is_some_and(|new_rt| {
+                                        expired.refresh_token.as_deref() != Some(new_rt.as_str())
+                                    });
+
                                 update_session_tokens(&expired.id, &tokens);
                                 extend_session_expiry(&expired.id, new_expires_at);
 
-                                eprintln!(
-                                    "[auth] Session {} auto-refreshed via refresh token",
-                                    &expired.id[..8]
-                                );
+                                if rotated_refresh_token {
+                                    eprintln!(
+                                        "[auth] Session {} auto-refreshed and rotated refresh token",
+                                        &expired.id[..8]
+                                    );
+                                } else {
+                                    eprintln!(
+                                        "[auth] Session {} auto-refreshed via refresh token",
+                                        &expired.id[..8]
+                                    );
+                                }
 
                                 let mut refreshed = expired;
                                 refreshed.access_token = Some(tokens.access_token);
-                                if let Some(rt) = tokens.refresh_token {
-                                    refreshed.refresh_token = Some(rt);
-                                }
+                                refreshed.refresh_token = tokens
+                                    .refresh_token
+                                    .clone()
+                                    .or_else(|| refreshed.refresh_token.clone());
                                 refreshed.token_expires_at = tokens.expires_in.map(|e| now + e);
                                 refreshed.expires_at = new_expires_at;
                                 return (
                                     Some(refreshed),
-                                    SessionAccessEffect::ExpiryUpdated {
+                                    SessionAccessEffect::TokensRefreshed {
                                         expires_at: new_expires_at,
+                                        refresh_rotated: rotated_refresh_token,
                                     },
                                 );
                             }


### PR DESCRIPTION
## Summary
- complete DD-043 Phase 6 OAuth hardening + observability
- preserve provider-specific refresh-token rotation semantics instead of pretending omitted refresh tokens are rotations
- add built-in `auth_health` diagnostics with dev-only-by-default exposure and explicit production opt-in
- update DD-043 and generated stdlib docs for the new observability surface

## What changed
- `refresh_access_token()` now preserves whether the provider actually returned a new refresh token
- session auto-refresh logs safe rotation events and refreshes cookie state for browser-safe navigations
- added `health_endpoint` auth config option plus `/auth/health` diagnostics output
- health diagnostics expose safe config posture, store/cookie/session settings, provider readiness, and common warning hints without leaking secrets
- documented provider refresh-token behavior differences in DD-043

## Tests
- `cargo fmt`
- `cargo build --profile dev-release`
- `cargo test --lib`
- `cargo build --release`
- `cargo test --release`
- `./target/release/ntnt docs --generate`
- `./target/release/ntnt validate examples/`
- `./target/release/ntnt lint examples/`

## Notes
- The prescribed `./target/release/ntnt lint examples/*.tnt` command no longer matches current CLI arity; I ran `./target/release/ntnt lint examples/` instead, which succeeded with the repo's pre-existing example warnings/suggestions and no errors.
- Codex CLI was available for review loops in principle, but the plan-review invocation failed immediately due to quota exhaustion, so this PR used an explicit manual review pass instead.
