### PR TITLE
auth: complete DD-043 Phase 8 session metadata plumbing

### DIFF
--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -233,6 +233,9 @@ pub struct Session {
     pub access_token: Option<String>,
     pub refresh_token: Option<String>,
     pub token_expires_at: Option<i64>,
+    pub device_name: Option<String>,
+    pub user_agent_hash: Option<String>,
+    pub last_ip_hash: Option<String>,
     pub created_at: i64,
     pub expires_at: i64,
 }
@@ -257,6 +260,10 @@ pub struct OAuthState {
     pub pkce_verifier: Option<String>, // PKCE code verifier
     pub provider: String,
     pub redirect_url: String,
+    pub remember_me: bool,
+    pub device_name: Option<String>,
+    pub user_agent_hash: Option<String>,
+    pub ip_hash: Option<String>,
     pub created_at: i64,
 }
 
@@ -423,6 +430,7 @@ pub struct SessionInfo {
     pub id: String,
     pub user_id: String,
     pub provider: String,
+    pub device_name: Option<String>,
     pub created_at: i64,
     pub expires_at: i64,
     pub is_current: bool,
@@ -567,6 +575,7 @@ impl InMemoryStore {
                 id: s.id.clone(),
                 user_id: s.user_id.clone(),
                 provider: s.provider.clone(),
+                device_name: s.device_name.clone(),
                 created_at: s.created_at,
                 expires_at: s.expires_at,
                 is_current: current_session_id.map(|c| c == s.id).unwrap_or(false),
@@ -3375,6 +3384,10 @@ pub fn init() -> HashMap<String, Value> {
                     &redirect_uri,
                     nonce.as_deref(),
                     pkce_verifier.as_deref(),
+                    false,
+                    None,
+                    None,
+                    None,
                 );
 
                 // Generate the authorization URL

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -263,7 +263,7 @@ pub struct OAuthState {
     pub remember_me: bool,
     pub device_name: Option<String>,
     pub user_agent_hash: Option<String>,
-    pub ip_hash: Option<String>,
+    pub last_ip_hash: Option<String>,
     pub created_at: i64,
 }
 
@@ -4402,7 +4402,7 @@ mod tests {
             remember_me: false,
             device_name: Some(format!("{} Browser", label)),
             user_agent_hash: Some(format!("ua-{}-oauth", label)),
-            ip_hash: Some(format!("ip-{}-oauth", label)),
+            last_ip_hash: Some(format!("ip-{}-oauth", label)),
             created_at: now,
         };
         store_oauth_state_record(&oauth_state)
@@ -4433,7 +4433,7 @@ mod tests {
             remember_me: false,
             device_name: None,
             user_agent_hash: None,
-            ip_hash: None,
+            last_ip_hash: None,
             created_at: now - OAUTH_STATE_TTL - 100,
         };
         store_oauth_state_record(&expired_oauth_state).unwrap_or_else(|e| {
@@ -4987,7 +4987,7 @@ mod tests {
             remember_me: false,
             device_name: None,
             user_agent_hash: None,
-            ip_hash: None,
+            last_ip_hash: None,
             created_at: now,
         });
         *SQLITE_CONN.lock().unwrap() = None;
@@ -5008,7 +5008,7 @@ mod tests {
             remember_me: false,
             device_name: None,
             user_agent_hash: None,
-            ip_hash: None,
+            last_ip_hash: None,
             created_at: now - 700,
         });
         *SQLITE_CONN.lock().unwrap() = None;
@@ -5071,7 +5071,7 @@ mod tests {
             remember_me: false,
             device_name: None,
             user_agent_hash: None,
-            ip_hash: None,
+            last_ip_hash: None,
             created_at: now - 700,
         });
         store.exchange_tokens.insert(
@@ -5290,7 +5290,7 @@ mod tests {
             remember_me: true,
             device_name: Some("SQLite Browser".to_string()),
             user_agent_hash: Some("ua-sqlite-oauth".to_string()),
-            ip_hash: Some("ip-sqlite-oauth".to_string()),
+            last_ip_hash: Some("ip-sqlite-oauth".to_string()),
             created_at: now,
         };
         store_oauth_state_record(&oauth_state).expect("sqlite oauth state store should succeed");
@@ -5310,7 +5310,7 @@ mod tests {
             remember_me: false,
             device_name: None,
             user_agent_hash: None,
-            ip_hash: None,
+            last_ip_hash: None,
             created_at: now - 700,
         };
         store_oauth_state_record(&expired_oauth_state)

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -4260,6 +4260,9 @@ mod tests {
             access_token: Some(format!("access-{}-1", label)),
             refresh_token: Some(format!("refresh-{}-1", label)),
             token_expires_at: Some(now + 60),
+            device_name: Some("SQLite Mac".to_string()),
+            user_agent_hash: Some("ua-sqlite-1".to_string()),
+            last_ip_hash: Some("ip-sqlite-1".to_string()),
             created_at: now,
             expires_at: now + 300,
         };
@@ -4317,6 +4320,9 @@ mod tests {
             access_token: Some(format!("access-{}-refreshable", label)),
             refresh_token: Some(format!("refresh-{}-refreshable", label)),
             token_expires_at: Some(now - 30),
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 30,
             expires_at: now - 5,
         };
@@ -4393,6 +4399,10 @@ mod tests {
             pkce_verifier: Some(format!("pkce-{}", label)),
             provider: "github".to_string(),
             redirect_url: "/auth/callback".to_string(),
+            remember_me: false,
+            device_name: Some(format!("{} Browser", label)),
+            user_agent_hash: Some(format!("ua-{}-oauth", label)),
+            ip_hash: Some(format!("ip-{}-oauth", label)),
             created_at: now,
         };
         store_oauth_state_record(&oauth_state)
@@ -4420,6 +4430,10 @@ mod tests {
             pkce_verifier: None,
             provider: "github".to_string(),
             redirect_url: "/auth/callback".to_string(),
+            remember_me: false,
+            device_name: None,
+            user_agent_hash: None,
+            ip_hash: None,
             created_at: now - OAUTH_STATE_TTL - 100,
         };
         store_oauth_state_record(&expired_oauth_state).unwrap_or_else(|e| {
@@ -4911,6 +4925,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now,
             expires_at: now + 300,
         };
@@ -4943,6 +4960,9 @@ mod tests {
             access_token: Some("access-memory-refresh".to_string()),
             refresh_token: Some("refresh-memory-refresh".to_string()),
             token_expires_at: Some(now - 30),
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 30,
             expires_at: now - 5,
         });
@@ -4964,6 +4984,10 @@ mod tests {
             pkce_verifier: None,
             provider: "github".to_string(),
             redirect_url: "/auth/callback".to_string(),
+            remember_me: false,
+            device_name: None,
+            user_agent_hash: None,
+            ip_hash: None,
             created_at: now,
         });
         *SQLITE_CONN.lock().unwrap() = None;
@@ -4981,6 +5005,10 @@ mod tests {
             pkce_verifier: None,
             provider: "github".to_string(),
             redirect_url: "/auth/callback".to_string(),
+            remember_me: false,
+            device_name: None,
+            user_agent_hash: None,
+            ip_hash: None,
             created_at: now - 700,
         });
         *SQLITE_CONN.lock().unwrap() = None;
@@ -5040,6 +5068,10 @@ mod tests {
             pkce_verifier: None,
             provider: "github".to_string(),
             redirect_url: "/auth/callback".to_string(),
+            remember_me: false,
+            device_name: None,
+            user_agent_hash: None,
+            ip_hash: None,
             created_at: now - 700,
         });
         store.exchange_tokens.insert(
@@ -5128,6 +5160,9 @@ mod tests {
             access_token: Some("access-sqlite-1".to_string()),
             refresh_token: Some("refresh-sqlite-1".to_string()),
             token_expires_at: Some(now + 60),
+            device_name: Some("SQLite Mac".to_string()),
+            user_agent_hash: Some("ua-sqlite-1".to_string()),
+            last_ip_hash: Some("ip-sqlite-1".to_string()),
             created_at: now,
             expires_at: now + 300,
         };
@@ -5184,6 +5219,9 @@ mod tests {
             access_token: Some("access-refreshable".to_string()),
             refresh_token: Some("refresh-refreshable".to_string()),
             token_expires_at: Some(now - 30),
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 30,
             expires_at: now - 5,
         };
@@ -5249,6 +5287,10 @@ mod tests {
             pkce_verifier: Some("pkce-sqlite".to_string()),
             provider: "github".to_string(),
             redirect_url: "/auth/callback".to_string(),
+            remember_me: true,
+            device_name: Some("SQLite Browser".to_string()),
+            user_agent_hash: Some("ua-sqlite-oauth".to_string()),
+            ip_hash: Some("ip-sqlite-oauth".to_string()),
             created_at: now,
         };
         store_oauth_state_record(&oauth_state).expect("sqlite oauth state store should succeed");
@@ -5265,6 +5307,10 @@ mod tests {
             pkce_verifier: None,
             provider: "github".to_string(),
             redirect_url: "/auth/callback".to_string(),
+            remember_me: false,
+            device_name: None,
+            user_agent_hash: None,
+            ip_hash: None,
             created_at: now - 700,
         };
         store_oauth_state_record(&expired_oauth_state)
@@ -5849,6 +5895,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 600,
             expires_at: now + 60,
         };
@@ -5893,6 +5942,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 1200,
             expires_at: now + 30,
         };
@@ -5926,6 +5978,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 1200,
             expires_at: now + 7200,
         };
@@ -5959,6 +6014,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 3600,
             expires_at: now + 60,
         };
@@ -6062,6 +6120,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 60,
             expires_at: now + 1200,
         };
@@ -6468,6 +6529,9 @@ mod tests {
             access_token: Some("access-old".to_string()),
             refresh_token: Some("refresh-old".to_string()),
             token_expires_at: Some(now + 60),
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now,
             expires_at: now + 600,
         };
@@ -6946,6 +7010,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 600,
             expires_at: now + 60,
         });
@@ -6998,6 +7065,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 600,
             expires_at: now + 60,
         });
@@ -7047,6 +7117,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 600,
             expires_at: now + 60,
         });
@@ -7110,6 +7183,9 @@ mod tests {
             access_token: None,
             refresh_token: None,
             token_expires_at: None,
+            device_name: None,
+            user_agent_hash: None,
+            last_ip_hash: None,
             created_at: now - 600,
             expires_at: now + 60,
         });

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -186,12 +186,22 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
             access_token TEXT,
             refresh_token TEXT,
             token_expires_at INTEGER,
+            device_name TEXT,
+            user_agent_hash TEXT,
+            last_ip_hash TEXT,
             created_at INTEGER NOT NULL,
             expires_at INTEGER NOT NULL
         )",
         [],
     )
     .map_err(|e| format!("Failed to create sessions table: {}", e))?;
+
+    let _ = conn.execute("ALTER TABLE auth_sessions ADD COLUMN device_name TEXT", []);
+    let _ = conn.execute(
+        "ALTER TABLE auth_sessions ADD COLUMN user_agent_hash TEXT",
+        [],
+    );
+    let _ = conn.execute("ALTER TABLE auth_sessions ADD COLUMN last_ip_hash TEXT", []);
 
     // Index for cleanup queries
     conn.execute(
@@ -271,12 +281,34 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
             access_token TEXT,
             refresh_token TEXT,
             token_expires_at BIGINT,
+            device_name TEXT,
+            user_agent_hash TEXT,
+            last_ip_hash TEXT,
             created_at BIGINT NOT NULL,
             expires_at BIGINT NOT NULL
         )",
             &[],
         )
         .map_err(|e| format!("Failed to create sessions table: {}", e))?;
+
+    client
+        .execute(
+            "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS device_name TEXT",
+            &[],
+        )
+        .ok();
+    client
+        .execute(
+            "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS user_agent_hash TEXT",
+            &[],
+        )
+        .ok();
+    client
+        .execute(
+            "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS last_ip_hash TEXT",
+            &[],
+        )
+        .ok();
 
     // Index for cleanup queries
     client

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -218,11 +218,29 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
             pkce_verifier TEXT,
             provider TEXT NOT NULL,
             redirect_url TEXT NOT NULL,
+            remember_me INTEGER NOT NULL DEFAULT 0,
+            device_name TEXT,
+            user_agent_hash TEXT,
+            ip_hash TEXT,
             created_at INTEGER NOT NULL
         )",
         [],
     )
     .map_err(|e| format!("Failed to create oauth_states table: {}", e))?;
+
+    let _ = conn.execute(
+        "ALTER TABLE auth_oauth_states ADD COLUMN remember_me INTEGER NOT NULL DEFAULT 0",
+        [],
+    );
+    let _ = conn.execute(
+        "ALTER TABLE auth_oauth_states ADD COLUMN device_name TEXT",
+        [],
+    );
+    let _ = conn.execute(
+        "ALTER TABLE auth_oauth_states ADD COLUMN user_agent_hash TEXT",
+        [],
+    );
+    let _ = conn.execute("ALTER TABLE auth_oauth_states ADD COLUMN ip_hash TEXT", []);
 
     // Exchange token table for Safari ITP cookie workaround
     conn.execute(
@@ -327,11 +345,40 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
             pkce_verifier TEXT,
             provider TEXT NOT NULL,
             redirect_url TEXT NOT NULL,
+            remember_me BOOLEAN NOT NULL DEFAULT FALSE,
+            device_name TEXT,
+            user_agent_hash TEXT,
+            ip_hash TEXT,
             created_at BIGINT NOT NULL
         )",
             &[],
         )
         .map_err(|e| format!("Failed to create oauth_states table: {}", e))?;
+
+    client
+        .execute(
+            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS remember_me BOOLEAN NOT NULL DEFAULT FALSE",
+            &[],
+        )
+        .ok();
+    client
+        .execute(
+            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS device_name TEXT",
+            &[],
+        )
+        .ok();
+    client
+        .execute(
+            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS user_agent_hash TEXT",
+            &[],
+        )
+        .ok();
+    client
+        .execute(
+            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS ip_hash TEXT",
+            &[],
+        )
+        .ok();
 
     // Exchange token table for Safari ITP cookie workaround
     client

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -221,7 +221,7 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
             remember_me INTEGER NOT NULL DEFAULT 0,
             device_name TEXT,
             user_agent_hash TEXT,
-            ip_hash TEXT,
+            last_ip_hash TEXT,
             created_at INTEGER NOT NULL
         )",
         [],
@@ -240,7 +240,10 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
         "ALTER TABLE auth_oauth_states ADD COLUMN user_agent_hash TEXT",
         [],
     );
-    let _ = conn.execute("ALTER TABLE auth_oauth_states ADD COLUMN ip_hash TEXT", []);
+    let _ = conn.execute(
+        "ALTER TABLE auth_oauth_states ADD COLUMN last_ip_hash TEXT",
+        [],
+    );
 
     // Exchange token table for Safari ITP cookie workaround
     conn.execute(
@@ -348,7 +351,7 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
             remember_me BOOLEAN NOT NULL DEFAULT FALSE,
             device_name TEXT,
             user_agent_hash TEXT,
-            ip_hash TEXT,
+            last_ip_hash TEXT,
             created_at BIGINT NOT NULL
         )",
             &[],
@@ -375,7 +378,7 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
         .ok();
     client
         .execute(
-            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS ip_hash TEXT",
+            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS last_ip_hash TEXT",
             &[],
         )
         .ok();

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -167,7 +167,35 @@ pub fn init_auth(config: AuthConfig) {
     }
 }
 
-/// Initialize SQLite session storage
+fn ignore_duplicate_column_sqlite(
+    result: rusqlite::Result<usize>,
+) -> std::result::Result<(), String> {
+    match result {
+        Ok(_) => Ok(()),
+        Err(rusqlite::Error::SqliteFailure(err, msg))
+            if err.extended_code == rusqlite::ffi::SQLITE_ERROR
+                && msg
+                    .as_deref()
+                    .unwrap_or("")
+                    .contains("duplicate column name") =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+fn run_postgres_migration(
+    client: &mut postgres::Client,
+    sql: &str,
+) -> std::result::Result<(), String> {
+    client
+        .execute(sql, &[])
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+// Initialize SQLite session storage
 fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     let conn =
         rusqlite::Connection::open(path).map_err(|e| format!("Failed to open SQLite: {}", e))?;
@@ -196,12 +224,16 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     )
     .map_err(|e| format!("Failed to create sessions table: {}", e))?;
 
-    let _ = conn.execute("ALTER TABLE auth_sessions ADD COLUMN device_name TEXT", []);
-    let _ = conn.execute(
+    ignore_duplicate_column_sqlite(
+        conn.execute("ALTER TABLE auth_sessions ADD COLUMN device_name TEXT", []),
+    )?;
+    ignore_duplicate_column_sqlite(conn.execute(
         "ALTER TABLE auth_sessions ADD COLUMN user_agent_hash TEXT",
         [],
-    );
-    let _ = conn.execute("ALTER TABLE auth_sessions ADD COLUMN last_ip_hash TEXT", []);
+    ))?;
+    ignore_duplicate_column_sqlite(
+        conn.execute("ALTER TABLE auth_sessions ADD COLUMN last_ip_hash TEXT", []),
+    )?;
 
     // Index for cleanup queries
     conn.execute(
@@ -228,22 +260,22 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     )
     .map_err(|e| format!("Failed to create oauth_states table: {}", e))?;
 
-    let _ = conn.execute(
+    ignore_duplicate_column_sqlite(conn.execute(
         "ALTER TABLE auth_oauth_states ADD COLUMN remember_me INTEGER NOT NULL DEFAULT 0",
         [],
-    );
-    let _ = conn.execute(
+    ))?;
+    ignore_duplicate_column_sqlite(conn.execute(
         "ALTER TABLE auth_oauth_states ADD COLUMN device_name TEXT",
         [],
-    );
-    let _ = conn.execute(
+    ))?;
+    ignore_duplicate_column_sqlite(conn.execute(
         "ALTER TABLE auth_oauth_states ADD COLUMN user_agent_hash TEXT",
         [],
-    );
-    let _ = conn.execute(
+    ))?;
+    ignore_duplicate_column_sqlite(conn.execute(
         "ALTER TABLE auth_oauth_states ADD COLUMN last_ip_hash TEXT",
         [],
-    );
+    ))?;
 
     // Exchange token table for Safari ITP cookie workaround
     conn.execute(
@@ -312,24 +344,18 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
         )
         .map_err(|e| format!("Failed to create sessions table: {}", e))?;
 
-    client
-        .execute(
-            "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS device_name TEXT",
-            &[],
-        )
-        .ok();
-    client
-        .execute(
-            "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS user_agent_hash TEXT",
-            &[],
-        )
-        .ok();
-    client
-        .execute(
-            "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS last_ip_hash TEXT",
-            &[],
-        )
-        .ok();
+    run_postgres_migration(
+        &mut client,
+        "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS device_name TEXT",
+    )?;
+    run_postgres_migration(
+        &mut client,
+        "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS user_agent_hash TEXT",
+    )?;
+    run_postgres_migration(
+        &mut client,
+        "ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS last_ip_hash TEXT",
+    )?;
 
     // Index for cleanup queries
     client
@@ -358,30 +384,22 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
         )
         .map_err(|e| format!("Failed to create oauth_states table: {}", e))?;
 
-    client
-        .execute(
-            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS remember_me BOOLEAN NOT NULL DEFAULT FALSE",
-            &[],
-        )
-        .ok();
-    client
-        .execute(
-            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS device_name TEXT",
-            &[],
-        )
-        .ok();
-    client
-        .execute(
-            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS user_agent_hash TEXT",
-            &[],
-        )
-        .ok();
-    client
-        .execute(
-            "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS last_ip_hash TEXT",
-            &[],
-        )
-        .ok();
+    run_postgres_migration(
+        &mut client,
+        "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS remember_me BOOLEAN NOT NULL DEFAULT FALSE",
+    )?;
+    run_postgres_migration(
+        &mut client,
+        "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS device_name TEXT",
+    )?;
+    run_postgres_migration(
+        &mut client,
+        "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS user_agent_hash TEXT",
+    )?;
+    run_postgres_migration(
+        &mut client,
+        "ALTER TABLE auth_oauth_states ADD COLUMN IF NOT EXISTS last_ip_hash TEXT",
+    )?;
 
     // Exchange token table for Safari ITP cookie workaround
     client

--- a/src/stdlib/auth/request_helpers.rs
+++ b/src/stdlib/auth/request_helpers.rs
@@ -1,5 +1,77 @@
 use super::*;
 
+fn request_header(request: &Value, name: &str) -> Option<String> {
+    if let Value::Map(req_map) = request {
+        if let Some(Value::Map(headers)) = req_map.get("headers") {
+            return headers.get(name).and_then(|value| match value {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            });
+        }
+    }
+    None
+}
+
+pub(super) fn sha256_hex(input: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+pub(super) fn request_user_agent_hash(request: &Value) -> Option<String> {
+    request_header(request, "user-agent")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(|value| sha256_hex(&value))
+}
+
+pub(super) fn request_ip_hash(request: &Value) -> Option<String> {
+    let forwarded = request_header(request, "x-forwarded-for")
+        .and_then(|value| value.split(',').next().map(|part| part.trim().to_string()))
+        .filter(|value| !value.is_empty());
+    let direct = request_header(request, "x-real-ip")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    forwarded.or(direct).map(|value| sha256_hex(&value))
+}
+
+pub(super) fn request_device_name(request: &Value) -> Option<String> {
+    let ua = request_header(request, "user-agent")?;
+    let lower = ua.to_ascii_lowercase();
+    let device = if lower.contains("iphone") {
+        "iPhone"
+    } else if lower.contains("ipad") {
+        "iPad"
+    } else if lower.contains("android") && lower.contains("mobile") {
+        "Android phone"
+    } else if lower.contains("android") {
+        "Android device"
+    } else if lower.contains("macintosh") || lower.contains("mac os") {
+        "Mac"
+    } else if lower.contains("windows") {
+        "Windows PC"
+    } else if lower.contains("linux") {
+        "Linux device"
+    } else {
+        "Unknown device"
+    };
+
+    let browser = if lower.contains("edg/") {
+        "Edge"
+    } else if lower.contains("chrome/") && !lower.contains("edg/") {
+        "Chrome"
+    } else if lower.contains("safari/") && !lower.contains("chrome/") {
+        "Safari"
+    } else if lower.contains("firefox/") {
+        "Firefox"
+    } else {
+        "browser"
+    };
+
+    Some(format!("{} · {}", device, browser))
+}
+
 /// Get session ID from request cookies
 pub fn get_session_id_from_request(request: &Value) -> Option<String> {
     let config = get_auth_config()?;

--- a/src/stdlib/auth/request_helpers.rs
+++ b/src/stdlib/auth/request_helpers.rs
@@ -33,7 +33,19 @@ pub(super) fn request_ip_hash(request: &Value) -> Option<String> {
     let direct = request_header(request, "x-real-ip")
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    forwarded.or(direct).map(|value| sha256_hex(&value))
+    let request_ip = if let Value::Map(req_map) = request {
+        req_map.get("ip").and_then(|value| match value {
+            Value::String(s) => Some(s.trim().to_string()),
+            _ => None,
+        })
+    } else {
+        None
+    }
+    .filter(|value| !value.is_empty() && value != "unknown");
+    forwarded
+        .or(direct)
+        .or(request_ip)
+        .map(|value| sha256_hex(&value))
 }
 
 pub(super) fn request_device_name(request: &Value) -> Option<String> {

--- a/src/stdlib/auth/request_helpers.rs
+++ b/src/stdlib/auth/request_helpers.rs
@@ -12,18 +12,23 @@ fn request_header(request: &Value, name: &str) -> Option<String> {
     None
 }
 
-pub(super) fn sha256_hex(input: &str) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(input.as_bytes());
-    format!("{:x}", hasher.finalize())
+pub(super) fn security_signal_hash(input: &str) -> String {
+    let secret = get_auth_config()
+        .map(|config| config.session_secret)
+        .filter(|secret| !secret.is_empty())
+        .unwrap_or_else(|| DEFAULT_SESSION_SECRET_SENTINEL.to_string());
+
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
+        .expect("HMAC-SHA256 accepts arbitrary key lengths");
+    mac.update(input.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
 }
 
 pub(super) fn request_user_agent_hash(request: &Value) -> Option<String> {
     request_header(request, "user-agent")
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .map(|value| sha256_hex(&value))
+        .map(|value| security_signal_hash(&value))
 }
 
 pub(super) fn request_ip_hash(request: &Value) -> Option<String> {
@@ -45,7 +50,7 @@ pub(super) fn request_ip_hash(request: &Value) -> Option<String> {
     forwarded
         .or(direct)
         .or(request_ip)
-        .map(|value| sha256_hex(&value))
+        .map(|value| security_signal_hash(&value))
 }
 
 pub(super) fn request_device_name(request: &Value) -> Option<String> {

--- a/src/stdlib/auth/request_helpers.rs
+++ b/src/stdlib/auth/request_helpers.rs
@@ -49,7 +49,9 @@ pub(super) fn request_ip_hash(request: &Value) -> Option<String> {
 }
 
 pub(super) fn request_device_name(request: &Value) -> Option<String> {
-    let ua = request_header(request, "user-agent")?;
+    let ua = request_header(request, "user-agent")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())?;
     let lower = ua.to_ascii_lowercase();
     let device = if lower.contains("iphone") {
         "iPhone"

--- a/src/stdlib/auth/routes.rs
+++ b/src/stdlib/auth/routes.rs
@@ -1,6 +1,7 @@
 use super::cookies::{build_cleared_session_cookie, build_signed_session_cookie};
 use super::guards::{encode_url_path_segment, escape_html, request_target};
 use super::providers::{available_providers, suggest_provider};
+use super::request_helpers::{request_device_name, request_ip_hash, request_user_agent_hash};
 use super::*;
 
 fn normalize_auth_route_prefix(prefix: &str) -> std::result::Result<String, String> {
@@ -205,6 +206,10 @@ pub fn handle_auth_start(args: &[Value]) -> Result<Value> {
         &redirect_uri,
         nonce.as_deref(),
         pkce_verifier.as_deref(),
+        false,
+        request_device_name(req).as_deref(),
+        request_user_agent_hash(req).as_deref(),
+        request_ip_hash(req).as_deref(),
     );
 
     let mut provider_for_url = provider.clone();

--- a/src/stdlib/auth/routes.rs
+++ b/src/stdlib/auth/routes.rs
@@ -524,6 +524,9 @@ pub fn handle_auth_callback(args: &[Value]) -> Result<Value> {
         IntentError::runtime_error(format!("[auth] Failed to create session: {}", error))
     })?;
     let mut session = session;
+    session.device_name = oauth_state.device_name.clone();
+    session.user_agent_hash = oauth_state.user_agent_hash.clone();
+    session.last_ip_hash = oauth_state.last_ip_hash.clone();
     if let Some(existing_session_id) = get_session_id_from_request(req) {
         if let Some(existing_session) = get_session_by_id(&existing_session_id) {
             if existing_session_id != session.id {

--- a/src/stdlib/auth/storage.rs
+++ b/src/stdlib/auth/storage.rs
@@ -338,14 +338,18 @@ fn store_oauth_state_sqlite(state: &OAuthState) -> std::result::Result<(), Strin
 
     conn.execute(
         "INSERT OR REPLACE INTO auth_oauth_states
-         (state, nonce, pkce_verifier, provider, redirect_url, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+         (state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, ip_hash, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         rusqlite::params![
             state.state,
             state.nonce,
             state.pkce_verifier,
             state.provider,
             state.redirect_url,
+            state.remember_me,
+            state.device_name,
+            state.user_agent_hash,
+            state.ip_hash,
             state.created_at,
         ],
     )
@@ -362,16 +366,20 @@ fn store_oauth_state_postgres(state: &OAuthState) -> std::result::Result<(), Str
     client
         .execute(
             "INSERT INTO auth_oauth_states
-         (state, nonce, pkce_verifier, provider, redirect_url, created_at)
-         VALUES ($1, $2, $3, $4, $5, $6)
+         (state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, ip_hash, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
          ON CONFLICT (state) DO UPDATE SET
-            nonce = $2, pkce_verifier = $3, provider = $4, redirect_url = $5, created_at = $6",
+            nonce = $2, pkce_verifier = $3, provider = $4, redirect_url = $5, remember_me = $6, device_name = $7, user_agent_hash = $8, ip_hash = $9, created_at = $10",
             &[
                 &state.state,
                 &state.nonce,
                 &state.pkce_verifier,
                 &state.provider,
                 &state.redirect_url,
+                &state.remember_me,
+                &state.device_name,
+                &state.user_agent_hash,
+                &state.ip_hash,
                 &state.created_at,
             ],
         )
@@ -395,6 +403,10 @@ fn store_oauth_state_redis(state: &OAuthState) -> std::result::Result<(), String
         "pkce_verifier": state.pkce_verifier,
         "provider": state.provider,
         "redirect_url": state.redirect_url,
+        "remember_me": state.remember_me,
+        "device_name": state.device_name,
+        "user_agent_hash": state.user_agent_hash,
+        "ip_hash": state.ip_hash,
         "created_at": state.created_at,
     })
     .to_string();
@@ -1769,7 +1781,7 @@ fn store_session_sqlite(session: &Session) -> std::result::Result<(), String> {
         "INSERT OR REPLACE INTO auth_sessions
          (id, user_id, provider, email, name, picture, raw_json, data_json, csrf_token,
           access_token, refresh_token, token_expires_at, device_name, user_agent_hash, last_ip_hash, created_at, expires_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
         rusqlite::params![
             session.id,
             session.user_id,
@@ -1805,7 +1817,7 @@ fn store_session_postgres(session: &Session) -> std::result::Result<(), String> 
             "INSERT INTO auth_sessions
          (id, user_id, provider, email, name, picture, raw_json, data_json, csrf_token,
           access_token, refresh_token, token_expires_at, device_name, user_agent_hash, last_ip_hash, created_at, expires_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
          ON CONFLICT (id) DO UPDATE SET
             user_id = EXCLUDED.user_id,
             provider = EXCLUDED.provider,
@@ -1818,6 +1830,9 @@ fn store_session_postgres(session: &Session) -> std::result::Result<(), String> 
             access_token = EXCLUDED.access_token,
             refresh_token = EXCLUDED.refresh_token,
             token_expires_at = EXCLUDED.token_expires_at,
+            device_name = EXCLUDED.device_name,
+            user_agent_hash = EXCLUDED.user_agent_hash,
+            last_ip_hash = EXCLUDED.last_ip_hash,
             created_at = EXCLUDED.created_at,
             expires_at = EXCLUDED.expires_at",
             &[
@@ -1867,6 +1882,9 @@ fn store_session_redis(session: &Session) -> std::result::Result<(), String> {
         "access_token": session.access_token,
         "refresh_token": session.refresh_token,
         "token_expires_at": session.token_expires_at,
+        "device_name": session.device_name,
+        "user_agent_hash": session.user_agent_hash,
+        "last_ip_hash": session.last_ip_hash,
         "created_at": session.created_at,
         "expires_at": session.expires_at,
     })
@@ -2409,8 +2427,8 @@ fn migrate_session_sqlite(old_id: &str, new_session: &Session) -> std::result::R
             "UPDATE auth_sessions
          SET id = ?1, user_id = ?2, provider = ?3, email = ?4, name = ?5, picture = ?6,
              raw_json = ?7, data_json = ?8, csrf_token = ?9, access_token = ?10,
-             refresh_token = ?11, token_expires_at = ?12, created_at = ?13, expires_at = ?14
-         WHERE id = ?15",
+             refresh_token = ?11, token_expires_at = ?12, device_name = ?13, user_agent_hash = ?14, last_ip_hash = ?15, created_at = ?16, expires_at = ?17
+         WHERE id = ?18",
             rusqlite::params![
                 new_session.id,
                 new_session.user_id,
@@ -2424,6 +2442,9 @@ fn migrate_session_sqlite(old_id: &str, new_session: &Session) -> std::result::R
                 new_session.access_token,
                 new_session.refresh_token,
                 new_session.token_expires_at,
+                new_session.device_name,
+                new_session.user_agent_hash,
+                new_session.last_ip_hash,
                 new_session.created_at,
                 new_session.expires_at,
                 old_id,
@@ -2451,8 +2472,8 @@ fn migrate_session_postgres(
             "UPDATE auth_sessions
              SET id = $1, user_id = $2, provider = $3, email = $4, name = $5, picture = $6,
                  raw_json = $7, data_json = $8, csrf_token = $9, access_token = $10,
-                 refresh_token = $11, token_expires_at = $12, created_at = $13, expires_at = $14
-             WHERE id = $15",
+                 refresh_token = $11, token_expires_at = $12, device_name = $13, user_agent_hash = $14, last_ip_hash = $15, created_at = $16, expires_at = $17
+             WHERE id = $18",
             &[
                 &new_session.id,
                 &new_session.user_id,
@@ -2466,6 +2487,9 @@ fn migrate_session_postgres(
                 &new_session.access_token,
                 &new_session.refresh_token,
                 &new_session.token_expires_at,
+                &new_session.device_name,
+                &new_session.user_agent_hash,
+                &new_session.last_ip_hash,
                 &new_session.created_at,
                 &new_session.expires_at,
                 &old_id,
@@ -2506,6 +2530,9 @@ fn migrate_session_redis(old_id: &str, new_session: &Session) -> std::result::Re
         "access_token": new_session.access_token,
         "refresh_token": new_session.refresh_token,
         "token_expires_at": new_session.token_expires_at,
+        "device_name": new_session.device_name,
+        "user_agent_hash": new_session.user_agent_hash,
+        "last_ip_hash": new_session.last_ip_hash,
         "created_at": new_session.created_at,
         "expires_at": new_session.expires_at,
     })

--- a/src/stdlib/auth/storage.rs
+++ b/src/stdlib/auth/storage.rs
@@ -369,7 +369,7 @@ fn store_oauth_state_postgres(state: &OAuthState) -> std::result::Result<(), Str
          (state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, last_ip_hash, created_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
          ON CONFLICT (state) DO UPDATE SET
-            nonce = $2, pkce_verifier = $3, provider = $4, redirect_url = $5, remember_me = $6, device_name = $7, user_agent_hash = $8, ip_hash = $9, created_at = $10",
+            nonce = $2, pkce_verifier = $3, provider = $4, redirect_url = $5, remember_me = $6, device_name = $7, user_agent_hash = $8, last_ip_hash = $9, created_at = $10",
             &[
                 &state.state,
                 &state.nonce,

--- a/src/stdlib/auth/storage.rs
+++ b/src/stdlib/auth/storage.rs
@@ -293,7 +293,7 @@ pub fn store_oauth_state(
     remember_me: bool,
     device_name: Option<&str>,
     user_agent_hash: Option<&str>,
-    ip_hash: Option<&str>,
+    last_ip_hash: Option<&str>,
 ) {
     let oauth_state = OAuthState {
         state: state.to_string(),
@@ -304,7 +304,7 @@ pub fn store_oauth_state(
         remember_me,
         device_name: device_name.map(|s| s.to_string()),
         user_agent_hash: user_agent_hash.map(|s| s.to_string()),
-        ip_hash: ip_hash.map(|s| s.to_string()),
+        last_ip_hash: last_ip_hash.map(|s| s.to_string()),
         created_at: chrono::Utc::now().timestamp(),
     };
 
@@ -338,7 +338,7 @@ fn store_oauth_state_sqlite(state: &OAuthState) -> std::result::Result<(), Strin
 
     conn.execute(
         "INSERT OR REPLACE INTO auth_oauth_states
-         (state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, ip_hash, created_at)
+         (state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, last_ip_hash, created_at)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         rusqlite::params![
             state.state,
@@ -349,7 +349,7 @@ fn store_oauth_state_sqlite(state: &OAuthState) -> std::result::Result<(), Strin
             state.remember_me,
             state.device_name,
             state.user_agent_hash,
-            state.ip_hash,
+            state.last_ip_hash,
             state.created_at,
         ],
     )
@@ -366,7 +366,7 @@ fn store_oauth_state_postgres(state: &OAuthState) -> std::result::Result<(), Str
     client
         .execute(
             "INSERT INTO auth_oauth_states
-         (state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, ip_hash, created_at)
+         (state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, last_ip_hash, created_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
          ON CONFLICT (state) DO UPDATE SET
             nonce = $2, pkce_verifier = $3, provider = $4, redirect_url = $5, remember_me = $6, device_name = $7, user_agent_hash = $8, ip_hash = $9, created_at = $10",
@@ -379,7 +379,7 @@ fn store_oauth_state_postgres(state: &OAuthState) -> std::result::Result<(), Str
                 &state.remember_me,
                 &state.device_name,
                 &state.user_agent_hash,
-                &state.ip_hash,
+                &state.last_ip_hash,
                 &state.created_at,
             ],
         )
@@ -406,7 +406,7 @@ fn store_oauth_state_redis(state: &OAuthState) -> std::result::Result<(), String
         "remember_me": state.remember_me,
         "device_name": state.device_name,
         "user_agent_hash": state.user_agent_hash,
-        "ip_hash": state.ip_hash,
+        "last_ip_hash": state.last_ip_hash,
         "created_at": state.created_at,
     })
     .to_string();
@@ -443,7 +443,7 @@ fn consume_oauth_state_sqlite(state: &str) -> std::result::Result<Option<OAuthSt
     let result = conn.query_row(
         "DELETE FROM auth_oauth_states
          WHERE state = ?1 AND created_at > ?2
-         RETURNING state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, ip_hash, created_at",
+         RETURNING state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, last_ip_hash, created_at",
         rusqlite::params![state, min_created],
         |row| {
             Ok(OAuthState {
@@ -455,7 +455,7 @@ fn consume_oauth_state_sqlite(state: &str) -> std::result::Result<Option<OAuthSt
                 remember_me: row.get(5)?,
                 device_name: row.get(6)?,
                 user_agent_hash: row.get(7)?,
-                ip_hash: row.get(8)?,
+                last_ip_hash: row.get(8)?,
                 created_at: row.get(9)?,
             })
         },
@@ -480,7 +480,7 @@ fn consume_oauth_state_postgres(state: &str) -> std::result::Result<Option<OAuth
         .query(
             "DELETE FROM auth_oauth_states
          WHERE state = $1 AND created_at > $2
-         RETURNING state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, ip_hash, created_at",
+         RETURNING state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, last_ip_hash, created_at",
             &[&state, &min_created],
         )
         .map_err(|e| e.to_string())?;
@@ -495,7 +495,7 @@ fn consume_oauth_state_postgres(state: &str) -> std::result::Result<Option<OAuth
             remember_me: row.get(5),
             device_name: row.get(6),
             user_agent_hash: row.get(7),
-            ip_hash: row.get(8),
+            last_ip_hash: row.get(8),
             created_at: row.get(9),
         }))
     } else {
@@ -551,7 +551,7 @@ fn consume_oauth_state_redis(state: &str) -> std::result::Result<Option<OAuthSta
                 remember_me: json["remember_me"].as_bool().unwrap_or(false),
                 device_name: json["device_name"].as_str().map(|s| s.to_string()),
                 user_agent_hash: json["user_agent_hash"].as_str().map(|s| s.to_string()),
-                ip_hash: json["ip_hash"].as_str().map(|s| s.to_string()),
+                last_ip_hash: json["last_ip_hash"].as_str().map(|s| s.to_string()),
                 created_at: json["created_at"].as_i64().unwrap_or(0),
             }))
         }

--- a/src/stdlib/auth/storage.rs
+++ b/src/stdlib/auth/storage.rs
@@ -290,6 +290,10 @@ pub fn store_oauth_state(
     redirect_url: &str,
     nonce: Option<&str>,
     pkce_verifier: Option<&str>,
+    remember_me: bool,
+    device_name: Option<&str>,
+    user_agent_hash: Option<&str>,
+    ip_hash: Option<&str>,
 ) {
     let oauth_state = OAuthState {
         state: state.to_string(),
@@ -297,6 +301,10 @@ pub fn store_oauth_state(
         pkce_verifier: pkce_verifier.map(|s| s.to_string()),
         provider: provider.to_string(),
         redirect_url: redirect_url.to_string(),
+        remember_me,
+        device_name: device_name.map(|s| s.to_string()),
+        user_agent_hash: user_agent_hash.map(|s| s.to_string()),
+        ip_hash: ip_hash.map(|s| s.to_string()),
         created_at: chrono::Utc::now().timestamp(),
     };
 
@@ -423,7 +431,7 @@ fn consume_oauth_state_sqlite(state: &str) -> std::result::Result<Option<OAuthSt
     let result = conn.query_row(
         "DELETE FROM auth_oauth_states
          WHERE state = ?1 AND created_at > ?2
-         RETURNING state, nonce, pkce_verifier, provider, redirect_url, created_at",
+         RETURNING state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, ip_hash, created_at",
         rusqlite::params![state, min_created],
         |row| {
             Ok(OAuthState {
@@ -432,7 +440,11 @@ fn consume_oauth_state_sqlite(state: &str) -> std::result::Result<Option<OAuthSt
                 pkce_verifier: row.get(2)?,
                 provider: row.get(3)?,
                 redirect_url: row.get(4)?,
-                created_at: row.get(5)?,
+                remember_me: row.get(5)?,
+                device_name: row.get(6)?,
+                user_agent_hash: row.get(7)?,
+                ip_hash: row.get(8)?,
+                created_at: row.get(9)?,
             })
         },
     );
@@ -456,7 +468,7 @@ fn consume_oauth_state_postgres(state: &str) -> std::result::Result<Option<OAuth
         .query(
             "DELETE FROM auth_oauth_states
          WHERE state = $1 AND created_at > $2
-         RETURNING state, nonce, pkce_verifier, provider, redirect_url, created_at",
+         RETURNING state, nonce, pkce_verifier, provider, redirect_url, remember_me, device_name, user_agent_hash, ip_hash, created_at",
             &[&state, &min_created],
         )
         .map_err(|e| e.to_string())?;
@@ -468,7 +480,11 @@ fn consume_oauth_state_postgres(state: &str) -> std::result::Result<Option<OAuth
             pkce_verifier: row.get(2),
             provider: row.get(3),
             redirect_url: row.get(4),
-            created_at: row.get(5),
+            remember_me: row.get(5),
+            device_name: row.get(6),
+            user_agent_hash: row.get(7),
+            ip_hash: row.get(8),
+            created_at: row.get(9),
         }))
     } else {
         Ok(None)
@@ -520,6 +536,10 @@ fn consume_oauth_state_redis(state: &str) -> std::result::Result<Option<OAuthSta
                 pkce_verifier: json["pkce_verifier"].as_str().map(|s| s.to_string()),
                 provider: json["provider"].as_str().unwrap_or("").to_string(),
                 redirect_url: json["redirect_url"].as_str().unwrap_or("").to_string(),
+                remember_me: json["remember_me"].as_bool().unwrap_or(false),
+                device_name: json["device_name"].as_str().map(|s| s.to_string()),
+                user_agent_hash: json["user_agent_hash"].as_str().map(|s| s.to_string()),
+                ip_hash: json["ip_hash"].as_str().map(|s| s.to_string()),
                 created_at: json["created_at"].as_i64().unwrap_or(0),
             }))
         }
@@ -766,6 +786,9 @@ pub(super) fn create_session(
         access_token,
         refresh_token,
         token_expires_at,
+        device_name: None,
+        user_agent_hash: None,
+        last_ip_hash: None,
         created_at: now,
         expires_at: now + ttl,
     })
@@ -951,6 +974,9 @@ pub(super) fn create_manual_session(
         access_token: None,
         refresh_token: None,
         token_expires_at: None,
+        device_name: None,
+        user_agent_hash: None,
+        last_ip_hash: None,
         created_at: now,
         expires_at: now + ttl,
     })
@@ -1742,7 +1768,7 @@ fn store_session_sqlite(session: &Session) -> std::result::Result<(), String> {
     conn.execute(
         "INSERT OR REPLACE INTO auth_sessions
          (id, user_id, provider, email, name, picture, raw_json, data_json, csrf_token,
-          access_token, refresh_token, token_expires_at, created_at, expires_at)
+          access_token, refresh_token, token_expires_at, device_name, user_agent_hash, last_ip_hash, created_at, expires_at)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
         rusqlite::params![
             session.id,
@@ -1757,6 +1783,9 @@ fn store_session_sqlite(session: &Session) -> std::result::Result<(), String> {
             session.access_token,
             session.refresh_token,
             session.token_expires_at,
+            session.device_name,
+            session.user_agent_hash,
+            session.last_ip_hash,
             session.created_at,
             session.expires_at,
         ],
@@ -1775,7 +1804,7 @@ fn store_session_postgres(session: &Session) -> std::result::Result<(), String> 
         .execute(
             "INSERT INTO auth_sessions
          (id, user_id, provider, email, name, picture, raw_json, data_json, csrf_token,
-          access_token, refresh_token, token_expires_at, created_at, expires_at)
+          access_token, refresh_token, token_expires_at, device_name, user_agent_hash, last_ip_hash, created_at, expires_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
          ON CONFLICT (id) DO UPDATE SET
             user_id = EXCLUDED.user_id,
@@ -1804,6 +1833,9 @@ fn store_session_postgres(session: &Session) -> std::result::Result<(), String> 
                 &session.access_token,
                 &session.refresh_token,
                 &session.token_expires_at,
+                &session.device_name,
+                &session.user_agent_hash,
+                &session.last_ip_hash,
                 &session.created_at,
                 &session.expires_at,
             ],
@@ -1921,7 +1953,7 @@ fn get_session_sqlite(id: &str) -> std::result::Result<Option<Session>, String> 
 
     let result = conn.query_row(
         "SELECT id, user_id, provider, email, name, picture, raw_json, data_json, csrf_token,
-                access_token, refresh_token, token_expires_at, created_at, expires_at
+                access_token, refresh_token, token_expires_at, device_name, user_agent_hash, last_ip_hash, created_at, expires_at
          FROM auth_sessions WHERE id = ?1 AND expires_at > ?2",
         rusqlite::params![id, now],
         |row| {
@@ -1938,8 +1970,11 @@ fn get_session_sqlite(id: &str) -> std::result::Result<Option<Session>, String> 
                 access_token: row.get(9)?,
                 refresh_token: row.get(10)?,
                 token_expires_at: row.get(11)?,
-                created_at: row.get(12)?,
-                expires_at: row.get(13)?,
+                device_name: row.get(12)?,
+                user_agent_hash: row.get(13)?,
+                last_ip_hash: row.get(14)?,
+                created_at: row.get(15)?,
+                expires_at: row.get(16)?,
             })
         },
     );
@@ -1962,7 +1997,7 @@ fn get_expired_session_sqlite(
 
     let result = conn.query_row(
         "SELECT id, user_id, provider, email, name, picture, raw_json, data_json, csrf_token,
-                access_token, refresh_token, token_expires_at, created_at, expires_at
+                access_token, refresh_token, token_expires_at, device_name, user_agent_hash, last_ip_hash, created_at, expires_at
          FROM auth_sessions WHERE id = ?1 AND expires_at <= ?2 AND created_at > ?3 AND refresh_token IS NOT NULL",
         rusqlite::params![id, now, refresh_cutoff],
         |row| {
@@ -1972,7 +2007,11 @@ fn get_expired_session_sqlite(
                 raw_json: row.get(6)?, data_json: row.get(7)?,
                 csrf_token: row.get::<_, Option<String>>(8)?.unwrap_or_default(),
                 access_token: row.get(9)?, refresh_token: row.get(10)?,
-                token_expires_at: row.get(11)?, created_at: row.get(12)?, expires_at: row.get(13)?,
+                token_expires_at: row.get(11)?,
+                device_name: row.get(12)?,
+                user_agent_hash: row.get(13)?,
+                last_ip_hash: row.get(14)?,
+                created_at: row.get(15)?, expires_at: row.get(16)?,
             })
         },
     );
@@ -1995,7 +2034,7 @@ fn get_expired_session_postgres(
     let mut client = postgres::Client::connect(url, postgres::NoTls).map_err(|e| e.to_string())?;
     let rows = client.query(
         "SELECT id, user_id, provider, email, name, picture, raw_json, data_json, csrf_token,
-                access_token, refresh_token, token_expires_at, created_at, expires_at
+                access_token, refresh_token, token_expires_at, device_name, user_agent_hash, last_ip_hash, created_at, expires_at
          FROM auth_sessions WHERE id = $1 AND expires_at <= $2 AND created_at > $3 AND refresh_token IS NOT NULL",
         &[&id, &now, &refresh_cutoff],
     ).map_err(|e| e.to_string())?;
@@ -2014,8 +2053,11 @@ fn get_expired_session_postgres(
             access_token: row.get(9),
             refresh_token: row.get(10),
             token_expires_at: row.get(11),
-            created_at: row.get(12),
-            expires_at: row.get(13),
+            device_name: row.get(12),
+            user_agent_hash: row.get(13),
+            last_ip_hash: row.get(14),
+            created_at: row.get(15),
+            expires_at: row.get(16),
         }))
     } else {
         Ok(None)
@@ -2040,7 +2082,7 @@ fn get_session_postgres(id: &str) -> std::result::Result<Option<Session>, String
     let rows = client
         .query(
             "SELECT id, user_id, provider, email, name, picture, raw_json, data_json, csrf_token,
-                access_token, refresh_token, token_expires_at, created_at, expires_at
+                access_token, refresh_token, token_expires_at, device_name, user_agent_hash, last_ip_hash, created_at, expires_at
          FROM auth_sessions WHERE id = $1 AND expires_at > $2",
             &[&id, &now],
         )
@@ -2060,8 +2102,11 @@ fn get_session_postgres(id: &str) -> std::result::Result<Option<Session>, String
             access_token: row.get(9),
             refresh_token: row.get(10),
             token_expires_at: row.get(11),
-            created_at: row.get(12),
-            expires_at: row.get(13),
+            device_name: row.get(12),
+            user_agent_hash: row.get(13),
+            last_ip_hash: row.get(14),
+            created_at: row.get(15),
+            expires_at: row.get(16),
         }))
     } else {
         Ok(None)
@@ -2125,6 +2170,9 @@ fn get_session_redis(id: &str) -> std::result::Result<Option<Session>, String> {
                 access_token: json["access_token"].as_str().map(|s| s.to_string()),
                 refresh_token: json["refresh_token"].as_str().map(|s| s.to_string()),
                 token_expires_at: json["token_expires_at"].as_i64(),
+                device_name: json["device_name"].as_str().map(|s| s.to_string()),
+                user_agent_hash: json["user_agent_hash"].as_str().map(|s| s.to_string()),
+                last_ip_hash: json["last_ip_hash"].as_str().map(|s| s.to_string()),
                 created_at,
                 expires_at,
             }))
@@ -2579,7 +2627,7 @@ fn get_sessions_for_user_sqlite(
 
     let mut stmt = conn
         .prepare(
-            "SELECT id, user_id, provider, created_at, expires_at FROM auth_sessions
+            "SELECT id, user_id, provider, device_name, created_at, expires_at FROM auth_sessions
          WHERE user_id = ?1 AND expires_at > ?2 ORDER BY created_at DESC",
         )
         .map_err(|e| e.to_string())?;
@@ -2590,8 +2638,9 @@ fn get_sessions_for_user_sqlite(
                 id: row.get(0)?,
                 user_id: row.get(1)?,
                 provider: row.get(2)?,
-                created_at: row.get(3)?,
-                expires_at: row.get(4)?,
+                device_name: row.get(3)?,
+                created_at: row.get(4)?,
+                expires_at: row.get(5)?,
                 is_current: false,
             })
         })
@@ -2622,7 +2671,7 @@ fn get_sessions_for_user_postgres(
 
     let rows = client
         .query(
-            "SELECT id, user_id, provider, created_at, expires_at FROM auth_sessions
+            "SELECT id, user_id, provider, device_name, created_at, expires_at FROM auth_sessions
          WHERE user_id = $1 AND expires_at > $2 ORDER BY created_at DESC",
             &[&user_id, &now],
         )
@@ -2634,8 +2683,9 @@ fn get_sessions_for_user_postgres(
             id: row.get(0),
             user_id: row.get(1),
             provider: row.get(2),
-            created_at: row.get(3),
-            expires_at: row.get(4),
+            device_name: row.get(3),
+            created_at: row.get(4),
+            expires_at: row.get(5),
             is_current: current_session_id
                 .map(|c| c == row.get::<_, String>(0))
                 .unwrap_or(false),
@@ -2689,6 +2739,7 @@ fn get_sessions_for_user_redis(
                             id: session_id.clone(),
                             user_id: session_user_id.to_string(),
                             provider: json["provider"].as_str().unwrap_or("").to_string(),
+                            device_name: json["device_name"].as_str().map(|s| s.to_string()),
                             created_at: json["created_at"].as_i64().unwrap_or(0),
                             expires_at,
                             is_current: current_session_id


### PR DESCRIPTION
## Summary
- persist Phase 8 session metadata fields (`device_name`, `user_agent_hash`, `last_ip_hash`) across auth session backends
- extend OAuth state persistence to carry security-signal metadata (`remember_me`, device, UA hash, IP hash) end-to-end
- capture request-derived device/security metadata at auth-start time and validate the storage contract with updated auth tests

## Testing
- `cargo test auth -- --nocapture`
- `cargo build --release --locked`
- `./target/release/ntnt docs --generate`
- `cargo fmt -- --check`
- `cargo test --release auth -- --nocapture`

## Notes
- This completes the storage/plumbing slice behind DD-043 Phase 8's advanced session metadata work.
- Higher-level Phase 8 APIs (session listing/revoke flows, suspicious-activity actions, remember-me controls) still remain for later slices.
