### PR TITLE
auth: prepare local auth roadmap and guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         image: postgres:16
         env:
           POSTGRES_DB: ntnt_auth_test
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: ntnt
         ports:
           - 5432:5432
@@ -124,8 +125,8 @@ jobs:
 
       - name: Run auth storage contract tests against Postgres and Redis
         run: |
-          cargo test --locked test_auth_storage_contract_postgres_round_trip_all_record_types -- --test-threads=1 --nocapture
-          cargo test --locked test_auth_storage_contract_redis_round_trip_all_record_types -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_auth_storage_contract_postgres_round_trip_all_record_types -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_auth_storage_contract_redis_round_trip_all_record_types -- --test-threads=1 --nocapture
         env:
           RUST_MIN_STACK: 8388608
           NTNT_AUTH_TEST_POSTGRES_URL: postgres://postgres:ntnt@localhost:5432/ntnt_auth_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,60 @@ jobs:
         env:
           RUST_MIN_STACK: 8388608
 
+  auth-backends:
+    name: Auth Backend Contracts
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: ntnt_auth_test
+          POSTGRES_PASSWORD: ntnt
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-auth-backends-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-auth-backends-cargo-
+
+      - name: Run auth storage contract tests against Postgres and Redis
+        run: |
+          cargo test --locked test_auth_storage_contract_postgres_round_trip_all_record_types -- --test-threads=1 --nocapture
+          cargo test --locked test_auth_storage_contract_redis_round_trip_all_record_types -- --test-threads=1 --nocapture
+        env:
+          RUST_MIN_STACK: 8388608
+          NTNT_AUTH_TEST_POSTGRES_URL: postgres://postgres:ntnt@localhost:5432/ntnt_auth_test
+          NTNT_AUTH_TEST_REDIS_URL: redis://127.0.0.1:6379/0
+
   lint:
     name: Lint
     needs: changes
@@ -171,12 +225,12 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [test, lint, examples, docs]
+    needs: [test, auth-backends, lint, examples, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results
         run: |
-          results=("${{ needs.test.result }}" "${{ needs.lint.result }}" "${{ needs.examples.result }}" "${{ needs.docs.result }}")
+          results=("${{ needs.test.result }}" "${{ needs['auth-backends'].result }}" "${{ needs.lint.result }}" "${{ needs.examples.result }}" "${{ needs.docs.result }}")
           for result in "${results[@]}"; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
               echo "::error::CI job failed or was cancelled: $result"

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -83,7 +83,7 @@ Apply this section to any change touching `src/stdlib/auth.rs`, `src/stdlib/auth
 ### Local Auth Review Checklist
 - Is local auth implemented as one subsystem under `std/auth`, not as disconnected helpers plus template-owned tables?
 - Are local credential/reset/TOTP stores auth-owned and fail-closed on backend errors?
-- Does local login use request-aware session completion instead of request-less `sign_in_session()` semantics?
+- Does local login use request-aware `sign_in_session(response, req, session, options?)` or the same internal completion primitive instead of creating a weaker parallel session path?
 - Are reset tokens hash-stored, TTL-bound, one-time-use, and replay-tested?
 - Is TOTP enrollment durable account state, not only pending challenge metadata?
 - Is the email/SMS delivery boundary explicit (`std/auth` issues/validates tokens and URLs; apps/plugins deliver messages)?

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -51,6 +51,44 @@ Full skill with workflow, examples, and deep review techniques: see ntnt-code-re
 - `ntnt docs --generate` must be run after any stdlib change
 - Rustdoc comments must be updated when function behavior changes — stale docs mislead callers
 
+## Auth-Specific Guardrails
+
+Apply this section to any change touching `src/stdlib/auth.rs`, `src/stdlib/auth/**`, auth docs, auth generated docs, auth typechecker signatures, or auth tests. DD-043 and DD-062 are the current roadmap for the auth architecture.
+
+### Module Ownership
+- `src/stdlib/auth.rs` should stay focused on public API registration, shared surface types that cannot move yet, and minimal coordination glue. Do not add new domain logic there just because it is convenient.
+- Prefer focused internal modules for domain behavior: config, cookies, providers, OAuth, guards, routes, request helpers, sessions, storage, primitives, local auth, password reset, and TOTP enrollment.
+- If a new auth feature needs durable state, define the record family and storage owner before implementing helpers or routes.
+- Avoid hiding durable behavior in generic `data_json` payloads. Challenge `data_json` is acceptable for pending flow metadata, not long-lived credential/reset/TOTP enrollment state.
+
+### Storage and Fallback Semantics
+- Treat auth storage behavior as a compatibility surface. Every new auth record family needs explicit store/get/consume/update/delete/cleanup semantics.
+- Existing transient auth state may use documented memory fallback paths. Do not copy those semantics to durable credential state by default.
+- Durable local-auth state must fail closed in production: local identities, password hashes, password-reset tokens, TOTP enrollment state, bootstrap state, and account-state changes must not silently fall back to process memory when the configured backend fails.
+- One-time records (`OAuthState`, exchange tokens, auth challenges, future reset tokens) need atomic consume semantics per backend. Verify replay rejection.
+- Schema/migration code must surface real failures. Do not swallow migration errors that leave metadata/credential columns missing.
+
+### Session and Metadata Plumbing
+- Request-derived session metadata (`device_name`, `user_agent_hash`, `last_ip_hash`) must be captured, persisted, and round-tripped deliberately. If it is intentionally hidden from public APIs, document why.
+- Local/manual sign-in flows must not be weaker than OAuth callback flows. Successful local auth should rotate/migrate existing sessions, attach cookies through the shared cookie policy, and preserve request metadata.
+- Remember-me changes must cover the full path: request/config capture → OAuth/local pending state → session TTL selection → cookie Max-Age/Expires → tests.
+- Current-user helpers (`user_sessions(req)`, `logout_all(req, ...)`) are not the same as future admin/arbitrary-user APIs (`list_sessions(user_id)`, `revoke_session(session_id)`, `revoke_all_sessions(user_id)`). Keep docs and API names precise.
+
+### Auth Contract Tests
+- New auth persistence/state shapes must extend the backend contract harness in the same PR that introduces them.
+- Contract tests should assert every field that matters, not only IDs. For session metadata, assert `device_name`, `user_agent_hash`, `last_ip_hash`, and `remember_me` where applicable.
+- Cover memory and SQLite by default. Postgres/Redis tests may be env-gated locally, but CI must make skipped backend coverage visible rather than silently green.
+- For route protection, prefer at least one end-to-end ntnt/server test in addition to helper-level path matching.
+
+### Local Auth Review Checklist
+- Is local auth implemented as one subsystem under `std/auth`, not as disconnected helpers plus template-owned tables?
+- Are local credential/reset/TOTP stores auth-owned and fail-closed on backend errors?
+- Does local login use request-aware session completion instead of request-less `sign_in_session()` semantics?
+- Are reset tokens hash-stored, TTL-bound, one-time-use, and replay-tested?
+- Is TOTP enrollment durable account state, not only pending challenge metadata?
+- Is the email/SMS delivery boundary explicit (`std/auth` issues/validates tokens and URLs; apps/plugins deliver messages)?
+- Does the template integration delete custom auth persistence instead of wrapping it?
+
 ## Skip
 - Formatting and whitespace (cargo fmt enforces this)
 - Test file organization

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -54,7 +54,7 @@ If a capability is security-sensitive lifecycle state that every app otherwise r
 ### What's Still Missing (the gap to "best ever")
 - [ ] First-class local email/password/TOTP credential lifecycle owned by `std/auth`
 - [ ] Auth-owned local credential/reset/TOTP enrollment stores with fail-closed fallback semantics
-- [ ] Request-aware local sign-in that uses the same rotation, metadata, cookie, and lifecycle semantics as OAuth sign-in
+- [ ] First-class local credential sign-in helper that feeds verified local credentials into the existing request-aware session-completion path
 - [ ] Admin/arbitrary-user session APIs (`list_sessions(user_id)`, `revoke_session(session_id)`, `revoke_all_sessions(user_id)`) distinct from current-user helpers
 - [ ] Security event storage and suspicious-activity policy actions (`warn`, `challenge`, `revoke`)
 - [ ] Fully behavioral remember-me support (`remember_ttl`, request capture, cookie/session TTL selection)
@@ -108,12 +108,12 @@ This is the single source of truth for how we should build `std/auth` forward. T
 ### Phase 3 — Session Core and Cookie Helpers
 **Goal:** Remove the most repetitive and error-prone login/logout/session code.
 
-**Result:** Merged in PR #78 (`feat: add auth session helpers`) on 2026-04-13.
+**Result:** Merged in PR #78 (`feat: add auth session helpers`) on 2026-04-13, then tightened on `feat/local-auth-blueprint` so manual/staged session completion is request-aware before first-class local auth builds on it.
 
 - [x] Rotate session ID automatically on successful OAuth callback/session upgrade paths
 - [x] Invalidate old session ID immediately after rotation
 - [x] Preserve intended session data across rotation
-- [ ] Add request-aware local/manual sign-in rotation and metadata capture before first-class local auth ships (tracked in Phase 9C)
+- [x] Add request-aware manual/staged session completion rotation and metadata capture before first-class local auth ships
 - [x] Session store migration implemented in Rust for Redis/Postgres/SQLite backends
 - [x] Keep `migrate_session(old_id, new_id)` internal to Rust/session-store code
 - [x] Public ntnt API exposes only high-level session helpers, not low-level store migration primitives (`sign_in_session`, `rotate_session`, `sign_out_session`, `current_session`, `current_user`)
@@ -310,7 +310,7 @@ Current pressure points:
 - persisted TOTP enrollment state
 - first-login / forced-password-change flow
 - bootstrap admin account creation
-- claims/role glue between local accounts and sessions
+- ad hoc session-claim handoff from custom local auth into `std/auth` sessions
 
 That is the current local-auth subsystem gap.
 
@@ -372,11 +372,14 @@ A later `enable_local_auth(...)` convenience wrapper is acceptable only if it de
 - [ ] Add memory/SQLite contract tests by default and Postgres/Redis contract tests in required backend CI
 
 #### Phase 9C — Request-Aware Local Sign-In Flow
+
+**Dependency already satisfied:** the shared manual/staged completion primitive is now request-aware via `sign_in_session(response, req, session, options?)` and `complete_auth_challenge(response, req, session?, options?)`. This phase should not invent a second session-completion path; it should build local credential verification and any higher-level local sign-in helper on that existing primitive.
+
 - [ ] Add built-in email/password verification through `std/auth`
-- [ ] Use a request-aware local sign-in path that receives `req` so it can rotate/migrate existing sessions and capture request metadata
+- [ ] Use the existing request-aware session-completion primitive from the local sign-in path so it can rotate/migrate existing sessions and capture request metadata
 - [ ] Reuse the same session cookie, session TTL, sliding/max-lifetime, metadata, and revocation semantics as OAuth-backed sign-in
 - [ ] Reuse staged auth challenge primitives for local login continuation instead of inventing a second pending-auth model
-- [ ] Support straightforward local sign-in that upgrades into a real auth session with configured claims/data
+- [ ] Support straightforward local sign-in that upgrades into a real auth session with app-supplied claims/session data
 - [ ] Ensure local sessions receive `device_name`, `user_agent_hash`, and `last_ip_hash` just like OAuth sessions
 
 #### Phase 9D — First-Login Activation, Forced Password Change, and TOTP Enrollment
@@ -527,7 +530,7 @@ Those are now shipped. The next big win is local email/password/TOTP auth, but o
 #### Wave 2 — Session Core
 **Shipped:**
 - session ID rotation on successful OAuth callback/session upgrade
-- `sign_in_session()`
+- request-aware `sign_in_session(response, req, session, options?)`
 - `sign_out_session()`
 - `current_session()` / `current_user()`
 - shared cookie defaults and overrides

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -330,32 +330,83 @@ return complete_auth_challenge(resp, req, map {
 ### Phase 8 — Advanced Sessions and Security Signals
 **Goal:** Add higher-end capabilities once the core mechanics are excellent.
 
-- [ ] Store user agent hash / device name on session creation
-- [ ] `list_sessions(user_id)` API
-- [ ] `revoke_session(session_id)` API
+**Status:** Phase 8A (session metadata + security-signal plumbing) is now implemented on branch `feat/auth-phase-8-advanced-sessions-complete` / PR #96. This slice focused on carrying richer session/security metadata cleanly through the existing auth system, plus the review-driven hardening needed to make that plumbing trustworthy across backends.
+
+**What landed in this slice:**
+- [x] Store user agent hash / device name on session creation
+- [x] Pass remember-me flag through OAuth state
+- [x] Persist OAuth-state security metadata (`remember_me`, `device_name`, `user_agent_hash`, `last_ip_hash`) across SQLite/Postgres/Redis + memory fallback
+- [x] Persist session security metadata (`device_name`, `user_agent_hash`, `last_ip_hash`) across SQLite/Postgres/Redis + memory fallback
+- [x] Copy captured OAuth-state metadata onto the real session at callback time before store/rotation
+- [x] Track IP signal material on sessions via `last_ip_hash`
+- [x] Fall back to request `ip` when proxy headers are absent for direct connections
+- [x] Use keyed HMAC-SHA256 for stored security-signal hashes instead of plain SHA-256
+- [x] Harden SQLite/Postgres migration behavior so schema updates stop swallowing real failures
+- [x] Extend auth storage contract tests and auth flow tests for the new metadata paths
+
+**What this slice did _not_ finish yet:**
+- [ ] `list_sessions(user_id)` API *(already partially represented by existing `user_sessions(req)` current-user helper, but no dedicated arbitrary-user/admin-facing API landed in this slice)*
+- [ ] `revoke_session(session_id)` API *(existing revocation helpers remain current-user/request-oriented)*
 - [ ] `revoke_all_sessions(user_id)` API
 - [ ] Password change hook support for revocation
 - [ ] Account disable hook support for revocation
 - [ ] Optional `revoke_on_password_change: true` config
 - [ ] Add `security_events` storage for auth events
-- [ ] Track IP changes per session
 - [ ] Configurable suspicious-activity actions: `warn`, `challenge`, `revoke`
 - [ ] Expose `auth_events(user_id, limit?)` for admin dashboards
 - [ ] Rate limit failed OAuth callbacks
-- [ ] Add `remember_me` and `remember_ttl`
-- [ ] Pass remember-me flag through OAuth state
-- [ ] Set appropriate TTL/persistence on session creation
+- [ ] Add `remember_ttl`
+- [ ] Set distinct remember-me TTL/persistence behavior on session creation
 
-**Ships real value:** this is where `std/auth` becomes genuinely standout, not just competent.
+**Assessment of the current Phase 8 outcome:** this slice successfully delivered the underlying metadata/security-signal plumbing that Phase 8 needed before higher-level features like suspicious-activity policies or auth event streams can be layered on safely. The main work was not just adding columns — it was making the metadata survive the real auth path, align across backends, survive review scrutiny, and avoid silent migration failures. That makes this a real Phase 8 foundation slice rather than cosmetic schema churn.
+
+**Ships real value:** this is where `std/auth` starts becoming genuinely standout, not just competent.
 
 ### Phase 9 — Post-Cleanup Complexity Discipline
 **Goal:** Prevent `std/auth` from collapsing back into a monolith after the 4.5 cleanup lands.
 
-- [ ] Track auth code size / complexity budget as features land
+**Assessment after the Phase 8 branch review (compared against the v0.4.8 release baseline):** the 4.5 cleanup largely achieved its intended effect, but only partially solved the long-term maintainability problem. The internal module split is real and materially improves clarity: config, cookies, guards, OAuth flow, providers, request helpers, routes, sessions, storage, and small utility layers now exist as distinct homes instead of one giant undifferentiated file. The storage contract is also much more coherent than before, and recent review feedback mostly hit end-to-end plumbing gaps and edge-case semantics rather than “where does this logic even belong?” confusion. That is a meaningful architectural win.
+
+**However:** `src/stdlib/auth.rs` is still very large and still acts as a gravity well for the public surface, native-function registration, shared types, and the main auth test module. So the cleanup should be viewed as **successful but incomplete**. `std/auth` is no longer a pure junk drawer, but it is also not yet structurally self-protecting. It is maintainable **if** future work is forced through the module boundaries and contract tests established in 4.5. If contributors drift back into broad `auth.rs` edits for convenience, the monolith will regrow quickly.
+
+**Bottom line:** the DD intent was mostly achieved for the cleanup wave — enough to justify continuing from this shape — but Phase 9 must turn the current structure into enforceable discipline rather than assuming the cleanup alone solved the problem.
+
+## Recommended implementation shape for Phase 9
+
+Phase 9 should be a **discipline phase, not a feature phase**. The goal is to make the architecture we now have more self-enforcing, so future auth work naturally lands in the right places and gets the right verification by default.
+
+### Phase 9A — Architecture Guardrails
+- [ ] Write explicit contributor guidance for what belongs in `auth.rs` vs internal auth modules
+- [ ] Document the allowed responsibilities of `auth.rs`: public surface, shared types, registration glue, and only the minimum unavoidable coordination logic
+- [ ] Document when a new auth change must extend an existing module versus when it merits a new focused module
+- [ ] Add an auth-specific review checklist covering the regressions exposed in Phase 8 (captured-but-not-persisted state, schema/query name drift, swallowed migration errors, backend mismatch paths, fallback ambiguity)
+
+### Phase 9B — Contract-Test Ratchet
+- [ ] Require new auth persistence/state shapes to extend the backend contract harness
+- [ ] Add missing contract coverage for any auth persistence paths still validated only indirectly
+- [ ] Require new fallback/error semantics to be tested in primary, fallback, and failure modes
+- [ ] Treat auth storage behavior as a compatibility surface, not just an implementation detail
+
+### Phase 9C — `auth.rs` Pressure Relief
+- [ ] Audit what still lives in `auth.rs` only because of historical gravity rather than good ownership
+- [ ] Move obvious non-surface helpers and test-heavy logic into module-local ownership where it improves clarity without destabilizing the public API
+- [ ] Reassess whether the main auth test concentration should be partially redistributed into focused module tests over time
+- [ ] Track `auth.rs` growth relative to the internal modules so “easy broad edits” become visible early
+
+### Phase 9D — Periodic Architecture Audit
+- [ ] Re-review new auth work periodically against the intended module boundaries
+- [ ] Check whether recent auth changes increased clarity or merely moved complexity around
+- [ ] Reconfirm that fallback semantics remain deliberate and documented as auth work expands
+- [ ] Update DD-043 / REVIEW guidance when review incidents reveal new recurring patterns
+
+- [ ] Track auth code size / complexity budget as features land, especially `auth.rs` vs the internal modules
 - [ ] Require new auth work to fit the post-4.5 module boundaries instead of reopening broad grab-bag files
+- [ ] Keep `auth.rs` focused on public surface, shared types, registration glue, and only the minimum unavoidable coordination logic
 - [ ] Extend backend contract tests when adding new auth state types, flows, or stores
 - [ ] Treat fallback/error semantics as design-level behavior, not incidental implementation detail
+- [ ] Add review guidance/checklists for common auth regressions: captured-but-not-persisted state, schema/name drift, swallowed migration errors, and backend mismatch paths
 - [ ] Periodically re-audit whether new features are preserving the intended internal architecture
+- [ ] Revisit whether large test concentrations inside `auth.rs` should migrate toward module-local test ownership as the structure stabilizes
 
 **Ships real value:** preserves the benefits of the cleanup so future auth work stays understandable instead of slowly regressing.
 

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -375,6 +375,8 @@ A later `enable_local_auth(...)` convenience wrapper is acceptable only if it de
 
 **Dependency already satisfied:** the shared manual/staged completion primitive is now request-aware via `sign_in_session(response, req, session, options?)` and `complete_auth_challenge(response, req, session?, options?)`. This phase should not invent a second session-completion path; it should build local credential verification and any higher-level local sign-in helper on that existing primitive.
 
+Because this lands before 0.4.9 is released, the old pre-release `sign_in_session(response, session, options?)` shape should not be kept as a compatibility shim. Callers must migrate by passing the route `req` as the second argument; otherwise local/manual auth would silently miss rotation, existing-session migration, and request metadata capture.
+
 - [ ] Add built-in email/password verification through `std/auth`
 - [ ] Use the existing request-aware session-completion primitive from the local sign-in path so it can rotate/migrate existing sessions and capture request metadata
 - [ ] Reuse the same session cookie, session TTL, sliding/max-lifetime, metadata, and revocation semantics as OAuth-backed sign-in

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -1,9 +1,9 @@
 # DD-043: World-Class Auth — Making `std/auth` the Best stdlib Auth Ever
 
-**Status:** In Progress  
-**Author:** Larri  
-**Date:** 2026-03-20  
-**Branch:** `main` (Phase 2 merged via PR #77, Phase 3 merged via PR #78, Phase 4 core + Phase 4.5A/4.5B refactor merged via PR #81)
+**Status:** In Progress
+**Author:** Larri
+**Date:** 2026-03-20
+**Branch:** `main` through v0.4.9; `feat/local-auth-blueprint` carries the next planning pass for first-class local auth and architecture discipline
 
 ---
 
@@ -15,31 +15,39 @@
 
 ---
 
-## Current State (v0.4.6)
+## Current State (v0.4.9)
 
-### What We Have (and it's solid)
+### What We Have (and it is solid)
 - [x] OAuth 2.0 + OIDC (Google, GitHub, Discord, Apple, Microsoft, generic)
 - [x] PKCE for all OAuth flows
 - [x] Server-side sessions (Redis, PostgreSQL, SQLite, memory)
 - [x] HMAC-signed session cookies (tamper-proof)
 - [x] CSRF protection (per-session tokens, automatic validation on state-changing requests)
-- [x] Automatic token refresh (access tokens refreshed via refresh tokens transparently)
+- [x] Automatic token refresh with provider-aware refresh-token rotation/preservation
 - [x] `HttpOnly`, `Secure`, `SameSite=Lax` cookies by default
-- [x] Configurable session/refresh TTLs
-- [x] Safari ITP workaround (two-phase exchange token flow)
-- [x] Session listing (`user_sessions`) and revocation (`revoke_session`)
-- [x] Periodic cleanup of expired sessions/tokens
-- [x] Password hashing (bcrypt, argon2 via `std/crypto`)
-- [x] TOTP/MFA support (`totp_secret`, `totp_verify`, `totp_uri`)
-- [x] API key validation
-- [x] Turnstile CAPTCHA verification
-- [x] OAuth token introspection
-- [x] Client credentials grant (M2M)
-- [x] OIDC discovery (`.well-known/openid-configuration`)
+- [x] Configurable session/refresh TTLs, sliding expiry, absolute max lifetime, and session presets
+- [x] Safari ITP workaround (two-phase exchange token flow), retained after validation
+- [x] Current-user session listing (`user_sessions(req)`) and current-user bulk revocation (`logout_all(req, keep_current)`)
+- [x] Session rotation/migration helpers and sign-in/sign-out/current-session helpers
+- [x] Staged auth challenge primitives for MFA/setup/step-up flows
+- [x] Internal auth module split for config, cookies, providers, OAuth, guards, routes, request helpers, sessions, storage, primitives, and utilities
+- [x] Explicit fallback/error policy for existing session, challenge, OAuth-state, and exchange-token storage
+- [x] Backend contract coverage for memory/SQLite by default and Postgres/Redis when env-gated services are available
+- [x] Configurable route prefixes, built-in auth route logging, auth health diagnostics, and a configurable built-in login page
+- [x] Session metadata/security-signal plumbing (`device_name`, `user_agent_hash`, `last_ip_hash`, `remember_me`) across the OAuth path and existing storage backends
+- [x] Password hashing and generic crypto helpers in `std/crypto`
+- [x] TOTP/MFA primitives (`totp_secret`, `totp_verify`, `totp_uri`) in `std/auth`
+- [x] API key validation, Turnstile CAPTCHA verification, OAuth token introspection, client credentials grant, and OIDC discovery
 
-### What's Missing (the gap to "best ever")
-
----
+### What's Still Missing (the gap to "best ever")
+- [ ] First-class local email/password/TOTP credential lifecycle owned by `std/auth`
+- [ ] Auth-owned local credential/reset/TOTP enrollment stores with fail-closed fallback semantics
+- [ ] Request-aware local sign-in that uses the same rotation, metadata, cookie, and lifecycle semantics as OAuth sign-in
+- [ ] Admin/arbitrary-user session APIs (`list_sessions(user_id)`, `revoke_session(session_id)`, `revoke_all_sessions(user_id)`) distinct from current-user helpers
+- [ ] Security event storage and suspicious-activity policy actions (`warn`, `challenge`, `revoke`)
+- [ ] Fully behavioral remember-me support (`remember_ttl`, request capture, cookie/session TTL selection)
+- [ ] Stronger test ratchets for session metadata round-trips, route-protection end-to-end flows, and Postgres/Redis CI coverage
+- [ ] Architecture guardrails that keep new auth work inside the post-4.5 module boundaries instead of re-growing `auth.rs` or `auth/storage.rs`
 
 ## Unified Phased Implementation Plan
 
@@ -90,9 +98,10 @@ This is the single source of truth for how we should build `std/auth` forward. T
 
 **Result:** Merged in PR #78 (`feat: add auth session helpers`) on 2026-04-13.
 
-- [x] Rotate session ID automatically on successful auth callback/login
+- [x] Rotate session ID automatically on successful OAuth callback/session upgrade paths
 - [x] Invalidate old session ID immediately after rotation
 - [x] Preserve intended session data across rotation
+- [ ] Add request-aware local/manual sign-in rotation and metadata capture before first-class local auth ships (tracked in Phase 9C)
 - [x] Session store migration implemented in Rust for Redis/Postgres/SQLite backends
 - [x] Keep `migrate_session(old_id, new_id)` internal to Rust/session-store code
 - [x] Public ntnt API exposes only high-level session helpers, not low-level store migration primitives (`sign_in_session`, `rotate_session`, `sign_out_session`, `current_session`, `current_user`)
@@ -159,124 +168,36 @@ return complete_auth_challenge(resp, req, map {
 **Ships real value:** the template’s password/TOTP/password-change flow gets much cleaner and more robust.
 
 ### Phase 4.5 — Auth Internal Architecture Cleanup
-**Goal:** Pay down the structural debt around `std/auth` before more lifecycle, observability, and security features pile onto the current shape.
+**Goal:** Pay down the structural debt around `std/auth` before more lifecycle, observability, local-auth, and security features pile onto the old shape.
 
-**Status:** In progress. PR #81 landed the planning/docs pass plus the major module split pass, and PR 4.5C-1 now carries the internal storage contract across sessions, staged auth challenges, OAuth states, and exchange tokens. The next unfinished architecture step is shared fallback/error semantics work, followed by the backend contract-test matrix.
+**Status:** Complete enough to proceed, but intentionally not declared "done forever." The major cleanup wave landed: auth is no longer one undifferentiated file, storage semantics are documented, backend contracts exist, and the later Phase 5–8 work proved the structure is usable. The follow-up work is now tracked explicitly in Phase 9A and Phase 10 instead of pretending the first cleanup pass solved every future pressure point.
 
-**Why now:** Phase 4 shipped the right staged-auth primitives, but it also made a pre-existing architecture issue impossible to ignore: `src/stdlib/auth.rs` is carrying too many responsibilities at once. The risk is not just storage duplication. It is that config parsing, cookie policy, OAuth flow logic, session/challenge persistence, route protection, built-in handlers, JWT/TOTP helpers, and tests are all evolving in one giant file with partially repeated semantics. If we want auth to become world-class instead of merely feature-rich, we should clean up the internal architecture now, while the surface area is still understandable.
+**What landed:**
+- [x] Split `src/stdlib/auth.rs` into focused internal modules for config, cookies, providers, OAuth flow, guards/route protection, built-in routes, request helpers, sessions, storage, primitives, and utilities
+- [x] Established a shared internal auth storage boundary for sessions, staged auth challenges, OAuth states, and exchange tokens
+- [x] Documented the fallback/error contract for existing auth record families
+- [x] Added backend contract coverage for memory/SQLite and env-gated Postgres/Redis paths
+- [x] Preserved the public `std/auth` API while moving behavior behind clearer internal boundaries
+- [x] Re-ran docs generation and auth validation gates during the implementation slices
 
-**Design principles for this phase:**
-- [ ] Keep the public `std/auth` API stable unless a change is overwhelmingly justified
-- [ ] Separate pure auth state transitions from HTTP request/response glue where practical
-- [ ] Prefer one intentional internal model over per-backend drift
-- [ ] Make backend-specific code explicit, localized, and contract-tested
-- [ ] Optimize for future auth work being easier to review, reason about, and extend
+**Important reality check:** the cleanup improved the architecture, but it did not make the architecture self-enforcing yet.
 
-**Workstream A — Internal module boundaries**
-- [x] Split `src/stdlib/auth.rs` into smaller focused modules without changing the public `std/auth` API surface
-- [x] Establish a clear internal layout for config, cookies, providers, OAuth flow, storage, sessions, staged auth challenges, middleware/route protection, built-in routes, JWT helpers, and TOTP helpers
-- [x] Move shared validation and conversion helpers to stable internal homes so they stop drifting across feature work
-- [x] Keep module boundaries understandable enough that a new contributor can answer “where does this logic live?” quickly and confidently
+Current pressure points:
+- `src/stdlib/auth.rs` is still large and remains the gravity well for public types, native-function registration, global memory state, JWT/TOTP wrappers, and most auth tests
+- `src/stdlib/auth/storage.rs` is now the second gravity well: it owns the storage contract plus backend-native logic for every existing auth record family
+- Backend contract tests are useful but concentrated in `auth.rs`, making them harder to extend as new auth state families arrive
+- The existing fallback policy is appropriate for mostly-transient session/challenge/OAuth state, but it must not be blindly reused for durable local credentials
 
-**Workstream B — Auth domain model and flow boundaries**
-- [ ] Identify the core auth state transitions that should be treated as domain logic rather than HTTP glue (for example: begin staged auth, consume challenge, rotate session, sign out, exchange OAuth result into session)
-- [ ] Refactor those transitions so request parsing, cookie mutation, and redirect/response shaping are thin adapters around clearer internal operations
-- [ ] Normalize the lifecycle vocabulary across sessions, auth challenges, OAuth states, and exchange tokens so store/get/consume/delete/cleanup semantics are easier to compare and reason about
+**Architecture standard after this phase:** every new auth feature must answer three questions before implementation:
+1. Which internal module owns the domain behavior?
+2. Which storage contract owns persistence semantics, and how are fallback/error paths tested?
+3. Which public API, docs, generated stdlib reference, and typechecker signatures need to agree?
 
-**Workstream C — Internal persistence contract**
-- [x] Extract a clearer internal auth storage abstraction so session, auth-challenge, OAuth-state, and exchange-token behavior is easier to keep consistent across SQLite/Postgres/Redis and memory fallback paths
-- [ ] Define one intentional place for fallback/error semantics instead of letting each code path decide ad hoc whether backend failures should surface, degrade to memory, or return `None`
-- [ ] Reduce copy-pasted backend logic where the operation shape is truly shared, while preserving backend-native implementations where atomicity or query shape genuinely differs
-- [ ] Revisit cleanup responsibilities so memory, SQLite, Postgres, and Redis all follow the same mental model even if the implementation details differ
+**Follow-up ownership:**
+- Phase 9A owns the preflight cleanup required before first-class local auth lands
+- Phase 10 owns ongoing guardrails, complexity budgets, and periodic architecture audits
 
-**Workstream D — Test architecture and verification matrix**
-- [x] Add backend contract tests that exercise the same auth storage behaviors across memory and SQLite for the current contract helpers
-- [x] Add env-gated Redis/Postgres integration coverage for auth storage flows so backend-specific regressions are caught before review comments or production incidents
-- [x] Add higher-level auth flow tests that verify staged auth, session rotation, protected-route lookup, and logout behavior against the cleaned-up internal boundaries
-- [x] Re-review Phase 3 and Phase 4 helpers after the refactor to ensure docs, tests, and public behavior still match exactly
-
-**Workstream E — Safety rails for the refactor itself**
-- [x] Preserve behavior first, then simplify structure, rather than mixing feature changes into the cleanup branch
-- [x] Write down the intended auth persistence/error/fallback model in the design doc and/or code comments before refactoring the trickiest paths
-- [x] Use small, reviewable commits or PR slices when possible so architecture cleanup does not become an unreadable mega-diff
-- [x] Regenerate docs and re-run the full auth validation gate after each meaningful slice, not just at the very end
-
-**Recommended execution order:**
-- [x] 4.5A: document the intended internal architecture and fallback/error model before moving code
-- [x] 4.5B: split modules and relocate helpers with behavior held constant
-- [x] 4.5C: introduce the internal storage contract and normalize shared semantics (4.5C-1 and 4.5C-2 complete)
-- [x] 4.5D: add/finish backend contract tests and env-gated integration coverage
-- [x] 4.5E: run a final API/docs behavior audit for all Phase 3 and Phase 4 helpers
-
-**Current recommendation:** Phase 4.5 is complete. The storage contract is in place, the fallback/error policy is now explicit and test-covered across sessions, auth challenges, OAuth states, and exchange tokens, and the final Phase 3/4 API/docs behavior pass is done. Move next into Phase 5 session lifecycle work.
-
-**Non-goals:**
-- [ ] Do not add major new end-user auth features in this phase
-- [ ] Do not redesign the public `std/auth` API unless the cleanup reveals a serious correctness issue
-- [ ] Do not force auth onto `std/kv` just for abstraction symmetry if a purpose-built internal auth store boundary is cleaner
-- [ ] Do not ship a prettier file layout while leaving core fallback and lifecycle semantics ambiguous
-
-**Exit criteria:**
-- [ ] We can explain auth internals as one coherent model instead of a set of backend-specific exceptions
-- [ ] Adding or modifying an auth backend no longer requires copy-pasting large sections of session/challenge/state logic
-- [ ] Future auth PRs can land in focused modules instead of reopening a 10k-line file every time
-- [ ] Reviewers can evaluate fallback/error behavior from one documented policy instead of rediscovering it thread by thread
-- [ ] The cleaned-up structure makes Phases 5–8 safer to implement, not merely nicer to look at
-
-**Current landed module map (after PR #81):**
-- [x] `auth/config.rs` — `AuthConfig`, defaults, option parsing, config validation, startup summary, and session-store initialization helpers
-- [x] `auth/cookies.rs` — cookie-name validation, shared cookie settings, signed session/challenge cookies, clear-cookie helpers, and `SITE_URL`-aware cookie posture helpers
-- [x] `auth/providers.rs` — built-in provider definitions, provider normalization, and provider/value conversion helpers
-- [x] `auth/oauth.rs` — OAuth start/exchange/refresh/discovery/introspection flow coordination and provider userinfo handling
-- [x] `auth/guards.rs` — protected-path registration/matching, auth enforcement behavior, and challenge-kind validation
-- [x] `auth/routes.rs` — built-in `/auth/*` handlers and request/response adapters
-- [x] `auth/request_helpers.rs` — request extraction plus `Session`/`User`/`AuthChallenge` to `Value` conversion helpers
-- [x] `auth/sessions.rs` — session lifecycle, mutation, and session-listing/revocation store coordination
-- [x] `auth/storage.rs` — auth-challenge, OAuth-state, exchange-token, and cleanup persistence logic across backends
-- [x] `auth/primitives.rs` — low-level auth primitives like IDs, nonces, HMAC signing helpers, and TOTP primitives
-- [x] `auth/utils.rs` — response builders and canonical JSON/value conversion helpers used across auth internals
-
-**Remaining target splits / normalization work:**
-- [ ] Split `auth/storage.rs` into a clearer internal storage contract plus backend-focused modules (`mod`, `memory`, `sqlite`, `postgres`, `redis`) once 4.5C starts
-- [ ] Decide whether session domain logic should stay centralized in `auth/sessions.rs` or split further into a narrower `session_core.rs` plus admin/query helpers
-- [ ] Pull staged-auth challenge lifecycle into a clearer domain boundary (`challenge_core.rs` or equivalent) if that materially improves the session/challenge split during 4.5C
-- [ ] Split JWT helpers out of `auth.rs` if they continue growing enough to deserve `auth/jwt.rs`
-- [ ] Keep TOTP primitives in `auth/primitives.rs` unless a dedicated `auth/totp.rs` becomes justified by size or clarity
-- [ ] Revisit whether `auth/request_helpers.rs` and `auth/utils.rs` should converge on a more explicit `value_maps.rs` style home for `Session`/`User`/`AuthChallenge` conversion semantics
-
-**Recommended PR slicing plan:**
-- [x] PR 4.5A-1: add architecture notes, auth persistence/error/fallback invariants, and TODO anchors without moving behavior yet
-- [x] PR 4.5A-2: add backend contract-test harness that can run against memory/SQLite immediately and Postgres/Redis when env-gated services are available
-- [x] PR 4.5B-1: move config/cookie/provider/JWT/TOTP helpers into modules with behavior held constant
-- [x] PR 4.5B-2: move middleware and built-in route glue into modules with no intentional semantic changes
-- [x] PR 4.5C-1: introduce the internal storage contract for sessions/auth challenges/OAuth states/exchange tokens while preserving existing backend-native implementations
-- [x] PR 4.5C-2: centralize fallback/error semantics and make each auth state type follow the same documented rules
-  - [x] Define the canonical fallback/error policy table for sessions, auth challenges, OAuth states, and exchange tokens
-  - [x] Make store/get/consume/delete/cleanup semantics follow that policy consistently across memory, SQLite, Postgres, and Redis
-  - [x] Normalize TTL/expiry behavior for memory fallback paths so they do not silently diverge from backend-native semantics
-  - [x] Add focused tests that prove the chosen fallback/error behavior instead of relying on comments and TODOs
-- [x] PR 4.5D-1: add/finish Redis/Postgres integration coverage and cross-backend contract assertions
-- [x] PR 4.5E-1: final audit PR for docs generation, public API parity, and cleanup of temporary compatibility shims
-
-**Highest-risk regression hotspots to guard during the refactor:**
-- [ ] Cookie naming/signing/clearing behavior for both session and auth-challenge cookies stays byte-for-byte compatible unless intentionally changed
-- [ ] HTML redirect vs API `401`/`403` behavior in `require_auth()` does not drift during middleware extraction
-- [ ] One-time consume semantics for OAuth states, exchange tokens, and auth challenges remain atomic per backend
-- [ ] Session rotation preserves intended claims/data while invalidating the old session immediately
-- [ ] Refresh-token and expired-session lookup behavior does not regress while storage semantics are being normalized
-- [x] Memory fallback continues to behave intentionally, especially under backend errors and mixed cleanup paths
-- [x] Generated stdlib docs and `@ntnt` signatures remain accurate after functions move files/modules
-
-**Validation matrix for phase completion:**
-- [x] Memory backend: session sign-in/current-user/sign-out/rotation/challenge begin-complete-cancel all pass
-- [x] SQLite backend: same core session + challenge flows pass with cleanup and consume behavior verified
-- [x] Postgres backend: same core session + challenge flows pass in env-gated integration coverage
-- [x] Redis/Valkey backend: same core session + challenge flows pass in env-gated integration coverage, including atomic consume paths
-- [x] Protected-route behavior verified for HTML pages and API routes after module split
-- [x] OAuth state and exchange-token paths still pass, including Safari/redirect-chain-related flows already covered by current behavior
-- [x] `cargo test stdlib::auth::tests`, any relevant integration suites, `cargo build --release --locked`, and `./target/release/ntnt docs --generate` all pass at the end of each major slice
-
-**Ships real value:** this phase does not add flashy new auth features, but it is what makes the next layers of auth quality, safety, and speed possible without quietly accumulating structural debt.
+**Ships real value:** this phase made the auth system understandable enough to keep improving. The next job is making that structure harder to accidentally bypass.
 
 ### Phase 5 — Session Lifecycle and Presets
 **Goal:** Harden session lifetime behavior and make strong defaults ergonomic.
@@ -305,7 +226,7 @@ return complete_auth_challenge(resp, req, map {
 - [x] Health output shows config state without leaking secrets
 - [x] Diagnose common issues like redirect mismatch, missing env, wrong store
 
-**Implementation note (2026-04-21 / PR pending):** Phase 6 now preserves provider-specific refresh-token behavior correctly (including rotation only when a provider actually returns a new refresh token), logs rotation events without exposing token material, and adds a built-in `/auth/health` diagnostics route that is dev-only by default and can be explicitly enabled in production.
+**Implementation note:** Phase 6 preserves provider-specific refresh-token behavior correctly (including rotation only when a provider actually returns a new refresh token), logs rotation events without exposing token material, and adds a built-in `/auth/health` diagnostics route that is dev-only by default and can be explicitly enabled in production.
 
 **Provider differences:** some providers return a fresh refresh token on every refresh, while others omit `refresh_token` unless rotation occurs. `std/auth` now preserves the stored token when providers omit it, replaces the stored token when they rotate it, and surfaces the distinction through safe auth logs and diagnostics rather than pretending all providers behave the same.
 
@@ -314,27 +235,28 @@ return complete_auth_challenge(resp, req, map {
 ### Phase 7 — Auto-Routes and Convenience UI
 **Goal:** Make the easy path extremely easy without forcing apps into one UI.
 
-**Status:** Phase 7A implemented in PR #94 (pending) on 2026-04-21. This slice ships configurable built-in auth route prefixes, startup route logging, truthful collision warnings for built-in auth routes vs protected-path config, and a configurable built-in login page with auto-generated provider buttons. Full auto-mount/override integration with app-owned route tables remains open.
+**Status:** Core Phase 7A landed in PR #94 and is on `main` in v0.4.9.
 
-- [ ] Auto-generate standard auth routes if not overridden
+- [ ] Auto-generate every standard auth route when not overridden
 - [x] Configurable path prefixes (`/auth/*` by default)
-- [x] Clear startup log showing registered routes
-- [x] Path collision detection with app-defined routes
+- [x] Clear startup log showing registered auth routes
+- [x] Path collision diagnostics for built-in auth routes and protected-path config
 - [x] Built-in login page template
 - [x] Configurable title/logo/copy
 - [x] Provider buttons generated automatically
 - [ ] Support custom HTML override if needed
+- [ ] Add end-to-end route-dispatch tests proving route protection works through actual ntnt server/file-route setup, not only helper-level matching
 
 **Ships real value:** simple apps get auth with almost no wiring, while custom apps still own their design.
 
 ### Phase 8 — Advanced Sessions and Security Signals
 **Goal:** Add higher-end capabilities once the core mechanics are excellent.
 
-**Status:** Phase 8A (session metadata + security-signal plumbing) is now implemented on branch `feat/auth-phase-8-advanced-sessions-complete` / PR #96. This slice focused on carrying richer session/security metadata cleanly through the existing auth system, plus the review-driven hardening needed to make that plumbing trustworthy across backends.
+**Status:** Phase 8A landed in PR #96 and is on `main` in v0.4.9. This slice delivered metadata/security-signal plumbing, not the full suspicious-activity product layer.
 
-**What landed in this slice:**
-- [x] Store user agent hash / device name on session creation
-- [x] Pass remember-me flag through OAuth state
+**What landed:**
+- [x] Store user agent hash / device name fields on session records
+- [x] Pass remember-me flag through OAuth state storage
 - [x] Persist OAuth-state security metadata (`remember_me`, `device_name`, `user_agent_hash`, `last_ip_hash`) across SQLite/Postgres/Redis + memory fallback
 - [x] Persist session security metadata (`device_name`, `user_agent_hash`, `last_ip_hash`) across SQLite/Postgres/Redis + memory fallback
 - [x] Copy captured OAuth-state metadata onto the real session at callback time before store/rotation
@@ -344,9 +266,10 @@ return complete_auth_challenge(resp, req, map {
 - [x] Harden SQLite/Postgres migration behavior so schema updates stop swallowing real failures
 - [x] Extend auth storage contract tests and auth flow tests for the new metadata paths
 
-**What this slice did _not_ finish yet:**
-- [ ] `list_sessions(user_id)` API *(already partially represented by existing `user_sessions(req)` current-user helper, but no dedicated arbitrary-user/admin-facing API landed in this slice)*
-- [ ] `revoke_session(session_id)` API *(existing revocation helpers remain current-user/request-oriented)*
+**Still open before Phase 8 is product-complete:**
+- [ ] Expose appropriate device metadata through session-management APIs (`device_name` yes; raw hashes no)
+- [ ] `list_sessions(user_id)` API for admin/arbitrary-user session lookup
+- [ ] `revoke_session(session_id)` API
 - [ ] `revoke_all_sessions(user_id)` API
 - [ ] Password change hook support for revocation
 - [ ] Account disable hook support for revocation
@@ -354,80 +277,115 @@ return complete_auth_challenge(resp, req, map {
 - [ ] Add `security_events` storage for auth events
 - [ ] Configurable suspicious-activity actions: `warn`, `challenge`, `revoke`
 - [ ] Expose `auth_events(user_id, limit?)` for admin dashboards
-- [ ] Rate limit failed OAuth callbacks
+- [ ] Rate limit failed OAuth callbacks and future local-auth login/reset attempts
 - [ ] Add `remember_ttl`
-- [ ] Set distinct remember-me TTL/persistence behavior on session creation
+- [ ] Capture remember-me intent from request/config instead of hard-coding false on auth start
+- [ ] Set distinct remember-me TTL/persistence behavior on session and cookie creation
+- [ ] Strengthen contract tests to assert metadata round-trips across store/get, migrate/rotate, session listing, refresh lookup, and OAuth-state consume
 
-**Assessment of the current Phase 8 outcome:** this slice successfully delivered the underlying metadata/security-signal plumbing that Phase 8 needed before higher-level features like suspicious-activity policies or auth event streams can be layered on safely. The main work was not just adding columns — it was making the metadata survive the real auth path, align across backends, survive review scrutiny, and avoid silent migration failures. That makes this a real Phase 8 foundation slice rather than cosmetic schema churn.
+**Assessment:** Phase 8A was the right foundation slice. It made the metadata survive real OAuth/session paths and existing backends. The next slices should turn that plumbing into visible session-management, remember-me, eventing, and suspicious-activity behavior.
 
 **Ships real value:** this is where `std/auth` starts becoming genuinely standout, not just competent.
 
 ### Phase 9 — First-Class Local Auth
 **Goal:** Make `std/auth` world-class not only for OAuth/session plumbing, but also for the extremely common app shape of **local email + password + TOTP auth**.
 
-**Why this must exist:** the current `std/auth` surface is already strong at sessions, cookies, staged auth challenges, OAuth/OIDC, TOTP primitives, sign-in/sign-out helpers, and protected-route handling. But for a very normal local admin/app flow, developers still have to build and own a mini auth system beside it:
+**Why this must exist:** the current `std/auth` surface is strong at sessions, cookies, staged auth challenges, OAuth/OIDC, TOTP primitives, sign-in/sign-out helpers, and protected-route handling. But a normal local admin/app flow still requires developers to build and own a mini auth system beside it:
 
-- local user table
-- password-hash storage
-- password verification
+- local user/credential table
+- password-hash storage and verification
 - password reset token storage
-- first-login / forced-password-change flow
 - persisted TOTP enrollment state
+- first-login / forced-password-change flow
 - bootstrap admin account creation
+- claims/role glue between local accounts and sessions
 
 That is the current local-auth subsystem gap.
 
-`std/auth` can already manage authenticated state beautifully. What it still cannot fully own is the **local credential lifecycle end-to-end**. As long as that remains true, templates and apps will keep carrying custom auth code that should really belong to the language.
+**Architectural standard:** a template app should not need a custom `lib/admin_db.tnt` mini-auth subsystem to get excellent email/password/TOTP auth. The template should mostly configure `std/auth`, provide custom views/copy if it wants them, and move on.
 
-**Architectural standard:** a template app should not need a custom `lib/admin_db.tnt` mini-auth subsystem to get excellent email/password/TOTP auth. The template should mostly configure `std/auth`, wire a few views if it wants custom UX, and move on.
+**Preferred public API direction:** local auth should be a first-class provider variant consumed by the existing `enable_auth(...)` entrypoint, not a separate parallel auth system.
 
-**Success test:** if a developer wants a local admin panel with email/password login, TOTP verification, password resets, first-login activation, and forced password changes, the path should feel as native and obvious as OAuth already does.
+```ntnt
+import { enable_auth, local_auth } from "std/auth"
+import { get_env } from "std/env"
 
-## Recommended implementation shape for Phase 9
+enable_auth([
+    local_auth(map {
+        "email_password": true,
+        "totp": true,
+        "password_reset": true,
+        "bootstrap_email": get_env("ADMIN_BOOTSTRAP_EMAIL"),
+        "bootstrap_password": get_env("ADMIN_BOOTSTRAP_PASSWORD"),
+        "claims": map { "role": "admin" }
+    })
+], "admin", map {
+    "login_page": false,
+    "success_url": "/admin",
+    "failure_url": "/admin/login"
+})
+```
 
-Phase 9 should be a **feature architecture phase**, not just a helper phase. The key is not to bolt on scattered primitives, but to let `std/auth` own one coherent local-auth model.
+A later `enable_local_auth(...)` convenience wrapper is acceptable if it simply delegates into the same underlying provider/config path. The implementation must not become two auth systems.
 
-### Phase 9A — Local Identity Store
-- [ ] Add a first-class local credential store owned by `std/auth`
-- [ ] Make **email** the canonical local identifier
+#### Phase 9A — Architecture Preflight and Storage Boundary
+- [ ] Split or carve `auth/storage.rs` enough that new local-auth state does not get buried in the existing storage monolith
+- [ ] Define explicit local-auth record families before code lands: local identity, credential secret, password reset token, TOTP enrollment/setup state, and bootstrap state
+- [ ] Define local-auth fallback/error policy before implementation; durable credential/TOTP/reset state should fail closed rather than silently fall back to process memory in production
+- [ ] Move the backend contract harness toward reusable storage-module ownership so every new local-auth record can extend it immediately
+- [ ] Document which parts of `auth.rs` are allowed to grow for local auth and which must live in focused modules
+- [ ] Add review checklist items for local-auth regressions: captured-but-not-persisted state, reset-token replay, backend mismatch, swallowed migration errors, and app/std ownership ambiguity
+
+**Exit criterion:** the storage and module homes for local auth are obvious before the first credential table/helper is implemented.
+
+#### Phase 9B — Local Identity and Credential Store
+- [ ] Add first-class local credential storage owned by `std/auth`
+- [ ] Make **email** the canonical local identifier, with documented normalization rules
 - [ ] Store password hashes in auth-owned tables rather than pushing that responsibility to apps
+- [ ] Define a lean durable local-user/account shape: identity + auth state first, not a full profile platform
+- [ ] Support account states needed by real flows: bootstrap/pending setup/active/disabled/locked/password-change-required
 - [ ] Support bootstrap account creation from config/env for the common admin-panel case
-- [ ] Define the minimum durable local-user shape intentionally instead of letting templates invent their own schemas
-- [ ] Keep the model lean: identity + auth state first, not a giant profile system
+- [ ] Ensure bootstrap credentials force rotation/setup instead of becoming a permanent production secret path
+- [ ] Add memory/SQLite contract tests by default and Postgres/Redis contract tests in required backend CI
 
-### Phase 9B — Local Sign-In Flow
+#### Phase 9C — Request-Aware Local Sign-In Flow
 - [ ] Add built-in email/password verification through `std/auth`
-- [ ] Reuse the existing staged-auth challenge primitives for local login continuation
+- [ ] Use a request-aware local sign-in path that receives `req` so it can rotate/migrate existing sessions and capture request metadata
+- [ ] Reuse the same session cookie, session TTL, sliding/max-lifetime, metadata, and revocation semantics as OAuth-backed sign-in
+- [ ] Reuse staged auth challenge primitives for local login continuation instead of inventing a second pending-auth model
 - [ ] Support straightforward local sign-in that upgrades into a real auth session with configured claims/data
-- [ ] Ensure local sign-in uses the same cookie/session lifecycle semantics as OAuth-backed sign-in
-- [ ] Keep local auth and OAuth auth aligned at the session layer so apps do not feel two different auth systems
+- [ ] Ensure local sessions receive `device_name`, `user_agent_hash`, and `last_ip_hash` just like OAuth sessions
 
-### Phase 9C — First-Login Activation and TOTP Enrollment
+#### Phase 9D — First-Login Activation, Forced Password Change, and TOTP Enrollment
 - [ ] Support first-login setup as a first-class local-auth flow
 - [ ] Support staged TOTP enrollment using the existing auth challenge model
 - [ ] Support forced password change before final session completion
-- [ ] Support completion into a normal signed-in session only after setup requirements are satisfied
-- [ ] Keep staged local flows expressed in the same lifecycle vocabulary as the rest of `std/auth`
+- [ ] Support completion into a normal signed-in session only after required setup steps are satisfied
+- [ ] Persist TOTP enrollment/setup state explicitly; do not hide durable enrollment state inside generic challenge `data_json`
+- [ ] Define TOTP reset/re-enrollment behavior after password reset or admin intervention
 
-### Phase 9D — Password Reset Lifecycle
+#### Phase 9E — Password Reset Lifecycle
 - [ ] Add auth-owned password-reset token storage and lifecycle helpers
 - [ ] Support reset token issue + consume flows through `std/auth`
+- [ ] Make reset tokens one-time-use, TTL-bound, and atomically consumed across every backend
 - [ ] Support optional TOTP reset / re-enrollment semantics after password reset
 - [ ] Support reset flows that intentionally force fresh staged setup when security posture demands it
-- [ ] Keep reset semantics coherent with the session/challenge model instead of inventing another separate sub-system
+- [ ] Define the email-delivery boundary: `std/auth` issues/validates tokens and builds safe URLs; apps/plugins send email
+- [ ] Rate-limit failed local login and password-reset attempts
 
-### Phase 9E — Template-Grade Integration
+#### Phase 9F — Template-Grade Integration and Deletion of App-Owned Mini-Auth
 - [ ] Make the Larri site template use the built-in local auth path instead of custom auth persistence code
 - [ ] Delete template-owned local-auth state machines and tables once parity exists
 - [ ] Leave the template with mostly config + views + app-specific copy, not a bespoke auth backend
 - [ ] Use the template migration as the proof that the local-auth architecture is actually simpler, not just theoretically cleaner
+- [ ] Keep custom UI possible without requiring custom credential/session/reset persistence
 
-### Phase 9F — Architecture Discipline for Local Auth
-- [ ] Keep local auth inside the post-4.5 module boundaries rather than re-growing a monolith in `auth.rs`
-- [ ] Extend the backend contract harness for every new local-auth persistence shape
-- [ ] Treat local auth storage semantics as a compatibility surface, not incidental implementation detail
-- [ ] Add explicit review guidance for local-auth regressions: captured-but-not-persisted staged state, reset-token lifecycle drift, backend mismatch, and “half-owned by app / half-owned by std/auth” ambiguity
-- [ ] Re-review the resulting structure periodically so local auth becomes a coherent subsystem, not a second pile of special cases
+#### Phase 9G — Local Auth Verification Matrix
+- [ ] Add contract tests for every local-auth record family across memory and SQLite by default
+- [ ] Add required CI coverage for Postgres and Redis/Valkey local-auth contracts
+- [ ] Add migration tests for existing DBs missing new local-auth columns/tables
+- [ ] Add end-to-end ntnt tests for bootstrap login, password change, TOTP setup, normal login, reset token issue/consume, reset replay rejection, disabled account rejection, and session revocation after credential changes
+- [ ] Add docs/reference examples that are runnable, lintable, and intentionally clear about app-owned UI/email boundaries
 
 **Non-goals for this phase:**
 - [ ] Do not turn `std/auth` into a giant full-profile identity platform in one shot
@@ -442,182 +400,214 @@ Phase 9 should be a **feature architecture phase**, not just a helper phase. The
 
 **Ships real value:** closes the biggest remaining gap between “great auth primitives” and “great auth architecture,” so apps can rely on `std/auth` for the full local email/password/TOTP lifecycle instead of rebuilding it.
 
-### Phase 10 — Post-Cleanup Complexity Discipline
-**Goal:** Prevent `std/auth` from collapsing back into a monolith after the 4.5 cleanup lands.
+### Phase 10 — Architecture Discipline and Complexity Budget
+**Goal:** Prevent `std/auth` from collapsing back into a monolith as local auth, session management, security events, and future auth features land.
 
-**Assessment after the Phase 8 branch review (compared against the v0.4.8 release baseline):** the 4.5 cleanup largely achieved its intended effect, but only partially solved the long-term maintainability problem. The internal module split is real and materially improves clarity: config, cookies, guards, OAuth flow, providers, request helpers, routes, sessions, storage, and small utility layers now exist as distinct homes instead of one giant undifferentiated file. The storage contract is also much more coherent than before, and recent review feedback mostly hit end-to-end plumbing gaps and edge-case semantics rather than “where does this logic even belong?” confusion. That is a meaningful architectural win.
+**Status:** Starts immediately. This phase is numbered after local auth because it is ongoing discipline, but its first guardrails must land before Phase 9 implementation begins.
 
-**However:** `src/stdlib/auth.rs` is still very large and still acts as a gravity well for the public surface, native-function registration, shared types, and the main auth test module. So the cleanup should be viewed as **successful but incomplete**. `std/auth` is no longer a pure junk drawer, but it is also not yet structurally self-protecting. It is maintainable **if** future work is forced through the module boundaries and contract tests established in 4.5. If contributors drift back into broad `auth.rs` edits for convenience, the monolith will regrow quickly.
+**Assessment after the Phase 8 branch review:** the 4.5 cleanup largely achieved its intended effect, but only partially solved the long-term maintainability problem. The module split is real and materially improves clarity. The storage contract is also much more coherent than before. Recent review feedback mostly hit end-to-end plumbing gaps and edge-case semantics rather than “where does this logic even belong?” confusion. That is a meaningful architectural win.
 
-**Bottom line:** the DD intent was mostly achieved for the cleanup wave — enough to justify continuing from this shape — but Phase 10 must turn the current structure into enforceable discipline rather than assuming the cleanup alone solved the problem.
+**However:** `src/stdlib/auth.rs` is still very large and still acts as a gravity well for public surface, native-function registration, shared types, global memory state, JWT/TOTP wrappers, and the main auth test module. `src/stdlib/auth/storage.rs` is also large enough that adding local credentials/reset/TOTP records there without further structure would create a second monolith.
 
-## Recommended implementation shape for Phase 10
+**Bottom line:** the DD intent was mostly achieved for the cleanup wave — enough to justify continuing from this shape — but future auth work must be forced through explicit module/storage/test boundaries. Cleanup alone is not a force field. Annoying, but here we are.
 
-Phase 10 should be a **discipline phase, not a feature phase**. The goal is to make the architecture we now have more self-enforcing, so future auth work naturally lands in the right places and gets the right verification by default.
-
-### Phase 10A — Architecture Guardrails
+#### Phase 10A — Contributor and Review Guardrails
 - [ ] Write explicit contributor guidance for what belongs in `auth.rs` vs internal auth modules
 - [ ] Document the allowed responsibilities of `auth.rs`: public surface, shared types, registration glue, and only the minimum unavoidable coordination logic
 - [ ] Document when a new auth change must extend an existing module versus when it merits a new focused module
-- [ ] Add an auth-specific review checklist covering the regressions exposed in Phase 8 and Phase 9 (captured-but-not-persisted state, schema/query name drift, swallowed migration errors, backend mismatch paths, fallback ambiguity, reset lifecycle drift, and app/std ownership confusion)
+- [ ] Add an auth-specific review checklist covering: captured-but-not-persisted state, schema/query name drift, swallowed migration errors, backend mismatch paths, fallback ambiguity, reset lifecycle drift, session metadata loss, remember-me behavior drift, and app/std ownership confusion
 
-### Phase 10B — Contract-Test Ratchet
-- [ ] Require new auth persistence/state shapes to extend the backend contract harness
-- [ ] Add missing contract coverage for any auth persistence paths still validated only indirectly
+#### Phase 10B — Contract-Test Ratchet
+- [ ] Require new auth persistence/state shapes to extend the backend contract harness in the same PR that introduces them
+- [ ] Add missing contract coverage for metadata round-trips across session store/get, migrate/rotate, list sessions, refresh lookup, and OAuth-state consume
 - [ ] Require new fallback/error semantics to be tested in primary, fallback, and failure modes
+- [ ] Make Postgres/Redis auth contract coverage visible in CI instead of silently green when env vars are absent
 - [ ] Treat auth storage behavior as a compatibility surface, not just an implementation detail
 
-### Phase 10C — `auth.rs` Pressure Relief
-- [ ] Audit what still lives in `auth.rs` only because of historical gravity rather than good ownership
-- [ ] Move obvious non-surface helpers and test-heavy logic into module-local ownership where it improves clarity without destabilizing the public API
-- [ ] Reassess whether the main auth test concentration should be partially redistributed into focused module tests over time
-- [ ] Track `auth.rs` growth relative to the internal modules so “easy broad edits” become visible early
+#### Phase 10C — `auth.rs` and `storage.rs` Pressure Relief
+- [ ] Move obvious non-surface types/helpers out of `auth.rs` when doing so improves ownership without destabilizing the public API
+- [ ] Extract JWT and TOTP wrappers if they continue to grow or distract from the public auth surface
+- [ ] Move memory-store/global-state code toward focused module ownership
+- [ ] Split storage by record family and/or backend before adding durable local-auth records
+- [ ] Reassess whether the main auth test concentration should move toward module-local test ownership over time
+- [ ] Track `auth.rs` and `auth/storage.rs` growth relative to internal modules so broad edits become visible early
 
-### Phase 10D — Periodic Architecture Audit
+#### Phase 10D — Periodic Architecture Audit
 - [ ] Re-review new auth work periodically against the intended module boundaries
 - [ ] Check whether recent auth changes increased clarity or merely moved complexity around
 - [ ] Reconfirm that fallback semantics remain deliberate and documented as auth work expands
-- [ ] Update DD-043 / REVIEW guidance when review incidents reveal new recurring patterns
+- [ ] Update DD-043, DD-062, and REVIEW guidance when review incidents reveal new recurring patterns
+- [ ] Revisit whether large tests inside `auth.rs` should migrate toward module-local test ownership as the structure stabilizes
 
-- [ ] Track auth code size / complexity budget as features land, especially `auth.rs` vs the internal modules
-- [ ] Require new auth work to fit the post-4.5 module boundaries instead of reopening broad grab-bag files
-- [ ] Keep `auth.rs` focused on public surface, shared types, registration glue, and only the minimum unavoidable coordination logic
-- [ ] Extend backend contract tests when adding new auth state types, flows, or stores
-- [ ] Treat fallback/error semantics as design-level behavior, not incidental implementation detail
-- [ ] Add review guidance/checklists for common auth regressions: captured-but-not-persisted state, schema/name drift, swallowed migration errors, backend mismatch paths, reset lifecycle drift, and ownership ambiguity between app code and `std/auth`
-- [ ] Periodically re-audit whether new features are preserving the intended internal architecture
-- [ ] Revisit whether large test concentrations inside `auth.rs` should migrate toward module-local test ownership as the structure stabilizes
-
-**Ships real value:** preserves the benefits of the cleanup and the local-auth work so future auth work stays understandable instead of slowly regressing.
+**Ships real value:** preserves the benefits of the cleanup and local-auth work so future auth development stays understandable instead of slowly regressing into a suspiciously feature-rich junk drawer.
 
 ## What We Explicitly Won't Do
 
-These are features that other auth systems offer but don't belong in a language stdlib:
+These boundaries keep `std/auth` focused as a language stdlib auth system rather than drifting into a hosted identity product.
 
-- **User management UI** — That's the app's job, not the language's
-- **Email/password signup flows** — We provide `hash_password`/`verify_password` + session management; the signup form and email verification is app logic
-- **Social login buttons/UI** — We handle the OAuth protocol; the "Sign in with Google" button is app HTML
-- **Multi-tenancy** — Session isolation between tenants is app-level routing
-- **Billing/subscription gating** — Not auth, not our problem
-- **SMS/email OTP delivery** — We provide TOTP verification; delivery channels are app-specific
+- **User management UI** — account-management pages, admin dashboards, visual design, and product-specific workflows are app-owned
+- **Public self-service signup product flows** — `std/auth` may own local credential storage and verification, but the decision to allow public signup, invite-only signup, approval workflows, email copy, and onboarding UX belongs to the app
+- **Email/SMS delivery** — `std/auth` should issue and validate reset/setup tokens and produce safe URLs; apps/plugins own the delivery channel
+- **Arbitrary profile systems** — names, avatars, preferences, organizations, billing fields, and app-specific profile data belong in app tables
+- **Full RBAC/ABAC/organization modeling** — `std/auth` can carry claims and expose hooks, but it should not solve every authorization model before shipping excellent auth
+- **Billing/subscription gating** — not auth, not our problem
+- **Vendor-hosted identity service semantics** — no pricing tiers, tenant dashboards, or hosted control planes inside the language runtime
 
----
+Clarification: **local email/password/TOTP credential lifecycle is in scope** for Phase 9. The non-goal is owning every product/business workflow around accounts, not the core credential/session/reset/setup mechanics that every app currently has to rebuild.
 
 ## Delivery Order
 
-The best delivery order is not just "security first" or "DX first". It should deliver a complete slice each time, where every wave leaves `std/auth` materially more useful in real apps.
+The best delivery order is not just "security first" or "DX first". Each wave should leave `std/auth` materially more useful in real apps while reducing, not increasing, long-term architectural drag.
 
-For template cleanup specifically, the biggest wins are:
+For template cleanup specifically, the biggest early wins were:
 1. section-wide route protection
 2. session/cookie helpers
 3. staged-auth challenge primitives
 
-So the plan should put those cleanup-heavy features first, but still start with a very thin foundation pass so the rest of the work lands on stable defaults and validation.
+Those are now shipped. The next big win is local email/password/TOTP auth, but only if it lands as a coherent subsystem with storage/test discipline rather than another layer of helpers.
 
 | Order | Delivery Wave | Feature Bundle | Why This Order |
 |-------|---------------|----------------|----------------|
-| **0** | Validation | 5.1 Safari ITP A/B test | Validate the constraint before optimizing around it |
-| **0.5** | Foundation Mini-Wave | 3.1 + 3.3 + 3.4 zero-config defaults, startup summary, typed config validation | Thin safety pass before the cleanup-heavy auth primitives |
-| **1** | Route Protection | 3.7 + 3.7.1 `require_auth` plus section/file-route protection | Biggest immediate cleanup win for file-routed apps and templates |
-| **2** | Session Core | 1.1 + 3.7.2 session rotation, sign-in/sign-out/current-session helpers | Removes the most repetitive login/logout/cookie boilerplate |
-| **3** | Staged Auth | 3.7.3 challenge primitives for pending auth states | Unlocks password → TOTP, first-login setup, and step-up auth cleanly |
-| **4** | Internal Architecture Cleanup | 4.5 internal module split, storage contract, fallback semantics, and backend verification matrix | Pay down auth structural debt before more lifecycle and security features stack onto the current shape |
-| **5** | Session Lifecycle | 1.2 + 1.3 + 3.6 sliding sessions, max lifetime, presets | Hardens lifecycle rules after the core mechanics and architecture are stable |
-| **6** | OAuth Hardening + Observability | 2.1 + 3.5 refresh token rotation and auth health check | Tightens security posture and makes behavior inspectable |
-| **7** | Auto-Routes + UI Convenience | 3.2 + 3.8 auto-routes and login page generator | Helpful DX layer after the mechanics are already excellent |
-| **8** | Advanced Sessions | 4.1 + 4.2 + 4.3 + 4.4 device sessions, cascade revoke, suspicious activity, remember me | Differentiators layered onto a solid core |
-| **9** | Post-Cleanup Discipline | Phase 9 module-boundary enforcement and complexity budget | Prevent the architecture cleanup from eroding over time |
+| **0** | Validation | Safari ITP A/B validation | Validate the constraint before optimizing around it |
+| **0.5** | Foundation Mini-Wave | zero-config defaults, startup summary, typed config validation | Thin safety pass before cleanup-heavy auth primitives |
+| **1** | Route Protection | `require_auth` plus section/file-route protection | Biggest immediate cleanup win for file-routed apps and templates |
+| **2** | Session Core | session rotation, sign-in/sign-out/current-session helpers | Removes repetitive login/logout/cookie boilerplate |
+| **3** | Staged Auth | pending auth challenge primitives | Unlocks password → TOTP, first-login setup, and step-up auth cleanly |
+| **4** | Internal Architecture Cleanup | module split, storage contract, fallback semantics, backend contract matrix | Makes later auth features safer to build and review |
+| **5** | Session Lifecycle | sliding expiration, max lifetime, presets | Hardens lifecycle rules after core mechanics are stable |
+| **6** | OAuth Hardening + Observability | refresh token rotation and auth health diagnostics | Tightens security posture and production debuggability |
+| **7** | Auto-Routes + UI Convenience | configurable auth routes and login page generator | Improves DX without compromising app-owned UX |
+| **8** | Advanced Sessions Foundation | metadata/security-signal plumbing, remember-me plumbing | Establishes the data path for device sessions and security events |
+| **8.5** | Architecture Guardrails Preflight | Phase 10A/10B minimum guardrails before local-auth code | Prevents Phase 9 from re-growing the monolith |
+| **9** | First-Class Local Auth | local identity store, request-aware login, TOTP setup, password reset, template migration | Closes the biggest remaining real-app auth gap |
+| **10** | Ongoing Architecture Discipline | complexity budget, contract-test ratchet, periodic audits | Keeps `std/auth` excellent as features continue landing |
 
 ### Delivery Wave Deliverables
 
 #### Wave 0.5 — Foundation Mini-Wave
-**Ships:**
+**Shipped:**
 - production-safe default auth config
 - startup summary showing active auth config
 - typed config validation with actionable errors
 
-**Strong value:** creates a stable floor for the cleanup-heavy phases without spending a whole early phase on lower-leverage convenience work.
+**Value:** creates a stable floor for the cleanup-heavy phases without spending a whole early phase on lower-leverage convenience work.
 
 #### Wave 1 — Route Protection
-**Ships:**
+**Shipped:**
 - `require_auth()` middleware
 - path/subtree protection for file-routed apps
 - HTML redirect vs API `401` behavior
 - section-wide protection for things like `routes/admin/*`
 
-**Strong value:** apps stop re-implementing auth checks in every page handler.
+**Value:** apps stop re-implementing auth checks in every page handler.
 
 #### Wave 2 — Session Core
-**Ships:**
-- session ID rotation on successful auth
+**Shipped:**
+- session ID rotation on successful OAuth callback/session upgrade
 - `sign_in_session()`
 - `sign_out_session()`
 - `current_session()` / `current_user()`
 - shared cookie defaults and overrides
 
-**Strong value:** the most repetitive and mistake-prone login/logout/cookie code disappears.
+**Follow-up:** local auth should use a request-aware sign-in path rather than relying on the existing request-less `sign_in_session()` semantics.
+
+**Value:** the most repetitive and mistake-prone login/logout/cookie code disappears.
 
 #### Wave 3 — Staged Auth
-**Ships:**
+**Shipped:**
 - `begin_auth_challenge()`
 - `current_auth_challenge()`
 - `complete_auth_challenge()`
 - `cancel_auth_challenge()`
 - one-time, TTL-bound pending auth state distinct from real sessions
 
-**Strong value:** multi-step auth becomes a normal pattern instead of ad hoc glue code.
+**Value:** multi-step auth becomes a normal pattern instead of ad hoc glue code.
 
 #### Wave 4 — Internal Architecture Cleanup
-**Ships:**
+**Shipped:**
 - module split into coherent auth internals
-- documented fallback/error semantics
+- documented fallback/error semantics for existing state families
 - internal storage contract across sessions/challenges/states/tokens
 - backend contract-test harness + env-gated Postgres/Redis verification
 
-**Strong value:** this is the quality wave that makes the next auth features safer to build instead of more expensive every time.
+**Follow-up:** split storage further before adding local-auth durable record families.
+
+**Value:** makes the next auth features safer to build instead of more expensive every time.
 
 #### Wave 5 — Session Lifecycle
-**Ships:**
+**Shipped:**
 - sliding expiration
 - absolute max lifetime
-- ergonomic presets (`strict`, `balanced`, `relaxed`, etc.)
+- lifecycle presets (`consumer`, `admin`, `internal`, `strict`)
+- preset + override merge
+- cookie refresh alignment for built-in/auth-enforced response paths
 
-**Current status:** Wave 5B added lifecycle presets (`consumer`, `admin`, `internal`, `strict`), preset+override merge, preset-string `enable_auth(...)` input support, and cookie refresh alignment for the built-in/auth-enforced response paths. Phase 5 is complete.
-
-**Strong value:** apps get secure lifecycle behavior without each team inventing different timeout logic.
+**Value:** apps get secure lifecycle behavior without each team inventing different timeout logic.
 
 #### Wave 6 — OAuth Hardening + Observability
-**Ships:**
-- refresh token rotation
+**Shipped:**
+- refresh token rotation/preservation semantics
+- safe refresh-token rotation logging
 - auth health check endpoint / diagnostics
 
-**Strong value:** security and operability improve together, which is the right trade for production auth.
+**Value:** security and operability improve together, which is the right trade for production auth.
 
 #### Wave 7 — Auto-Routes + UI Convenience
+**Shipped:**
+- configurable auth route prefixes
+- startup route logging
+- collision diagnostics
+- built-in login page generator
+
+**Remaining:** full auto-mount/override behavior and custom HTML override support.
+
+**Value:** fast starts for simple apps, while custom apps can still own their UX.
+
+#### Wave 8 — Advanced Sessions Foundation
+**Shipped:**
+- device/session metadata plumbing
+- keyed hashes for user-agent/IP security signals
+- remember-me flag storage plumbing
+- backend migration hardening for metadata fields
+
+**Remaining:** visible session-management APIs, behavioral remember-me TTLs, security event storage, suspicious-activity policy, and admin revocation APIs.
+
+**Value:** moves `std/auth` from solid to category-leading, provided the plumbing is turned into product behavior in later slices.
+
+#### Wave 8.5 — Architecture Guardrails Preflight
+**Ships before Phase 9 implementation:**
+- auth contributor/review guidance
+- storage/module ownership decision for local auth
+- contract-test ratchet for new auth record families
+- local-auth fallback/error policy
+
+**Value:** prevents the local-auth wave from undoing the architecture cleanup.
+
+#### Wave 9 — First-Class Local Auth
 **Ships:**
-- auto-mounted auth routes
-- optional login page generator and convenience UI helpers
+- local identity and credential store
+- request-aware email/password sign-in
+- staged first-login / forced-password-change / TOTP enrollment
+- password reset token lifecycle
+- local-auth backend contract tests
+- template migration away from custom local auth persistence
 
-**Strong value:** fast starts for simple apps, while custom apps can still own their UX.
+**Value:** closes the gap between great auth primitives and great auth architecture.
 
-#### Wave 8 — Advanced Sessions
-**Ships:**
-- device-aware session tracking
-- revocation cascades
-- suspicious activity signals
-- remember-me semantics built on the hardened lifecycle model
+#### Wave 10 — Ongoing Architecture Discipline
+**Ships continuously:**
+- module-boundary enforcement
+- complexity budgets for `auth.rs` and `auth/storage.rs`
+- backend contract coverage for every new auth state type
+- periodic architecture audits and review-guidance updates
 
-**Strong value:** this is where `std/auth` moves from solid to category-leading.
-
-#### Wave 9 — Post-Cleanup Discipline
-**Ships:**
-- ongoing enforcement of module boundaries, complexity budget, and backend contract coverage for new auth work
-
-**Strong value:** protects the cleanup investment so auth does not slowly collapse back into a grab-bag implementation.
+**Value:** protects the cleanup/local-auth investment so `std/auth` stays understandable instead of becoming a heroic pile of security-sensitive features.
 
 ## Competitive Landscape
 
-| Feature | ntnt (today) | ntnt (this DD) | Auth.js v5 | Lucia v3 | Laravel Sanctum | Django Auth |
+This table tracks the intended competitive posture after the v0.4.9 auth work and the DD-043/062 roadmap. "ntnt today" means current `main` behavior; "roadmap" means the target state after the remaining DD-043 waves.
+
+| Feature | ntnt today (v0.4.9) | ntnt roadmap | Auth.js v5 | Lucia v3 | Laravel Sanctum | Django Auth |
 |---------|:---:|:---:|:---:|:---:|:---:|:---:|
 | OAuth/OIDC | ✅ | ✅ | ✅ | ❌¹ | ❌² | ❌² |
 | PKCE | ✅ | ✅ | ✅ | ❌¹ | ❌ | ❌ |
@@ -625,30 +615,35 @@ So the plan should put those cleanup-heavy features first, but still start with 
 | Signed cookies | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 | CSRF auto-protection | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Token auto-refresh | ✅ | ✅ | ✅ | ❌¹ | ❌ | ❌ |
-| Session rotation | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ |
-| Sliding sessions | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Refresh token rotation | ❌ | ✅ | ✅ | ❌¹ | ❌ | ❌ |
-| Device-aware sessions | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Config presets | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Health check endpoint | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Suspicious activity | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| TOTP/MFA | ✅ | ✅ | ❌ | ❌¹ | ❌ | ❌³ |
-| ITP workaround | ✅ | ✅⁴ | ❌ | ❌ | ❌ | ❌ |
-| **Zero-config setup** | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Auto route registration** | ❌ | ✅ | ✅⁵ | ❌ | ❌ | ✅ |
-| **Startup config summary** | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Config validation** | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Built-in route protection** | ❌ | ✅ | ✅⁶ | ❌ | ✅ | ✅ |
-| **Built-in login page** | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **0 boilerplate files** | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Session rotation | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
+| Sliding sessions | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Absolute max session lifetime | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Refresh token rotation/preservation | ✅ | ✅ | ✅ | ❌¹ | ❌ | ❌ |
+| Device/session metadata plumbing | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Device-session management APIs | ◐ | ✅ | ❌ | ❌ | ❌ | ◐ |
+| Config presets | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Health check endpoint | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Suspicious activity policy | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Behavioral remember-me TTL | ❌ | ✅ | ✅ | ◐ | ✅ | ✅ |
+| TOTP/MFA primitives | ✅ | ✅ | ❌ | ❌¹ | ❌ | ❌³ |
+| First-class local email/password/TOTP lifecycle | ❌ | ✅ | ❌ | ❌ | ◐ | ✅ |
+| Auth-owned password reset tokens | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Bootstrap admin local auth | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Safari ITP workaround | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Zero-config setup | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Auto route registration / auth route prefixing | ◐ | ✅ | ✅⁴ | ❌ | ❌ | ✅ |
+| Startup config summary | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Config validation | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Built-in route protection | ✅ | ✅ | ✅⁵ | ❌ | ✅ | ✅ |
+| Built-in login page | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| 0 boilerplate files for common local admin auth | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | One-line setup | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
 
-¹ Lucia is sessions-only — OAuth/tokens/MFA are app-level  
-² Requires additional packages (Socialite, django-allauth)  
-³ Requires django-otp  
-⁴ Pending A/B validation — may be removed if unnecessary  
-⁵ Auth.js uses file-system convention (`[...nextauth]/route.ts`) — auto but requires specific file structure  
-⁶ Auth.js middleware.ts works but is a separate file with its own config — not integrated into the auth call  
+¹ Lucia is sessions-only — OAuth/tokens/MFA are app-level
+² Requires additional packages (Socialite, django-allauth)
+³ Requires django-otp
+⁴ Auth.js uses file-system convention (`[...nextauth]/route.ts`) — auto but requires specific file structure
+⁵ Auth.js middleware.ts works but is a separate file with its own config — not integrated into the auth call
 
 ---
 
@@ -656,13 +651,18 @@ So the plan should put those cleanup-heavy features first, but still start with 
 
 We'll know this is "the best auth system ever made for any language" when:
 
-1. **Zero-config security:** `enable_auth([google])` with no options map is already production-safe
-2. **No CVE surface:** Every OWASP session management recommendation is implemented by default
-3. **RFC 9700 compliant:** Full OAuth security BCP compliance
-4. **Observable:** Developers can see exactly what auth is doing and whether it's configured correctly
-5. **Competitive table is all green:** Every feature other systems offer, plus device sessions, presets, health checks, and suspicious activity that nobody else has in a stdlib
-6. **< 30 seconds to auth:** From `ntnt new` to authenticated app in under 30 seconds of developer time
+1. **Zero-config security:** `enable_auth([google])` with no options map is already production-safe.
+2. **Common local auth is first-class:** a local admin/app flow with email/password, TOTP setup, password reset, bootstrap account creation, forced password change, and session creation does not require custom app-owned credential tables.
+3. **One auth system, not two:** OAuth, local credentials, staged setup, password reset, and future step-up flows all converge on the same session/cookie/lifecycle/security-event model.
+4. **Fail-closed durable credentials:** local credential, reset, and TOTP enrollment state never silently degrades to process memory in production when the configured durable backend fails.
+5. **OWASP session-management posture by default:** session rotation, idle timeout, absolute lifetime, secure cookies, CSRF posture, revocation, and fixation defenses are built in and hard to misconfigure.
+6. **OAuth security BCP alignment:** OAuth/OIDC flows use PKCE, state, nonce where appropriate, refresh-token rotation/preservation, safe diagnostics, and no token leakage in logs or health endpoints.
+7. **Observable without leaking secrets:** developers can see exactly what auth is doing and whether it is configured correctly, while diagnostics never expose token/secret material.
+8. **Backend behavior is contractual:** every auth state family has contract tests for memory/SQLite plus required Postgres/Redis coverage when relevant, including fallback/error behavior.
+9. **Architecture resists entropy:** new auth features have obvious module homes, storage contracts, generated docs, typechecker signatures, and review checklist coverage.
+10. **< 30 seconds to auth:** from `ntnt new` to authenticated app in under 30 seconds of developer time for OAuth or common local admin auth.
+11. **Competitive table is mostly green:** ntnt matches the mainstream auth systems on core capability and beats them on stdlib cohesion, observability, local-auth ergonomics, and boilerplate.
 
 ---
 
-*This is a living document. Update checkboxes as implementation progresses.*
+*This is a living document. Update checkboxes, roadmap status, and review guidance as implementation progresses.*

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -9,9 +9,21 @@
 
 ## Vision
 
-`std/auth` should be the auth system that makes developers say "I don't need a third-party auth service." One import, one function call, and you get security that matches or exceeds Auth0, Firebase Auth, Clerk, and Lucia — without the vendor lock-in, pricing tiers, or complexity.
+`std/auth` should be the auth layer that makes app developers stop rebuilding security-sensitive auth plumbing. Its job is not to become a hosted identity product, a profile system, or an opinionated app-auth framework. It should provide standards-based primitives, safe defaults, durable storage contracts, request-aware session completion, and thin reference flows that apps can compose without losing the secure path.
 
-**Design principle:** Secure by default, simple to use, hard to misconfigure. Every feature should either be automatic (the developer never thinks about it) or one line of config (the developer opts in explicitly). No feature should require the developer to understand the security implications — the safe path should be the easy path.
+**Design principle:** language-level auth should make the secure primitive the obvious primitive. OAuth callbacks, local credentials, staged setup, password reset, and future step-up flows should all converge on the same session/cookie/lifecycle/storage semantics. Optional reference routes/pages may exist, but business policy remains app-owned.
+
+### Ownership Boundary
+
+Draw this line before adding auth surface area:
+
+| Layer | Owned by `std/auth` | Not owned by `std/auth` |
+|---|---|---|
+| **Core primitives** | OAuth/OIDC, signed cookies, server-side sessions, CSRF, route protection, staged auth challenges, TOTP verification/enrollment primitives, local credential/reset/TOTP storage contracts, request-aware session completion, diagnostics, backend contract tests | App-specific onboarding, invite/approval rules, profile fields, orgs, permissions models, copy/design decisions |
+| **Reference flows** | Optional built-in login/reset/setup/bootstrap routes and minimal default pages that compose the primitives | Mandatory UI structure, product-specific account-management screens, hosted-dashboard semantics |
+| **App policy** | Explicit hooks/options that feed claims/session data into the shared session completion path | Static universal roles/claims baked into provider config, hidden suspicious-activity policy engines, email/SMS delivery choices |
+
+If a capability is security-sensitive lifecycle state that every app otherwise reimplements badly, it belongs in `std/auth` primitives. If it is product/business behavior, `std/auth` should expose a hook or reference flow and get out of the way.
 
 ---
 
@@ -105,7 +117,7 @@ This is the single source of truth for how we should build `std/auth` forward. T
 - [x] Session store migration implemented in Rust for Redis/Postgres/SQLite backends
 - [x] Keep `migrate_session(old_id, new_id)` internal to Rust/session-store code
 - [x] Public ntnt API exposes only high-level session helpers, not low-level store migration primitives (`sign_in_session`, `rotate_session`, `sign_out_session`, `current_session`, `current_user`)
-- [x] `sign_in_session()` helper that persists session + attaches cookie
+- [x] Request-aware `sign_in_session(response, req, session, options?)` helper that persists session + attaches cookie while rotating/migrating existing sessions and capturing request metadata
 - [x] `sign_out_session()` helper that revokes session + clears cookie
 - [x] `current_session()` / `current_user()` helper for request-time lookups
 - [x] Shared auth cookie defaults with per-app overrides
@@ -116,9 +128,9 @@ This is the single source of truth for how we should build `std/auth` forward. T
 
 ```ntnt
 let resp = redirect("/admin")
-return sign_in_session(resp, map {
+return sign_in_session(resp, req, map {
     "subject_id": user["id"],
-    "claims": map { "role": "admin" }
+    "claims": app_claims_for_user(user)
 })
 
 let session = current_session(req)
@@ -161,7 +173,7 @@ return begin_auth_challenge(resp, map {
 let challenge = current_auth_challenge(req)
 let resp = redirect("/admin")
 return complete_auth_challenge(resp, req, map {
-    "claims": map { "role": "admin" }
+    "claims": app_claims_for_user(user)
 })
 ```
 
@@ -304,29 +316,40 @@ That is the current local-auth subsystem gap.
 
 **Architectural standard:** a template app should not need a custom `lib/admin_db.tnt` mini-auth subsystem to get excellent email/password/TOTP auth. The template should mostly configure `std/auth`, provide custom views/copy if it wants them, and move on.
 
-**Preferred public API direction:** local auth should be a first-class provider variant consumed by the existing `enable_auth(...)` entrypoint, not a separate parallel auth system.
+**Preferred public API direction:** local auth should be a first-class primitive family that feeds the existing `enable_auth(...)` and request-aware session-completion path, not a bundled app-auth product. Config may enable reference routes, but core local credential behavior should remain decomposed enough that custom UI does not require custom persistence.
 
 ```ntnt
-import { enable_auth, local_auth } from "std/auth"
-import { get_env } from "std/env"
+import {
+    enable_auth,
+    local_credentials,
+    verify_local_password,
+    sign_in_session,
+} from "std/auth"
+import { parse_form, redirect } from "std/http/server"
 
-enable_auth([
-    local_auth(map {
-        "email_password": true,
+enable_auth([], "admin", map {
+    "local_credentials": local_credentials(map {
+        "identifier": "email",
         "totp": true,
-        "password_reset": true,
-        "bootstrap_email": get_env("ADMIN_BOOTSTRAP_EMAIL"),
-        "bootstrap_password": get_env("ADMIN_BOOTSTRAP_PASSWORD"),
-        "claims": map { "role": "admin" }
-    })
-], "admin", map {
+        "password_reset": true
+    }),
     "login_page": false,
     "success_url": "/admin",
     "failure_url": "/admin/login"
 })
+
+fn login(req) {
+    let form = parse_form(req)
+    let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")?
+    return sign_in_session(redirect("/admin"), req, map {
+        "subject_id": verified["subject_id"],
+        "email": verified["email"],
+        "claims": app_claims_for_local_user(verified)
+    })
+}
 ```
 
-A later `enable_local_auth(...)` convenience wrapper is acceptable if it simply delegates into the same underlying provider/config path. The implementation must not become two auth systems.
+A later `enable_local_auth(...)` convenience wrapper is acceptable only if it delegates into the same primitive provider/config path and keeps policy hooks explicit. It must not become two auth systems or bake roles, onboarding, email delivery, or account UI into `std/auth`.
 
 #### Phase 9A — Architecture Preflight and Storage Boundary
 - [ ] Split or carve `auth/storage.rs` enough that new local-auth state does not get buried in the existing storage monolith
@@ -340,7 +363,7 @@ A later `enable_local_auth(...)` convenience wrapper is acceptable if it simply 
 
 #### Phase 9B — Local Identity and Credential Store
 - [ ] Add first-class local credential storage owned by `std/auth`
-- [ ] Make **email** the canonical local identifier, with documented normalization rules
+- [ ] Support a generic local subject + identifier model; ship email as the first documented identifier preset with normalization rules, not as the only possible local-auth identity shape
 - [ ] Store password hashes in auth-owned tables rather than pushing that responsibility to apps
 - [ ] Define a lean durable local-user/account shape: identity + auth state first, not a full profile platform
 - [ ] Support account states needed by real flows: bootstrap/pending setup/active/disabled/locked/password-change-required
@@ -509,7 +532,7 @@ Those are now shipped. The next big win is local email/password/TOTP auth, but o
 - `current_session()` / `current_user()`
 - shared cookie defaults and overrides
 
-**Follow-up:** local auth should use a request-aware sign-in path rather than relying on the existing request-less `sign_in_session()` semantics.
+**Follow-up:** local auth should use the request-aware `sign_in_session(response, req, session, options?)` path or a higher-level primitive that delegates to it, not create a second session-completion model.
 
 **Value:** the most repetitive and mistake-prone login/logout/cookie code disappears.
 

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -362,38 +362,118 @@ return complete_auth_challenge(resp, req, map {
 
 **Ships real value:** this is where `std/auth` starts becoming genuinely standout, not just competent.
 
-### Phase 9 — Post-Cleanup Complexity Discipline
+### Phase 9 — First-Class Local Auth
+**Goal:** Make `std/auth` world-class not only for OAuth/session plumbing, but also for the extremely common app shape of **local email + password + TOTP auth**.
+
+**Why this must exist:** the current `std/auth` surface is already strong at sessions, cookies, staged auth challenges, OAuth/OIDC, TOTP primitives, sign-in/sign-out helpers, and protected-route handling. But for a very normal local admin/app flow, developers still have to build and own a mini auth system beside it:
+
+- local user table
+- password-hash storage
+- password verification
+- password reset token storage
+- first-login / forced-password-change flow
+- persisted TOTP enrollment state
+- bootstrap admin account creation
+
+That is the current local-auth subsystem gap.
+
+`std/auth` can already manage authenticated state beautifully. What it still cannot fully own is the **local credential lifecycle end-to-end**. As long as that remains true, templates and apps will keep carrying custom auth code that should really belong to the language.
+
+**Architectural standard:** a template app should not need a custom `lib/admin_db.tnt` mini-auth subsystem to get excellent email/password/TOTP auth. The template should mostly configure `std/auth`, wire a few views if it wants custom UX, and move on.
+
+**Success test:** if a developer wants a local admin panel with email/password login, TOTP verification, password resets, first-login activation, and forced password changes, the path should feel as native and obvious as OAuth already does.
+
+## Recommended implementation shape for Phase 9
+
+Phase 9 should be a **feature architecture phase**, not just a helper phase. The key is not to bolt on scattered primitives, but to let `std/auth` own one coherent local-auth model.
+
+### Phase 9A — Local Identity Store
+- [ ] Add a first-class local credential store owned by `std/auth`
+- [ ] Make **email** the canonical local identifier
+- [ ] Store password hashes in auth-owned tables rather than pushing that responsibility to apps
+- [ ] Support bootstrap account creation from config/env for the common admin-panel case
+- [ ] Define the minimum durable local-user shape intentionally instead of letting templates invent their own schemas
+- [ ] Keep the model lean: identity + auth state first, not a giant profile system
+
+### Phase 9B — Local Sign-In Flow
+- [ ] Add built-in email/password verification through `std/auth`
+- [ ] Reuse the existing staged-auth challenge primitives for local login continuation
+- [ ] Support straightforward local sign-in that upgrades into a real auth session with configured claims/data
+- [ ] Ensure local sign-in uses the same cookie/session lifecycle semantics as OAuth-backed sign-in
+- [ ] Keep local auth and OAuth auth aligned at the session layer so apps do not feel two different auth systems
+
+### Phase 9C — First-Login Activation and TOTP Enrollment
+- [ ] Support first-login setup as a first-class local-auth flow
+- [ ] Support staged TOTP enrollment using the existing auth challenge model
+- [ ] Support forced password change before final session completion
+- [ ] Support completion into a normal signed-in session only after setup requirements are satisfied
+- [ ] Keep staged local flows expressed in the same lifecycle vocabulary as the rest of `std/auth`
+
+### Phase 9D — Password Reset Lifecycle
+- [ ] Add auth-owned password-reset token storage and lifecycle helpers
+- [ ] Support reset token issue + consume flows through `std/auth`
+- [ ] Support optional TOTP reset / re-enrollment semantics after password reset
+- [ ] Support reset flows that intentionally force fresh staged setup when security posture demands it
+- [ ] Keep reset semantics coherent with the session/challenge model instead of inventing another separate sub-system
+
+### Phase 9E — Template-Grade Integration
+- [ ] Make the Larri site template use the built-in local auth path instead of custom auth persistence code
+- [ ] Delete template-owned local-auth state machines and tables once parity exists
+- [ ] Leave the template with mostly config + views + app-specific copy, not a bespoke auth backend
+- [ ] Use the template migration as the proof that the local-auth architecture is actually simpler, not just theoretically cleaner
+
+### Phase 9F — Architecture Discipline for Local Auth
+- [ ] Keep local auth inside the post-4.5 module boundaries rather than re-growing a monolith in `auth.rs`
+- [ ] Extend the backend contract harness for every new local-auth persistence shape
+- [ ] Treat local auth storage semantics as a compatibility surface, not incidental implementation detail
+- [ ] Add explicit review guidance for local-auth regressions: captured-but-not-persisted staged state, reset-token lifecycle drift, backend mismatch, and “half-owned by app / half-owned by std/auth” ambiguity
+- [ ] Re-review the resulting structure periodically so local auth becomes a coherent subsystem, not a second pile of special cases
+
+**Non-goals for this phase:**
+- [ ] Do not turn `std/auth` into a giant full-profile identity platform in one shot
+- [ ] Do not block local auth on solving every RBAC / organizations / account-management use case
+- [ ] Do not make templates keep custom persistence “just for flexibility” if `std/auth` can own the common case cleanly
+- [ ] Do not ship disconnected helper functions without a coherent local-auth architecture behind them
+
+**Design standard for this phase:**
+- [ ] Local auth should feel like one intentional subsystem, not “some templates plus some helpers plus some tables”
+- [ ] Email/password/TOTP should be a primary path in `std/auth`, not a second-class example
+- [ ] If a normal local admin/auth flow still requires custom app tables after this phase, the phase is incomplete
+
+**Ships real value:** closes the biggest remaining gap between “great auth primitives” and “great auth architecture,” so apps can rely on `std/auth` for the full local email/password/TOTP lifecycle instead of rebuilding it.
+
+### Phase 10 — Post-Cleanup Complexity Discipline
 **Goal:** Prevent `std/auth` from collapsing back into a monolith after the 4.5 cleanup lands.
 
 **Assessment after the Phase 8 branch review (compared against the v0.4.8 release baseline):** the 4.5 cleanup largely achieved its intended effect, but only partially solved the long-term maintainability problem. The internal module split is real and materially improves clarity: config, cookies, guards, OAuth flow, providers, request helpers, routes, sessions, storage, and small utility layers now exist as distinct homes instead of one giant undifferentiated file. The storage contract is also much more coherent than before, and recent review feedback mostly hit end-to-end plumbing gaps and edge-case semantics rather than “where does this logic even belong?” confusion. That is a meaningful architectural win.
 
 **However:** `src/stdlib/auth.rs` is still very large and still acts as a gravity well for the public surface, native-function registration, shared types, and the main auth test module. So the cleanup should be viewed as **successful but incomplete**. `std/auth` is no longer a pure junk drawer, but it is also not yet structurally self-protecting. It is maintainable **if** future work is forced through the module boundaries and contract tests established in 4.5. If contributors drift back into broad `auth.rs` edits for convenience, the monolith will regrow quickly.
 
-**Bottom line:** the DD intent was mostly achieved for the cleanup wave — enough to justify continuing from this shape — but Phase 9 must turn the current structure into enforceable discipline rather than assuming the cleanup alone solved the problem.
+**Bottom line:** the DD intent was mostly achieved for the cleanup wave — enough to justify continuing from this shape — but Phase 10 must turn the current structure into enforceable discipline rather than assuming the cleanup alone solved the problem.
 
-## Recommended implementation shape for Phase 9
+## Recommended implementation shape for Phase 10
 
-Phase 9 should be a **discipline phase, not a feature phase**. The goal is to make the architecture we now have more self-enforcing, so future auth work naturally lands in the right places and gets the right verification by default.
+Phase 10 should be a **discipline phase, not a feature phase**. The goal is to make the architecture we now have more self-enforcing, so future auth work naturally lands in the right places and gets the right verification by default.
 
-### Phase 9A — Architecture Guardrails
+### Phase 10A — Architecture Guardrails
 - [ ] Write explicit contributor guidance for what belongs in `auth.rs` vs internal auth modules
 - [ ] Document the allowed responsibilities of `auth.rs`: public surface, shared types, registration glue, and only the minimum unavoidable coordination logic
 - [ ] Document when a new auth change must extend an existing module versus when it merits a new focused module
-- [ ] Add an auth-specific review checklist covering the regressions exposed in Phase 8 (captured-but-not-persisted state, schema/query name drift, swallowed migration errors, backend mismatch paths, fallback ambiguity)
+- [ ] Add an auth-specific review checklist covering the regressions exposed in Phase 8 and Phase 9 (captured-but-not-persisted state, schema/query name drift, swallowed migration errors, backend mismatch paths, fallback ambiguity, reset lifecycle drift, and app/std ownership confusion)
 
-### Phase 9B — Contract-Test Ratchet
+### Phase 10B — Contract-Test Ratchet
 - [ ] Require new auth persistence/state shapes to extend the backend contract harness
 - [ ] Add missing contract coverage for any auth persistence paths still validated only indirectly
 - [ ] Require new fallback/error semantics to be tested in primary, fallback, and failure modes
 - [ ] Treat auth storage behavior as a compatibility surface, not just an implementation detail
 
-### Phase 9C — `auth.rs` Pressure Relief
+### Phase 10C — `auth.rs` Pressure Relief
 - [ ] Audit what still lives in `auth.rs` only because of historical gravity rather than good ownership
 - [ ] Move obvious non-surface helpers and test-heavy logic into module-local ownership where it improves clarity without destabilizing the public API
 - [ ] Reassess whether the main auth test concentration should be partially redistributed into focused module tests over time
 - [ ] Track `auth.rs` growth relative to the internal modules so “easy broad edits” become visible early
 
-### Phase 9D — Periodic Architecture Audit
+### Phase 10D — Periodic Architecture Audit
 - [ ] Re-review new auth work periodically against the intended module boundaries
 - [ ] Check whether recent auth changes increased clarity or merely moved complexity around
 - [ ] Reconfirm that fallback semantics remain deliberate and documented as auth work expands
@@ -404,11 +484,11 @@ Phase 9 should be a **discipline phase, not a feature phase**. The goal is to ma
 - [ ] Keep `auth.rs` focused on public surface, shared types, registration glue, and only the minimum unavoidable coordination logic
 - [ ] Extend backend contract tests when adding new auth state types, flows, or stores
 - [ ] Treat fallback/error semantics as design-level behavior, not incidental implementation detail
-- [ ] Add review guidance/checklists for common auth regressions: captured-but-not-persisted state, schema/name drift, swallowed migration errors, and backend mismatch paths
+- [ ] Add review guidance/checklists for common auth regressions: captured-but-not-persisted state, schema/name drift, swallowed migration errors, backend mismatch paths, reset lifecycle drift, and ownership ambiguity between app code and `std/auth`
 - [ ] Periodically re-audit whether new features are preserving the intended internal architecture
 - [ ] Revisit whether large test concentrations inside `auth.rs` should migrate toward module-local test ownership as the structure stabilizes
 
-**Ships real value:** preserves the benefits of the cleanup so future auth work stays understandable instead of slowly regressing.
+**Ships real value:** preserves the benefits of the cleanup and the local-auth work so future auth work stays understandable instead of slowly regressing.
 
 ## What We Explicitly Won't Do
 

--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -1,0 +1,118 @@
+# DD-062: First-Class Local Email/Password/TOTP Auth in `std/auth`
+
+## Problem
+
+`std/auth` already owns sessions, staged auth challenges, cookies, OAuth/OIDC, CSRF, and TOTP primitives.
+
+But for a very common real app shape — a local admin area using **email + password + TOTP** — developers still have to build and maintain their own mini auth system around those primitives:
+
+- local user table
+- password-hash storage
+- password reset tokens
+- TOTP enrollment state
+- local login route handlers
+- first-login / forced-password-change flows
+- admin-role / claims glue
+
+That is exactly the wrong level of abstraction.
+
+The template app should not need a custom `lib/admin_db.tnt` auth subsystem just to get a normal local admin login.
+
+## Goal
+
+Make **local email/password/TOTP auth** a first-class `std/auth` path so apps can configure it instead of rebuilding it.
+
+Target outcome:
+
+- no custom account tables in the template
+- no template-owned password login state machine
+- no template-owned password-reset token model
+- no template-owned staged-setup persistence model
+- template becomes mostly configuration + views
+
+## Desired Developer Experience
+
+Something in this family should be possible:
+
+```ntnt
+import { enable_auth, local_auth } from "std/auth"
+
+enable_auth([
+  local_auth(map {
+    "email_password": true,
+    "totp": true,
+    "password_reset": true,
+    "bootstrap_email": get_env("ADMIN_BOOTSTRAP_EMAIL"),
+    "bootstrap_password": get_env("ADMIN_BOOTSTRAP_PASSWORD"),
+    "claims": map { "role": "admin" }
+  })
+], "admin", map {
+  "login_page": false,
+  "success_url": "/admin",
+  "failure_url": "/admin/login"
+})
+```
+
+Or, if that is too provider-shaped, an equivalent `enable_local_auth(...)` surface is acceptable.
+
+The specific API name matters less than the capability.
+
+## Scope
+
+### Phase 1 — Local identity store
+- [ ] Add built-in local user storage owned by `std/auth`
+- [ ] Canonical identifier is **email**
+- [ ] Store password hashes in auth-owned tables
+- [ ] Support bootstrap account creation from config/env
+- [ ] Support password verification through `std/auth`
+
+### Phase 2 — Local login + staged auth flow
+- [ ] Add built-in email/password sign-in entrypoint
+- [ ] Reuse current staged-auth challenge primitives for TOTP / setup / forced-password-change
+- [ ] Support first-login setup flow
+- [ ] Support forced password change after bootstrap or reset
+- [ ] Support completion into real auth sessions with configured claims/data
+
+### Phase 3 — Password reset
+- [ ] Add auth-owned password-reset token storage
+- [ ] Add helpers/routes for reset-token issue + consume
+- [ ] Support reset flows that clear TOTP enrollment when configured
+- [ ] Support forcing re-enrollment after reset
+
+### Phase 4 — Turnkey template fit
+- [ ] Make the Larri site template use the built-in local auth system instead of custom tables
+- [ ] Delete template-owned local auth persistence/state machine code
+- [ ] Keep template customization at the UI/copy layer only
+
+## Why this belongs in `std/auth`
+
+We already have most of the hard parts:
+
+- signed session cookies
+- session stores
+- staged auth challenges
+- TOTP helpers
+- logout/sign-in helpers
+- OAuth/OIDC flows
+- auth route configuration
+
+What is missing is not raw capability. What is missing is **cohesion around local credentials**.
+
+This is why local apps still feel like they have to build a second auth system beside `std/auth`.
+
+## Non-Goals
+
+- replacing OAuth/OIDC work
+- building a full end-user identity platform in one shot
+- modeling arbitrary profile fields up front
+- solving every RBAC problem before shipping local auth
+
+This should start with the smallest excellent local-auth core:
+
+**email + password + TOTP + reset + staged setup**
+
+## Recommendation
+
+Treat this as the next practical `std/auth` simplification step.
+
+If `std/auth` can own OAuth well but still cannot cleanly own a normal local admin login, the library remains incomplete in a way users feel immediately.

--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -67,6 +67,8 @@ DD-062 is the detailed child plan for DD-043 Phase 9.
 
 Current 0.4.9 baseline: the shared manual/staged session completion path is already request-aware. `sign_in_session(response, req, session, options?)` and `complete_auth_challenge(response, req, session?, options?)` rotate/migrate existing sessions and capture request-derived metadata. Local auth should consume that path rather than introduce its own session creation semantics.
 
+This is an intentional 0.4.9 pre-release API correction, not a compatibility surface to preserve. The migration path is explicit: insert the current route `req` as the second argument wherever old branch code called `sign_in_session(response, session, options?)`.
+
 | DD-043 Phase | DD-062 Section | Purpose |
 |---|---|---|
 | 9A — Architecture Preflight and Storage Boundary | Phase 0 | Prepare module/storage/test boundaries before adding durable local-auth state |

--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -1,118 +1,443 @@
 # DD-062: First-Class Local Email/Password/TOTP Auth in `std/auth`
 
+**Status:** Draft / implementation blueprint
+**Parent:** DD-043 Phase 9 — First-Class Local Auth
+**Target:** v0.4.x auth roadmap after the v0.4.9 DD-043 foundation
+
+---
+
 ## Problem
 
-`std/auth` already owns sessions, staged auth challenges, cookies, OAuth/OIDC, CSRF, and TOTP primitives.
+`std/auth` already owns a strong set of auth primitives:
+
+- OAuth/OIDC providers and callback handling
+- signed session cookies
+- server-side session stores
+- staged auth challenges
+- route protection
+- CSRF posture
+- session lifecycle controls
+- request/session metadata plumbing
+- TOTP primitives
+- sign-in/sign-out/current-session helpers
 
 But for a very common real app shape — a local admin area using **email + password + TOTP** — developers still have to build and maintain their own mini auth system around those primitives:
 
-- local user table
-- password-hash storage
+- local user/credential table
+- password-hash storage and verification
 - password reset tokens
 - TOTP enrollment state
-- local login route handlers
+- bootstrap admin account creation
 - first-login / forced-password-change flows
+- local login route handlers
 - admin-role / claims glue
 
 That is exactly the wrong level of abstraction.
 
-The template app should not need a custom `lib/admin_db.tnt` auth subsystem just to get a normal local admin login.
+A template app should not need a custom `lib/admin_db.tnt` auth subsystem just to get a normal local admin login. If the language already owns sessions, cookies, staged challenges, TOTP primitives, and protected-route enforcement, it should also own the common local credential lifecycle that feeds those mechanisms.
+
+---
 
 ## Goal
 
-Make **local email/password/TOTP auth** a first-class `std/auth` path so apps can configure it instead of rebuilding it.
+Make **local email/password/TOTP auth** a first-class `std/auth` path so apps configure it instead of rebuilding it.
 
 Target outcome:
 
-- no custom account tables in the template
+- no custom credential/account tables in the template
 - no template-owned password login state machine
 - no template-owned password-reset token model
 - no template-owned staged-setup persistence model
-- template becomes mostly configuration + views
+- no request-less local sign-in path that misses session rotation or request metadata
+- template becomes mostly auth config + views/copy + app-specific authorization policy
 
-## Desired Developer Experience
+This DD is not about turning `std/auth` into a hosted identity product. It is about making the boring, security-sensitive local credential lifecycle native, coherent, and hard to misuse.
 
-Something in this family should be possible:
+---
+
+## Relationship to DD-043
+
+DD-062 is the detailed child plan for DD-043 Phase 9.
+
+| DD-043 Phase | DD-062 Section | Purpose |
+|---|---|---|
+| 9A — Architecture Preflight and Storage Boundary | Phase 0 | Prepare module/storage/test boundaries before adding durable local-auth state |
+| 9B — Local Identity and Credential Store | Phase 1 | Add auth-owned local identity/account/credential records |
+| 9C — Request-Aware Local Sign-In Flow | Phase 2 | Verify email/password and create sessions with OAuth-equivalent lifecycle semantics |
+| 9D — First-Login Activation, Forced Password Change, and TOTP Enrollment | Phase 3 | Model setup and MFA enrollment through staged auth, not app-owned state machines |
+| 9E — Password Reset Lifecycle | Phase 4 | Add reset token issue/consume/reset semantics |
+| 9F — Template-Grade Integration | Phase 5 | Migrate template off custom local-auth persistence |
+| 9G — Local Auth Verification Matrix | Phase 6 | Ratchet backend contracts, end-to-end flows, docs, and CI |
+
+---
+
+## Design Principles
+
+1. **One auth system, not two.** Local auth, OAuth, staged setup, password reset, and future step-up flows must converge on the same session/cookie/lifecycle/security-event model.
+2. **Durable credential state fails closed.** Local credentials, reset tokens, TOTP enrollment state, bootstrap state, and account-state changes must not silently degrade to process memory in production when the configured durable backend fails.
+3. **Request-aware session creation.** Local login must receive the request so it can rotate/migrate existing sessions, capture `device_name`, `user_agent_hash`, and `last_ip_hash`, and apply the same cookie/session TTL behavior as OAuth.
+4. **Staged auth is the continuation model.** Password → TOTP, first-login setup, forced password change, and reset recovery should use existing staged challenge semantics where appropriate.
+5. **Local identity is not a profile platform.** Store the minimum durable auth state. App profile data remains app-owned.
+6. **Storage behavior is a compatibility surface.** Every local-auth record family needs contract tests across backends at the same time it is introduced.
+7. **UI stays optional.** `std/auth` may offer default routes/pages, but custom UI must not require custom credential/session/reset persistence.
+
+---
+
+## Preferred Developer Experience
+
+Primary shape: local auth is a first-class provider variant consumed by `enable_auth(...)`.
 
 ```ntnt
 import { enable_auth, local_auth } from "std/auth"
+import { get_env } from "std/env"
 
 enable_auth([
-  local_auth(map {
-    "email_password": true,
-    "totp": true,
-    "password_reset": true,
-    "bootstrap_email": get_env("ADMIN_BOOTSTRAP_EMAIL"),
-    "bootstrap_password": get_env("ADMIN_BOOTSTRAP_PASSWORD"),
-    "claims": map { "role": "admin" }
-  })
+    local_auth(map {
+        "email_password": true,
+        "totp": true,
+        "password_reset": true,
+        "bootstrap_email": get_env("ADMIN_BOOTSTRAP_EMAIL"),
+        "bootstrap_password": get_env("ADMIN_BOOTSTRAP_PASSWORD"),
+        "claims": map { "role": "admin" }
+    })
 ], "admin", map {
-  "login_page": false,
-  "success_url": "/admin",
-  "failure_url": "/admin/login"
+    "login_page": false,
+    "success_url": "/admin",
+    "failure_url": "/admin/login"
 })
 ```
 
-Or, if that is too provider-shaped, an equivalent `enable_local_auth(...)` surface is acceptable.
+Rationale:
 
-The specific API name matters less than the capability.
+- Developers should still have one obvious auth entrypoint: `enable_auth(...)`.
+- Local auth should share route prefixes, cookies, sessions, lifecycle presets, protected paths, health diagnostics, and startup summaries.
+- Internally, local auth should be a distinct provider/config variant, not a fake OAuth provider.
 
-## Scope
+Acceptable later convenience:
 
-### Phase 1 — Local identity store
-- [ ] Add built-in local user storage owned by `std/auth`
-- [ ] Canonical identifier is **email**
-- [ ] Store password hashes in auth-owned tables
+```ntnt
+enable_local_auth(map {
+    "preset": "admin",
+    "totp": true,
+    "password_reset": true
+})
+```
+
+If added, this must delegate to the same underlying local-auth provider/config path. It must not become a parallel auth subsystem.
+
+---
+
+## Public API Direction
+
+Names are still draft, but the capability shape should be stable.
+
+### Configuration
+
+- `local_auth(config: Map) -> AuthProvider`
+- local provider accepted inside `enable_auth([providers...], preset_or_options?, options?)`
+- startup summary includes local-auth status without exposing secrets
+- `/auth/health` reports local-auth configuration posture without exposing hashes, reset tokens, TOTP secrets, or bootstrap password material
+
+### Local identity/admin helpers
+
+Possible helpers; exact names can change during implementation:
+
+- `local_user(email) -> Result<LocalUser?, String>`
+- `create_local_user(email, options) -> Result<LocalUser, String>`
+- `disable_local_user(email_or_id) -> Result<Unit, String>`
+- `require_password_change(email_or_id) -> Result<Unit, String>`
+- `set_local_password(email_or_id, new_password, options?) -> Result<Unit, String>`
+
+These should be intentionally small. App profile and authorization data should remain app-owned unless it is needed to produce session claims.
+
+### Local sign-in/session helpers
+
+The built-in local sign-in route can be enough for simple apps, but custom login forms need a safe lower-level helper.
+
+The helper must be request-aware. A shape in this family is acceptable:
+
+```ntnt
+local_sign_in(req, response, map {
+    "email": email,
+    "password": password,
+    "remember_me": remember_me
+})
+```
+
+It should return either:
+
+- a completed signed-in response, or
+- a staged-auth continuation response for TOTP/setup/password-change, or
+- a safe auth error result
+
+It must not be a thin wrapper around the current request-less `sign_in_session(response, session, options?)` path unless that path grows request-aware rotation/metadata behavior.
+
+### Password reset helpers
+
+- `issue_password_reset(email, options?) -> Result<PasswordReset, String>`
+- `consume_password_reset(token, new_password, options?) -> Result<PasswordResetResult, String>`
+- default routes can wrap these helpers, but apps/plugins own email delivery
+
+`std/auth` owns token generation, token hashing/storage, one-time consume, TTL, replay rejection, and reset consequences. Apps own the email/SMS/provider used to deliver reset links.
+
+---
+
+## Internal Architecture Target
+
+The current auth code already has modules, but local auth should not expand the remaining monoliths.
+
+Target ownership:
+
+```text
+src/stdlib/auth.rs                     public exports, registration glue, shared surface only
+src/stdlib/auth/types.rs               shared public/internal structs and value conversions
+src/stdlib/auth/local.rs               local-auth domain operations
+src/stdlib/auth/local_passwords.rs     password verification/hash policy wrappers if needed
+src/stdlib/auth/local_totp.rs          TOTP enrollment/reset domain logic if it outgrows primitives
+src/stdlib/auth/password_reset.rs      reset token domain operations
+src/stdlib/auth/sessions.rs            shared session lifecycle and request-aware sign-in completion
+src/stdlib/auth/storage/mod.rs         storage contract boundary
+src/stdlib/auth/storage/session.rs     session records
+src/stdlib/auth/storage/challenge.rs   staged challenge records
+src/stdlib/auth/storage/oauth.rs       OAuth state records
+src/stdlib/auth/storage/exchange.rs    Safari/session exchange tokens
+src/stdlib/auth/storage/local.rs       local identity/credential/TOTP/reset/bootstrap records
+```
+
+Exact file names can change. The important rule: durable local-auth state must have a clear storage/domain home and must not be hidden inside generic challenge `data_json` or appended casually to `auth.rs`.
+
+---
+
+## Local Auth Data Model
+
+Keep this lean. The goal is auth state, not profiles.
+
+### Local identity/account
+
+Minimum durable shape:
+
+- `id` — stable internal local user id
+- `email` — canonical local identifier
+- `email_normalized` — normalized lookup key
+- `created_at`
+- `updated_at`
+- `state` — `bootstrap`, `pending_setup`, `active`, `disabled`, `locked`, `password_change_required`
+- `claims_json` — optional configured/default claims for session creation
+- `metadata_json` — small auth-owned metadata only; not app profile data
+
+### Credential secret
+
+- `local_user_id`
+- `password_hash`
+- `password_hash_algorithm`
+- `password_hash_params_json` or encoded hash metadata
+- `password_changed_at`
+- `must_change_password`
+- optional future `password_rehash_required`
+
+Password hashing may continue to use `std/crypto` internally, but local auth owns storage, verification orchestration, and hash-upgrade policy.
+
+### TOTP enrollment
+
+- `local_user_id`
+- `state` — `not_enrolled`, `pending_enrollment`, `enrolled`, `reset_required`
+- encrypted/secret TOTP material or storage-compatible secret representation
+- `created_at`
+- `verified_at`
+- `last_reset_at`
+
+Do not store durable TOTP enrollment state only in staged challenge `data_json`. Challenges are pending flow state; enrollment is account state.
+
+### Password reset token
+
+- token id / selector
+- token hash, never raw token
+- `local_user_id`
+- `created_at`
+- `expires_at`
+- `consumed_at`
+- reset consequences: force password change, clear TOTP, require TOTP re-enrollment, revoke sessions
+
+Reset consume must be one-time and atomic per backend.
+
+### Bootstrap state
+
+- bootstrap email/config fingerprint
+- created local user id
+- `created_at`
+- `consumed` / `rotated` / `setup_completed` marker
+
+Bootstrap passwords should be treated as temporary. Successful bootstrap login should force password rotation and/or setup completion based on config.
+
+---
+
+## Fallback and Error Policy
+
+Existing DD-043 fallback semantics allow memory fallback for some transient state. Local auth needs a stricter policy.
+
+| Record family | Store failure | Lookup failure | Consume/update failure | Memory fallback? |
+|---|---|---|---|---|
+| Local identity/account | fail closed | fail closed | fail closed | dev/test only if explicitly configured |
+| Credential secret/hash | fail closed | fail closed | fail closed | no production fallback |
+| TOTP enrollment state | fail closed | fail closed | fail closed | no production fallback |
+| Password reset token | fail closed | fail closed | fail closed; atomic consume required | no production fallback |
+| Bootstrap state | fail closed | fail closed | fail closed | dev/test only if explicitly configured |
+| Staged local challenge | existing challenge policy, but TTL/consume must be tested | existing challenge policy | existing challenge policy | acceptable for transient challenge state only |
+| Session after local login | existing session policy | existing session policy | migrate/update/delete errors propagate | existing session policy |
+
+This table should become implementation comments and contract tests, not just documentation confetti.
+
+---
+
+## Phased Implementation Plan
+
+### Phase 0 — Architecture Preflight
+
+**Purpose:** make the local-auth implementation path obvious before adding durable credential state.
+
+- [ ] Split or carve `auth/storage.rs` enough to give local-auth storage a focused home
+- [ ] Move or isolate the auth storage contract harness so local-auth record families can reuse it cleanly
+- [ ] Add local-auth fallback/error policy comments near the storage contract boundary
+- [ ] Add auth review checklist entries for local-auth-specific regressions
+- [ ] Decide exact module names and public API names before implementation starts
+
+**Exit criteria:** no one has to guess where local identity, password reset, TOTP enrollment, or bootstrap state belongs.
+
+### Phase 1 — Local Identity and Credential Store
+
+**Purpose:** add durable local users/credentials owned by `std/auth`.
+
+- [ ] Create the local identity/account model
+- [ ] Create credential-secret storage and verification helpers
+- [ ] Normalize email lookup rules and document them
+- [ ] Add account states: bootstrap, pending setup, active, disabled, locked, password-change-required
 - [ ] Support bootstrap account creation from config/env
-- [ ] Support password verification through `std/auth`
+- [ ] Force bootstrap credential rotation/setup completion according to config
+- [ ] Add memory/SQLite contract tests by default
+- [ ] Add Postgres/Redis contract coverage in backend CI
+- [ ] Add migration tests for existing SQLite/Postgres stores
 
-### Phase 2 — Local login + staged auth flow
-- [ ] Add built-in email/password sign-in entrypoint
-- [ ] Reuse current staged-auth challenge primitives for TOTP / setup / forced-password-change
-- [ ] Support first-login setup flow
-- [ ] Support forced password change after bootstrap or reset
-- [ ] Support completion into real auth sessions with configured claims/data
+### Phase 2 — Request-Aware Local Sign-In
 
-### Phase 3 — Password reset
-- [ ] Add auth-owned password-reset token storage
-- [ ] Add helpers/routes for reset-token issue + consume
-- [ ] Support reset flows that clear TOTP enrollment when configured
-- [ ] Support forcing re-enrollment after reset
+**Purpose:** let email/password login produce sessions with the same safety posture as OAuth login.
 
-### Phase 4 — Turnkey template fit
-- [ ] Make the Larri site template use the built-in local auth system instead of custom tables
-- [ ] Delete template-owned local auth persistence/state machine code
-- [ ] Keep template customization at the UI/copy layer only
+- [ ] Add local password verification through `std/auth`
+- [ ] Add request-aware local sign-in domain operation
+- [ ] Rotate/migrate existing sessions on successful local login
+- [ ] Capture `device_name`, `user_agent_hash`, and `last_ip_hash` from request metadata
+- [ ] Apply configured session TTL, max lifetime, sliding expiry, cookie policy, and remember-me behavior
+- [ ] Return staged continuation when TOTP/setup/password-change is required
+- [ ] Add tests proving local login does not lose session metadata compared with OAuth login
 
-## Why this belongs in `std/auth`
+### Phase 3 — First Login, Forced Password Change, and TOTP Enrollment
 
-We already have most of the hard parts:
+**Purpose:** make setup and MFA enrollment native rather than app-owned state machines.
 
-- signed session cookies
-- session stores
-- staged auth challenges
-- TOTP helpers
-- logout/sign-in helpers
-- OAuth/OIDC flows
-- auth route configuration
+- [ ] Add staged first-login setup flow
+- [ ] Add forced-password-change flow before final session completion
+- [ ] Add TOTP enrollment challenge flow
+- [ ] Persist TOTP enrollment state explicitly after verification
+- [ ] Define TOTP reset/re-enrollment semantics
+- [ ] Ensure no protected-route access is granted until setup requirements complete
+- [ ] Add end-to-end tests for bootstrap → password change → TOTP enrollment → session completion
 
-What is missing is not raw capability. What is missing is **cohesion around local credentials**.
+### Phase 4 — Password Reset Lifecycle
 
-This is why local apps still feel like they have to build a second auth system beside `std/auth`.
+**Purpose:** make reset tokens secure, backend-consistent, and app-ergonomic.
+
+- [ ] Add auth-owned reset token issue helper
+- [ ] Store only reset token hashes/selectors, never raw reset tokens
+- [ ] Add atomic one-time reset token consume helper
+- [ ] Add reset replay rejection tests
+- [ ] Add reset expiry tests
+- [ ] Define reset consequences: session revocation, forced password change, optional TOTP reset/re-enrollment
+- [ ] Define email-delivery boundary and examples
+- [ ] Add failed-login and reset-attempt rate limiting hooks or built-in policy
+
+### Phase 5 — Template-Grade Integration
+
+**Purpose:** prove the abstraction by deleting the custom local-auth subsystem from a real template.
+
+- [ ] Migrate the Larri site template to `std/auth` local auth
+- [ ] Delete template-owned local credential tables/state machines once parity exists
+- [ ] Keep custom login/setup/reset views possible without custom auth persistence
+- [ ] Document the before/after diff as proof the system got simpler
+- [ ] Add examples for custom UI with built-in local-auth persistence
+
+### Phase 6 — Verification and Documentation Ratchet
+
+**Purpose:** make local auth hard to regress.
+
+- [ ] Contract tests for every local-auth record family across memory and SQLite by default
+- [ ] Required Postgres/Redis backend contract CI job or explicit non-silent skip reporting
+- [ ] End-to-end ntnt tests for bootstrap, normal login, TOTP setup, forced password change, reset issue/consume, reset replay, disabled account rejection, and session revocation
+- [ ] Generated stdlib docs for every public helper
+- [ ] `docs/AI_AGENT_GUIDE.md` examples for local auth
+- [ ] DD-043 status/checklist updates after each implementation slice
+- [ ] Review checklist updates for any bug class discovered during implementation
+
+---
+
+## Testing Matrix
+
+| Behavior | Unit | Storage contract | End-to-end ntnt/server | Backend CI |
+|---|:---:|:---:|:---:|:---:|
+| Email normalization/lookup | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Bootstrap account creation | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Password verify success/failure | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Disabled/locked account rejection | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Password-change-required continuation | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Session rotation on local login | ✅ | — | ✅ | all session backends |
+| Device/IP/UA metadata capture | ✅ | ✅ | ✅ | all session backends |
+| TOTP enrollment/setup completion | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Password reset issue/consume | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Reset replay rejection | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Reset expiry | ✅ | ✅ | ✅ | SQLite/Postgres/Redis |
+| Reset-triggered session revocation | ✅ | ✅ | ✅ | all session backends |
+| Backend failure fail-closed behavior | ✅ | ✅ | — | SQLite/Postgres/Redis |
+
+---
 
 ## Non-Goals
 
-- replacing OAuth/OIDC work
-- building a full end-user identity platform in one shot
-- modeling arbitrary profile fields up front
-- solving every RBAC problem before shipping local auth
+- Building a full end-user identity/profile platform
+- Owning arbitrary app profile fields
+- Solving every RBAC/ABAC/organizations use case before shipping local auth
+- Owning public signup UX, invite policy, onboarding copy, or email templates
+- Sending email/SMS directly from `std/auth`
+- Making templates keep custom auth persistence “for flexibility” once `std/auth` can own the common case
 
-This should start with the smallest excellent local-auth core:
+Clarification: local credential storage, password verification, reset tokens, bootstrap setup, and TOTP enrollment are **in scope**. The app/product workflows around those mechanics remain app-owned.
 
-**email + password + TOTP + reset + staged setup**
+---
+
+## Acceptance Criteria
+
+DD-062 is complete when:
+
+1. A template can configure local email/password/TOTP auth without creating custom credential/reset/TOTP tables.
+2. Local login creates sessions with the same cookie, lifecycle, rotation, metadata, and revocation semantics as OAuth login.
+3. Password reset tokens are one-time, TTL-bound, hash-stored, backend-consistent, and replay-tested.
+4. TOTP enrollment state is durable and explicit, not hidden only in challenge payloads.
+5. Durable credential/reset/TOTP state fails closed on backend errors in production.
+6. Memory/SQLite contract tests run by default and Postgres/Redis coverage is visible in CI.
+7. The Larri site template deletes its app-owned local-auth mini-system and gets simpler.
+8. Public docs make the easy path obvious and the app-owned boundaries explicit.
+
+---
 
 ## Recommendation
 
-Treat this as the next practical `std/auth` simplification step.
+Treat local auth as the next practical `std/auth` simplification step, but do not implement it as a pile of helpers.
 
-If `std/auth` can own OAuth well but still cannot cleanly own a normal local admin login, the library remains incomplete in a way users feel immediately.
+The right implementation order is:
+
+1. architecture/storage/test preflight
+2. local identity and credential store
+3. request-aware local sign-in
+4. staged setup/TOTP
+5. password reset
+6. template migration
+7. contract/docs/CI ratchet
+
+If `std/auth` can own OAuth well but still cannot cleanly own a normal local admin login, the library remains incomplete in a way users feel immediately. If it owns local auth with the same discipline as OAuth/session/challenge state, it becomes genuinely hard to beat.

--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -30,7 +30,7 @@ But for a very common real app shape — a local admin area using **email + pass
 - bootstrap admin account creation
 - first-login / forced-password-change flows
 - local login route handlers
-- admin-role / claims glue
+- ad hoc admin/session claim handoff from custom local auth into `std/auth` sessions
 
 That is exactly the wrong level of abstraction.
 
@@ -64,6 +64,8 @@ This DD is not about turning `std/auth` into a hosted identity product or a univ
 ## Relationship to DD-043
 
 DD-062 is the detailed child plan for DD-043 Phase 9.
+
+Current 0.4.9 baseline: the shared manual/staged session completion path is already request-aware. `sign_in_session(response, req, session, options?)` and `complete_auth_challenge(response, req, session?, options?)` rotate/migrate existing sessions and capture request-derived metadata. Local auth should consume that path rather than introduce its own session creation semantics.
 
 | DD-043 Phase | DD-062 Section | Purpose |
 |---|---|---|
@@ -191,7 +193,7 @@ It should return either:
 - a staged-auth continuation response for TOTP/setup/password-change, or
 - a safe auth error result
 
-It must delegate to request-aware `sign_in_session(response, req, session, options?)` or the same internal session-completion primitive so local login receives OAuth-equivalent rotation, metadata capture, cookie, TTL, and lifecycle behavior.
+It must delegate to request-aware `sign_in_session(response, req, session, options?)` or the same internal session-completion primitive so local login receives OAuth-equivalent rotation, metadata capture, cookie, TTL, and lifecycle behavior. It should not directly create sessions, attach cookies, or bypass the shared completion path.
 
 ### Password reset helpers
 
@@ -244,8 +246,9 @@ Minimum durable shape:
 - `created_at`
 - `updated_at`
 - `state` — `bootstrap`, `pending_setup`, `active`, `disabled`, `locked`, `password_change_required`
-- `claims_json` — optional configured/default claims for session creation
-- `metadata_json` — small auth-owned metadata only; not app profile data
+- `metadata_json` — small auth-owned metadata needed for auth lifecycle only; not app profile data, roles, permissions, organizations, or session claims
+
+Do **not** store app authorization claims/roles on the local identity as part of the primitive data model. Claims for sessions should come from an app-owned hook/helper at session completion, e.g. `app_claims_for_local_user(verified)`, so `std/auth` owns credential lifecycle without becoming the app's authorization database.
 
 ### Credential secret
 
@@ -343,8 +346,10 @@ This table should become implementation comments and contract tests, not just do
 
 **Purpose:** let email/password login produce sessions with the same safety posture as OAuth login.
 
+**Baseline:** request-aware manual session completion already exists in 0.4.9 branch work. This phase should wire local credential verification into that primitive, not design a new cookie/session attachment path.
+
 - [ ] Add local password verification through `std/auth`
-- [ ] Add request-aware local sign-in domain operation
+- [ ] Add local sign-in domain operation that delegates to `sign_in_session(response, req, session, options?)` or the same internal primitive
 - [ ] Rotate/migrate existing sessions on successful local login
 - [ ] Capture `device_name`, `user_agent_hash`, and `last_ip_hash` from request metadata
 - [ ] Apply configured session TTL, max lifetime, sliding expiry, cookie policy, and remember-me behavior

--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -40,7 +40,7 @@ A template app should not need a custom `lib/admin_db.tnt` auth subsystem just t
 
 ## Goal
 
-Make **local email/password/TOTP auth** a first-class `std/auth` path so apps configure it instead of rebuilding it.
+Make **local email/password/TOTP auth** a first-class `std/auth` path so apps configure or call primitives instead of rebuilding security-sensitive lifecycle state.
 
 Target outcome:
 
@@ -51,7 +51,13 @@ Target outcome:
 - no request-less local sign-in path that misses session rotation or request metadata
 - template becomes mostly auth config + views/copy + app-specific authorization policy
 
-This DD is not about turning `std/auth` into a hosted identity product. It is about making the boring, security-sensitive local credential lifecycle native, coherent, and hard to misuse.
+This DD is not about turning `std/auth` into a hosted identity product or a universal app-account framework. It draws a hard boundary:
+
+| Layer | Belongs in `std/auth` | Belongs in the app/plugin |
+|---|---|---|
+| **Primitives** | local credential records, password verification orchestration, reset-token issue/consume, TOTP enrollment state, staged auth continuations, request-aware session completion, backend contracts | profile fields, org membership, billing/account management, invite/approval policy |
+| **Reference flows** | optional bootstrap/login/reset/setup routes and minimal pages built from the primitives | custom UI, copy, email/SMS delivery, onboarding decisions |
+| **Policy hooks** | explicit hooks/options for deriving session data/claims and choosing reset/setup consequences | static universal roles/claims embedded in local-auth config, hidden risk-policy engines |
 
 ---
 
@@ -85,45 +91,59 @@ DD-062 is the detailed child plan for DD-043 Phase 9.
 
 ## Preferred Developer Experience
 
-Primary shape: local auth is a first-class provider variant consumed by `enable_auth(...)`.
+Primary shape: local auth is a primitive family used by `enable_auth(...)` for shared config/diagnostics and by request-aware helpers for custom UI. Reference routes can be generated from the same primitives, but the primitives must remain usable without accepting built-in UI or app policy.
 
 ```ntnt
-import { enable_auth, local_auth } from "std/auth"
-import { get_env } from "std/env"
+import {
+    enable_auth,
+    local_credentials,
+    verify_local_password,
+    sign_in_session,
+} from "std/auth"
+import { parse_form, redirect } from "std/http/server"
 
-enable_auth([
-    local_auth(map {
-        "email_password": true,
+enable_auth([], "admin", map {
+    "local_credentials": local_credentials(map {
+        "identifier": "email",
         "totp": true,
-        "password_reset": true,
-        "bootstrap_email": get_env("ADMIN_BOOTSTRAP_EMAIL"),
-        "bootstrap_password": get_env("ADMIN_BOOTSTRAP_PASSWORD"),
-        "claims": map { "role": "admin" }
-    })
-], "admin", map {
+        "password_reset": true
+    }),
     "login_page": false,
     "success_url": "/admin",
     "failure_url": "/admin/login"
 })
+
+fn login(req) {
+    let form = parse_form(req)
+    let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")?
+    return sign_in_session(redirect("/admin"), req, map {
+        "subject_id": verified["subject_id"],
+        "email": verified["email"],
+        "claims": app_claims_for_local_user(verified)
+    })
+}
 ```
 
 Rationale:
 
-- Developers should still have one obvious auth entrypoint: `enable_auth(...)`.
-- Local auth should share route prefixes, cookies, sessions, lifecycle presets, protected paths, health diagnostics, and startup summaries.
-- Internally, local auth should be a distinct provider/config variant, not a fake OAuth provider.
+- Developers should still have one obvious auth configuration entrypoint: `enable_auth(...)`.
+- Local credentials should share route prefixes, cookies, sessions, lifecycle presets, protected paths, health diagnostics, startup summaries, and backend contract tests.
+- `sign_in_session(response, req, session, options?)` is intentionally request-aware so local/manual auth gets OAuth-equivalent session rotation and request metadata capture.
+- Claims/session data should come from app hooks or explicit session-completion data, not static authorization policy buried in credential config.
+- Email is the first identifier preset, not the universal identity model.
 
 Acceptable later convenience:
 
 ```ntnt
 enable_local_auth(map {
     "preset": "admin",
+    "identifier": "email",
     "totp": true,
     "password_reset": true
 })
 ```
 
-If added, this must delegate to the same underlying local-auth provider/config path. It must not become a parallel auth subsystem.
+If added, this must delegate to the same underlying primitive/config path. It must not become a parallel auth subsystem or quietly own signup policy, onboarding, email delivery, profile data, roles/orgs, or account-management UI.
 
 ---
 
@@ -133,8 +153,9 @@ Names are still draft, but the capability shape should be stable.
 
 ### Configuration
 
-- `local_auth(config: Map) -> AuthProvider`
-- local provider accepted inside `enable_auth([providers...], preset_or_options?, options?)`
+- `local_credentials(config: Map) -> LocalCredentialConfig` (or equivalent final name)
+- local credential config accepted through `enable_auth(..., options)` so it shares auth diagnostics, stores, route prefixes, protected-path behavior, and lifecycle presets
+- optional reference route/page generation can wrap the same primitive config, but custom UI must call the same verification/session-completion helpers
 - startup summary includes local-auth status without exposing secrets
 - `/auth/health` reports local-auth configuration posture without exposing hashes, reset tokens, TOTP secrets, or bootstrap password material
 
@@ -142,13 +163,13 @@ Names are still draft, but the capability shape should be stable.
 
 Possible helpers; exact names can change during implementation:
 
-- `local_user(email) -> Result<LocalUser?, String>`
-- `create_local_user(email, options) -> Result<LocalUser, String>`
-- `disable_local_user(email_or_id) -> Result<Unit, String>`
-- `require_password_change(email_or_id) -> Result<Unit, String>`
-- `set_local_password(email_or_id, new_password, options?) -> Result<Unit, String>`
+- `local_user(identifier) -> Result<LocalUser?, String>`
+- `create_local_user(identifier, options) -> Result<LocalUser, String>`
+- `disable_local_user(identifier_or_id) -> Result<Unit, String>`
+- `require_password_change(identifier_or_id) -> Result<Unit, String>`
+- `set_local_password(identifier_or_id, new_password, options?) -> Result<Unit, String>`
 
-These should be intentionally small. App profile and authorization data should remain app-owned unless it is needed to produce session claims.
+These should be intentionally small. App profile and authorization data should remain app-owned. Session claims should be supplied through explicit hooks/session-completion data, not static universal `claims` config on the credential provider.
 
 ### Local sign-in/session helpers
 
@@ -170,7 +191,7 @@ It should return either:
 - a staged-auth continuation response for TOTP/setup/password-change, or
 - a safe auth error result
 
-It must not be a thin wrapper around the current request-less `sign_in_session(response, session, options?)` path unless that path grows request-aware rotation/metadata behavior.
+It must delegate to request-aware `sign_in_session(response, req, session, options?)` or the same internal session-completion primitive so local login receives OAuth-equivalent rotation, metadata capture, cookie, TTL, and lifecycle behavior.
 
 ### Password reset helpers
 
@@ -216,9 +237,10 @@ Keep this lean. The goal is auth state, not profiles.
 
 Minimum durable shape:
 
-- `id` — stable internal local user id
-- `email` — canonical local identifier
-- `email_normalized` — normalized lookup key
+- `id` — stable internal local subject id
+- `identifier_kind` — e.g. `email`; extensible beyond the first preset
+- `identifier` — canonical display/source identifier for the chosen kind
+- `identifier_normalized` — normalized lookup key for the chosen kind
 - `created_at`
 - `updated_at`
 - `state` — `bootstrap`, `pending_setup`, `active`, `disabled`, `locked`, `password_change_required`

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2900,7 +2900,7 @@ sign_in_session(response: Response, req: Request, session: Map, options?: Map) -
 
 Persist a request-aware session and attach the auth cookie to an existing response.
 
-Use this after password, magic-link, or other non-OAuth login flows. The request argument lets `std/auth` rotate/migrate any existing session and capture the same device/IP/user-agent metadata used by OAuth callbacks. The session map must include `subject_id`, and may optionally include `provider`, `email`, `name`, `picture`, `claims`, `data`, or `raw`.
+Use this after password, magic-link, or other non-OAuth login flows. The request argument lets `std/auth` rotate/migrate any existing session and capture the same device/IP/user-agent metadata used by OAuth callbacks. If an existing session for the same user is rotated and the new session has no explicit `claims`/`data`, its session data is preserved. Cross-user sign-in always starts with only the provided session data. Migration note for 0.4.9 pre-release callers: the old `sign_in_session(response, session, options?)` shape is intentionally not supported; pass the current request as the second argument so metadata and session rotation are not silently skipped. The session map must include `subject_id`, and may optionally include `provider`, `email`, `name`, `picture`, `claims`, `data`, or `raw`.
 
 **Parameters:**
 
@@ -2916,6 +2916,10 @@ Use this after password, magic-link, or other non-OAuth login flows. The request
 ```ntnt
 sign_in_session(redirect("/admin"), req, map { "subject_id": user.id, "claims": app_claims_for_user(user) })  // Sign in and redirect
 ```
+
+**Errors:**
+
+- **TypeError**: request must be an HTTP request map — *Fix: Call sign_in_session(response, req, session, options?) from a route handler and pass the current req*
 
 **See also:** `sign_out_session`, `current_session`, `rotate_session`
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -3014,7 +3014,7 @@ user_sessions(req: Request) -> Result<Array<SessionInfo>, String>
 
 Get all active sessions for the current user.
 
-Returns an array of session info objects, each containing id, provider, created_at, expires_at, and is_current (boolean indicating if it's the current session). Useful for "manage your sessions" UI.
+Returns an array of session info objects, each containing id, provider, device_name (when captured), created_at, expires_at, and is_current (boolean indicating if it's the current session). Sensitive raw hashes are never exposed. Useful for "manage your sessions" UI.
 
 **Parameters:**
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1856,7 +1856,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`session_data`](#sessiondata) | Get custom data stored in the current session. |
 | [`sessions_cleanup`](#sessionscleanup) | Clean up expired sessions, auth challenges, OAuth states, and exchange tokens from the session store. |
 | [`set_session`](#setsession) | Store custom data in the current session. |
-| [`sign_in_session`](#signinsession) | Persist a session and attach the auth cookie to an existing response. |
+| [`sign_in_session`](#signinsession) | Persist a request-aware session and attach the auth cookie to an existing response. |
 | [`sign_out_session`](#signoutsession) | Revoke the current session and attach a clearing auth cookie to a response. |
 | [`totp_secret`](#totpsecret) | Generate a new TOTP secret for MFA setup. |
 | [`totp_uri`](#totpuri) | Generate an otpauth:// URI for QR codes. |
@@ -2085,7 +2085,7 @@ This consumes the active challenge, creates a real session, attaches the normal 
 **Examples:**
 
 ```ntnt
-complete_auth_challenge(redirect("/admin"), req, map { "claims": map { "role": "admin" } })  // Upgrade staged auth into a session
+complete_auth_challenge(redirect("/admin"), req, map { "claims": app_claims_for_user(user) })  // Upgrade staged auth into a session
 ```
 
 **See also:** `begin_auth_challenge`, `current_auth_challenge`, `cancel_auth_challenge`, `sign_in_session`
@@ -2895,16 +2895,17 @@ set_session(req, map { "roles": ["admin"], "theme": "dark" })  // Store user pre
 #### `sign_in_session`
 
 ```ntnt
-sign_in_session(response: Response, session: Map, options?: Map) -> Response
+sign_in_session(response: Response, req: Request, session: Map, options?: Map) -> Response
 ```
 
-Persist a session and attach the auth cookie to an existing response.
+Persist a request-aware session and attach the auth cookie to an existing response.
 
-Use this after password, magic-link, or other non-OAuth login flows. The session map must include `subject_id`, and may optionally include `provider`, `email`, `name`, `picture`, `claims`, `data`, or `raw`.
+Use this after password, magic-link, or other non-OAuth login flows. The request argument lets `std/auth` rotate/migrate any existing session and capture the same device/IP/user-agent metadata used by OAuth callbacks. The session map must include `subject_id`, and may optionally include `provider`, `email`, `name`, `picture`, `claims`, `data`, or `raw`.
 
 **Parameters:**
 
 - `response` — The Response map to attach the session cookie to
+- `req` — The current HTTP request
 - `session` — Session data map, including required `subject_id`
 - `options` — Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
 
@@ -2913,7 +2914,7 @@ Use this after password, magic-link, or other non-OAuth login flows. The session
 **Examples:**
 
 ```ntnt
-sign_in_session(redirect("/admin"), map { "subject_id": user.id, "claims": map { "role": "admin" } })  // Sign in and redirect
+sign_in_session(redirect("/admin"), req, map { "subject_id": user.id, "claims": app_claims_for_user(user) })  // Sign in and redirect
 ```
 
 **See also:** `sign_out_session`, `current_session`, `rotate_session`

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -5137,6 +5137,37 @@ mod tests {
     }
 
     #[test]
+    fn test_local_auth_durable_record_families_fail_closed_by_policy() {
+        use super::storage::{local_auth_record_fallback_policy, LocalAuthRecordKind};
+
+        for record_kind in [
+            LocalAuthRecordKind::Identity,
+            LocalAuthRecordKind::CredentialSecret,
+            LocalAuthRecordKind::TotpEnrollment,
+            LocalAuthRecordKind::PasswordResetToken,
+            LocalAuthRecordKind::BootstrapState,
+        ] {
+            let policy = local_auth_record_fallback_policy(record_kind);
+            assert!(
+                policy.store_failure_fails_closed,
+                "{record_kind:?} store failures must fail closed"
+            );
+            assert!(
+                policy.lookup_failure_fails_closed,
+                "{record_kind:?} lookup failures must fail closed"
+            );
+            assert!(
+                policy.update_failure_fails_closed,
+                "{record_kind:?} update/consume failures must fail closed"
+            );
+            assert!(
+                !policy.production_memory_fallback_allowed,
+                "{record_kind:?} must not allow production memory fallback"
+            );
+        }
+    }
+
+    #[test]
     fn test_auth_storage_contract_postgres_round_trip_all_record_types() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         let Some(store) = auth_test_postgres_store() else {

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -633,6 +633,48 @@ pub fn get_auth_config() -> Option<AuthConfig> {
     AUTH_CONFIG.lock().unwrap().clone()
 }
 
+fn validate_http_request_arg(function_name: &str, req: &Value) -> Result<()> {
+    let req_map = match req {
+        Value::Map(map) => map,
+        other => {
+            return Err(IntentError::type_error(format!(
+                "[auth] {}() request must be an HTTP request map, got {}",
+                function_name,
+                other.type_name()
+            )))
+        }
+    };
+
+    for key in ["method", "path"] {
+        match req_map.get(key) {
+            Some(Value::String(_)) => {}
+            Some(other) => {
+                return Err(IntentError::type_error(format!(
+                    "[auth] {}() request.{} must be a string, got {}",
+                    function_name,
+                    key,
+                    other.type_name()
+                )))
+            }
+            None => {
+                return Err(IntentError::type_error(format!(
+                    "[auth] {}() request must include {}",
+                    function_name, key
+                )))
+            }
+        }
+    }
+
+    match req_map.get("headers") {
+        Some(Value::Map(_)) | None => Ok(()),
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() request.headers must be a map, got {}",
+            function_name,
+            other.type_name()
+        ))),
+    }
+}
+
 fn prepare_request_aware_manual_session(req: &Value, mut session: Session) -> Session {
     session.device_name = request_device_name(req);
     session.user_agent_hash = request_user_agent_hash(req);
@@ -644,7 +686,10 @@ fn persist_manual_session_record(req: &Value, mut session: Session) -> Result<()
     if let Some(existing_session_id) = get_session_id_from_request(req) {
         if let Some(existing_session) = get_session_by_id(&existing_session_id) {
             if existing_session_id != session.id {
-                if session.data_json == "{}" && existing_session.data_json != "{}" {
+                if existing_session.user_id == session.user_id
+                    && session.data_json == "{}"
+                    && existing_session.data_json != "{}"
+                {
                     session.data_json = existing_session.data_json.clone();
                 }
                 migrate_session(&existing_session_id, &session)
@@ -1661,6 +1706,8 @@ pub fn init() -> HashMap<String, Value> {
                             .to_string(),
                     )
                 })?;
+
+                validate_http_request_arg("complete_auth_challenge", &args[1])?;
 
                 let session_spec = match args.get(2) {
                     Some(Value::Map(map)) => map.clone(),
@@ -3695,6 +3742,13 @@ pub fn init() -> HashMap<String, Value> {
     // Use this after password, magic-link, or other non-OAuth login flows. The
     // request argument lets `std/auth` rotate/migrate any existing session and
     // capture the same device/IP/user-agent metadata used by OAuth callbacks.
+    // If an existing session for the same user is rotated and the new session
+    // has no explicit `claims`/`data`, its session data is preserved. Cross-user
+    // sign-in always starts with only the provided session data.
+    // Migration note for 0.4.9 pre-release callers: the old
+    // `sign_in_session(response, session, options?)` shape is intentionally not
+    // supported; pass the current request as the second argument so metadata and
+    // session rotation are not silently skipped.
     // The session map must include `subject_id`, and may optionally include
     // `provider`, `email`, `name`, `picture`, `claims`, `data`, or `raw`.
     // @param response The Response map to attach the session cookie to
@@ -3702,6 +3756,7 @@ pub fn init() -> HashMap<String, Value> {
     // @param session Session data map, including required `subject_id`
     // @param options Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
     // @returns Response with a persisted session and Set-Cookie header
+    // @error TypeError ~ "request must be an HTTP request map" fix: "Call sign_in_session(response, req, session, options?) from a route handler and pass the current req"
     // @see_also sign_out_session, current_session, rotate_session
     // @since v0.4.9
     // @tags #auth, #session
@@ -3727,6 +3782,8 @@ pub fn init() -> HashMap<String, Value> {
                             .to_string(),
                     )
                 })?;
+
+                validate_http_request_arg("sign_in_session", &args[1])?;
 
                 let session_spec = match &args[2] {
                     Value::Map(map) => map.clone(),
@@ -4265,17 +4322,23 @@ mod tests {
     }
 
     fn request_with_cookies(cookies: &[&str]) -> Value {
-        Value::Map(HashMap::from([(
-            "headers".to_string(),
-            Value::Map(HashMap::from([(
-                "cookie".to_string(),
-                Value::String(cookies.join("; ")),
-            )])),
-        )]))
+        Value::Map(HashMap::from([
+            ("method".to_string(), Value::String("GET".to_string())),
+            ("path".to_string(), Value::String("/admin".to_string())),
+            (
+                "headers".to_string(),
+                Value::Map(HashMap::from([(
+                    "cookie".to_string(),
+                    Value::String(cookies.join("; ")),
+                )])),
+            ),
+        ]))
     }
 
     fn request_with_cookie_and_security_headers(cookie: &str) -> Value {
         Value::Map(HashMap::from([
+            ("method".to_string(), Value::String("GET".to_string())),
+            ("path".to_string(), Value::String("/admin".to_string())),
             (
                 "headers".to_string(),
                 Value::Map(HashMap::from([
@@ -6408,6 +6471,109 @@ mod tests {
         let new_session = get_session_by_id(&new_id).expect("new session should be persisted");
         assert_eq!(new_session.user_id, "local:second-user");
         assert_eq!(new_session.device_name.as_deref(), Some("Mac · Safari"));
+    }
+
+    #[test]
+    fn test_sign_in_session_preserves_existing_data_only_for_same_user() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+
+        let first = sign_in_session(&[
+            redirect_response("/admin", None),
+            request_with_cookie(""),
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("same-user".to_string()),
+                ),
+                (
+                    "claims".to_string(),
+                    Value::Map(HashMap::from([(
+                        "role".to_string(),
+                        Value::String("admin".to_string()),
+                    )])),
+                ),
+            ])),
+        ])
+        .unwrap();
+        let first_cookie = cookie_header_from_response(&first);
+
+        let same_user = sign_in_session(&[
+            redirect_response("/admin", None),
+            request_with_cookie(&first_cookie),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("same-user".to_string()),
+            )])),
+        ])
+        .unwrap();
+        let same_user_cookie = cookie_header_from_response(&same_user);
+        let same_user_id = get_session_id_from_request(&request_with_cookie(&same_user_cookie))
+            .expect("same-user session cookie should verify");
+        let same_user_session = get_session_by_id(&same_user_id).expect("session should exist");
+        assert_eq!(same_user_session.data_json, r#"{"role":"admin"}"#);
+
+        let different_user = sign_in_session(&[
+            redirect_response("/admin", None),
+            request_with_cookie(&same_user_cookie),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("different-user".to_string()),
+            )])),
+        ])
+        .unwrap();
+        let different_user_cookie = cookie_header_from_response(&different_user);
+        let different_user_id =
+            get_session_id_from_request(&request_with_cookie(&different_user_cookie))
+                .expect("different-user session cookie should verify");
+        let different_user_session =
+            get_session_by_id(&different_user_id).expect("session should exist");
+        assert_eq!(different_user_session.user_id, "local:different-user");
+        assert_eq!(different_user_session.data_json, "{}");
+    }
+
+    #[test]
+    fn test_sign_in_session_rejects_invalid_request_argument() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let err = sign_in_session(&[
+            redirect_response("/admin", None),
+            Value::String("not-a-request".to_string()),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err)
+            .contains("[auth] sign_in_session() request must be an HTTP request map"));
+    }
+
+    #[test]
+    fn test_complete_auth_challenge_rejects_invalid_request_argument() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let complete_auth_challenge = module_fn(&module, "complete_auth_challenge");
+        let err = complete_auth_challenge(&[
+            redirect_response("/admin", None),
+            Value::String("not-a-request".to_string()),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err)
+            .contains("[auth] complete_auth_challenge() request must be an HTTP request map"));
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -88,7 +88,10 @@ pub use request_helpers::{
     auth_challenge_to_value, get_auth_challenge_id_from_request, get_session_id_from_request,
     session_to_value, user_to_value,
 };
-use request_helpers::{get_host_and_proto, get_user_from_request};
+use request_helpers::{
+    get_host_and_proto, get_user_from_request, request_device_name, request_ip_hash,
+    request_user_agent_hash,
+};
 pub use routes::{
     handle_auth_callback, handle_auth_health, handle_auth_index, handle_auth_logout,
     handle_auth_protect, handle_auth_start,
@@ -628,6 +631,50 @@ static AUTH_PROTECTED_PATHS: std::sync::LazyLock<Arc<Mutex<Vec<String>>>> =
 
 pub fn get_auth_config() -> Option<AuthConfig> {
     AUTH_CONFIG.lock().unwrap().clone()
+}
+
+fn prepare_request_aware_manual_session(req: &Value, mut session: Session) -> Session {
+    session.device_name = request_device_name(req);
+    session.user_agent_hash = request_user_agent_hash(req);
+    session.last_ip_hash = request_ip_hash(req);
+    session
+}
+
+fn persist_manual_session_record(req: &Value, mut session: Session) -> Result<()> {
+    if let Some(existing_session_id) = get_session_id_from_request(req) {
+        if let Some(existing_session) = get_session_by_id(&existing_session_id) {
+            if existing_session_id != session.id {
+                if session.data_json == "{}" && existing_session.data_json != "{}" {
+                    session.data_json = existing_session.data_json.clone();
+                }
+                migrate_session(&existing_session_id, &session)
+                    .map_err(IntentError::runtime_error)?;
+            } else {
+                store_session(session);
+            }
+        } else {
+            store_session(session);
+        }
+    } else {
+        store_session(session);
+    }
+
+    Ok(())
+}
+
+fn persist_request_aware_manual_session(
+    response: &Value,
+    req: &Value,
+    session: Session,
+    options: Option<&HashMap<String, Value>>,
+    config: &AuthConfig,
+) -> Result<Value> {
+    let session = prepare_request_aware_manual_session(req, session);
+    let cookie = build_signed_session_cookie(config, &session.id, options)
+        .map_err(IntentError::type_error)?;
+    let response = add_set_cookie_header(response, &cookie).map_err(IntentError::type_error)?;
+    persist_manual_session_record(req, session)?;
+    Ok(response)
 }
 
 pub fn init() -> HashMap<String, Value> {
@@ -1592,7 +1639,7 @@ pub fn init() -> HashMap<String, Value> {
     // @see_also begin_auth_challenge, current_auth_challenge, cancel_auth_challenge, sign_in_session
     // @since v0.4.9
     // @tags #auth, #session, #mfa
-    // @example complete_auth_challenge(redirect("/admin"), req, map { "claims": map { "role": "admin" } }) ~ "Upgrade staged auth into a session"
+    // @example complete_auth_challenge(redirect("/admin"), req, map { "claims": app_claims_for_user(user) }) ~ "Upgrade staged auth into a session"
     module.insert(
         "complete_auth_challenge".to_string(),
         Value::NativeFunction {
@@ -1716,6 +1763,7 @@ pub fn init() -> HashMap<String, Value> {
                     .min(config.max_session_ttl.unwrap_or(session_ttl));
                 let session = create_manual_session(&merged_session, effective_session_ttl)
                     .map_err(IntentError::type_error)?;
+                let session = prepare_request_aware_manual_session(&args[1], session);
                 let session_cookie =
                     build_signed_session_cookie(&config, &session.id, options.as_ref())
                         .map_err(IntentError::type_error)?;
@@ -1735,7 +1783,7 @@ pub fn init() -> HashMap<String, Value> {
                     ));
                 }
 
-                store_session(session);
+                persist_manual_session_record(&args[1], session)?;
                 Ok(response)
             },
         },
@@ -3641,31 +3689,34 @@ pub fn init() -> HashMap<String, Value> {
 
     // @ntnt sign_in_session
     // @module std/auth
-    // @signature sign_in_session(response: Response, session: Map, options?: Map) -> Response
-    // Persist a session and attach the auth cookie to an existing response.
+    // @signature sign_in_session(response: Response, req: Request, session: Map, options?: Map) -> Response
+    // Persist a request-aware session and attach the auth cookie to an existing response.
     //
     // Use this after password, magic-link, or other non-OAuth login flows. The
-    // session map must include `subject_id`, and may optionally include `provider`,
-    // `email`, `name`, `picture`, `claims`, `data`, or `raw`.
+    // request argument lets `std/auth` rotate/migrate any existing session and
+    // capture the same device/IP/user-agent metadata used by OAuth callbacks.
+    // The session map must include `subject_id`, and may optionally include
+    // `provider`, `email`, `name`, `picture`, `claims`, `data`, or `raw`.
     // @param response The Response map to attach the session cookie to
+    // @param req The current HTTP request
     // @param session Session data map, including required `subject_id`
     // @param options Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
     // @returns Response with a persisted session and Set-Cookie header
     // @see_also sign_out_session, current_session, rotate_session
     // @since v0.4.9
     // @tags #auth, #session
-    // @example sign_in_session(redirect("/admin"), map { "subject_id": user.id, "claims": map { "role": "admin" } }) ~ "Sign in and redirect"
+    // @example sign_in_session(redirect("/admin"), req, map { "subject_id": user.id, "claims": app_claims_for_user(user) }) ~ "Sign in and redirect"
     module.insert(
         "sign_in_session".to_string(),
         Value::NativeFunction {
             name: "sign_in_session".to_string(),
-            arity: 2,
-            max_arity: 3,
+            arity: 3,
+            max_arity: 4,
             requires: None,
             func: |args| {
-                if args.len() < 2 || args.len() > 3 {
+                if args.len() < 3 || args.len() > 4 {
                     return Err(IntentError::type_error(
-                        "[auth] sign_in_session() requires response, session, and optional options"
+                        "[auth] sign_in_session() requires response, request, session, and optional options"
                             .to_string(),
                     ));
                 }
@@ -3677,7 +3728,7 @@ pub fn init() -> HashMap<String, Value> {
                     )
                 })?;
 
-                let session_spec = match &args[1] {
+                let session_spec = match &args[2] {
                     Value::Map(map) => map.clone(),
                     other => {
                         return Err(IntentError::type_error(format!(
@@ -3687,7 +3738,7 @@ pub fn init() -> HashMap<String, Value> {
                     }
                 };
 
-                let options = match args.get(2) {
+                let options = match args.get(3) {
                     Some(Value::Map(map)) => Some(map.clone()),
                     Some(other) => {
                         return Err(IntentError::type_error(format!(
@@ -3713,15 +3764,14 @@ pub fn init() -> HashMap<String, Value> {
                     session_ttl.min(config.max_session_ttl.unwrap_or(session_ttl));
                 let session = create_manual_session(&session_spec, effective_session_ttl)
                     .map_err(IntentError::type_error)?;
-                let session_id = session.id.clone();
 
-                let cookie = build_signed_session_cookie(&config, &session_id, options.as_ref())
-                    .map_err(IntentError::type_error)?;
-                let response =
-                    add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)?;
-
-                store_session(session);
-                Ok(response)
+                persist_request_aware_manual_session(
+                    &args[0],
+                    &args[1],
+                    session,
+                    options.as_ref(),
+                    &config,
+                )
             },
         },
     );
@@ -4222,6 +4272,26 @@ mod tests {
                 Value::String(cookies.join("; ")),
             )])),
         )]))
+    }
+
+    fn request_with_cookie_and_security_headers(cookie: &str) -> Value {
+        Value::Map(HashMap::from([
+            (
+                "headers".to_string(),
+                Value::Map(HashMap::from([
+                    ("cookie".to_string(), Value::String(cookie.to_string())),
+                    (
+                        "user-agent".to_string(),
+                        Value::String("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15".to_string()),
+                    ),
+                    (
+                        "x-forwarded-for".to_string(),
+                        Value::String("203.0.113.10".to_string()),
+                    ),
+                ])),
+            ),
+            ("ip".to_string(), Value::String("198.51.100.20".to_string())),
+        ]))
     }
 
     fn init_test_auth(session_store: SessionStore) {
@@ -5896,6 +5966,7 @@ mod tests {
 
         let signed_in = sign_in_session(&[
             redirect_response("/admin", None),
+            request_with_cookie(""),
             Value::Map(HashMap::from([(
                 "subject_id".to_string(),
                 Value::String("user-123".to_string()),
@@ -6205,6 +6276,7 @@ mod tests {
         let response = redirect_response("/admin", None);
         let signed_in = sign_in_session(&[
             response,
+            request_with_cookie(""),
             Value::Map(HashMap::from([
                 (
                     "subject_id".to_string(),
@@ -6264,6 +6336,120 @@ mod tests {
             }
             other => panic!("expected Some(user), got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_sign_in_session_captures_request_metadata() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+        let request = request_with_cookie_and_security_headers("");
+
+        let signed_in = sign_in_session(&[
+            redirect_response("/admin", None),
+            request.clone(),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("user-123".to_string()),
+            )])),
+        ])
+        .unwrap();
+
+        let cookie = cookie_header_from_response(&signed_in);
+        let session_id = get_session_id_from_request(&request_with_cookie(&cookie))
+            .expect("session cookie should verify");
+        let session = get_session_by_id(&session_id).expect("session should be persisted");
+        assert_eq!(session.device_name.as_deref(), Some("Mac · Safari"));
+        assert!(session.user_agent_hash.is_some());
+        assert!(session.last_ip_hash.is_some());
+    }
+
+    #[test]
+    fn test_sign_in_session_rotates_existing_session() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let sign_in_session = module_fn(&module, "sign_in_session");
+
+        let first = sign_in_session(&[
+            redirect_response("/admin", None),
+            request_with_cookie(""),
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("first-user".to_string()),
+            )])),
+        ])
+        .unwrap();
+        let old_cookie = cookie_header_from_response(&first);
+        let old_id = get_session_id_from_request(&request_with_cookie(&old_cookie))
+            .expect("old session cookie should verify");
+
+        let second_req = request_with_cookie_and_security_headers(&old_cookie);
+        let second = sign_in_session(&[
+            redirect_response("/admin", None),
+            second_req,
+            Value::Map(HashMap::from([(
+                "subject_id".to_string(),
+                Value::String("second-user".to_string()),
+            )])),
+        ])
+        .unwrap();
+        let new_cookie = cookie_header_from_response(&second);
+        let new_id = get_session_id_from_request(&request_with_cookie(&new_cookie))
+            .expect("new session cookie should verify");
+
+        assert_ne!(old_id, new_id);
+        assert!(get_session_by_id(&old_id).is_none());
+        let new_session = get_session_by_id(&new_id).expect("new session should be persisted");
+        assert_eq!(new_session.user_id, "local:second-user");
+        assert_eq!(new_session.device_name.as_deref(), Some("Mac · Safari"));
+    }
+
+    #[test]
+    fn test_complete_auth_challenge_captures_request_metadata() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let begin_auth_challenge = module_fn(&module, "begin_auth_challenge");
+        let complete_auth_challenge = module_fn(&module, "complete_auth_challenge");
+
+        let started = begin_auth_challenge(&[
+            redirect_response("/admin/verify", None),
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("user-123".to_string()),
+                ),
+                ("kind".to_string(), Value::String("mfa_pending".to_string())),
+            ])),
+        ])
+        .unwrap();
+        let challenge_cookie = cookie_header_from_response(&started);
+        let req = request_with_cookie_and_security_headers(&challenge_cookie);
+
+        let completed = complete_auth_challenge(&[
+            redirect_response("/admin", None),
+            req,
+            Value::Map(HashMap::new()),
+        ])
+        .unwrap();
+        let session_cookie = cookie_headers_from_response(&completed)
+            .into_iter()
+            .find(|cookie| cookie.starts_with("ntnt_session="))
+            .expect("missing session cookie");
+        let session_id = get_session_id_from_request(&request_with_cookie(&session_cookie))
+            .expect("session cookie should verify");
+        let session = get_session_by_id(&session_id).expect("session should be persisted");
+        assert_eq!(session.device_name.as_deref(), Some("Mac · Safari"));
+        assert!(session.user_agent_hash.is_some());
+        assert!(session.last_ip_hash.is_some());
     }
 
     #[test]
@@ -6347,6 +6533,7 @@ mod tests {
         let sign_in_session = module_fn(&module, "sign_in_session");
         let err = sign_in_session(&[
             redirect_response("/admin", None),
+            request_with_cookie(""),
             Value::Map(HashMap::from([(
                 "provider".to_string(),
                 Value::String("local".to_string()),
@@ -6369,6 +6556,7 @@ mod tests {
         let sign_in_session = module_fn(&module, "sign_in_session");
         let err = sign_in_session(&[
             Value::String("not-a-response".to_string()),
+            request_with_cookie(""),
             Value::Map(HashMap::from([(
                 "subject_id".to_string(),
                 Value::String("user-123".to_string()),
@@ -6390,6 +6578,7 @@ mod tests {
         let sign_in_session = module_fn(&module, "sign_in_session");
         let err = sign_in_session(&[
             redirect_response("/admin", None),
+            request_with_cookie(""),
             Value::Map(HashMap::from([(
                 "subject_id".to_string(),
                 Value::String("user-123".to_string()),
@@ -6418,6 +6607,7 @@ mod tests {
 
         let signed_in = sign_in_session(&[
             redirect_response("/admin", None),
+            request_with_cookie(""),
             Value::Map(HashMap::from([(
                 "subject_id".to_string(),
                 Value::String("user-123".to_string()),
@@ -6488,6 +6678,7 @@ mod tests {
 
         let signed_in = sign_in_session(&[
             redirect_response("/admin", None),
+            request_with_cookie(""),
             Value::Map(HashMap::from([(
                 "subject_id".to_string(),
                 Value::String("user-123".to_string()),
@@ -6547,6 +6738,7 @@ mod tests {
 
         let signed_in = sign_in_session(&[
             redirect_response("/admin", None),
+            request_with_cookie(""),
             Value::Map(HashMap::from([(
                 "subject_id".to_string(),
                 Value::String("user-123".to_string()),
@@ -6599,6 +6791,7 @@ mod tests {
 
         let signed_in = sign_in_session(&[
             redirect_response("/admin", None),
+            request_with_cookie(""),
             Value::Map(HashMap::from([(
                 "subject_id".to_string(),
                 Value::String("user-123".to_string()),

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -2117,8 +2117,9 @@ pub fn init() -> HashMap<String, Value> {
     // Get all active sessions for the current user.
     //
     // Returns an array of session info objects, each containing id, provider,
-    // created_at, expires_at, and is_current (boolean indicating if it's the
-    // current session). Useful for "manage your sessions" UI.
+    // device_name (when captured), created_at, expires_at, and is_current
+    // (boolean indicating if it's the current session). Sensitive raw hashes are
+    // never exposed. Useful for "manage your sessions" UI.
     // @param req The HTTP request object
     // @returns Result containing array of session info, or error
     // @see_also logout_all, get_session
@@ -2154,6 +2155,12 @@ pub fn init() -> HashMap<String, Value> {
                                         "provider".to_string(),
                                         Value::String(si.provider.clone()),
                                     );
+                                    if let Some(device_name) = &si.device_name {
+                                        map.insert(
+                                            "device_name".to_string(),
+                                            Value::String(device_name.clone()),
+                                        );
+                                    }
                                     map.insert("created_at".to_string(), Value::Int(si.created_at));
                                     map.insert("expires_at".to_string(), Value::Int(si.expires_at));
                                     map.insert(
@@ -4268,13 +4275,16 @@ mod tests {
         };
         store_session_record(&session)
             .unwrap_or_else(|e| panic!("{} session store should succeed: {}", label, e));
+        let stored_session = get_session_record(&session.id)
+            .unwrap_or_else(|e| panic!("{} session lookup should succeed: {}", label, e))
+            .unwrap_or_else(|| panic!("{} session should exist", label));
+        assert_eq!(stored_session.id, session.id);
+        assert_eq!(stored_session.device_name.as_deref(), Some("SQLite Mac"));
         assert_eq!(
-            get_session_record(&session.id)
-                .unwrap_or_else(|e| panic!("{} session lookup should succeed: {}", label, e))
-                .unwrap_or_else(|| panic!("{} session should exist", label))
-                .id,
-            session.id
+            stored_session.user_agent_hash.as_deref(),
+            Some("ua-sqlite-1")
         );
+        assert_eq!(stored_session.last_ip_hash.as_deref(), Some("ip-sqlite-1"));
         update_session_record_data(&session.id, r#"{"role":"admin"}"#)
             .unwrap_or_else(|e| panic!("{} session data update should succeed: {}", label, e));
         update_session_record_tokens(
@@ -4306,6 +4316,12 @@ mod tests {
         );
         assert_eq!(updated_session.token_expires_at, Some(now + 120));
         assert_eq!(updated_session.expires_at, now + 600);
+        assert_eq!(updated_session.device_name.as_deref(), Some("SQLite Mac"));
+        assert_eq!(
+            updated_session.user_agent_hash.as_deref(),
+            Some("ua-sqlite-1")
+        );
+        assert_eq!(updated_session.last_ip_hash.as_deref(), Some("ip-sqlite-1"));
 
         let refreshable_session = Session {
             id: format!("session-{}-refreshable", label),
@@ -4359,16 +4375,16 @@ mod tests {
         assert!(get_session_record(&session.id)
             .unwrap_or_else(|e| panic!("{} old session lookup should succeed: {}", label, e))
             .is_none());
+        let rotated_lookup = get_session_record(&rotated_session.id)
+            .unwrap_or_else(|e| panic!("{} rotated session lookup should succeed: {}", label, e))
+            .unwrap_or_else(|| panic!("{} rotated session should exist", label));
+        assert_eq!(rotated_lookup.csrf_token, format!("csrf-{}-rotated", label));
+        assert_eq!(rotated_lookup.device_name.as_deref(), Some("SQLite Mac"));
         assert_eq!(
-            get_session_record(&rotated_session.id)
-                .unwrap_or_else(|e| panic!(
-                    "{} rotated session lookup should succeed: {}",
-                    label, e
-                ))
-                .unwrap_or_else(|| panic!("{} rotated session should exist", label))
-                .csrf_token,
-            format!("csrf-{}-rotated", label)
+            rotated_lookup.user_agent_hash.as_deref(),
+            Some("ua-sqlite-1")
         );
+        assert_eq!(rotated_lookup.last_ip_hash.as_deref(), Some("ip-sqlite-1"));
         let listed_sessions = list_session_records_for_user(
             &format!("user-{}", label),
             Some(&rotated_session.id),
@@ -4376,9 +4392,11 @@ mod tests {
         )
         .unwrap_or_else(|e| panic!("{} session listing should succeed: {}", label, e));
         assert_eq!(listed_sessions.len(), 1);
-        assert!(listed_sessions
+        let listed_current = listed_sessions
             .iter()
-            .any(|session| session.id == rotated_session.id && session.is_current));
+            .find(|session| session.id == rotated_session.id && session.is_current)
+            .unwrap_or_else(|| panic!("{} current session should be listed", label));
+        assert_eq!(listed_current.device_name.as_deref(), Some("SQLite Mac"));
         assert_eq!(
             delete_all_session_records_for_user(
                 &format!("user-{}", label),
@@ -4399,7 +4417,7 @@ mod tests {
             pkce_verifier: Some(format!("pkce-{}", label)),
             provider: "github".to_string(),
             redirect_url: "/auth/callback".to_string(),
-            remember_me: false,
+            remember_me: true,
             device_name: Some(format!("{} Browser", label)),
             user_agent_hash: Some(format!("ua-{}-oauth", label)),
             last_ip_hash: Some(format!("ip-{}-oauth", label)),
@@ -4407,12 +4425,22 @@ mod tests {
         };
         store_oauth_state_record(&oauth_state)
             .unwrap_or_else(|e| panic!("{} oauth state store should succeed: {}", label, e));
+        let consumed_oauth_state = consume_oauth_state_record(&oauth_state.state)
+            .unwrap_or_else(|e| panic!("{} oauth state consume should succeed: {}", label, e))
+            .unwrap_or_else(|| panic!("{} oauth state should exist", label));
+        assert_eq!(consumed_oauth_state.state, oauth_state.state);
+        assert!(consumed_oauth_state.remember_me);
         assert_eq!(
-            consume_oauth_state_record(&oauth_state.state)
-                .unwrap_or_else(|e| panic!("{} oauth state consume should succeed: {}", label, e))
-                .unwrap_or_else(|| panic!("{} oauth state should exist", label))
-                .state,
-            oauth_state.state
+            consumed_oauth_state.device_name.as_deref(),
+            Some(format!("{} Browser", label).as_str())
+        );
+        assert_eq!(
+            consumed_oauth_state.user_agent_hash.as_deref(),
+            Some(format!("ua-{}-oauth", label).as_str())
+        );
+        assert_eq!(
+            consumed_oauth_state.last_ip_hash.as_deref(),
+            Some(format!("ip-{}-oauth", label).as_str())
         );
         assert!(
             consume_oauth_state_record(&oauth_state.state)
@@ -6205,6 +6233,77 @@ mod tests {
             }
             other => panic!("expected Some(user), got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_user_sessions_exposes_safe_device_name_metadata() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let now = chrono::Utc::now().timestamp();
+        let session = Session {
+            id: "session-device-name".to_string(),
+            user_id: "local:user-123".to_string(),
+            provider: "local".to_string(),
+            email: Some("alice@example.com".to_string()),
+            name: Some("Alice".to_string()),
+            picture: None,
+            raw_json: "{}".to_string(),
+            data_json: "{}".to_string(),
+            csrf_token: "csrf-device-name".to_string(),
+            access_token: None,
+            refresh_token: None,
+            token_expires_at: None,
+            device_name: Some("Mac · Safari".to_string()),
+            user_agent_hash: Some("ua-hash-must-stay-private".to_string()),
+            last_ip_hash: Some("ip-hash-must-stay-private".to_string()),
+            created_at: now,
+            expires_at: now + 300,
+        };
+        store_session_record(&session).expect("session store should succeed");
+
+        let config = get_auth_config().expect("auth config should be initialized");
+        let cookie = build_signed_session_cookie(&config, &session.id, None)
+            .expect("session cookie should build");
+        let req = request_with_cookie(cookie.split(';').next().unwrap());
+
+        let module = init();
+        let user_sessions = module_fn(&module, "user_sessions");
+        let listed = user_sessions(&[req]).expect("user_sessions should run");
+
+        let sessions = match listed {
+            Value::EnumValue {
+                enum_name,
+                variant,
+                values,
+            } => {
+                assert_eq!(enum_name, "Result");
+                assert_eq!(variant, "Ok");
+                match values.into_iter().next() {
+                    Some(Value::Array(sessions)) => sessions,
+                    other => panic!("expected Ok(Array), got {:?}", other),
+                }
+            }
+            other => panic!("expected Result::Ok, got {:?}", other),
+        };
+        assert_eq!(sessions.len(), 1);
+        let session_info = match sessions.first() {
+            Some(Value::Map(map)) => map,
+            other => panic!("expected session info map, got {:?}", other),
+        };
+        match session_info.get("device_name") {
+            Some(Value::String(device_name)) => assert_eq!(device_name, "Mac · Safari"),
+            other => panic!("expected public device_name string, got {:?}", other),
+        }
+        assert!(
+            !session_info.contains_key("user_agent_hash"),
+            "user_sessions() must not expose raw user-agent hash"
+        );
+        assert!(
+            !session_info.contains_key("last_ip_hash"),
+            "user_sessions() must not expose raw IP hash"
+        );
     }
 
     #[test]

--- a/src/stdlib/auth/routes.rs
+++ b/src/stdlib/auth/routes.rs
@@ -530,7 +530,10 @@ pub fn handle_auth_callback(args: &[Value]) -> Result<Value> {
     if let Some(existing_session_id) = get_session_id_from_request(req) {
         if let Some(existing_session) = get_session_by_id(&existing_session_id) {
             if existing_session_id != session.id {
-                if session.data_json == "{}" && existing_session.data_json != "{}" {
+                if existing_session.user_id == session.user_id
+                    && session.data_json == "{}"
+                    && existing_session.data_json != "{}"
+                {
                     session.data_json = existing_session.data_json.clone();
                 }
                 migrate_session(&existing_session_id, &session).map_err(|error| {

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -1,0 +1,38 @@
+/// Durable local-auth record families planned by DD-062.
+///
+/// These are deliberately modeled before implementation so credential-related
+/// state does not inherit the softer memory fallback semantics used by some
+/// transient session/OAuth/challenge paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::stdlib::auth) enum LocalAuthRecordKind {
+    Identity,
+    CredentialSecret,
+    TotpEnrollment,
+    PasswordResetToken,
+    BootstrapState,
+}
+
+/// Fallback contract for a local-auth record family.
+///
+/// Durable local-auth state is security-critical account state. In production,
+/// backend failures must fail closed instead of silently degrading to process
+/// memory. This policy is the scaffold future local-auth storage code must wire
+/// into real store/get/update/consume helpers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::stdlib::auth) struct LocalAuthFallbackPolicy {
+    pub(in crate::stdlib::auth) store_failure_fails_closed: bool,
+    pub(in crate::stdlib::auth) lookup_failure_fails_closed: bool,
+    pub(in crate::stdlib::auth) update_failure_fails_closed: bool,
+    pub(in crate::stdlib::auth) production_memory_fallback_allowed: bool,
+}
+
+pub(in crate::stdlib::auth) fn local_auth_record_fallback_policy(
+    _record_kind: LocalAuthRecordKind,
+) -> LocalAuthFallbackPolicy {
+    LocalAuthFallbackPolicy {
+        store_failure_fails_closed: true,
+        lookup_failure_fails_closed: true,
+        update_failure_fails_closed: true,
+        production_memory_fallback_allowed: false,
+    }
+}

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -1875,7 +1875,26 @@ fn store_session_redis(session: &Session) -> std::result::Result<(), String> {
         .get_connection()
         .map_err(|e| format!("Redis connection error: {}", e))?;
 
-    let session_json = serde_json::json!({
+    let session_json = session_to_redis_json(session);
+    let key = format!("ntnt:session:{}", session.id);
+    let ttl = redis_session_retention_ttl(session, chrono::Utc::now().timestamp());
+
+    if ttl <= 0 {
+        return Err("Session already expired before Redis retention window".to_string());
+    }
+
+    redis::cmd("SETEX")
+        .arg(&key)
+        .arg(ttl)
+        .arg(&session_json)
+        .query::<()>(&mut conn)
+        .map_err(|e| format!("Redis SETEX error: {}", e))?;
+
+    Ok(())
+}
+
+fn session_to_redis_json(session: &Session) -> String {
+    serde_json::json!({
         "id": session.id,
         "user_id": session.user_id,
         "provider": session.provider,
@@ -1894,23 +1913,72 @@ fn store_session_redis(session: &Session) -> std::result::Result<(), String> {
         "created_at": session.created_at,
         "expires_at": session.expires_at,
     })
-    .to_string();
+    .to_string()
+}
 
-    let key = format!("ntnt:session:{}", session.id);
-    let ttl = session.expires_at - chrono::Utc::now().timestamp();
+fn redis_refresh_retention_ttl() -> i64 {
+    get_auth_config()
+        .map(|config| config.refresh_ttl)
+        .unwrap_or_else(|| AuthConfig::default().refresh_ttl)
+}
 
-    if ttl <= 0 {
-        return Err("Session already expired before Redis store".to_string());
-    }
+fn redis_session_retention_ttl(session: &Session, now: i64) -> i64 {
+    let active_ttl = session.expires_at - now;
+    let refresh_retention_ttl = session
+        .refresh_token
+        .as_ref()
+        .map(|_| session.created_at + redis_refresh_retention_ttl() - now)
+        .unwrap_or(i64::MIN);
 
-    redis::cmd("SETEX")
-        .arg(&key)
-        .arg(ttl)
-        .arg(&session_json)
-        .query::<()>(&mut conn)
-        .map_err(|e| format!("Redis SETEX error: {}", e))?;
+    active_ttl.max(refresh_retention_ttl)
+}
 
-    Ok(())
+fn parse_redis_session_json(json_str: &str) -> std::result::Result<Session, String> {
+    let json: serde_json::Value =
+        serde_json::from_str(json_str).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let id = json["id"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Session missing or empty 'id' field".to_string())?;
+    let user_id = json["user_id"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Session missing or empty 'user_id' field".to_string())?;
+    let provider = json["provider"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Session missing or empty 'provider' field".to_string())?;
+    let csrf_token = json["csrf_token"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Session missing or empty 'csrf_token' field".to_string())?;
+    let expires_at = json["expires_at"]
+        .as_i64()
+        .ok_or_else(|| "Session missing 'expires_at' field".to_string())?;
+    let created_at = json["created_at"]
+        .as_i64()
+        .ok_or_else(|| "Session missing 'created_at' field".to_string())?;
+
+    Ok(Session {
+        id: id.to_string(),
+        user_id: user_id.to_string(),
+        provider: provider.to_string(),
+        email: json["email"].as_str().map(|s| s.to_string()),
+        name: json["name"].as_str().map(|s| s.to_string()),
+        picture: json["picture"].as_str().map(|s| s.to_string()),
+        raw_json: json["raw_json"].as_str().unwrap_or("{}").to_string(),
+        data_json: json["data_json"].as_str().unwrap_or("{}").to_string(),
+        csrf_token: csrf_token.to_string(),
+        access_token: json["access_token"].as_str().map(|s| s.to_string()),
+        refresh_token: json["refresh_token"].as_str().map(|s| s.to_string()),
+        token_expires_at: json["token_expires_at"].as_i64(),
+        device_name: json["device_name"].as_str().map(|s| s.to_string()),
+        user_agent_hash: json["user_agent_hash"].as_str().map(|s| s.to_string()),
+        last_ip_hash: json["last_ip_hash"].as_str().map(|s| s.to_string()),
+        created_at,
+        expires_at,
+    })
 }
 
 fn extend_session_expiry_sqlite(id: &str, new_expires_at: i64) -> std::result::Result<(), String> {
@@ -1957,13 +2025,24 @@ fn extend_session_expiry_redis(id: &str, new_expires_at: i64) -> std::result::Re
             if not session then return nil end
             local data = cjson.decode(session)
             data.expires_at = tonumber(ARGV[1])
-            redis.call('SETEX', KEYS[1], tonumber(ARGV[2]), cjson.encode(data))
+            local ttl = tonumber(ARGV[2])
+            if data.refresh_token ~= nil and data.refresh_token ~= cjson.null then
+                local refresh_ttl = (tonumber(data.created_at) + tonumber(ARGV[3])) - tonumber(ARGV[4])
+                if refresh_ttl > ttl then ttl = refresh_ttl end
+            end
+            if ttl > 0 then
+                redis.call('SETEX', KEYS[1], ttl, cjson.encode(data))
+            else
+                redis.call('DEL', KEYS[1])
+            end
             return 1
         "#;
         let _: Option<i32> = redis::Script::new(lua_script)
             .key(&key)
             .arg(new_expires_at)
             .arg(new_ttl)
+            .arg(redis_refresh_retention_ttl())
+            .arg(now)
             .invoke(&mut conn)
             .map_err(|e| e.to_string())?;
     }
@@ -2092,8 +2171,36 @@ fn get_expired_session_redis(
     id: &str,
     refresh_ttl: i64,
 ) -> std::result::Result<Option<Session>, String> {
-    let _ = (id, refresh_ttl);
-    Ok(None)
+    let url_guard = REDIS_URL.lock().unwrap();
+    let url = url_guard.as_ref().ok_or("Redis not initialized")?;
+    let now = chrono::Utc::now().timestamp();
+    let refresh_cutoff = now - refresh_ttl;
+
+    let client =
+        redis::Client::open(url.as_str()).map_err(|e| format!("Redis client error: {}", e))?;
+    let mut conn = client
+        .get_connection()
+        .map_err(|e| format!("Redis connection error: {}", e))?;
+
+    let key = format!("ntnt:session:{}", id);
+    let result: Option<String> = redis::cmd("GET")
+        .arg(&key)
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+
+    if let Some(json_str) = result {
+        let session = parse_redis_session_json(&json_str)?;
+        if session.expires_at <= now
+            && session.created_at > refresh_cutoff
+            && session.refresh_token.is_some()
+        {
+            Ok(Some(session))
+        } else {
+            Ok(None)
+        }
+    } else {
+        Ok(None)
+    }
 }
 
 fn get_session_postgres(id: &str) -> std::result::Result<Option<Session>, String> {
@@ -2155,51 +2262,12 @@ fn get_session_redis(id: &str) -> std::result::Result<Option<Session>, String> {
 
     match result {
         Some(json_str) => {
-            let json: serde_json::Value =
-                serde_json::from_str(&json_str).map_err(|e| format!("JSON parse error: {}", e))?;
-
-            let id = json["id"]
-                .as_str()
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| "Session missing or empty 'id' field".to_string())?;
-            let user_id = json["user_id"]
-                .as_str()
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| "Session missing or empty 'user_id' field".to_string())?;
-            let provider = json["provider"]
-                .as_str()
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| "Session missing or empty 'provider' field".to_string())?;
-            let csrf_token = json["csrf_token"]
-                .as_str()
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| "Session missing or empty 'csrf_token' field".to_string())?;
-            let expires_at = json["expires_at"]
-                .as_i64()
-                .ok_or_else(|| "Session missing 'expires_at' field".to_string())?;
-            let created_at = json["created_at"]
-                .as_i64()
-                .ok_or_else(|| "Session missing 'created_at' field".to_string())?;
-
-            Ok(Some(Session {
-                id: id.to_string(),
-                user_id: user_id.to_string(),
-                provider: provider.to_string(),
-                email: json["email"].as_str().map(|s| s.to_string()),
-                name: json["name"].as_str().map(|s| s.to_string()),
-                picture: json["picture"].as_str().map(|s| s.to_string()),
-                raw_json: json["raw_json"].as_str().unwrap_or("{}").to_string(),
-                data_json: json["data_json"].as_str().unwrap_or("{}").to_string(),
-                csrf_token: csrf_token.to_string(),
-                access_token: json["access_token"].as_str().map(|s| s.to_string()),
-                refresh_token: json["refresh_token"].as_str().map(|s| s.to_string()),
-                token_expires_at: json["token_expires_at"].as_i64(),
-                device_name: json["device_name"].as_str().map(|s| s.to_string()),
-                user_agent_hash: json["user_agent_hash"].as_str().map(|s| s.to_string()),
-                last_ip_hash: json["last_ip_hash"].as_str().map(|s| s.to_string()),
-                created_at,
-                expires_at,
-            }))
+            let session = parse_redis_session_json(&json_str)?;
+            if session.expires_at <= chrono::Utc::now().timestamp() {
+                Ok(None)
+            } else {
+                Ok(Some(session))
+            }
         }
         None => Ok(None),
     }
@@ -2275,13 +2343,18 @@ fn update_session_tokens_redis(
             data.token_expires_at = nil
         end
         local new_session = cjson.encode(data)
-        local ttl = redis.call('TTL', KEYS[1])
+        local ttl = tonumber(data.expires_at) - tonumber(ARGV[4])
+        if data.refresh_token ~= nil and data.refresh_token ~= cjson.null then
+            local refresh_ttl = (tonumber(data.created_at) + tonumber(ARGV[5])) - tonumber(ARGV[4])
+            if refresh_ttl > ttl then ttl = refresh_ttl end
+        end
         if ttl > 0 then
             redis.call('SETEX', KEYS[1], ttl, new_session)
+            return 'OK'
         else
-            redis.call('SET', KEYS[1], new_session)
+            redis.call('DEL', KEYS[1])
+            return nil
         end
-        return 'OK'
     "#;
 
     let refresh_token = tokens.refresh_token.as_deref().unwrap_or("");
@@ -2294,6 +2367,8 @@ fn update_session_tokens_redis(
         .arg(&tokens.access_token)
         .arg(refresh_token)
         .arg(&expires_at_str)
+        .arg(now)
+        .arg(redis_refresh_retention_ttl())
         .query(&mut conn)
         .map_err(|e| format!("Redis EVAL error: {}", e))?;
 
@@ -2361,20 +2436,28 @@ fn update_session_data_redis(id: &str, data_json: &str) -> std::result::Result<(
         local data = cjson.decode(session)
         data.data_json = ARGV[1]
         local new_session = cjson.encode(data)
-        local ttl = redis.call('TTL', KEYS[1])
+        local ttl = tonumber(data.expires_at) - tonumber(ARGV[2])
+        if data.refresh_token ~= nil and data.refresh_token ~= cjson.null then
+            local refresh_ttl = (tonumber(data.created_at) + tonumber(ARGV[3])) - tonumber(ARGV[2])
+            if refresh_ttl > ttl then ttl = refresh_ttl end
+        end
         if ttl > 0 then
             redis.call('SETEX', KEYS[1], ttl, new_session)
+            return 'OK'
         else
-            redis.call('SET', KEYS[1], new_session)
+            redis.call('DEL', KEYS[1])
+            return nil
         end
-        return 'OK'
     "#;
 
+    let now = chrono::Utc::now().timestamp();
     let result: Option<String> = redis::cmd("EVAL")
         .arg(lua_script)
         .arg(1)
         .arg(&key)
         .arg(data_json)
+        .arg(now)
+        .arg(redis_refresh_retention_ttl())
         .query(&mut conn)
         .map_err(|e| format!("Redis EVAL error: {}", e))?;
 
@@ -2522,30 +2605,11 @@ fn migrate_session_redis(old_id: &str, new_session: &Session) -> std::result::Re
 
     let old_key = format!("ntnt:session:{}", old_id);
     let new_key = format!("ntnt:session:{}", new_session.id);
-    let ttl = (new_session.expires_at - chrono::Utc::now().timestamp()).max(0);
-    let session_json = serde_json::json!({
-        "id": new_session.id,
-        "user_id": new_session.user_id,
-        "provider": new_session.provider,
-        "email": new_session.email,
-        "name": new_session.name,
-        "picture": new_session.picture,
-        "raw_json": new_session.raw_json,
-        "data_json": new_session.data_json,
-        "csrf_token": new_session.csrf_token,
-        "access_token": new_session.access_token,
-        "refresh_token": new_session.refresh_token,
-        "token_expires_at": new_session.token_expires_at,
-        "device_name": new_session.device_name,
-        "user_agent_hash": new_session.user_agent_hash,
-        "last_ip_hash": new_session.last_ip_hash,
-        "created_at": new_session.created_at,
-        "expires_at": new_session.expires_at,
-    })
-    .to_string();
+    let ttl = redis_session_retention_ttl(new_session, chrono::Utc::now().timestamp());
+    let session_json = session_to_redis_json(new_session);
 
     if ttl <= 0 {
-        return Err("Session already expired before Redis migration".to_string());
+        return Err("Session already expired before Redis migration retention window".to_string());
     }
 
     let lua_script = r#"
@@ -2608,6 +2672,7 @@ fn cleanup_expired_sessions_redis(now: i64) -> std::result::Result<u64, String> 
         .get_connection()
         .map_err(|e| format!("Redis connection error: {}", e))?;
 
+    let refresh_cutoff = now - redis_refresh_retention_ttl();
     let mut count = 0u64;
     let mut cursor = 0u64;
     loop {
@@ -2627,15 +2692,16 @@ fn cleanup_expired_sessions_redis(now: i64) -> std::result::Result<u64, String> 
                 .map_err(|e| format!("Redis GET error: {}", e))?;
 
             if let Some(json_str) = result {
-                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&json_str) {
-                    if let Some(expires_at) = json["expires_at"].as_i64() {
-                        if expires_at < now {
-                            let _: () = redis::cmd("DEL")
-                                .arg(&key)
-                                .query(&mut conn)
-                                .map_err(|e| format!("Redis DEL error: {}", e))?;
-                            count += 1;
-                        }
+                if let Ok(session) = parse_redis_session_json(&json_str) {
+                    let refreshable_within_window = session.expires_at < now
+                        && session.refresh_token.is_some()
+                        && session.created_at > refresh_cutoff;
+                    if session.expires_at < now && !refreshable_within_window {
+                        let _: () = redis::cmd("DEL")
+                            .arg(&key)
+                            .query(&mut conn)
+                            .map_err(|e| format!("Redis DEL error: {}", e))?;
+                        count += 1;
                     }
                 }
             }

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -4,8 +4,9 @@ use super::*;
 mod local;
 
 // The local-auth storage policy scaffold is test-only until production local-auth
-// records land. Real credential/reset/TOTP/bootstrap storage must move this
-// policy into production code and remove these cfg(test) gates in the same PR.
+// records land. Do not add production credential/reset/TOTP/bootstrap storage
+// until this policy is moved into production code and both cfg(test) gates are
+// removed in the same PR.
 #[cfg(test)]
 pub(super) use local::{local_auth_record_fallback_policy, LocalAuthRecordKind};
 

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -3,6 +3,9 @@ use super::*;
 #[cfg(test)]
 mod local;
 
+// The local-auth storage policy scaffold is test-only until production local-auth
+// records land. Real credential/reset/TOTP/bootstrap storage must move this
+// policy into production code and remove these cfg(test) gates in the same PR.
 #[cfg(test)]
 pub(super) use local::{local_auth_record_fallback_policy, LocalAuthRecordKind};
 

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+#[cfg(test)]
+mod local;
+
+#[cfg(test)]
+pub(super) use local::{local_auth_record_fallback_policy, LocalAuthRecordKind};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum AuthStorageBackend {
     Memory,


### PR DESCRIPTION
## Summary

This PR turns the DD-043 local-auth assessment into an executable roadmap and lands the first guardrails/preflight work for the next auth wave.

- Refines DD-043 and DD-062 around first-class local email/password/TOTP auth
- Adds auth-specific review guardrails to `REVIEW.md`
- Exposes safe `device_name` metadata from `user_sessions(req)` while keeping raw hashes private
- Strengthens auth storage contract tests for session/OAuth metadata round-trips
- Adds a CI job that runs Postgres and Redis auth backend contract tests against real services
- Carves `auth/storage.rs` into `auth/storage/mod.rs` and adds a local-auth fail-closed storage policy scaffold

## Validation

- `cargo fmt --all -- --check`
- `cargo test stdlib::auth::tests::test_local_auth_durable_record_families_fail_closed_by_policy -- --test-threads=1`
- `cargo test auth -- --test-threads=1`
- `cargo build --release --locked`
- `./target/release/ntnt docs --generate`
- workflow YAML parsed locally with Python/PyYAML
- `git diff --check`

## Notes

The new `auth-backends` CI job is intentionally included so Postgres/Redis auth contract coverage is visible instead of quietly skipped when env vars are absent locally.