### PR TITLE
feat: add local auth credential primitives

### DIFF
--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -334,13 +334,13 @@ This table should become implementation comments and contract tests, not just do
 
 **Purpose:** add durable local users/credentials owned by `std/auth`.
 
-- [ ] Create the local identity/account model
-- [ ] Create credential-secret storage and verification helpers
-- [ ] Normalize email lookup rules and document them
-- [ ] Add account states: bootstrap, pending setup, active, disabled, locked, password-change-required
+- [x] Create the local identity/account model
+- [x] Create credential-secret storage and verification helpers
+- [x] Normalize email lookup rules and document them
+- [x] Add account states: bootstrap, pending setup, active, disabled, locked, password-change-required
 - [ ] Support bootstrap account creation from config/env
 - [ ] Force bootstrap credential rotation/setup completion according to config
-- [ ] Add memory/SQLite contract tests by default
+- [x] Add memory/SQLite contract tests by default
 - [ ] Add Postgres/Redis contract coverage in backend CI
 - [ ] Add migration tests for existing SQLite/Postgres stores
 
@@ -350,7 +350,7 @@ This table should become implementation comments and contract tests, not just do
 
 **Baseline:** request-aware manual session completion already exists in 0.4.9 branch work. This phase should wire local credential verification into that primitive, not design a new cookie/session attachment path.
 
-- [ ] Add local password verification through `std/auth`
+- [x] Add local password verification through `std/auth`
 - [ ] Add local sign-in domain operation that delegates to `sign_in_session(response, req, session, options?)` or the same internal primitive
 - [ ] Rotate/migrate existing sessions on successful local login
 - [ ] Capture `device_name`, `user_agent_hash`, and `last_ip_hash` from request metadata

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1699,7 +1699,29 @@ fn get(req) {
 
 Boundary rule: use `std/auth` for auth flows, sessions, CSRF, current-user helpers, and TOTP. Use `std/crypto` for generic crypto helpers like `uuid`, `hash_password`, and `verify_password`.
 
-Full OAuth, session management, CSRF, JWT, and TOTP support — 34 functions.
+Full OAuth, session management, CSRF, JWT, TOTP, and local credential verification support.
+
+### Local Credential Verification
+
+`std/auth` owns the local credential verification path; `std/crypto` remains the place for generic password hash helpers. After a local identity/credential has been provisioned by auth-owned setup/bootstrap flows, custom login UI should verify credentials, derive app-owned claims, then complete the session through the shared request-aware session primitive.
+
+```ntnt
+import { verify_local_password, sign_in_session } from "std/auth"
+import { parse_form, redirect } from "std/http/server"
+
+fn login(req) {
+    let form = parse_form(req)
+    let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")?
+
+    return sign_in_session(redirect("/admin"), req, map {
+        "subject_id": verified["subject_id"],
+        "email": verified["email"],
+        "claims": app_claims_for_local_user(verified)
+    })
+}
+```
+
+Session claims, roles, profiles, and organization membership stay app-owned; local auth only owns credential lifecycle state and safe verification results.
 
 ### Basic OAuth Setup
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -3111,7 +3111,7 @@ verify_local_password(identifier: String, password: String, options?: Map) -> Re
 
 Verify a local credential record and return a safe auth user payload.
 
-The helper normalizes the identifier (email by default), loads the auth-owned local identity and credential secret, verifies the password hash, and returns a map suitable for app-specific session claim derivation and `sign_in_session(...)`. It never exposes password hashes or hash parameters. Missing identities, missing credential secrets, bad passwords, disabled accounts, and locked accounts all return the same invalid-credentials error to avoid account-state or identity enumeration. Corrupted or unsupported stored hashes return a generic operational auth error without backend parser details.
+The helper normalizes the identifier (email by default), loads the auth-owned local identity and credential secret, verifies the password hash, and returns a map suitable for app-specific session claim derivation and `sign_in_session(...)`. It never exposes password hashes or hash parameters. Missing identities, missing credential secrets, bad passwords, disabled accounts, and locked accounts all return the same invalid-credentials error to avoid account-state or identity enumeration. Corrupted or unsupported stored hashes return a generic operational auth error without backend parser details after running the same dummy verification work used for absent credentials. Bootstrap, pending-setup, and password-change-required identities can verify credentials, but the returned payload forces `must_change_password: true` so callers do not accidentally treat setup-required accounts as fully active sessions.
 
 **Parameters:**
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -3111,7 +3111,7 @@ verify_local_password(identifier: String, password: String, options?: Map) -> Re
 
 Verify a local credential record and return a safe auth user payload.
 
-The helper normalizes the identifier (email by default), loads the auth-owned local identity and credential secret, verifies the password hash, and returns a map suitable for app-specific session claim derivation and `sign_in_session(...)`. It never exposes password hashes or hash parameters. Disabled and locked accounts are rejected after password verification.
+The helper normalizes the identifier (email by default), loads the auth-owned local identity and credential secret, verifies the password hash, and returns a map suitable for app-specific session claim derivation and `sign_in_session(...)`. It never exposes password hashes or hash parameters. Missing identities, missing credential secrets, bad passwords, disabled accounts, and locked accounts all return the same invalid-credentials error to avoid account-state or identity enumeration. Corrupted or unsupported stored hashes return a generic operational auth error without backend parser details.
 
 **Parameters:**
 
@@ -3119,12 +3119,12 @@ The helper normalizes the identifier (email by default), loads the auth-owned lo
 - `password` — The plaintext password from the login form
 - `options` — Optional map with `identifier_kind` (default `"email"`)
 
-**Returns:** Ok(map) with `subject_id`, `provider`, identifier fields, account `state`, and password-change metadata; Err(message) on invalid credentials or account rejection
+**Returns:** Ok(map) with `subject_id`, `provider`, identifier fields, account `state`, and password-change metadata; Err(message) on invalid credentials or operational credential errors
 
 **Examples:**
 
 ```ntnt
-verify_local_password(form["email"] ?? "", form["password"] ?? "")?  // Verify email/password credentials
+let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")?  // Verify email/password credentials
 sign_in_session(redirect("/admin"), req, map { "subject_id": verified["subject_id"], "email": verified["email"] })  // Complete request-aware local sign-in after verification
 ```
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1863,6 +1863,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`user_sessions`](#usersessions) | Get all active sessions for the current user. |
 | [`validate_csrf`](#validatecsrf) | Validate CSRF token on state-changing requests (POST, PUT, DELETE, PATCH). |
 | [`verify_csrf`](#verifycsrf) | Verify a CSRF token against the session's token. |
+| [`verify_local_password`](#verifylocalpassword) | Verify a local credential record and return a safe auth user payload. |
 | [`verify_totp`](#verifytotp) | Verify a TOTP code against a secret. |
 
 #### `auth_callback`
@@ -3099,6 +3100,42 @@ verify_csrf(req, form["_csrf"])  // Validate form submission
 **See also:** `csrf_token`, `csrf_field`
 
 *Since v0.3.11*
+
+---
+
+#### `verify_local_password`
+
+```ntnt
+verify_local_password(identifier: String, password: String, options?: Map) -> Result<Map, String>
+```
+
+Verify a local credential record and return a safe auth user payload.
+
+The helper normalizes the identifier (email by default), loads the auth-owned local identity and credential secret, verifies the password hash, and returns a map suitable for app-specific session claim derivation and `sign_in_session(...)`. It never exposes password hashes or hash parameters. Disabled and locked accounts are rejected after password verification.
+
+**Parameters:**
+
+- `identifier` — The local login identifier. Email is the default identifier kind.
+- `password` — The plaintext password from the login form
+- `options` — Optional map with `identifier_kind` (default `"email"`)
+
+**Returns:** Ok(map) with `subject_id`, `provider`, identifier fields, account `state`, and password-change metadata; Err(message) on invalid credentials or account rejection
+
+**Examples:**
+
+```ntnt
+verify_local_password(form["email"] ?? "", form["password"] ?? "")?  // Verify email/password credentials
+sign_in_session(redirect("/admin"), req, map { "subject_id": verified["subject_id"], "email": verified["email"] })  // Complete request-aware local sign-in after verification
+```
+
+**Errors:**
+
+- **RuntimeError**: Auth not initialized — *Fix: Call enable_auth(...) during app startup before verifying local credentials*
+- **TypeError**: identifier must be a string — *Fix: Pass the submitted email/identifier as a string*
+
+**See also:** `sign_in_session`, `current_session`
+
+*Since v0.4.9*
 
 ---
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -46,6 +46,7 @@ use totp_rs::{Algorithm as TotpAlgorithm, Secret, TOTP};
 mod config;
 mod cookies;
 mod guards;
+mod local;
 mod oauth;
 mod primitives;
 mod providers;
@@ -69,6 +70,7 @@ use guards::validate_auth_challenge_kind;
 pub use guards::{
     enforce_auth_for_request, get_protected_paths, register_protected_paths, reset_protected_paths,
 };
+use local::{verified_local_password_to_value, verify_local_password_record};
 use oauth::extract_user_info;
 pub use oauth::{
     client_credentials_grant, decode_id_token, exchange_code_for_tokens, fetch_oidc_discovery,
@@ -446,6 +448,7 @@ struct InMemoryStore {
     oauth_states: HashMap<String, OAuthState>,
     exchange_tokens: HashMap<String, (String, i64)>, // token → (session_id, created_at)
     auth_challenges: HashMap<String, AuthChallenge>,
+    local_auth: storage::LocalAuthMemoryStore,
 }
 
 impl InMemoryStore {
@@ -455,6 +458,7 @@ impl InMemoryStore {
             oauth_states: HashMap::new(),
             exchange_tokens: HashMap::new(),
             auth_challenges: HashMap::new(),
+            local_auth: storage::LocalAuthMemoryStore::default(),
         }
     }
 
@@ -3734,6 +3738,95 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt verify_local_password
+    // @module std/auth
+    // @signature verify_local_password(identifier: String, password: String, options?: Map) -> Result<Map, String>
+    // Verify a local credential record and return a safe auth user payload.
+    //
+    // The helper normalizes the identifier (email by default), loads the auth-owned
+    // local identity and credential secret, verifies the password hash, and returns
+    // a map suitable for app-specific session claim derivation and
+    // `sign_in_session(...)`. It never exposes password hashes or hash parameters.
+    // Disabled and locked accounts are rejected after password verification.
+    // @param identifier The local login identifier. Email is the default identifier kind.
+    // @param password The plaintext password from the login form
+    // @param options Optional map with `identifier_kind` (default `"email"`)
+    // @returns Ok(map) with `subject_id`, `provider`, identifier fields, account `state`, and password-change metadata; Err(message) on invalid credentials or account rejection
+    // @error RuntimeError ~ "Auth not initialized" fix: "Call enable_auth(...) during app startup before verifying local credentials"
+    // @error TypeError ~ "identifier must be a string" fix: "Pass the submitted email/identifier as a string"
+    // @see_also sign_in_session, current_session
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #security
+    // @example verify_local_password(form["email"] ?? "", form["password"] ?? "")? ~ "Verify email/password credentials"
+    // @example sign_in_session(redirect("/admin"), req, map { "subject_id": verified["subject_id"], "email": verified["email"] }) ~ "Complete request-aware local sign-in after verification"
+    module.insert(
+        "verify_local_password".to_string(),
+        Value::NativeFunction {
+            name: "verify_local_password".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] verify_local_password() requires identifier, password, and optional options"
+                            .to_string(),
+                    ));
+                }
+
+                let _config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before verify_local_password()."
+                            .to_string(),
+                    )
+                })?;
+
+                let identifier = match &args[0] {
+                    Value::String(s) => s.as_str(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] verify_local_password() identifier must be a string, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+                let password = match &args[1] {
+                    Value::String(s) => s.as_str(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] verify_local_password() password must be a string, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+                let identifier_kind = match args.get(2) {
+                    Some(Value::Map(map)) => match map.get("identifier_kind") {
+                        Some(Value::String(kind)) => kind.as_str(),
+                        Some(other) => {
+                            return Err(IntentError::type_error(format!(
+                                "[auth] verify_local_password() identifier_kind must be a string, got {}",
+                                other.type_name()
+                            )))
+                        }
+                        None => "email",
+                    },
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] verify_local_password() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => "email",
+                };
+
+                match verify_local_password_record(identifier_kind, identifier, password) {
+                    Ok(verified) => Ok(Value::ok(verified_local_password_to_value(verified))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
     // @ntnt sign_in_session
     // @module std/auth
     // @signature sign_in_session(response: Response, req: Request, session: Map, options?: Map) -> Response
@@ -5298,6 +5391,206 @@ mod tests {
                 "{record_kind:?} must not allow production memory fallback"
             );
         }
+    }
+
+    #[test]
+    fn test_local_identity_and_credential_store_round_trip_memory_and_sqlite() {
+        use super::storage::{
+            get_local_credential_secret_record, get_local_identity_by_id_record,
+            get_local_identity_by_identifier_record, store_local_credential_secret_record,
+            store_local_identity_record, LocalAccountState, LocalCredentialSecret, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let identity = LocalIdentity {
+                id: "local-user-1".to_string(),
+                identifier_kind: "email".to_string(),
+                identifier: "Alice@Example.COM".to_string(),
+                identifier_normalized: "alice@example.com".to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state: LocalAccountState::Active,
+                metadata_json: "{}".to_string(),
+            };
+            let credential = LocalCredentialSecret {
+                local_user_id: identity.id.clone(),
+                password_hash: "argon2$hash".to_string(),
+                password_hash_algorithm: "argon2id".to_string(),
+                password_hash_params_json: "{}".to_string(),
+                password_changed_at: 101,
+                must_change_password: false,
+            };
+
+            store_local_identity_record(&identity).unwrap();
+            store_local_credential_secret_record(&credential).unwrap();
+
+            assert_eq!(
+                get_local_identity_by_identifier_record("email", "alice@example.com").unwrap(),
+                Some(identity.clone())
+            );
+            assert_eq!(
+                get_local_identity_by_id_record("local-user-1").unwrap(),
+                Some(identity.clone())
+            );
+            assert_eq!(
+                get_local_credential_secret_record("local-user-1").unwrap(),
+                Some(credential)
+            );
+        }
+    }
+
+    #[test]
+    fn test_local_credential_store_rejects_missing_identity_memory_and_sqlite() {
+        use super::storage::{store_local_credential_secret_record, LocalCredentialSecret};
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let credential = LocalCredentialSecret {
+                local_user_id: "missing-local-user".to_string(),
+                password_hash: "argon2$hash".to_string(),
+                password_hash_algorithm: "argon2id".to_string(),
+                password_hash_params_json: "{}".to_string(),
+                password_changed_at: 101,
+                must_change_password: false,
+            };
+
+            let err = store_local_credential_secret_record(&credential)
+                .expect_err("orphaned local credentials must be rejected");
+            assert!(
+                err.contains("local credential") || err.contains("FOREIGN KEY"),
+                "unexpected orphan credential error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_verify_local_password_native_helper_returns_auth_safe_user() {
+        use super::storage::{
+            store_local_credential_secret_record, store_local_identity_record, LocalAccountState,
+            LocalCredentialSecret, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let password_hash = bcrypt::hash("correct horse battery staple", 4).unwrap();
+            store_local_identity_record(&LocalIdentity {
+                id: "local-user-verify".to_string(),
+                identifier_kind: "email".to_string(),
+                identifier: "Admin@Example.COM".to_string(),
+                identifier_normalized: "admin@example.com".to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state: LocalAccountState::Active,
+                metadata_json: "{}".to_string(),
+            })
+            .unwrap();
+            store_local_credential_secret_record(&LocalCredentialSecret {
+                local_user_id: "local-user-verify".to_string(),
+                password_hash,
+                password_hash_algorithm: "bcrypt".to_string(),
+                password_hash_params_json: "{}".to_string(),
+                password_changed_at: 101,
+                must_change_password: false,
+            })
+            .unwrap();
+
+            let module = init();
+            let verify_local_password = module_fn(&module, "verify_local_password");
+            let verified = verify_local_password(&[
+                Value::String(" admin@example.com ".to_string()),
+                Value::String("correct horse battery staple".to_string()),
+            ])
+            .unwrap();
+
+            let Value::EnumValue {
+                enum_name,
+                variant,
+                values,
+            } = verified
+            else {
+                panic!("verify_local_password should return Result");
+            };
+            assert_eq!(enum_name, "Result");
+            assert_eq!(variant, "Ok");
+            let Value::Map(user) = &values[0] else {
+                panic!("verify_local_password Ok payload should be a map");
+            };
+            match user.get("subject_id") {
+                Some(Value::String(subject_id)) => assert_eq!(subject_id, "local-user-verify"),
+                other => panic!("unexpected subject_id payload: {other:?}"),
+            }
+            match user.get("email") {
+                Some(Value::String(email)) => assert_eq!(email, "Admin@Example.COM"),
+                other => panic!("unexpected email payload: {other:?}"),
+            }
+            match user.get("state") {
+                Some(Value::String(state)) => assert_eq!(state, "active"),
+                other => panic!("unexpected state payload: {other:?}"),
+            }
+            assert!(
+                !user.contains_key("password_hash"),
+                "verified local user payload must not expose password hashes"
+            );
+
+            let wrong_password = verify_local_password(&[
+                Value::String("admin@example.com".to_string()),
+                Value::String("wrong".to_string()),
+            ])
+            .unwrap();
+            let Value::EnumValue {
+                enum_name,
+                variant,
+                values,
+            } = wrong_password
+            else {
+                panic!("wrong password should return Result");
+            };
+            assert_eq!(enum_name, "Result");
+            assert_eq!(variant, "Err");
+            match values.first() {
+                Some(Value::String(message)) => assert_eq!(message, "Invalid local credentials"),
+                other => panic!("unexpected wrong-password error payload: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_verify_local_password_requires_auth_initialization() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+
+        let module = init();
+        let verify_local_password = module_fn(&module, "verify_local_password");
+        let err = verify_local_password(&[
+            Value::String("admin@example.com".to_string()),
+            Value::String("password".to_string()),
+        ])
+        .expect_err("verify_local_password should require initialized auth");
+        assert!(
+            err.to_string().contains("enable_auth"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -3750,7 +3750,11 @@ pub fn init() -> HashMap<String, Value> {
     // Missing identities, missing credential secrets, bad passwords, disabled accounts,
     // and locked accounts all return the same invalid-credentials error to avoid
     // account-state or identity enumeration. Corrupted or unsupported stored hashes
-    // return a generic operational auth error without backend parser details.
+    // return a generic operational auth error without backend parser details after
+    // running the same dummy verification work used for absent credentials. Bootstrap,
+    // pending-setup, and password-change-required identities can verify credentials,
+    // but the returned payload forces `must_change_password: true` so callers do not
+    // accidentally treat setup-required accounts as fully active sessions.
     // @param identifier The local login identifier. Email is the default identifier kind.
     // @param password The plaintext password from the login form
     // @param options Optional map with `identifier_kind` (default `"email"`)
@@ -5628,6 +5632,78 @@ mod tests {
             match values.first() {
                 Some(Value::String(message)) => assert_eq!(message, "Invalid local credentials"),
                 other => panic!("unexpected wrong-password error payload: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_verify_local_password_marks_setup_states_must_change_password() {
+        use super::storage::{
+            store_local_credential_secret_record, store_local_identity_record, LocalAccountState,
+            LocalCredentialSecret, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let module = init();
+            let verify_local_password = module_fn(&module, "verify_local_password");
+            for (state, must_change_password) in [
+                (LocalAccountState::Bootstrap, true),
+                (LocalAccountState::PendingSetup, true),
+                (LocalAccountState::PasswordChangeRequired, true),
+                (LocalAccountState::Active, false),
+            ] {
+                let email = format!("{}@example.com", state.as_str());
+                let local_user_id = format!("local-user-{}", state.as_str());
+                store_local_identity_record(&LocalIdentity {
+                    id: local_user_id.clone(),
+                    identifier_kind: "email".to_string(),
+                    identifier: email.clone(),
+                    identifier_normalized: email.clone(),
+                    created_at: 100,
+                    updated_at: 100,
+                    state,
+                    metadata_json: "{}".to_string(),
+                })
+                .unwrap();
+                store_local_credential_secret_record(&LocalCredentialSecret {
+                    local_user_id,
+                    password_hash: bcrypt::hash("state setup password", 4).unwrap(),
+                    password_hash_algorithm: "bcrypt".to_string(),
+                    password_hash_params_json: "{}".to_string(),
+                    password_changed_at: 101,
+                    must_change_password: false,
+                })
+                .unwrap();
+
+                let verified = verify_local_password(&[
+                    Value::String(email),
+                    Value::String("state setup password".to_string()),
+                ])
+                .unwrap();
+                let Value::EnumValue {
+                    enum_name,
+                    variant,
+                    values,
+                } = verified
+                else {
+                    panic!("verify_local_password should return Result");
+                };
+                assert_eq!(enum_name, "Result");
+                assert_eq!(variant, "Ok");
+                let Value::Map(user) = &values[0] else {
+                    panic!("verify_local_password Ok payload should be a map");
+                };
+                match user.get("must_change_password") {
+                    Some(Value::Bool(value)) => assert_eq!(*value, must_change_password),
+                    other => panic!("unexpected must_change_password payload: {other:?}"),
+                }
             }
         }
     }

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -3747,17 +3747,20 @@ pub fn init() -> HashMap<String, Value> {
     // local identity and credential secret, verifies the password hash, and returns
     // a map suitable for app-specific session claim derivation and
     // `sign_in_session(...)`. It never exposes password hashes or hash parameters.
-    // Disabled and locked accounts are rejected after password verification.
+    // Missing identities, missing credential secrets, bad passwords, disabled accounts,
+    // and locked accounts all return the same invalid-credentials error to avoid
+    // account-state or identity enumeration. Corrupted or unsupported stored hashes
+    // return a generic operational auth error without backend parser details.
     // @param identifier The local login identifier. Email is the default identifier kind.
     // @param password The plaintext password from the login form
     // @param options Optional map with `identifier_kind` (default `"email"`)
-    // @returns Ok(map) with `subject_id`, `provider`, identifier fields, account `state`, and password-change metadata; Err(message) on invalid credentials or account rejection
+    // @returns Ok(map) with `subject_id`, `provider`, identifier fields, account `state`, and password-change metadata; Err(message) on invalid credentials or operational credential errors
     // @error RuntimeError ~ "Auth not initialized" fix: "Call enable_auth(...) during app startup before verifying local credentials"
     // @error TypeError ~ "identifier must be a string" fix: "Pass the submitted email/identifier as a string"
     // @see_also sign_in_session, current_session
     // @since v0.4.9
     // @tags #auth, #local-auth, #security
-    // @example verify_local_password(form["email"] ?? "", form["password"] ?? "")? ~ "Verify email/password credentials"
+    // @example let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")? ~ "Verify email/password credentials"
     // @example sign_in_session(redirect("/admin"), req, map { "subject_id": verified["subject_id"], "email": verified["email"] }) ~ "Complete request-aware local sign-in after verification"
     module.insert(
         "verify_local_password".to_string(),
@@ -4359,6 +4362,7 @@ mod tests {
         store.oauth_states.clear();
         store.exchange_tokens.clear();
         store.auth_challenges.clear();
+        store.local_auth = storage::LocalAuthMemoryStore::default();
         drop(store);
         *AUTH_CONFIG.lock().unwrap() = None;
         *SQLITE_CONN.lock().unwrap() = None;
@@ -4371,6 +4375,23 @@ mod tests {
         match module.get(name) {
             Some(Value::NativeFunction { func, .. }) => *func,
             other => panic!("expected native function {} got {:?}", name, other),
+        }
+    }
+
+    fn result_err_string(value: Value) -> String {
+        let Value::EnumValue {
+            enum_name,
+            variant,
+            values,
+        } = value
+        else {
+            panic!("expected Result::Err, got {value:?}");
+        };
+        assert_eq!(enum_name, "Result");
+        assert_eq!(variant, "Err");
+        match values.first() {
+            Some(Value::String(message)) => message.clone(),
+            other => panic!("unexpected Result::Err payload: {other:?}"),
         }
     }
 
@@ -5479,6 +5500,42 @@ mod tests {
     }
 
     #[test]
+    fn test_local_identity_store_normalizes_lookup_fields_on_write_memory_and_sqlite() {
+        use super::storage::{
+            get_local_identity_by_identifier_record, store_local_identity_record,
+            LocalAccountState, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            store_local_identity_record(&LocalIdentity {
+                id: "local-user-normalized-write".to_string(),
+                identifier_kind: " Email ".to_string(),
+                identifier: "Admin@Example.COM".to_string(),
+                identifier_normalized: " Admin@Example.COM ".to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state: LocalAccountState::Active,
+                metadata_json: "{}".to_string(),
+            })
+            .unwrap();
+
+            let fetched = get_local_identity_by_identifier_record("email", "admin@example.com")
+                .unwrap()
+                .expect("stored local identity should be queryable by canonical lookup");
+            assert_eq!(fetched.identifier_kind, "email");
+            assert_eq!(fetched.identifier_normalized, "admin@example.com");
+        }
+    }
+
+    #[test]
     fn test_verify_local_password_native_helper_returns_auth_safe_user() {
         use super::storage::{
             store_local_credential_secret_record, store_local_identity_record, LocalAccountState,
@@ -5571,6 +5628,153 @@ mod tests {
             match values.first() {
                 Some(Value::String(message)) => assert_eq!(message, "Invalid local credentials"),
                 other => panic!("unexpected wrong-password error payload: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_verify_local_password_rejects_enumeration_states_with_generic_error() {
+        use super::storage::{
+            store_local_credential_secret_record, store_local_identity_record, LocalAccountState,
+            LocalCredentialSecret, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let password_hash = bcrypt::hash("valid local password", 4).unwrap();
+            for (id, email, state, with_credential) in [
+                (
+                    "local-user-active",
+                    "active@example.com",
+                    LocalAccountState::Active,
+                    true,
+                ),
+                (
+                    "local-user-disabled",
+                    "disabled@example.com",
+                    LocalAccountState::Disabled,
+                    true,
+                ),
+                (
+                    "local-user-locked",
+                    "locked@example.com",
+                    LocalAccountState::Locked,
+                    true,
+                ),
+                (
+                    "local-user-no-credential",
+                    "no-credential@example.com",
+                    LocalAccountState::Active,
+                    false,
+                ),
+            ] {
+                store_local_identity_record(&LocalIdentity {
+                    id: id.to_string(),
+                    identifier_kind: "email".to_string(),
+                    identifier: email.to_string(),
+                    identifier_normalized: email.to_string(),
+                    created_at: 100,
+                    updated_at: 100,
+                    state,
+                    metadata_json: "{}".to_string(),
+                })
+                .unwrap();
+                if with_credential {
+                    store_local_credential_secret_record(&LocalCredentialSecret {
+                        local_user_id: id.to_string(),
+                        password_hash: password_hash.clone(),
+                        password_hash_algorithm: "bcrypt".to_string(),
+                        password_hash_params_json: "{}".to_string(),
+                        password_changed_at: 101,
+                        must_change_password: false,
+                    })
+                    .unwrap();
+                }
+            }
+
+            let module = init();
+            let verify_local_password = module_fn(&module, "verify_local_password");
+            for (email, password) in [
+                ("active@example.com", "wrong local password"),
+                ("missing@example.com", "valid local password"),
+                ("no-credential@example.com", "valid local password"),
+                ("disabled@example.com", "valid local password"),
+                ("locked@example.com", "valid local password"),
+            ] {
+                let message = result_err_string(
+                    verify_local_password(&[
+                        Value::String(email.to_string()),
+                        Value::String(password.to_string()),
+                    ])
+                    .unwrap(),
+                );
+                assert_eq!(message, "Invalid local credentials");
+            }
+        }
+    }
+
+    #[test]
+    fn test_verify_local_password_reports_corrupted_hashes_as_safe_operational_errors() {
+        use super::storage::{
+            store_local_credential_secret_record, store_local_identity_record, LocalAccountState,
+            LocalCredentialSecret, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+            store_local_identity_record(&LocalIdentity {
+                id: "local-user-corrupted-hash".to_string(),
+                identifier_kind: "email".to_string(),
+                identifier: "corrupt@example.com".to_string(),
+                identifier_normalized: "corrupt@example.com".to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state: LocalAccountState::Active,
+                metadata_json: "{}".to_string(),
+            })
+            .unwrap();
+
+            let module = init();
+            let verify_local_password = module_fn(&module, "verify_local_password");
+            for (password_hash, algorithm) in [
+                ("not-a-valid-password-hash", "bcrypt"),
+                ("not-a-valid-password-hash", "argon2id"),
+                ("not-a-valid-password-hash", "scrypt"),
+            ] {
+                store_local_credential_secret_record(&LocalCredentialSecret {
+                    local_user_id: "local-user-corrupted-hash".to_string(),
+                    password_hash: password_hash.to_string(),
+                    password_hash_algorithm: algorithm.to_string(),
+                    password_hash_params_json: "{}".to_string(),
+                    password_changed_at: 101,
+                    must_change_password: false,
+                })
+                .unwrap();
+
+                let message = result_err_string(
+                    verify_local_password(&[
+                        Value::String("corrupt@example.com".to_string()),
+                        Value::String("valid local password".to_string()),
+                    ])
+                    .unwrap(),
+                );
+                assert_eq!(
+                    message,
+                    "[auth] local credential hash is invalid or unsupported"
+                );
+                assert!(!message.contains(algorithm));
+                assert!(!message.contains("password hash"));
             }
         }
     }

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -5504,6 +5504,54 @@ mod tests {
     }
 
     #[test]
+    fn test_sqlite_local_credentials_cascade_when_identity_deleted() {
+        use super::storage::{
+            get_local_credential_secret_record, store_local_credential_secret_record,
+            store_local_identity_record, LocalAccountState, LocalCredentialSecret, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        store_local_identity_record(&LocalIdentity {
+            id: "local-user-delete-cascade".to_string(),
+            identifier_kind: "email".to_string(),
+            identifier: "delete@example.com".to_string(),
+            identifier_normalized: "delete@example.com".to_string(),
+            created_at: 100,
+            updated_at: 100,
+            state: LocalAccountState::Active,
+            metadata_json: "{}".to_string(),
+        })
+        .unwrap();
+        store_local_credential_secret_record(&LocalCredentialSecret {
+            local_user_id: "local-user-delete-cascade".to_string(),
+            password_hash: "argon2$hash".to_string(),
+            password_hash_algorithm: "argon2id".to_string(),
+            password_hash_params_json: "{}".to_string(),
+            password_changed_at: 101,
+            must_change_password: false,
+        })
+        .unwrap();
+
+        {
+            let conn_guard = SQLITE_CONN.lock().unwrap();
+            let conn = conn_guard.as_ref().expect("SQLite should be initialized");
+            conn.execute(
+                "DELETE FROM auth_local_identities WHERE id = ?1",
+                rusqlite::params!["local-user-delete-cascade"],
+            )
+            .expect("deleting a local identity should cascade credential cleanup");
+        }
+
+        assert_eq!(
+            get_local_credential_secret_record("local-user-delete-cascade").unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn test_local_identity_store_normalizes_lookup_fields_on_write_memory_and_sqlite() {
         use super::storage::{
             get_local_identity_by_identifier_record, store_local_identity_record,

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -200,6 +200,9 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     let conn =
         rusqlite::Connection::open(path).map_err(|e| format!("Failed to open SQLite: {}", e))?;
 
+    conn.execute("PRAGMA foreign_keys = ON", [])
+        .map_err(|e| format!("Failed to enable SQLite foreign key enforcement: {}", e))?;
+
     conn.execute(
         "CREATE TABLE IF NOT EXISTS auth_sessions (
             id TEXT PRIMARY KEY,
@@ -307,6 +310,36 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
         [],
     )
     .map_err(|e| format!("Failed to create auth_challenges index: {}", e))?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS auth_local_identities (
+            id TEXT PRIMARY KEY,
+            identifier_kind TEXT NOT NULL,
+            identifier TEXT NOT NULL,
+            identifier_normalized TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            state TEXT NOT NULL,
+            metadata_json TEXT NOT NULL,
+            UNIQUE(identifier_kind, identifier_normalized)
+        )",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_local_identities table: {}", e))?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS auth_local_credentials (
+            local_user_id TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            password_hash_algorithm TEXT NOT NULL,
+            password_hash_params_json TEXT NOT NULL,
+            password_changed_at INTEGER NOT NULL,
+            must_change_password INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY(local_user_id) REFERENCES auth_local_identities(id)
+        )",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_local_credentials table: {}", e))?;
 
     let mut sqlite_conn = SQLITE_CONN.lock().unwrap();
     *sqlite_conn = Some(conn);

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -335,7 +335,7 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
             password_hash_params_json TEXT NOT NULL,
             password_changed_at INTEGER NOT NULL,
             must_change_password INTEGER NOT NULL DEFAULT 0,
-            FOREIGN KEY(local_user_id) REFERENCES auth_local_identities(id)
+            FOREIGN KEY(local_user_id) REFERENCES auth_local_identities(id) ON DELETE CASCADE
         )",
         [],
     )

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -46,7 +46,13 @@ pub(in crate::stdlib::auth) fn verify_local_password_record(
         return Err(INVALID_LOCAL_CREDENTIALS.to_string());
     };
 
-    let password_matches = verify_credential_password(&credential, password)?;
+    let password_matches = match verify_credential_password(&credential, password) {
+        Ok(password_matches) => password_matches,
+        Err(err) => {
+            let _ = verify_dummy_local_password(password);
+            return Err(err);
+        }
+    };
     let state_allows_password_login = !matches!(
         identity.state,
         LocalAccountState::Disabled | LocalAccountState::Locked
@@ -136,7 +142,12 @@ pub(in crate::stdlib::auth) fn verified_local_password_to_value(
             "must_change_password".to_string(),
             Value::Bool(
                 verified.credential.must_change_password
-                    || verified.identity.state == LocalAccountState::PasswordChangeRequired,
+                    || matches!(
+                        verified.identity.state,
+                        LocalAccountState::Bootstrap
+                            | LocalAccountState::PendingSetup
+                            | LocalAccountState::PasswordChangeRequired
+                    ),
             ),
         ),
         (

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -21,6 +21,29 @@ pub(in crate::stdlib::auth) struct VerifiedLocalPassword {
     credential: LocalCredentialSecret,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CredentialPasswordAlgorithm {
+    Bcrypt,
+    Argon2,
+}
+
+impl CredentialPasswordAlgorithm {
+    fn parse(algorithm: &str) -> std::result::Result<Self, String> {
+        match algorithm.trim().to_ascii_lowercase().as_str() {
+            "bcrypt" | "bcrypt2" => Ok(Self::Bcrypt),
+            "argon2" | "argon2id" => Ok(Self::Argon2),
+            _ => Err(INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
+        }
+    }
+
+    fn storage_name(self) -> &'static str {
+        match self {
+            Self::Bcrypt => "bcrypt",
+            Self::Argon2 => "argon2id",
+        }
+    }
+}
+
 pub(in crate::stdlib::auth) fn verify_local_password_record(
     identifier_kind: &str,
     identifier: &str,
@@ -57,18 +80,16 @@ pub(in crate::stdlib::auth) fn verify_local_password_record(
         }
     };
 
-    let credential_algorithm = credential
-        .password_hash_algorithm
-        .trim()
-        .to_ascii_lowercase();
     let password_matches = match verify_credential_password(&credential, password) {
-        Ok(password_matches) => password_matches,
+        Ok((password_matches, algorithm)) => {
+            verify_complementary_dummy_local_password(password, algorithm)?;
+            password_matches
+        }
         Err(err) => {
             let _ = verify_all_dummy_local_passwords(password);
             return Err(err);
         }
     };
-    verify_complementary_dummy_local_password(password, &credential_algorithm)?;
     let state_allows_password_login = !matches!(
         identity.state,
         LocalAccountState::Disabled | LocalAccountState::Locked
@@ -84,32 +105,37 @@ pub(in crate::stdlib::auth) fn verify_local_password_record(
 }
 
 fn verify_all_dummy_local_passwords(password: &str) -> std::result::Result<(), String> {
-    verify_dummy_local_password(password, "bcrypt")?;
-    verify_dummy_local_password(password, "argon2id")?;
+    verify_dummy_local_password(password, CredentialPasswordAlgorithm::Bcrypt)?;
+    verify_dummy_local_password(password, CredentialPasswordAlgorithm::Argon2)?;
     Ok(())
 }
 
 fn verify_complementary_dummy_local_password(
     password: &str,
-    algorithm: &str,
+    algorithm: CredentialPasswordAlgorithm,
 ) -> std::result::Result<(), String> {
     match algorithm {
-        "bcrypt" | "bcrypt2" => verify_dummy_local_password(password, "argon2id"),
-        "argon2" | "argon2id" => verify_dummy_local_password(password, "bcrypt"),
-        _ => verify_all_dummy_local_passwords(password),
+        CredentialPasswordAlgorithm::Bcrypt => {
+            verify_dummy_local_password(password, CredentialPasswordAlgorithm::Argon2)
+        }
+        CredentialPasswordAlgorithm::Argon2 => {
+            verify_dummy_local_password(password, CredentialPasswordAlgorithm::Bcrypt)
+        }
     }
 }
 
-fn verify_dummy_local_password(password: &str, algorithm: &str) -> std::result::Result<(), String> {
+fn verify_dummy_local_password(
+    password: &str,
+    algorithm: CredentialPasswordAlgorithm,
+) -> std::result::Result<(), String> {
     let password_hash = match algorithm {
-        "bcrypt" | "bcrypt2" => DUMMY_LOCAL_BCRYPT_PASSWORD_HASH,
-        "argon2" | "argon2id" => DUMMY_LOCAL_ARGON2_PASSWORD_HASH,
-        _ => return Err(INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
+        CredentialPasswordAlgorithm::Bcrypt => DUMMY_LOCAL_BCRYPT_PASSWORD_HASH,
+        CredentialPasswordAlgorithm::Argon2 => DUMMY_LOCAL_ARGON2_PASSWORD_HASH,
     };
     let credential = LocalCredentialSecret {
         local_user_id: "__dummy__".to_string(),
         password_hash: password_hash.to_string(),
-        password_hash_algorithm: algorithm.to_string(),
+        password_hash_algorithm: algorithm.storage_name().to_string(),
         password_hash_params_json: "{}".to_string(),
         password_changed_at: 0,
         must_change_password: false,
@@ -121,17 +147,16 @@ fn verify_dummy_local_password(password: &str, algorithm: &str) -> std::result::
 fn verify_credential_password(
     credential: &LocalCredentialSecret,
     password: &str,
-) -> std::result::Result<bool, String> {
-    let algorithm = credential
-        .password_hash_algorithm
-        .trim()
-        .to_ascii_lowercase();
-    match algorithm.as_str() {
-        "bcrypt" | "bcrypt2" => bcrypt::verify(password, &credential.password_hash)
-            .map_err(|_| INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
-        "argon2" | "argon2id" => verify_argon2_password(password, &credential.password_hash),
-        _ => Err(INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
-    }
+) -> std::result::Result<(bool, CredentialPasswordAlgorithm), String> {
+    let algorithm = CredentialPasswordAlgorithm::parse(&credential.password_hash_algorithm)?;
+    let password_matches = match algorithm {
+        CredentialPasswordAlgorithm::Bcrypt => bcrypt::verify(password, &credential.password_hash)
+            .map_err(|_| INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string())?,
+        CredentialPasswordAlgorithm::Argon2 => {
+            verify_argon2_password(password, &credential.password_hash)?
+        }
+    };
+    Ok((password_matches, algorithm))
 }
 
 fn verify_argon2_password(

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -1,6 +1,8 @@
 use crate::interpreter::Value;
+use argon2::password_hash::Error as PasswordHashError;
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 use super::storage::{
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
@@ -8,6 +10,13 @@ use super::storage::{
 };
 
 const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
+const INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH: &str =
+    "[auth] local credential hash is invalid or unsupported";
+
+static DUMMY_LOCAL_PASSWORD_HASH: LazyLock<String> = LazyLock::new(|| {
+    bcrypt::hash("ntnt local auth dummy password", bcrypt::DEFAULT_COST)
+        .expect("dummy local auth password hash must be constructible")
+});
 
 pub(in crate::stdlib::auth) struct VerifiedLocalPassword {
     identity: LocalIdentity,
@@ -19,26 +28,50 @@ pub(in crate::stdlib::auth) fn verify_local_password_record(
     identifier: &str,
     password: &str,
 ) -> std::result::Result<VerifiedLocalPassword, String> {
-    let identifier_normalized = normalize_local_identifier(identifier_kind, identifier)
-        .map_err(|_| INVALID_LOCAL_CREDENTIALS.to_string())?;
-    let identity =
+    let identifier_normalized = match normalize_local_identifier(identifier_kind, identifier) {
+        Ok(identifier_normalized) => identifier_normalized,
+        Err(_) => {
+            verify_dummy_local_password(password)?;
+            return Err(INVALID_LOCAL_CREDENTIALS.to_string());
+        }
+    };
+    let Some(identity) =
         get_local_identity_by_identifier_record(identifier_kind, &identifier_normalized)?
-            .ok_or_else(|| INVALID_LOCAL_CREDENTIALS.to_string())?;
-    let credential = get_local_credential_secret_record(&identity.id)?
-        .ok_or_else(|| INVALID_LOCAL_CREDENTIALS.to_string())?;
+    else {
+        verify_dummy_local_password(password)?;
+        return Err(INVALID_LOCAL_CREDENTIALS.to_string());
+    };
+    let Some(credential) = get_local_credential_secret_record(&identity.id)? else {
+        verify_dummy_local_password(password)?;
+        return Err(INVALID_LOCAL_CREDENTIALS.to_string());
+    };
 
-    if !verify_credential_password(&credential, password)? {
+    let password_matches = verify_credential_password(&credential, password)?;
+    let state_allows_password_login = !matches!(
+        identity.state,
+        LocalAccountState::Disabled | LocalAccountState::Locked
+    );
+    if !password_matches || !state_allows_password_login {
         return Err(INVALID_LOCAL_CREDENTIALS.to_string());
     }
 
-    match identity.state {
-        LocalAccountState::Disabled => Err("Local account is disabled".to_string()),
-        LocalAccountState::Locked => Err("Local account is locked".to_string()),
-        _ => Ok(VerifiedLocalPassword {
-            identity,
-            credential,
-        }),
-    }
+    Ok(VerifiedLocalPassword {
+        identity,
+        credential,
+    })
+}
+
+fn verify_dummy_local_password(password: &str) -> std::result::Result<(), String> {
+    let credential = LocalCredentialSecret {
+        local_user_id: "__dummy__".to_string(),
+        password_hash: DUMMY_LOCAL_PASSWORD_HASH.clone(),
+        password_hash_algorithm: "bcrypt".to_string(),
+        password_hash_params_json: "{}".to_string(),
+        password_changed_at: 0,
+        must_change_password: false,
+    };
+    let _ = verify_credential_password(&credential, password)?;
+    Ok(())
 }
 
 fn verify_credential_password(
@@ -51,12 +84,9 @@ fn verify_credential_password(
         .to_ascii_lowercase();
     match algorithm.as_str() {
         "bcrypt" | "bcrypt2" => bcrypt::verify(password, &credential.password_hash)
-            .map_err(|e| format!("[auth] local credential hash verify failed: {}", e)),
+            .map_err(|_| INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
         "argon2" | "argon2id" => verify_argon2_password(password, &credential.password_hash),
-        other => Err(format!(
-            "[auth] unsupported local credential hash algorithm \"{}\"",
-            other
-        )),
+        _ => Err(INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
     }
 }
 
@@ -65,10 +95,12 @@ fn verify_argon2_password(
     password_hash: &str,
 ) -> std::result::Result<bool, String> {
     let parsed_hash = PasswordHash::new(password_hash)
-        .map_err(|e| format!("[auth] local argon2 password hash is invalid: {}", e))?;
-    Ok(Argon2::default()
-        .verify_password(password.as_bytes(), &parsed_hash)
-        .is_ok())
+        .map_err(|_| INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string())?;
+    match Argon2::default().verify_password(password.as_bytes(), &parsed_hash) {
+        Ok(()) => Ok(true),
+        Err(PasswordHashError::Password) => Ok(false),
+        Err(_) => Err(INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
+    }
 }
 
 pub(in crate::stdlib::auth) fn verified_local_password_to_value(

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -1,0 +1,124 @@
+use crate::interpreter::Value;
+use argon2::{Argon2, PasswordHash, PasswordVerifier};
+use std::collections::HashMap;
+
+use super::storage::{
+    get_local_credential_secret_record, get_local_identity_by_identifier_record,
+    normalize_local_identifier, LocalAccountState, LocalCredentialSecret, LocalIdentity,
+};
+
+const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
+
+pub(in crate::stdlib::auth) struct VerifiedLocalPassword {
+    identity: LocalIdentity,
+    credential: LocalCredentialSecret,
+}
+
+pub(in crate::stdlib::auth) fn verify_local_password_record(
+    identifier_kind: &str,
+    identifier: &str,
+    password: &str,
+) -> std::result::Result<VerifiedLocalPassword, String> {
+    let identifier_normalized = normalize_local_identifier(identifier_kind, identifier)
+        .map_err(|_| INVALID_LOCAL_CREDENTIALS.to_string())?;
+    let identity =
+        get_local_identity_by_identifier_record(identifier_kind, &identifier_normalized)?
+            .ok_or_else(|| INVALID_LOCAL_CREDENTIALS.to_string())?;
+    let credential = get_local_credential_secret_record(&identity.id)?
+        .ok_or_else(|| INVALID_LOCAL_CREDENTIALS.to_string())?;
+
+    if !verify_credential_password(&credential, password)? {
+        return Err(INVALID_LOCAL_CREDENTIALS.to_string());
+    }
+
+    match identity.state {
+        LocalAccountState::Disabled => Err("Local account is disabled".to_string()),
+        LocalAccountState::Locked => Err("Local account is locked".to_string()),
+        _ => Ok(VerifiedLocalPassword {
+            identity,
+            credential,
+        }),
+    }
+}
+
+fn verify_credential_password(
+    credential: &LocalCredentialSecret,
+    password: &str,
+) -> std::result::Result<bool, String> {
+    let algorithm = credential
+        .password_hash_algorithm
+        .trim()
+        .to_ascii_lowercase();
+    match algorithm.as_str() {
+        "bcrypt" | "bcrypt2" => bcrypt::verify(password, &credential.password_hash)
+            .map_err(|e| format!("[auth] local credential hash verify failed: {}", e)),
+        "argon2" | "argon2id" => verify_argon2_password(password, &credential.password_hash),
+        other => Err(format!(
+            "[auth] unsupported local credential hash algorithm \"{}\"",
+            other
+        )),
+    }
+}
+
+fn verify_argon2_password(
+    password: &str,
+    password_hash: &str,
+) -> std::result::Result<bool, String> {
+    let parsed_hash = PasswordHash::new(password_hash)
+        .map_err(|e| format!("[auth] local argon2 password hash is invalid: {}", e))?;
+    Ok(Argon2::default()
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .is_ok())
+}
+
+pub(in crate::stdlib::auth) fn verified_local_password_to_value(
+    verified: VerifiedLocalPassword,
+) -> Value {
+    let mut map = HashMap::from([
+        (
+            "subject_id".to_string(),
+            Value::String(verified.identity.id.clone()),
+        ),
+        (
+            "id".to_string(),
+            Value::String(verified.identity.id.clone()),
+        ),
+        ("provider".to_string(), Value::String("local".to_string())),
+        (
+            "identifier_kind".to_string(),
+            Value::String(verified.identity.identifier_kind.clone()),
+        ),
+        (
+            "identifier".to_string(),
+            Value::String(verified.identity.identifier.clone()),
+        ),
+        (
+            "identifier_normalized".to_string(),
+            Value::String(verified.identity.identifier_normalized.clone()),
+        ),
+        (
+            "state".to_string(),
+            Value::String(verified.identity.state.as_str().to_string()),
+        ),
+        (
+            "must_change_password".to_string(),
+            Value::Bool(
+                verified.credential.must_change_password
+                    || verified.identity.state == LocalAccountState::PasswordChangeRequired,
+            ),
+        ),
+        (
+            "password_changed_at".to_string(),
+            Value::Int(verified.credential.password_changed_at),
+        ),
+    ]);
+
+    if verified.identity.identifier_kind == "email" {
+        map.insert(
+            "email".to_string(),
+            Value::String(verified.identity.identifier.clone()),
+        );
+    }
+
+    Value::Map(map)
+}

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -2,7 +2,6 @@ use crate::interpreter::Value;
 use argon2::password_hash::Error as PasswordHashError;
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use std::collections::HashMap;
-use std::sync::LazyLock;
 
 use super::storage::{
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
@@ -12,11 +11,10 @@ use super::storage::{
 const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
 const INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH: &str =
     "[auth] local credential hash is invalid or unsupported";
-
-static DUMMY_LOCAL_PASSWORD_HASH: LazyLock<String> = LazyLock::new(|| {
-    bcrypt::hash("ntnt local auth dummy password", bcrypt::DEFAULT_COST)
-        .expect("dummy local auth password hash must be constructible")
-});
+const DUMMY_LOCAL_BCRYPT_PASSWORD_HASH: &str =
+    "$2b$12$.yG5RREnsakkWw6jeYfJNOxZnY6SGO22Ce8jBqKkvXnbV/2Hm3h.y";
+const DUMMY_LOCAL_ARGON2_PASSWORD_HASH: &str =
+    "$argon2id$v=19$m=19456,t=2,p=1$bnRudCBsb2NhbCBhdXRoIGR1bW15IHNhbHQ$kWVUWPBuKgDKDzEhE8gQJdr9ig91IJGYCQ+HrISyEIs";
 
 pub(in crate::stdlib::auth) struct VerifiedLocalPassword {
     identity: LocalIdentity,
@@ -31,28 +29,46 @@ pub(in crate::stdlib::auth) fn verify_local_password_record(
     let identifier_normalized = match normalize_local_identifier(identifier_kind, identifier) {
         Ok(identifier_normalized) => identifier_normalized,
         Err(_) => {
-            verify_dummy_local_password(password)?;
+            verify_all_dummy_local_passwords(password)?;
             return Err(INVALID_LOCAL_CREDENTIALS.to_string());
         }
     };
-    let Some(identity) =
-        get_local_identity_by_identifier_record(identifier_kind, &identifier_normalized)?
-    else {
-        verify_dummy_local_password(password)?;
-        return Err(INVALID_LOCAL_CREDENTIALS.to_string());
-    };
-    let Some(credential) = get_local_credential_secret_record(&identity.id)? else {
-        verify_dummy_local_password(password)?;
-        return Err(INVALID_LOCAL_CREDENTIALS.to_string());
-    };
-
-    let password_matches = match verify_credential_password(&credential, password) {
-        Ok(password_matches) => password_matches,
+    let identity =
+        match get_local_identity_by_identifier_record(identifier_kind, &identifier_normalized) {
+            Ok(Some(identity)) => identity,
+            Ok(None) => {
+                verify_all_dummy_local_passwords(password)?;
+                return Err(INVALID_LOCAL_CREDENTIALS.to_string());
+            }
+            Err(err) => {
+                verify_all_dummy_local_passwords(password)?;
+                return Err(err);
+            }
+        };
+    let credential = match get_local_credential_secret_record(&identity.id) {
+        Ok(Some(credential)) => credential,
+        Ok(None) => {
+            verify_all_dummy_local_passwords(password)?;
+            return Err(INVALID_LOCAL_CREDENTIALS.to_string());
+        }
         Err(err) => {
-            let _ = verify_dummy_local_password(password);
+            verify_all_dummy_local_passwords(password)?;
             return Err(err);
         }
     };
+
+    let credential_algorithm = credential
+        .password_hash_algorithm
+        .trim()
+        .to_ascii_lowercase();
+    let password_matches = match verify_credential_password(&credential, password) {
+        Ok(password_matches) => password_matches,
+        Err(err) => {
+            let _ = verify_all_dummy_local_passwords(password);
+            return Err(err);
+        }
+    };
+    verify_complementary_dummy_local_password(password, &credential_algorithm)?;
     let state_allows_password_login = !matches!(
         identity.state,
         LocalAccountState::Disabled | LocalAccountState::Locked
@@ -67,11 +83,33 @@ pub(in crate::stdlib::auth) fn verify_local_password_record(
     })
 }
 
-fn verify_dummy_local_password(password: &str) -> std::result::Result<(), String> {
+fn verify_all_dummy_local_passwords(password: &str) -> std::result::Result<(), String> {
+    verify_dummy_local_password(password, "bcrypt")?;
+    verify_dummy_local_password(password, "argon2id")?;
+    Ok(())
+}
+
+fn verify_complementary_dummy_local_password(
+    password: &str,
+    algorithm: &str,
+) -> std::result::Result<(), String> {
+    match algorithm {
+        "bcrypt" | "bcrypt2" => verify_dummy_local_password(password, "argon2id"),
+        "argon2" | "argon2id" => verify_dummy_local_password(password, "bcrypt"),
+        _ => verify_all_dummy_local_passwords(password),
+    }
+}
+
+fn verify_dummy_local_password(password: &str, algorithm: &str) -> std::result::Result<(), String> {
+    let password_hash = match algorithm {
+        "bcrypt" | "bcrypt2" => DUMMY_LOCAL_BCRYPT_PASSWORD_HASH,
+        "argon2" | "argon2id" => DUMMY_LOCAL_ARGON2_PASSWORD_HASH,
+        _ => return Err(INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
+    };
     let credential = LocalCredentialSecret {
         local_user_id: "__dummy__".to_string(),
-        password_hash: DUMMY_LOCAL_PASSWORD_HASH.clone(),
-        password_hash_algorithm: "bcrypt".to_string(),
+        password_hash: password_hash.to_string(),
+        password_hash_algorithm: algorithm.to_string(),
         password_hash_params_json: "{}".to_string(),
         password_changed_at: 0,
         must_change_password: false,

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -145,6 +145,7 @@ impl LocalAuthMemoryStore {
         &mut self,
         identity: LocalIdentity,
     ) -> std::result::Result<(), String> {
+        let identity = normalize_local_identity_for_storage(identity)?;
         if identity.id.trim().is_empty() {
             return Err("[auth] local identity id must not be empty".to_string());
         }
@@ -246,6 +247,16 @@ fn local_identity_lookup_key(
     Ok(format!("{}:{}", kind, normalized))
 }
 
+fn normalize_local_identity_for_storage(
+    mut identity: LocalIdentity,
+) -> std::result::Result<LocalIdentity, String> {
+    let kind = identity.identifier_kind.trim().to_ascii_lowercase();
+    let normalized = normalize_local_identifier(&kind, &identity.identifier)?;
+    identity.identifier_kind = kind;
+    identity.identifier_normalized = normalized;
+    Ok(identity)
+}
+
 pub(in crate::stdlib::auth) fn store_local_identity_record(
     identity: &LocalIdentity,
 ) -> std::result::Result<(), String> {
@@ -345,6 +356,7 @@ pub(in crate::stdlib::auth) fn get_local_credential_secret_record(
 }
 
 fn store_local_identity_sqlite(identity: &LocalIdentity) -> std::result::Result<(), String> {
+    let identity = normalize_local_identity_for_storage(identity.clone())?;
     let conn_guard = SQLITE_CONN.lock().unwrap();
     let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
     conn.execute(

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -1,3 +1,11 @@
+// Local-auth storage intentionally includes write-side helpers before the
+// public create/reset/bootstrap flows land in later DD-062 slices.
+#![cfg_attr(not(test), allow(dead_code))]
+
+use super::*;
+use rusqlite::OptionalExtension;
+use std::collections::HashMap;
+
 /// Durable local-auth record families planned by DD-062.
 ///
 /// These are deliberately modeled before implementation so credential-related
@@ -34,5 +42,527 @@ pub(in crate::stdlib::auth) fn local_auth_record_fallback_policy(
         lookup_failure_fails_closed: true,
         update_failure_fails_closed: true,
         production_memory_fallback_allowed: false,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::stdlib::auth) enum LocalAccountState {
+    Bootstrap,
+    PendingSetup,
+    Active,
+    Disabled,
+    Locked,
+    PasswordChangeRequired,
+}
+
+impl LocalAccountState {
+    pub(in crate::stdlib::auth) fn as_str(self) -> &'static str {
+        match self {
+            LocalAccountState::Bootstrap => "bootstrap",
+            LocalAccountState::PendingSetup => "pending_setup",
+            LocalAccountState::Active => "active",
+            LocalAccountState::Disabled => "disabled",
+            LocalAccountState::Locked => "locked",
+            LocalAccountState::PasswordChangeRequired => "password_change_required",
+        }
+    }
+
+    pub(in crate::stdlib::auth) fn from_str(value: &str) -> std::result::Result<Self, String> {
+        match value {
+            "bootstrap" => Ok(LocalAccountState::Bootstrap),
+            "pending_setup" => Ok(LocalAccountState::PendingSetup),
+            "active" => Ok(LocalAccountState::Active),
+            "disabled" => Ok(LocalAccountState::Disabled),
+            "locked" => Ok(LocalAccountState::Locked),
+            "password_change_required" => Ok(LocalAccountState::PasswordChangeRequired),
+            other => Err(format!(
+                "[auth] unknown local account state \"{}\". Expected one of: bootstrap, pending_setup, active, disabled, locked, password_change_required",
+                other
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::stdlib::auth) struct LocalIdentity {
+    pub(in crate::stdlib::auth) id: String,
+    pub(in crate::stdlib::auth) identifier_kind: String,
+    pub(in crate::stdlib::auth) identifier: String,
+    pub(in crate::stdlib::auth) identifier_normalized: String,
+    pub(in crate::stdlib::auth) created_at: i64,
+    pub(in crate::stdlib::auth) updated_at: i64,
+    pub(in crate::stdlib::auth) state: LocalAccountState,
+    pub(in crate::stdlib::auth) metadata_json: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::stdlib::auth) struct LocalCredentialSecret {
+    pub(in crate::stdlib::auth) local_user_id: String,
+    pub(in crate::stdlib::auth) password_hash: String,
+    pub(in crate::stdlib::auth) password_hash_algorithm: String,
+    pub(in crate::stdlib::auth) password_hash_params_json: String,
+    pub(in crate::stdlib::auth) password_changed_at: i64,
+    pub(in crate::stdlib::auth) must_change_password: bool,
+}
+
+pub(in crate::stdlib::auth) fn normalize_local_identifier(
+    identifier_kind: &str,
+    identifier: &str,
+) -> std::result::Result<String, String> {
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    match kind.as_str() {
+        "email" => normalize_email_identifier(identifier),
+        other => Err(format!(
+            "[auth] unsupported local identifier kind \"{}\". Supported kinds: email",
+            other
+        )),
+    }
+}
+
+fn normalize_email_identifier(identifier: &str) -> std::result::Result<String, String> {
+    let normalized = identifier.trim().to_ascii_lowercase();
+    let Some((local, domain)) = normalized.split_once('@') else {
+        return Err("[auth] local email identifier must contain @".to_string());
+    };
+    if local.is_empty() || domain.is_empty() || domain.starts_with('.') || domain.ends_with('.') {
+        return Err("[auth] local email identifier must have a local part and domain".to_string());
+    }
+    if domain.split('.').any(|part| part.is_empty()) {
+        return Err("[auth] local email identifier domain is invalid".to_string());
+    }
+    Ok(normalized)
+}
+
+#[derive(Debug, Default, Clone)]
+pub(in crate::stdlib::auth) struct LocalAuthMemoryStore {
+    identities_by_id: HashMap<String, LocalIdentity>,
+    identity_id_by_lookup_key: HashMap<String, String>,
+    credential_secrets_by_local_user_id: HashMap<String, LocalCredentialSecret>,
+}
+
+impl LocalAuthMemoryStore {
+    pub(in crate::stdlib::auth) fn store_identity(
+        &mut self,
+        identity: LocalIdentity,
+    ) -> std::result::Result<(), String> {
+        if identity.id.trim().is_empty() {
+            return Err("[auth] local identity id must not be empty".to_string());
+        }
+        let lookup_key =
+            local_identity_lookup_key(&identity.identifier_kind, &identity.identifier_normalized)?;
+        if let Some(existing_id) = self.identity_id_by_lookup_key.get(&lookup_key) {
+            if existing_id != &identity.id {
+                return Err(format!(
+                    "[auth] local identity identifier already exists for {}",
+                    identity.identifier_kind
+                ));
+            }
+        }
+
+        if let Some(previous) = self.identities_by_id.get(&identity.id) {
+            let previous_lookup_key = local_identity_lookup_key(
+                &previous.identifier_kind,
+                &previous.identifier_normalized,
+            )?;
+            if previous_lookup_key != lookup_key {
+                self.identity_id_by_lookup_key.remove(&previous_lookup_key);
+            }
+        }
+
+        self.identity_id_by_lookup_key
+            .insert(lookup_key, identity.id.clone());
+        self.identities_by_id.insert(identity.id.clone(), identity);
+        Ok(())
+    }
+
+    pub(in crate::stdlib::auth) fn get_identity_by_id(
+        &self,
+        id: &str,
+    ) -> std::result::Result<Option<LocalIdentity>, String> {
+        Ok(self.identities_by_id.get(id).cloned())
+    }
+
+    pub(in crate::stdlib::auth) fn get_identity_by_identifier(
+        &self,
+        identifier_kind: &str,
+        identifier_normalized: &str,
+    ) -> std::result::Result<Option<LocalIdentity>, String> {
+        let lookup_key = local_identity_lookup_key(identifier_kind, identifier_normalized)?;
+        Ok(self
+            .identity_id_by_lookup_key
+            .get(&lookup_key)
+            .and_then(|id| self.identities_by_id.get(id))
+            .cloned())
+    }
+
+    pub(in crate::stdlib::auth) fn store_credential_secret(
+        &mut self,
+        credential: LocalCredentialSecret,
+    ) -> std::result::Result<(), String> {
+        if credential.local_user_id.trim().is_empty() {
+            return Err("[auth] local credential local_user_id must not be empty".to_string());
+        }
+        if credential.password_hash.trim().is_empty() {
+            return Err("[auth] local credential password_hash must not be empty".to_string());
+        }
+        if credential.password_hash_algorithm.trim().is_empty() {
+            return Err(
+                "[auth] local credential password_hash_algorithm must not be empty".to_string(),
+            );
+        }
+        if !self
+            .identities_by_id
+            .contains_key(&credential.local_user_id)
+        {
+            return Err(
+                "[auth] local credential must reference an existing local identity".to_string(),
+            );
+        }
+        self.credential_secrets_by_local_user_id
+            .insert(credential.local_user_id.clone(), credential);
+        Ok(())
+    }
+
+    pub(in crate::stdlib::auth) fn get_credential_secret(
+        &self,
+        local_user_id: &str,
+    ) -> std::result::Result<Option<LocalCredentialSecret>, String> {
+        Ok(self
+            .credential_secrets_by_local_user_id
+            .get(local_user_id)
+            .cloned())
+    }
+}
+
+fn local_identity_lookup_key(
+    identifier_kind: &str,
+    identifier_normalized: &str,
+) -> std::result::Result<String, String> {
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let normalized = identifier_normalized.trim().to_ascii_lowercase();
+    if kind.is_empty() || normalized.is_empty() {
+        return Err("[auth] local identity identifier kind/value must not be empty".to_string());
+    }
+    Ok(format!("{}:{}", kind, normalized))
+}
+
+pub(in crate::stdlib::auth) fn store_local_identity_record(
+    identity: &LocalIdentity,
+) -> std::result::Result<(), String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .store_identity(identity.clone()),
+        AuthStorageBackend::Sqlite => store_local_identity_sqlite(identity),
+        AuthStorageBackend::Postgres => {
+            Err("[auth] local identity storage is not implemented for PostgreSQL yet".to_string())
+        }
+        AuthStorageBackend::Redis => {
+            Err("[auth] local identity storage is not implemented for Redis/Valkey yet".to_string())
+        }
+    }
+}
+
+pub(in crate::stdlib::auth) fn get_local_identity_by_id_record(
+    id: &str,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .get_identity_by_id(id),
+        AuthStorageBackend::Sqlite => get_local_identity_by_id_sqlite(id),
+        AuthStorageBackend::Postgres => {
+            Err("[auth] local identity lookup is not implemented for PostgreSQL yet".to_string())
+        }
+        AuthStorageBackend::Redis => {
+            Err("[auth] local identity lookup is not implemented for Redis/Valkey yet".to_string())
+        }
+    }
+}
+
+pub(in crate::stdlib::auth) fn get_local_identity_by_identifier_record(
+    identifier_kind: &str,
+    identifier_normalized: &str,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .get_identity_by_identifier(identifier_kind, identifier_normalized),
+        AuthStorageBackend::Sqlite => {
+            get_local_identity_by_identifier_sqlite(identifier_kind, identifier_normalized)
+        }
+        AuthStorageBackend::Postgres => {
+            Err("[auth] local identity lookup is not implemented for PostgreSQL yet".to_string())
+        }
+        AuthStorageBackend::Redis => {
+            Err("[auth] local identity lookup is not implemented for Redis/Valkey yet".to_string())
+        }
+    }
+}
+
+pub(in crate::stdlib::auth) fn store_local_credential_secret_record(
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .store_credential_secret(credential.clone()),
+        AuthStorageBackend::Sqlite => store_local_credential_secret_sqlite(credential),
+        AuthStorageBackend::Postgres => {
+            Err("[auth] local credential storage is not implemented for PostgreSQL yet".to_string())
+        }
+        AuthStorageBackend::Redis => Err(
+            "[auth] local credential storage is not implemented for Redis/Valkey yet".to_string(),
+        ),
+    }
+}
+
+pub(in crate::stdlib::auth) fn get_local_credential_secret_record(
+    local_user_id: &str,
+) -> std::result::Result<Option<LocalCredentialSecret>, String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .get_credential_secret(local_user_id),
+        AuthStorageBackend::Sqlite => get_local_credential_secret_sqlite(local_user_id),
+        AuthStorageBackend::Postgres => {
+            Err("[auth] local credential lookup is not implemented for PostgreSQL yet".to_string())
+        }
+        AuthStorageBackend::Redis => Err(
+            "[auth] local credential lookup is not implemented for Redis/Valkey yet".to_string(),
+        ),
+    }
+}
+
+fn store_local_identity_sqlite(identity: &LocalIdentity) -> std::result::Result<(), String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    conn.execute(
+        "INSERT INTO auth_local_identities
+         (id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(id) DO UPDATE SET
+            identifier_kind = excluded.identifier_kind,
+            identifier = excluded.identifier,
+            identifier_normalized = excluded.identifier_normalized,
+            updated_at = excluded.updated_at,
+            state = excluded.state,
+            metadata_json = excluded.metadata_json",
+        rusqlite::params![
+            identity.id,
+            identity.identifier_kind,
+            identity.identifier,
+            identity.identifier_normalized,
+            identity.created_at,
+            identity.updated_at,
+            identity.state.as_str(),
+            identity.metadata_json,
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store local identity: {}", e))?;
+    Ok(())
+}
+
+fn local_identity_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<LocalIdentity> {
+    let state: String = row.get(6)?;
+    let state = LocalAccountState::from_str(&state).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            6,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+    Ok(LocalIdentity {
+        id: row.get(0)?,
+        identifier_kind: row.get(1)?,
+        identifier: row.get(2)?,
+        identifier_normalized: row.get(3)?,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+        state,
+        metadata_json: row.get(7)?,
+    })
+}
+
+fn get_local_identity_by_id_sqlite(id: &str) -> std::result::Result<Option<LocalIdentity>, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    conn.query_row(
+        "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+         FROM auth_local_identities
+         WHERE id = ?1",
+        rusqlite::params![id],
+        local_identity_from_row,
+    )
+    .optional()
+    .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))
+}
+
+fn get_local_identity_by_identifier_sqlite(
+    identifier_kind: &str,
+    identifier_normalized: &str,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let normalized = identifier_normalized.trim().to_ascii_lowercase();
+    conn.query_row(
+        "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+         FROM auth_local_identities
+         WHERE identifier_kind = ?1 AND identifier_normalized = ?2",
+        rusqlite::params![kind, normalized],
+        local_identity_from_row,
+    )
+    .optional()
+    .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))
+}
+
+fn store_local_credential_secret_sqlite(
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    conn.execute(
+        "INSERT INTO auth_local_credentials
+         (local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(local_user_id) DO UPDATE SET
+            password_hash = excluded.password_hash,
+            password_hash_algorithm = excluded.password_hash_algorithm,
+            password_hash_params_json = excluded.password_hash_params_json,
+            password_changed_at = excluded.password_changed_at,
+            must_change_password = excluded.must_change_password",
+        rusqlite::params![
+            credential.local_user_id,
+            credential.password_hash,
+            credential.password_hash_algorithm,
+            credential.password_hash_params_json,
+            credential.password_changed_at,
+            if credential.must_change_password { 1 } else { 0 },
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
+    Ok(())
+}
+
+fn get_local_credential_secret_sqlite(
+    local_user_id: &str,
+) -> std::result::Result<Option<LocalCredentialSecret>, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    conn.query_row(
+        "SELECT local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password
+         FROM auth_local_credentials
+         WHERE local_user_id = ?1",
+        rusqlite::params![local_user_id],
+        |row| {
+            let must_change_password: i64 = row.get(5)?;
+            Ok(LocalCredentialSecret {
+                local_user_id: row.get(0)?,
+                password_hash: row.get(1)?,
+                password_hash_algorithm: row.get(2)?,
+                password_hash_params_json: row.get(3)?,
+                password_changed_at: row.get(4)?,
+                must_change_password: must_change_password != 0,
+            })
+        },
+    )
+    .optional()
+    .map_err(|e| format!("[auth] failed to lookup local credential: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_local_identifier_email() {
+        assert_eq!(
+            normalize_local_identifier("email", "  Alice@Example.COM  ").unwrap(),
+            "alice@example.com"
+        );
+        assert!(normalize_local_identifier("email", "not-an-email").is_err());
+    }
+
+    #[test]
+    fn test_memory_local_identity_and_credential_round_trip() {
+        let identity = LocalIdentity {
+            id: "local-user-1".to_string(),
+            identifier_kind: "email".to_string(),
+            identifier: "Alice@Example.COM".to_string(),
+            identifier_normalized: "alice@example.com".to_string(),
+            created_at: 100,
+            updated_at: 100,
+            state: LocalAccountState::Active,
+            metadata_json: "{}".to_string(),
+        };
+        let credential = LocalCredentialSecret {
+            local_user_id: identity.id.clone(),
+            password_hash: "argon2$hash".to_string(),
+            password_hash_algorithm: "argon2id".to_string(),
+            password_hash_params_json: "{}".to_string(),
+            password_changed_at: 101,
+            must_change_password: false,
+        };
+
+        let mut store = LocalAuthMemoryStore::default();
+        store.store_identity(identity.clone()).unwrap();
+        store.store_credential_secret(credential.clone()).unwrap();
+
+        assert_eq!(
+            store
+                .get_identity_by_identifier("email", "alice@example.com")
+                .unwrap(),
+            Some(identity.clone())
+        );
+        assert_eq!(
+            store.get_credential_secret("local-user-1").unwrap(),
+            Some(credential)
+        );
+    }
+
+    #[test]
+    fn test_memory_local_credential_requires_identity() {
+        let mut store = LocalAuthMemoryStore::default();
+        let credential = LocalCredentialSecret {
+            local_user_id: "missing-user".to_string(),
+            password_hash: "argon2$hash".to_string(),
+            password_hash_algorithm: "argon2id".to_string(),
+            password_hash_params_json: "{}".to_string(),
+            password_changed_at: 101,
+            must_change_password: false,
+        };
+
+        assert!(store.store_credential_secret(credential).is_err());
+    }
+
+    #[test]
+    fn test_memory_local_identity_rejects_identifier_collision() {
+        let mut store = LocalAuthMemoryStore::default();
+        let first = LocalIdentity {
+            id: "local-user-1".to_string(),
+            identifier_kind: "email".to_string(),
+            identifier: "alice@example.com".to_string(),
+            identifier_normalized: "alice@example.com".to_string(),
+            created_at: 100,
+            updated_at: 100,
+            state: LocalAccountState::Active,
+            metadata_json: "{}".to_string(),
+        };
+        let mut second = first.clone();
+        second.id = "local-user-2".to_string();
+
+        store.store_identity(first).unwrap();
+        assert!(store.store_identity(second).is_err());
     }
 }

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -1,14 +1,17 @@
 use super::*;
 
-#[cfg(test)]
 mod local;
 
-// The local-auth storage policy scaffold is test-only until production local-auth
-// records land. Do not add production credential/reset/TOTP/bootstrap storage
-// until this policy is moved into production code and both cfg(test) gates are
-// removed in the same PR.
+pub(super) use local::{
+    get_local_credential_secret_record, get_local_identity_by_identifier_record,
+    normalize_local_identifier, LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret,
+    LocalIdentity,
+};
 #[cfg(test)]
-pub(super) use local::{local_auth_record_fallback_policy, LocalAuthRecordKind};
+pub(super) use local::{
+    get_local_identity_by_id_record, local_auth_record_fallback_policy,
+    store_local_credential_secret_record, store_local_identity_record, LocalAuthRecordKind,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum AuthStorageBackend {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3805,6 +3805,30 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("stringify", ["data" => Type::Array(Box::new(Type::Any))], Type::String);
             sig!("stringify_with_headers", ["data" => Type::Array(Box::new(Type::Any)), "headers" => Type::Array(Box::new(Type::String))], Type::String);
         }
+        "std/auth" => {
+            sig!(
+                "verify_local_password",
+                [
+                    "identifier" => Type::String,
+                    "password" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(2)
+            );
+        }
         "std/crypto" => {
             sig!("sha256", ["data" => Type::String], Type::String);
             sig!("sha256_bytes", ["data" => Type::String], Type::Array(Box::new(Type::Int)));
@@ -4171,6 +4195,19 @@ mod tests {
             r#"
             import { split } from "std/string"
             split(42, ",")
+            "#,
+        );
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].message.contains("expected String"));
+        assert!(errs[0].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_verify_local_password_signature_checks_args() {
+        let errs = check_errors(
+            r#"
+            import { verify_local_password } from "std/auth"
+            verify_local_password(42, "pw")
             "#,
         );
         assert_eq!(errs.len(), 1);


### PR DESCRIPTION
## Summary
- add local identity/account and credential-secret storage records for memory + SQLite
- add fail-closed local-auth record policy and referential integrity checks
- add request-flow-ready verify_local_password() helper returning safe auth user payloads
- update DD-062, generated stdlib docs, AI agent guide, and typechecker signature coverage

## Test Plan
- [x] cargo fmt --all --check
- [x] git diff --check
- [x] cargo build --release --locked
- [x] ./target/release/ntnt docs --generate
- [x] cargo build --profile dev-release
- [x] cargo test auth -- --test-threads=1
- [x] cargo test