### PR TITLE
auth: add local bootstrap and request-aware sign-in

### DIFF
--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -3,7 +3,7 @@
 **Status:** In Progress
 **Author:** Larri
 **Date:** 2026-03-20
-**Branch:** `main` through v0.4.9; `feat/local-auth-blueprint` carries the next planning pass for first-class local auth and architecture discipline
+**Branch:** `main` through v0.4.9; PR #98 landed the first local-auth credential/storage slice, and `feat/local-auth-sign-in-bootstrap` adds the next bootstrap/request-aware sign-in slice before DD-062 continues with setup completion, TOTP, and reset work
 
 ---
 
@@ -50,16 +50,18 @@ If a capability is security-sensitive lifecycle state that every app otherwise r
 - [x] Password hashing and generic crypto helpers in `std/crypto`
 - [x] TOTP/MFA primitives (`totp_secret`, `totp_verify`, `totp_uri`) in `std/auth`
 - [x] API key validation, Turnstile CAPTCHA verification, OAuth token introspection, client credentials grant, and OIDC discovery
+- [x] Local-auth credential foundation from PR #98: focused `auth/storage/local.rs` storage home, explicit local-auth record/fallback policy, local identity/account state model, memory/SQLite identity + credential storage, and public `verify_local_password(identifier, password, options?)`
+- [x] Local-auth bootstrap/sign-in branch: public `create_local_user`, `bootstrap_local_user`, and request-aware `local_sign_in(response, req, credentials, session?, options?)` helpers that reuse shared session/challenge cookie semantics
 
 ### What's Still Missing (the gap to "best ever")
-- [ ] First-class local email/password/TOTP credential lifecycle owned by `std/auth`
-- [ ] Auth-owned local credential/reset/TOTP enrollment stores with fail-closed fallback semantics
-- [ ] First-class local credential sign-in helper that feeds verified local credentials into the existing request-aware session-completion path
+- [ ] Complete first-class local email/password/TOTP credential lifecycle owned by `std/auth`; local identity/credential storage, bootstrap provisioning, password verification, and request-aware sign-in are started, but setup completion/reset/TOTP flows are not complete
+- [ ] Auth-owned password reset and TOTP enrollment stores with fail-closed fallback semantics
+- [x] First-class local credential sign-in domain helper that feeds verified local credentials into the existing request-aware session-completion path
 - [ ] Admin/arbitrary-user session APIs (`list_sessions(user_id)`, `revoke_session(session_id)`, `revoke_all_sessions(user_id)`) distinct from current-user helpers
 - [ ] Security event storage and suspicious-activity policy actions (`warn`, `challenge`, `revoke`)
 - [ ] Fully behavioral remember-me support (`remember_ttl`, request capture, cookie/session TTL selection)
-- [ ] Stronger test ratchets for session metadata round-trips, route-protection end-to-end flows, and Postgres/Redis CI coverage
-- [ ] Architecture guardrails that keep new auth work inside the post-4.5 module boundaries instead of re-growing `auth.rs` or `auth/storage.rs`
+- [ ] Stronger test ratchets for session metadata round-trips, route-protection end-to-end flows, local-auth migration paths, and Postgres/Redis CI coverage
+- [ ] Architecture guardrails that keep new auth work inside focused auth modules instead of re-growing `auth.rs` or the storage contract boundary
 
 ## Unified Phased Implementation Plan
 
@@ -108,7 +110,7 @@ This is the single source of truth for how we should build `std/auth` forward. T
 ### Phase 3 — Session Core and Cookie Helpers
 **Goal:** Remove the most repetitive and error-prone login/logout/session code.
 
-**Result:** Merged in PR #78 (`feat: add auth session helpers`) on 2026-04-13, then tightened on `feat/local-auth-blueprint` so manual/staged session completion is request-aware before first-class local auth builds on it.
+**Result:** Merged in PR #78 (`feat: add auth session helpers`) on 2026-04-13, then tightened in PR #97 so manual/staged session completion is request-aware before first-class local auth builds on it.
 
 - [x] Rotate session ID automatically on successful OAuth callback/session upgrade paths
 - [x] Invalidate old session ID immediately after rotation
@@ -352,24 +354,25 @@ fn login(req) {
 A later `enable_local_auth(...)` convenience wrapper is acceptable only if it delegates into the same primitive provider/config path and keeps policy hooks explicit. It must not become two auth systems or bake roles, onboarding, email delivery, or account UI into `std/auth`.
 
 #### Phase 9A — Architecture Preflight and Storage Boundary
-- [ ] Split or carve `auth/storage.rs` enough that new local-auth state does not get buried in the existing storage monolith
-- [ ] Define explicit local-auth record families before code lands: local identity, credential secret, password reset token, TOTP enrollment/setup state, and bootstrap state
-- [ ] Define local-auth fallback/error policy before implementation; durable credential/TOTP/reset state should fail closed rather than silently fall back to process memory in production
+- [x] Split or carve `auth/storage.rs` enough that new local-auth state does not get buried in the existing storage monolith (`auth/storage/local.rs` now owns the first local-auth records)
+- [x] Define explicit local-auth record families before code lands: local identity, credential secret, password reset token, TOTP enrollment/setup state, and bootstrap state
+- [x] Define local-auth fallback/error policy before implementation; durable credential/TOTP/reset state should fail closed rather than silently fall back to process memory in production
 - [ ] Move the backend contract harness toward reusable storage-module ownership so every new local-auth record can extend it immediately
 - [ ] Document which parts of `auth.rs` are allowed to grow for local auth and which must live in focused modules
 - [ ] Add review checklist items for local-auth regressions: captured-but-not-persisted state, reset-token replay, backend mismatch, swallowed migration errors, and app/std ownership ambiguity
 
-**Exit criterion:** the storage and module homes for local auth are obvious before the first credential table/helper is implemented.
+**Status after PR #98:** the first credential table/helper slice has a focused storage/domain home, but the reusable contract-harness/review-guidance ratchet is still open and should be paired with the next local-auth slice.
 
 #### Phase 9B — Local Identity and Credential Store
-- [ ] Add first-class local credential storage owned by `std/auth`
-- [ ] Support a generic local subject + identifier model; ship email as the first documented identifier preset with normalization rules, not as the only possible local-auth identity shape
-- [ ] Store password hashes in auth-owned tables rather than pushing that responsibility to apps
-- [ ] Define a lean durable local-user/account shape: identity + auth state first, not a full profile platform
-- [ ] Support account states needed by real flows: bootstrap/pending setup/active/disabled/locked/password-change-required
-- [ ] Support bootstrap account creation from config/env for the common admin-panel case
-- [ ] Ensure bootstrap credentials force rotation/setup instead of becoming a permanent production secret path
-- [ ] Add memory/SQLite contract tests by default and Postgres/Redis contract tests in required backend CI
+- [x] Add first-class local credential storage owned by `std/auth` for memory and SQLite
+- [x] Support a generic local subject + identifier model; ship email as the first documented identifier preset with normalization rules, not as the only possible local-auth identity shape
+- [x] Store password hashes in auth-owned tables rather than pushing that responsibility to apps
+- [x] Define a lean durable local-user/account shape: identity + auth state first, not a full profile platform
+- [x] Support account states needed by real flows: bootstrap/pending setup/active/disabled/locked/password-change-required
+- [x] Support bootstrap account creation from config/env for the common admin-panel case
+- [x] Ensure bootstrap credentials force rotation/setup instead of becoming a permanent production secret path
+- [x] Add memory/SQLite contract tests by default
+- [ ] Add Postgres/Redis contract tests in required backend CI
 
 #### Phase 9C — Request-Aware Local Sign-In Flow
 
@@ -377,12 +380,13 @@ A later `enable_local_auth(...)` convenience wrapper is acceptable only if it de
 
 Because this lands before 0.4.9 is released, the old pre-release `sign_in_session(response, session, options?)` shape should not be kept as a compatibility shim. Callers must migrate by passing the route `req` as the second argument; otherwise local/manual auth would silently miss rotation, existing-session migration, and request metadata capture.
 
-- [ ] Add built-in email/password verification through `std/auth`
-- [ ] Use the existing request-aware session-completion primitive from the local sign-in path so it can rotate/migrate existing sessions and capture request metadata
-- [ ] Reuse the same session cookie, session TTL, sliding/max-lifetime, metadata, and revocation semantics as OAuth-backed sign-in
-- [ ] Reuse staged auth challenge primitives for local login continuation instead of inventing a second pending-auth model
-- [ ] Support straightforward local sign-in that upgrades into a real auth session with app-supplied claims/session data
-- [ ] Ensure local sessions receive `device_name`, `user_agent_hash`, and `last_ip_hash` just like OAuth sessions
+- [x] Add built-in email/password verification through `std/auth` (`verify_local_password`)
+- [x] Use the existing request-aware session-completion primitive from the local sign-in path so it can rotate/migrate existing sessions and capture request metadata
+- [x] Reuse the same session cookie, session TTL, metadata, and rotation semantics as OAuth-backed sign-in
+- [x] Reuse staged auth challenge primitives for local login continuation instead of inventing a second pending-auth model
+- [x] Support straightforward local sign-in that upgrades into a real auth session with app-supplied claims/session data
+- [x] Ensure local sessions receive `device_name`, `user_agent_hash`, and `last_ip_hash` just like OAuth sessions
+- [ ] Finish full remember-me behavior for local sign-in once `remember_ttl` policy is ratcheted end-to-end
 
 #### Phase 9D — First-Login Activation, Forced Password Change, and TOTP Enrollment
 - [ ] Support first-login setup as a first-class local-auth flow
@@ -431,7 +435,7 @@ Because this lands before 0.4.9 is released, the old pre-release `sign_in_sessio
 ### Phase 10 — Architecture Discipline and Complexity Budget
 **Goal:** Prevent `std/auth` from collapsing back into a monolith as local auth, session management, security events, and future auth features land.
 
-**Status:** Starts immediately. This phase is numbered after local auth because it is ongoing discipline, but its first guardrails must land before Phase 9 implementation begins.
+**Status:** Active. This phase is numbered after local auth because it is ongoing discipline; PR #98 landed the first local-auth storage guardrail, but contributor guidance, reusable contract harnesses, and backend CI visibility still need to harden.
 
 **Assessment after the Phase 8 branch review:** the 4.5 cleanup largely achieved its intended effect, but only partially solved the long-term maintainability problem. The module split is real and materially improves clarity. The storage contract is also much more coherent than before. Recent review feedback mostly hit end-to-end plumbing gaps and edge-case semantics rather than “where does this logic even belong?” confusion. That is a meaningful architectural win.
 
@@ -456,7 +460,8 @@ Because this lands before 0.4.9 is released, the old pre-release `sign_in_sessio
 - [ ] Move obvious non-surface types/helpers out of `auth.rs` when doing so improves ownership without destabilizing the public API
 - [ ] Extract JWT and TOTP wrappers if they continue to grow or distract from the public auth surface
 - [ ] Move memory-store/global-state code toward focused module ownership
-- [ ] Split storage by record family and/or backend before adding durable local-auth records
+- [x] Start splitting storage by record family before adding durable local-auth records (`auth/storage/local.rs`)
+- [ ] Continue splitting storage/test ownership as reset, TOTP, bootstrap, and backend implementations land
 - [ ] Reassess whether the main auth test concentration should move toward module-local test ownership over time
 - [ ] Track `auth.rs` and `auth/storage.rs` growth relative to internal modules so broad edits become visible early
 
@@ -506,8 +511,8 @@ Those are now shipped. The next big win is local email/password/TOTP auth, but o
 | **6** | OAuth Hardening + Observability | refresh token rotation and auth health diagnostics | Tightens security posture and production debuggability |
 | **7** | Auto-Routes + UI Convenience | configurable auth routes and login page generator | Improves DX without compromising app-owned UX |
 | **8** | Advanced Sessions Foundation | metadata/security-signal plumbing, remember-me plumbing | Establishes the data path for device sessions and security events |
-| **8.5** | Architecture Guardrails Preflight | Phase 10A/10B minimum guardrails before local-auth code | Prevents Phase 9 from re-growing the monolith |
-| **9** | First-Class Local Auth | local identity store, request-aware login, TOTP setup, password reset, template migration | Closes the biggest remaining real-app auth gap |
+| **8.5** | Architecture Guardrails Preflight | Focused local-auth storage home and fail-closed policy baseline | Prevented the first Phase 9 slice from re-growing the monolith |
+| **9** | First-Class Local Auth | local identity store, request-aware login, TOTP setup, password reset, template migration | In progress; credential storage/verification landed first, remaining lifecycle work closes the real-app auth gap |
 | **10** | Ongoing Architecture Discipline | complexity budget, contract-test ratchet, periodic audits | Keeps `std/auth` excellent as features continue landing |
 
 ### Delivery Wave Deliverables
@@ -603,24 +608,35 @@ Those are now shipped. The next big win is local email/password/TOTP auth, but o
 **Value:** moves `std/auth` from solid to category-leading, provided the plumbing is turned into product behavior in later slices.
 
 #### Wave 8.5 — Architecture Guardrails Preflight
-**Ships before Phase 9 implementation:**
-- auth contributor/review guidance
-- storage/module ownership decision for local auth
-- contract-test ratchet for new auth record families
-- local-auth fallback/error policy
+**Shipped in PR #98:**
+- focused `auth/storage/local.rs` home for the first local-auth record families
+- explicit local-auth record-family enum and fail-closed fallback policy baseline
+- memory/SQLite local identity + credential contract coverage in module-local tests
 
-**Value:** prevents the local-auth wave from undoing the architecture cleanup.
+**Still needed:**
+- auth contributor/review guidance
+- reusable contract-test ratchet for every new auth record family
+- visible Postgres/Redis backend coverage instead of env-gated silence
+
+**Value:** prevented the first local-auth slice from undoing the architecture cleanup. The ratchet still needs teeth, because vibes are not a test harness.
 
 #### Wave 9 — First-Class Local Auth
-**Ships:**
-- local identity and credential store
-- request-aware email/password sign-in
-- staged first-login / forced-password-change / TOTP enrollment
-- password reset token lifecycle
-- local-auth backend contract tests
-- template migration away from custom local auth persistence
+**Shipped so far in PR #98:**
+- local identity/account-state model
+- memory and SQLite local identity/credential storage
+- public `verify_local_password(identifier, password, options?)` with safe non-enumerating failure behavior
+- generated stdlib docs and AI agent guide examples for verify-then-`sign_in_session` usage
 
-**Value:** closes the gap between great auth primitives and great auth architecture.
+**Landing in `feat/local-auth-sign-in-bootstrap`:**
+- first-class `local_sign_in(response, req, credentials, session?, options?)` domain operation that delegates to request-aware session completion or staged auth challenges
+- `create_local_user(...)` and exactly-once `bootstrap_local_user(...)` provisioning with forced setup/credential-rotation semantics
+
+**Still ships next:**
+- completion handlers for first-login setup / forced password change and staged TOTP enrollment
+- password reset token lifecycle
+- local-auth backend CI/contracts beyond the memory/SQLite local credential baseline, plus template migration away from custom auth persistence
+
+**Value:** closes the gap between great auth primitives and great auth architecture. This branch lands the provisioning and request-aware sign-in entry points; the remaining work is the full setup/reset/TOTP lifecycle after those staged continuations.
 
 #### Wave 10 — Ongoing Architecture Discipline
 **Ships continuously:**
@@ -654,7 +670,7 @@ This table tracks the intended competitive posture after the v0.4.9 auth work an
 | Suspicious activity policy | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Behavioral remember-me TTL | ❌ | ✅ | ✅ | ◐ | ✅ | ✅ |
 | TOTP/MFA primitives | ✅ | ✅ | ❌ | ❌¹ | ❌ | ❌³ |
-| First-class local email/password/TOTP lifecycle | ❌ | ✅ | ❌ | ❌ | ◐ | ✅ |
+| First-class local email/password/TOTP lifecycle | ◐ | ✅ | ❌ | ❌ | ◐ | ✅ |
 | Auth-owned password reset tokens | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
 | Bootstrap admin local auth | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
 | Safari ITP workaround | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |

--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -1,6 +1,6 @@
 # DD-062: First-Class Local Email/Password/TOTP Auth in `std/auth`
 
-**Status:** Draft / implementation blueprint
+**Status:** In Progress — PR #98 merged the Phase 1 credential/storage foundation; `feat/local-auth-sign-in-bootstrap` adds bootstrap provisioning plus request-aware local sign-in
 **Parent:** DD-043 Phase 9 — First-Class Local Auth
 **Target:** v0.4.x auth roadmap after the v0.4.9 DD-043 foundation
 
@@ -21,7 +21,7 @@
 - TOTP primitives
 - sign-in/sign-out/current-session helpers
 
-But for a very common real app shape — a local admin area using **email + password + TOTP** — developers still have to build and maintain their own mini auth system around those primitives:
+For a very common real app shape — a local admin area using **email + password + TOTP** — the historical gap was that developers had to build and maintain their own mini auth system around those primitives:
 
 - local user/credential table
 - password-hash storage and verification
@@ -32,7 +32,7 @@ But for a very common real app shape — a local admin area using **email + pass
 - local login route handlers
 - ad hoc admin/session claim handoff from custom local auth into `std/auth` sessions
 
-That is exactly the wrong level of abstraction.
+PR #98 closed the first slice of that gap by giving `std/auth` an auth-owned local identity/credential storage home and public password-verification helper. The `feat/local-auth-sign-in-bootstrap` slice closes the next practical gap with bootstrap/user provisioning and request-aware `local_sign_in(...)` orchestration. The remaining wrong-level-of-abstraction problem is the lifecycle after that: setup completion, TOTP enrollment, password reset, backend CI, and template migration.
 
 A template app should not need a custom `lib/admin_db.tnt` auth subsystem just to get a normal local admin login. If the language already owns sessions, cookies, staged challenges, TOTP primitives, and protected-route enforcement, it should also own the common local credential lifecycle that feeds those mechanisms.
 
@@ -63,7 +63,7 @@ This DD is not about turning `std/auth` into a hosted identity product or a univ
 
 ## Relationship to DD-043
 
-DD-062 is the detailed child plan for DD-043 Phase 9.
+DD-062 is the detailed child plan for DD-043 Phase 9. PR #98 landed the first implementation slice: local identity/account-state records, auth-owned credential-secret storage for memory and SQLite, public `verify_local_password(...)`, and generated docs/examples. The `feat/local-auth-sign-in-bootstrap` slice adds `create_local_user(...)`, `bootstrap_local_user(...)`, request-aware `local_sign_in(...)`, and local-auth docs/examples. The remaining phases turn that into complete setup/TOTP/reset lifecycle behavior.
 
 Current 0.4.9 baseline: the shared manual/staged session completion path is already request-aware. `sign_in_session(response, req, session, options?)` and `complete_auth_challenge(response, req, session?, options?)` rotate/migrate existing sessions and capture request-derived metadata. Local auth should consume that path rather than introduce its own session creation semantics.
 
@@ -101,10 +101,12 @@ Primary shape: local auth is a primitive family used by `enable_auth(...)` for s
 import {
     enable_auth,
     local_credentials,
-    verify_local_password,
-    sign_in_session,
+    bootstrap_local_user,
+    create_local_user,
+    local_sign_in,
 } from "std/auth"
 import { parse_form, redirect } from "std/http/server"
+import { get_env } from "std/env"
 
 enable_auth([], "admin", map {
     "local_credentials": local_credentials(map {
@@ -117,13 +119,25 @@ enable_auth([], "admin", map {
     "failure_url": "/admin/login"
 })
 
+// Bootstrap/provisioning stays in std/auth credential state, while app profile
+// and authorization policy remain app-owned.
+bootstrap_local_user(map {
+    "email": get_env("ADMIN_EMAIL") ?? "",
+    "password": get_env("ADMIN_BOOTSTRAP_PASSWORD") ?? ""
+})
+
+create_local_user("operator@example.com", get_env("OPERATOR_PASSWORD") ?? "", map {
+    "state": "active"
+})
+
 fn login(req) {
     let form = parse_form(req)
-    let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")?
-    return sign_in_session(redirect("/admin"), req, map {
-        "subject_id": verified["subject_id"],
-        "email": verified["email"],
-        "claims": app_claims_for_local_user(verified)
+    return local_sign_in(redirect("/admin"), req, map {
+        "identifier": form["email"] ?? "",
+        "password": form["password"] ?? "",
+        "remember_me": form["remember_me"] == "on"
+    }, map {
+        "claims": app_claims_for_identifier(form["email"] ?? "")
     })
 }
 ```
@@ -132,7 +146,7 @@ Rationale:
 
 - Developers should still have one obvious auth configuration entrypoint: `enable_auth(...)`.
 - Local credentials should share route prefixes, cookies, sessions, lifecycle presets, protected paths, health diagnostics, startup summaries, and backend contract tests.
-- `sign_in_session(response, req, session, options?)` is intentionally request-aware so local/manual auth gets OAuth-equivalent session rotation and request metadata capture.
+- `local_sign_in(response, req, credentials, session?, options?)` is intentionally request-aware and delegates to the same session-completion primitive as manual/OAuth flows, so local auth gets OAuth-equivalent session rotation and request metadata capture without every app composing that glue by hand.
 - Claims/session data should come from app hooks or explicit session-completion data, not static authorization policy buried in credential config.
 - Email is the first identifier preset, not the universal identity model.
 
@@ -182,11 +196,11 @@ The built-in local sign-in route can be enough for simple apps, but custom login
 The helper must be request-aware. A shape in this family is acceptable:
 
 ```ntnt
-local_sign_in(req, response, map {
+local_sign_in(response, req, map {
     "email": email,
     "password": password,
     "remember_me": remember_me
-})
+}, session, options)
 ```
 
 It should return either:
@@ -322,13 +336,13 @@ This table should become implementation comments and contract tests, not just do
 
 **Purpose:** make the local-auth implementation path obvious before adding durable credential state.
 
-- [ ] Split or carve `auth/storage.rs` enough to give local-auth storage a focused home
+- [x] Split or carve `auth/storage.rs` enough to give local-auth storage a focused home (`auth/storage/local.rs`)
 - [ ] Move or isolate the auth storage contract harness so local-auth record families can reuse it cleanly
-- [ ] Add local-auth fallback/error policy comments near the storage contract boundary
+- [x] Add local-auth fallback/error policy comments near the storage contract boundary
 - [ ] Add auth review checklist entries for local-auth-specific regressions
-- [ ] Decide exact module names and public API names before implementation starts
+- [x] Decide exact module names and public API names for the first credential-storage slice
 
-**Exit criteria:** no one has to guess where local identity, password reset, TOTP enrollment, or bootstrap state belongs.
+**Status after PR #98:** local identity and credential state now have an obvious storage/domain home. The remaining preflight work is the reusable contract-harness and review-guidance ratchet for reset, TOTP, bootstrap, and backend failure semantics.
 
 ### Phase 1 — Local Identity and Credential Store
 
@@ -338,8 +352,8 @@ This table should become implementation comments and contract tests, not just do
 - [x] Create credential-secret storage and verification helpers
 - [x] Normalize email lookup rules and document them
 - [x] Add account states: bootstrap, pending setup, active, disabled, locked, password-change-required
-- [ ] Support bootstrap account creation from config/env
-- [ ] Force bootstrap credential rotation/setup completion according to config
+- [x] Support bootstrap account creation from config/env
+- [x] Force bootstrap credential rotation/setup completion according to config
 - [x] Add memory/SQLite contract tests by default
 - [ ] Add Postgres/Redis contract coverage in backend CI
 - [ ] Add migration tests for existing SQLite/Postgres stores
@@ -351,12 +365,13 @@ This table should become implementation comments and contract tests, not just do
 **Baseline:** request-aware manual session completion already exists in 0.4.9 branch work. This phase should wire local credential verification into that primitive, not design a new cookie/session attachment path.
 
 - [x] Add local password verification through `std/auth`
-- [ ] Add local sign-in domain operation that delegates to `sign_in_session(response, req, session, options?)` or the same internal primitive
-- [ ] Rotate/migrate existing sessions on successful local login
-- [ ] Capture `device_name`, `user_agent_hash`, and `last_ip_hash` from request metadata
-- [ ] Apply configured session TTL, max lifetime, sliding expiry, cookie policy, and remember-me behavior
-- [ ] Return staged continuation when TOTP/setup/password-change is required
-- [ ] Add tests proving local login does not lose session metadata compared with OAuth login
+- [x] Add local sign-in domain operation that delegates to `sign_in_session(response, req, session, options?)` or the same internal primitive
+- [x] Rotate/migrate existing sessions on successful local login
+- [x] Capture `device_name`, `user_agent_hash`, and `last_ip_hash` from request metadata
+- [x] Apply configured session TTL/cookie policy through the shared session helper
+- [ ] Finish full remember-me behavior (`remember_ttl`, option capture, and policy tests) end-to-end
+- [x] Return staged continuation when setup/password-change is required
+- [x] Add tests proving local login keeps request-aware session metadata and rejects bad credentials without cookies
 
 ### Phase 3 — First Login, Forced Password Change, and TOTP Enrollment
 
@@ -400,9 +415,11 @@ This table should become implementation comments and contract tests, not just do
 - [ ] Contract tests for every local-auth record family across memory and SQLite by default
 - [ ] Required Postgres/Redis backend contract CI job or explicit non-silent skip reporting
 - [ ] End-to-end ntnt tests for bootstrap, normal login, TOTP setup, forced password change, reset issue/consume, reset replay, disabled account rejection, and session revocation
-- [ ] Generated stdlib docs for every public helper
-- [ ] `docs/AI_AGENT_GUIDE.md` examples for local auth
-- [ ] DD-043 status/checklist updates after each implementation slice
+- [x] Generated stdlib docs for every public helper in the credential/bootstrap/sign-in slices
+- [x] `docs/AI_AGENT_GUIDE.md` examples for local auth
+- [x] DD-043 status/checklist updates after the PR #98 credential slice
+- [x] DD-043 status/checklist updates after the bootstrap/request-aware sign-in slice
+- [ ] DD-043 status/checklist updates after setup-completion, TOTP, reset, and backend-CI slices
 - [ ] Review checklist updates for any bug class discovered during implementation
 
 ---

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1699,29 +1699,47 @@ fn get(req) {
 
 Boundary rule: use `std/auth` for auth flows, sessions, CSRF, current-user helpers, and TOTP. Use `std/crypto` for generic crypto helpers like `uuid`, `hash_password`, and `verify_password`.
 
-Full OAuth, session management, CSRF, JWT, TOTP, and local credential verification support.
+Full OAuth, session management, CSRF, JWT, TOTP, local credential provisioning, local sign-in, and password verification support.
 
-### Local Credential Verification
+### Local Email/Password Auth
 
-`std/auth` owns the local credential verification path; `std/crypto` remains the place for generic password hash helpers. After a local identity/credential has been provisioned by auth-owned setup/bootstrap flows, custom login UI should verify credentials, derive app-owned claims, then complete the session through the shared request-aware session primitive.
+`std/auth` owns local credential storage, bootstrap provisioning, password verification, staged setup continuations, and request-aware session completion. The current local identity/credential implementation supports the memory and SQLite auth stores; PostgreSQL and Redis fail closed until their local-auth record families are implemented. `std/crypto` remains the place for generic password hash helpers. App code owns UI, profiles, roles, organization membership, and the policy that turns a verified local identity into app-specific session claims.
+
+Use `bootstrap_local_user(...)` for the one-time admin/bootstrap account path, or `create_local_user(...)` for explicit provisioning. These helpers return safe local-auth metadata only; they never expose password hashes.
 
 ```ntnt
-import { verify_local_password, sign_in_session } from "std/auth"
+import { bootstrap_local_user, create_local_user, local_sign_in } from "std/auth"
 import { parse_form, redirect } from "std/http/server"
+import { get_env } from "std/env"
+
+fn ensure_bootstrap_admin() {
+    return bootstrap_local_user(map {
+        "email": get_env("ADMIN_EMAIL") ?? "",
+        "password": get_env("ADMIN_INITIAL_PASSWORD") ?? ""
+    })
+}
+
+fn provision_admin(email, temporary_password) {
+    return create_local_user(email, temporary_password, map {
+        "state": "password_change_required"
+    })
+}
 
 fn login(req) {
     let form = parse_form(req)
-    let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")?
 
-    return sign_in_session(redirect("/admin"), req, map {
-        "subject_id": verified["subject_id"],
-        "email": verified["email"],
-        "claims": app_claims_for_local_user(verified)
+    return local_sign_in(redirect("/admin"), req, map {
+        "email": form["email"] ?? "",
+        "password": form["password"] ?? ""
+    }, map {
+        "claims": app_claims_for_local_email(form["email"] ?? "")
     })
 }
 ```
 
-Session claims, roles, profiles, and organization membership stay app-owned; local auth only owns credential lifecycle state and safe verification results.
+`local_sign_in(response, req, credentials, session?, options?)` verifies the local credential and then uses the same request-aware session-completion path as OAuth/manual sign-in, including session rotation/migration, session TTL/cookie policy, and request-derived metadata such as `device_name`, `user_agent_hash`, and `last_ip_hash`. If the local account is in a setup state such as `bootstrap`, `pending_setup`, or `password_change_required`, it returns a staged auth challenge cookie instead of issuing a full session.
+
+Session claims, roles, profiles, and organization membership stay app-owned; local auth only owns credential lifecycle state and safe verification/sign-in results.
 
 ### Basic OAuth Setup
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1827,8 +1827,10 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`auth_me`](#authme) | Return current user as JSON for SPAs. |
 | [`auth_start`](#authstart) | Handle OAuth login start - redirects to the provider's authorization page. |
 | [`begin_auth_challenge`](#beginauthchallenge) | Persist a pending auth challenge and attach the challenge cookie. |
+| [`bootstrap_local_user`](#bootstraplocaluser) | Create the initial bootstrap local account exactly once. |
 | [`cancel_auth_challenge`](#cancelauthchallenge) | Cancel the current auth challenge and clear the challenge cookie. |
 | [`complete_auth_challenge`](#completeauthchallenge) | Upgrade the current auth challenge into a full authenticated session. |
+| [`create_local_user`](#createlocaluser) | Create an auth-owned local identity and password credential. |
 | [`create_session_from_oauth`](#createsessionfromoauth) | Create a session from OAuth user info and tokens. |
 | [`csrf_field`](#csrffield) | Get an HTML hidden input field with the CSRF token. |
 | [`csrf_token`](#csrftoken) | Get the CSRF token for the current session. |
@@ -1841,6 +1843,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`jwt_decode`](#jwtdecode) | Decode a JWT token WITHOUT verifying the signature. |
 | [`jwt_sign`](#jwtsign) | Create a signed JWT token from claims. |
 | [`jwt_verify`](#jwtverify) | Verify a JWT token and return its claims. |
+| [`local_sign_in`](#localsignin) | Verify local credentials and complete or stage local sign-in. |
 | [`logout_all`](#logoutall) | Log out all sessions for the current user. |
 | [`logout_user`](#logoutuser) | Log out the current user and return a redirect response. |
 | [`oauth`](#oauth) | Create an OAuth provider configuration. |
@@ -2035,10 +2038,42 @@ begin_auth_challenge(redirect("/admin/verify"), map { "subject_id": user.id, "ki
 
 ---
 
+#### `bootstrap_local_user`
+
+```ntnt
+bootstrap_local_user(options?: Map) -> Result<Map, String>
+```
+
+Create the initial bootstrap local account exactly once.
+
+Reads `email`/`identifier` and `password` from the options map, or from `NTNT_AUTH_BOOTSTRAP_EMAIL` and `NTNT_AUTH_BOOTSTRAP_PASSWORD` by default. If the identity already exists, it returns `created: false` and does not replace the stored credential, preventing env-configured bootstrap passwords from becoming a recurring password-reset path on restart. Local bootstrap state currently supports the memory and SQLite auth stores; PostgreSQL and Redis fail closed until their local-auth record families are implemented.
+
+**Parameters:**
+
+- `options` — Optional map with `email` or `identifier`, `password`, `identifier_kind`, `identifier_env`, and `password_env`
+
+**Returns:** Ok(map) with safe local user metadata and `created`, or Err(message)
+
+**Examples:**
+
+```ntnt
+bootstrap_local_user(map { "email": get_env("ADMIN_EMAIL")?, "password": get_env("ADMIN_PASSWORD")? })  // Create first admin credential
+```
+
+**Errors:**
+
+- **RuntimeError**: requires email/password — *Fix: Pass options or set bootstrap env vars*
+
+**See also:** `create_local_user`, `verify_local_password`, `local_sign_in`
+
+*Since v0.4.9*
+
+---
+
 #### `cancel_auth_challenge`
 
 ```ntnt
-cancel_auth_challenge(response: Response, req: Request) -> Response
+cancel_auth_challenge(response: Response, req: Request, options?: Map) -> Response
 ```
 
 Cancel the current auth challenge and clear the challenge cookie.
@@ -2049,6 +2084,7 @@ Use this when a staged auth flow is abandoned, fails, or needs to be reset.
 
 - `response` — The Response map to attach the clearing cookie to
 - `req` — The current HTTP request
+- `options` — Optional cookie overrides matching the challenge cookie path/settings
 
 **Returns:** Response with the challenge cookie cleared
 
@@ -2079,7 +2115,7 @@ This consumes the active challenge, creates a real session, attaches the normal 
 - `response` — The Response map to attach cookies to
 - `req` — The current HTTP request
 - `session` — Optional session data map merged onto the completed session
-- `options` — Optional session options like `session_ttl` and cookie overrides
+- `options` — Optional `session_ttl` and challenge-cookie clearing overrides
 
 **Returns:** Response with the auth challenge consumed and the session cookie attached
 
@@ -2090,6 +2126,40 @@ complete_auth_challenge(redirect("/admin"), req, map { "claims": app_claims_for_
 ```
 
 **See also:** `begin_auth_challenge`, `current_auth_challenge`, `cancel_auth_challenge`, `sign_in_session`
+
+*Since v0.4.9*
+
+---
+
+#### `create_local_user`
+
+```ntnt
+create_local_user(identifier: String, password: String, options?: Map) -> Result<Map, String>
+```
+
+Create an auth-owned local identity and password credential.
+
+This is a primitive for provisioning local accounts without app-owned credential tables. Email is the default identifier kind. Options may include `identifier_kind`, `state`, `must_change_password`, `metadata`, and `id`. App profile fields, roles, orgs, and session claims remain app-owned. Local identity/credential provisioning currently supports the memory and SQLite auth stores; PostgreSQL and Redis fail closed until their local-auth record families are implemented.
+
+**Parameters:**
+
+- `identifier` — Local login identifier; email by default
+- `password` — Plaintext initial password to hash and store
+- `options` — Optional map with identifier/account-state settings
+
+**Returns:** Ok(map) with safe local user metadata, or Err(message)
+
+**Examples:**
+
+```ntnt
+create_local_user("admin@example.com", password, map { "state": "password_change_required" })  // Provision a local user
+```
+
+**Errors:**
+
+- **RuntimeError**: Auth not initialized — *Fix: Call enable_auth(...) before creating local users*
+
+**See also:** `bootstrap_local_user`, `verify_local_password`, `local_sign_in`
 
 *Since v0.4.9*
 
@@ -2446,6 +2516,42 @@ jwt_verify(token, secret)  // Verify and get claims
 
 ---
 
+#### `local_sign_in`
+
+```ntnt
+local_sign_in(response: Response, req: Request, credentials: Map, session?: Map, options?: Map) -> Result<Response, String>
+```
+
+Verify local credentials and complete or stage local sign-in.
+
+Active users are signed in through the same request-aware session completion path as `sign_in_session(...)`, including session rotation and request-derived metadata capture. Setup-required users (bootstrap, pending setup, or password change required) receive an auth challenge cookie instead of a full session. Invalid credentials return `Err("Invalid local credentials")` without setting cookies. Local identity/credential lookup currently supports the memory and SQLite auth stores; PostgreSQL and Redis fail closed until their local-auth record families are implemented.
+
+**Parameters:**
+
+- `response` — Response to attach the session or challenge cookie to
+- `req` — Current HTTP request
+- `credentials` — Map with `email` or `identifier`, `password`, and optional `identifier_kind`
+- `session` — Optional app-owned session data such as `claims`, `data`, `name`, or `picture`
+- `options` — Optional map with `session_ttl`, `challenge_kind`, `challenge_ttl`, and cookie overrides (`cookie_path`, `cookie_domain`, `cookie_secure`, `cookie_http_only`, `cookie_same_site`, `cookie_max_age`)
+
+**Returns:** Ok(Response) with a session/challenge cookie, or Err(message)
+
+**Examples:**
+
+```ntnt
+local_sign_in(redirect("/admin"), req, map { "email": email, "password": password }, map { "claims": app_claims })  // Verify and sign in local user
+```
+
+**Errors:**
+
+- **TypeError**: request must be an HTTP request map — *Fix: Pass the current route request as the second argument*
+
+**See also:** `create_local_user`, `bootstrap_local_user`, `verify_local_password`, `sign_in_session`
+
+*Since v0.4.9*
+
+---
+
 #### `logout_all`
 
 ```ntnt
@@ -2796,7 +2902,7 @@ Use this after privilege changes or sensitive login completion to prevent sessio
 
 - `response` — The Response map to attach the rotated cookie to
 - `req` — The current HTTP request
-- `options` — Optional cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+- `options` — Optional cookie override keys (`cookie_path`, `cookie_domain`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
 
 **Returns:** Response with the rotated session cookie
 
@@ -2908,7 +3014,7 @@ Use this after password, magic-link, or other non-OAuth login flows. The request
 - `response` — The Response map to attach the session cookie to
 - `req` — The current HTTP request
 - `session` — Session data map, including required `subject_id`
-- `options` — Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+- `options` — Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_domain`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
 
 **Returns:** Response with a persisted session and Set-Cookie header
 
@@ -2942,7 +3048,7 @@ Use this when your app wants logout behavior without being forced into the built
 
 - `response` — The Response map to attach the clearing cookie to
 - `req` — The current HTTP request
-- `options` — Optional cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
+- `options` — Optional cookie override keys (`cookie_path`, `cookie_domain`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
 
 **Returns:** Response with the auth cookie cleared
 
@@ -3111,7 +3217,7 @@ verify_local_password(identifier: String, password: String, options?: Map) -> Re
 
 Verify a local credential record and return a safe auth user payload.
 
-The helper normalizes the identifier (email by default), loads the auth-owned local identity and credential secret, verifies the password hash, and returns a map suitable for app-specific session claim derivation and `sign_in_session(...)`. It never exposes password hashes or hash parameters. Missing identities, missing credential secrets, bad passwords, disabled accounts, and locked accounts all return the same invalid-credentials error to avoid account-state or identity enumeration. Corrupted or unsupported stored hashes return a generic operational auth error without backend parser details after running the same dummy verification work used for absent credentials. Bootstrap, pending-setup, and password-change-required identities can verify credentials, but the returned payload forces `must_change_password: true` so callers do not accidentally treat setup-required accounts as fully active sessions.
+The helper normalizes the identifier (email by default), loads the auth-owned local identity and credential secret, verifies the password hash, and returns a map suitable for app-specific session claim derivation and `sign_in_session(...)`. It never exposes password hashes or hash parameters. Missing identities, missing credential secrets, bad passwords, disabled accounts, and locked accounts all return the same invalid-credentials error to avoid account-state or identity enumeration. Corrupted or unsupported stored hashes return a generic operational auth error without backend parser details after running the same dummy verification work used for absent credentials. Local identity/credential lookup currently supports the memory and SQLite auth stores; PostgreSQL and Redis fail closed until their local-auth record families are implemented. Bootstrap, pending-setup, and password-change-required identities can verify credentials, but the returned payload forces `must_change_password: true` so callers do not accidentally treat setup-required accounts as fully active sessions.
 
 **Parameters:**
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -70,7 +70,10 @@ use guards::validate_auth_challenge_kind;
 pub use guards::{
     enforce_auth_for_request, get_protected_paths, register_protected_paths, reset_protected_paths,
 };
-use local::{verified_local_password_to_value, verify_local_password_record};
+use local::{
+    bootstrap_local_user_record, create_local_user_record, local_user_creation_to_value,
+    verified_local_password_to_value, verify_local_password_record,
+};
 use oauth::extract_user_info;
 pub use oauth::{
     client_credentials_grant, decode_id_token, exchange_code_for_tokens, fetch_oidc_discovery,
@@ -723,6 +726,417 @@ fn persist_request_aware_manual_session(
         .map_err(IntentError::type_error)?;
     let response = add_set_cookie_header(response, &cookie).map_err(IntentError::type_error)?;
     persist_manual_session_record(req, session)?;
+    Ok(response)
+}
+
+fn local_setup_state_requires_password_change(state: storage::LocalAccountState) -> bool {
+    matches!(
+        state,
+        storage::LocalAccountState::Bootstrap
+            | storage::LocalAccountState::PendingSetup
+            | storage::LocalAccountState::PasswordChangeRequired
+    )
+}
+
+fn local_options_identifier_kind<'a>(
+    options: Option<&'a HashMap<String, Value>>,
+    function_name: &str,
+) -> Result<&'a str> {
+    match options.and_then(|m| m.get("identifier_kind")) {
+        Some(Value::String(kind)) => Ok(kind.as_str()),
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() identifier_kind must be a string, got {}",
+            function_name,
+            other.type_name()
+        ))),
+        None => Ok("email"),
+    }
+}
+
+fn local_creation_options(
+    options: Option<&HashMap<String, Value>>,
+) -> Result<(storage::LocalAccountState, bool, String, Option<String>)> {
+    let state = match options.and_then(|m| m.get("state")) {
+        Some(Value::String(state)) => {
+            storage::LocalAccountState::from_str(state).map_err(IntentError::type_error)?
+        }
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] create_local_user() state must be a string, got {}",
+                other.type_name()
+            )))
+        }
+        None => storage::LocalAccountState::Active,
+    };
+
+    let must_change_password = match options.and_then(|m| m.get("must_change_password")) {
+        Some(Value::Bool(value)) => *value,
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] create_local_user() must_change_password must be a bool, got {}",
+                other.type_name()
+            )))
+        }
+        None => local_setup_state_requires_password_change(state),
+    };
+
+    let metadata_json = match options.and_then(|m| m.get("metadata")) {
+        Some(Value::Map(metadata)) => value_map_to_json_string(metadata),
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] create_local_user() metadata must be a map, got {}",
+                other.type_name()
+            )))
+        }
+        None => "{}".to_string(),
+    };
+
+    let id = match options.and_then(|m| m.get("id")) {
+        Some(Value::String(id)) if !id.trim().is_empty() => Some(id.clone()),
+        Some(Value::String(_)) => {
+            return Err(IntentError::type_error(
+                "[auth] create_local_user() id must not be empty".to_string(),
+            ))
+        }
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] create_local_user() id must be a string, got {}",
+                other.type_name()
+            )))
+        }
+        None => None,
+    };
+
+    Ok((state, must_change_password, metadata_json, id))
+}
+
+fn bootstrap_option_string(
+    options: &HashMap<String, Value>,
+    direct_keys: &[&str],
+    env_key_name: &str,
+    default_env_key: &str,
+    label: &str,
+) -> Result<String> {
+    for key in direct_keys {
+        match options.get(*key) {
+            Some(Value::String(value)) if !value.is_empty() => return Ok(value.clone()),
+            Some(Value::String(_)) => {
+                return Err(IntentError::type_error(format!(
+                    "[auth] bootstrap_local_user() {} must not be empty",
+                    key
+                )))
+            }
+            Some(other) => {
+                return Err(IntentError::type_error(format!(
+                    "[auth] bootstrap_local_user() {} must be a string, got {}",
+                    key,
+                    other.type_name()
+                )))
+            }
+            None => {}
+        }
+    }
+
+    let env_key = match options.get(env_key_name) {
+        Some(Value::String(key)) if !key.is_empty() => key.as_str(),
+        Some(Value::String(_)) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] bootstrap_local_user() {} must not be empty",
+                env_key_name
+            )))
+        }
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] bootstrap_local_user() {} must be a string, got {}",
+                env_key_name,
+                other.type_name()
+            )))
+        }
+        None => default_env_key,
+    };
+
+    match std::env::var(env_key) {
+        Ok(value) if !value.is_empty() => Ok(value),
+        Ok(_) => Err(IntentError::runtime_error(format!(
+            "[auth] bootstrap_local_user() {} env var must not be empty",
+            env_key
+        ))),
+        Err(_) => Err(IntentError::runtime_error(format!(
+            "[auth] bootstrap_local_user() requires {} or {} env var",
+            label, env_key
+        ))),
+    }
+}
+
+fn local_sign_in_credentials(
+    credentials: &HashMap<String, Value>,
+) -> Result<(String, String, String)> {
+    let identifier_kind = match credentials.get("identifier_kind") {
+        Some(Value::String(kind)) => kind.trim().to_ascii_lowercase(),
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] local_sign_in() identifier_kind must be a string, got {}",
+                other.type_name()
+            )))
+        }
+        None => "email".to_string(),
+    };
+
+    let identifier = match credentials.get("identifier") {
+        Some(Value::String(identifier)) if !identifier.is_empty() => identifier.clone(),
+        Some(Value::String(_)) => {
+            return Err(IntentError::type_error(
+                "[auth] local_sign_in() identifier must not be empty".to_string(),
+            ))
+        }
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] local_sign_in() identifier must be a string, got {}",
+                other.type_name()
+            )))
+        }
+        None if identifier_kind == "email" => match credentials.get("email") {
+            Some(Value::String(email)) if !email.is_empty() => email.clone(),
+            Some(Value::String(_)) => {
+                return Err(IntentError::type_error(
+                    "[auth] local_sign_in() email must not be empty".to_string(),
+                ))
+            }
+            Some(other) => {
+                return Err(IntentError::type_error(format!(
+                    "[auth] local_sign_in() email must be a string, got {}",
+                    other.type_name()
+                )))
+            }
+            None => return Err(IntentError::type_error(
+                "[auth] local_sign_in() credentials.identifier or credentials.email is required"
+                    .to_string(),
+            )),
+        },
+        None => {
+            return Err(IntentError::type_error(
+                "[auth] local_sign_in() credentials.identifier is required".to_string(),
+            ))
+        }
+    };
+
+    let password = match credentials.get("password") {
+        Some(Value::String(password)) if !password.is_empty() => password.clone(),
+        Some(Value::String(_)) => {
+            return Err(IntentError::type_error(
+                "[auth] local_sign_in() password must not be empty".to_string(),
+            ))
+        }
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] local_sign_in() password must be a string, got {}",
+                other.type_name()
+            )))
+        }
+        None => {
+            return Err(IntentError::type_error(
+                "[auth] local_sign_in() credentials.password is required".to_string(),
+            ))
+        }
+    };
+
+    Ok((identifier_kind, identifier, password))
+}
+
+fn is_auth_option_key(key: &str) -> bool {
+    matches!(
+        key,
+        "session_ttl"
+            | "challenge_kind"
+            | "challenge_ttl"
+            | "cookie_path"
+            | "cookie_domain"
+            | "cookie_secure"
+            | "cookie_http_only"
+            | "cookie_same_site"
+            | "cookie_name"
+            | "cookie_max_age"
+    )
+}
+
+fn is_auth_session_data_key(key: &str) -> bool {
+    matches!(
+        key,
+        "subject_id"
+            | "provider"
+            | "email"
+            | "identifier"
+            | "identifier_kind"
+            | "name"
+            | "picture"
+            | "claims"
+            | "data"
+            | "raw"
+    )
+}
+
+fn optional_session_and_options(
+    function_name: &str,
+    first: Option<&Value>,
+    second: Option<&Value>,
+) -> Result<(HashMap<String, Value>, Option<HashMap<String, Value>>)> {
+    let first_map = match first {
+        Some(Value::Map(map)) => Some(map),
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] {}() session must be a map, got {}",
+                function_name,
+                other.type_name()
+            )))
+        }
+        None => None,
+    };
+
+    let second_map = match second {
+        Some(Value::Map(map)) => Some(map.clone()),
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] {}() options must be a map, got {}",
+                function_name,
+                other.type_name()
+            )))
+        }
+        None => None,
+    };
+
+    match (first_map, second_map) {
+        (Some(session), Some(options)) => Ok((session.clone(), Some(options))),
+        (Some(map), None) => {
+            let has_option_keys = map.keys().any(|key| is_auth_option_key(key));
+            let has_session_keys = map.keys().any(|key| is_auth_session_data_key(key));
+            if has_option_keys && !has_session_keys {
+                Ok((HashMap::new(), Some(map.clone())))
+            } else if has_option_keys && has_session_keys {
+                Err(IntentError::type_error(format!(
+                    "[auth] {}() optional map mixes session data and auth options; pass session and options as separate maps",
+                    function_name
+                )))
+            } else {
+                Ok((map.clone(), None))
+            }
+        }
+        (None, Some(options)) => Ok((HashMap::new(), Some(options))),
+        (None, None) => Ok((HashMap::new(), None)),
+    }
+}
+
+fn local_sign_in_options(
+    args: &[Value],
+) -> Result<(HashMap<String, Value>, Option<HashMap<String, Value>>)> {
+    optional_session_and_options("local_sign_in", args.get(3), args.get(4))
+}
+
+fn staged_session_from_challenge_data(
+    function_name: &str,
+    data_json: &str,
+) -> Result<HashMap<String, Value>> {
+    let data = json_string_to_value_map(data_json);
+    match data.get("session") {
+        Some(Value::Map(session)) => Ok(session.clone()),
+        Some(Value::Unit) | None => Ok(HashMap::new()),
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() auth challenge session data must be a map, got {}",
+            function_name,
+            other.type_name()
+        ))),
+    }
+}
+
+fn build_local_session_spec(
+    verified_map: &HashMap<String, Value>,
+    app_session: &HashMap<String, Value>,
+) -> HashMap<String, Value> {
+    let mut session_spec = HashMap::new();
+    for key in [
+        "subject_id",
+        "provider",
+        "email",
+        "identifier",
+        "identifier_kind",
+    ] {
+        if let Some(value) = verified_map.get(key) {
+            session_spec.insert(key.to_string(), value.clone());
+        }
+    }
+    for key in ["name", "picture", "claims", "data", "raw"] {
+        if let Some(value) = app_session.get(key) {
+            session_spec.insert(key.to_string(), value.clone());
+        }
+    }
+    session_spec
+}
+
+fn should_stage_local_sign_in(verified_map: &HashMap<String, Value>) -> bool {
+    matches!(
+        verified_map.get("must_change_password"),
+        Some(Value::Bool(true))
+    )
+}
+
+fn stage_local_sign_in(
+    response: &Value,
+    verified_map: &HashMap<String, Value>,
+    app_session: &HashMap<String, Value>,
+    options: Option<&HashMap<String, Value>>,
+    config: &AuthConfig,
+) -> Result<Value> {
+    let subject_id = match verified_map.get("subject_id") {
+        Some(Value::String(subject_id)) => subject_id.clone(),
+        _ => {
+            return Err(IntentError::runtime_error(
+                "[auth] local_sign_in() verified credential missing subject_id".to_string(),
+            ))
+        }
+    };
+    let kind = match options.and_then(|m| m.get("challenge_kind")) {
+        Some(Value::String(kind)) => {
+            validate_auth_challenge_kind(kind).map_err(IntentError::type_error)?
+        }
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] local_sign_in() challenge_kind must be a string, got {}",
+                other.type_name()
+            )))
+        }
+        None => "password_change_required".to_string(),
+    };
+    let ttl = match options.and_then(|m| m.get("challenge_ttl")) {
+        Some(Value::Int(ttl)) if *ttl > 0 => *ttl,
+        Some(Value::Int(_)) => {
+            return Err(IntentError::type_error(
+                "[auth] local_sign_in() challenge_ttl must be greater than 0".to_string(),
+            ))
+        }
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "[auth] local_sign_in() challenge_ttl must be an int, got {}",
+                other.type_name()
+            )))
+        }
+        None => storage::AUTH_CHALLENGE_TTL,
+    };
+
+    let mut data = verified_map.clone();
+    if !app_session.is_empty() {
+        data.insert("session".to_string(), Value::Map(app_session.clone()));
+    }
+    let challenge = create_auth_challenge(&HashMap::from([
+        ("subject_id".to_string(), Value::String(subject_id)),
+        ("provider".to_string(), Value::String("local".to_string())),
+        ("kind".to_string(), Value::String(kind)),
+        ("ttl".to_string(), Value::Int(ttl)),
+        ("data".to_string(), Value::Map(data)),
+    ]))
+    .map_err(IntentError::type_error)?;
+    let cookie = build_signed_auth_challenge_cookie(config, &challenge.id, ttl, options)
+        .map_err(IntentError::type_error)?;
+    let response = add_set_cookie_header(response, &cookie).map_err(IntentError::type_error)?;
+    store_auth_challenge(challenge);
     Ok(response)
 }
 
@@ -1662,7 +2076,7 @@ pub fn init() -> HashMap<String, Value> {
                 let challenge =
                     create_auth_challenge(&challenge_spec).map_err(IntentError::type_error)?;
                 let ttl = challenge.expires_at - chrono::Utc::now().timestamp();
-                let cookie = build_signed_auth_challenge_cookie(&config, &challenge.id, ttl)
+                let cookie = build_signed_auth_challenge_cookie(&config, &challenge.id, ttl, None)
                     .map_err(IntentError::type_error)?;
                 let response =
                     add_set_cookie_header(&args[0], &cookie).map_err(IntentError::type_error)?;
@@ -1683,7 +2097,7 @@ pub fn init() -> HashMap<String, Value> {
     // @param response The Response map to attach cookies to
     // @param req The current HTTP request
     // @param session Optional session data map merged onto the completed session
-    // @param options Optional session options like `session_ttl` and cookie overrides
+    // @param options Optional `session_ttl` and challenge-cookie clearing overrides
     // @returns Response with the auth challenge consumed and the session cookie attached
     // @see_also begin_auth_challenge, current_auth_challenge, cancel_auth_challenge, sign_in_session
     // @since v0.4.9
@@ -1713,27 +2127,11 @@ pub fn init() -> HashMap<String, Value> {
 
                 validate_http_request_arg("complete_auth_challenge", &args[1])?;
 
-                let session_spec = match args.get(2) {
-                    Some(Value::Map(map)) => map.clone(),
-                    Some(other) => {
-                        return Err(IntentError::type_error(format!(
-                            "[auth] complete_auth_challenge() session must be a map, got {}",
-                            other.type_name()
-                        )))
-                    }
-                    None => HashMap::new(),
-                };
-
-                let options = match args.get(3) {
-                    Some(Value::Map(map)) => Some(map.clone()),
-                    Some(other) => {
-                        return Err(IntentError::type_error(format!(
-                            "[auth] complete_auth_challenge() options must be a map, got {}",
-                            other.type_name()
-                        )))
-                    }
-                    None => None,
-                };
+                let (session_spec, options) = optional_session_and_options(
+                    "complete_auth_challenge",
+                    args.get(2),
+                    args.get(3),
+                )?;
 
                 let challenge_id = get_auth_challenge_id_from_request(&args[1]).ok_or_else(|| {
                     IntentError::runtime_error(
@@ -1754,7 +2152,11 @@ pub fn init() -> HashMap<String, Value> {
                         )
                     })?;
 
-                let mut merged_session = session_spec.clone();
+                let mut merged_session = staged_session_from_challenge_data(
+                    "complete_auth_challenge",
+                    &challenge.data_json,
+                )?;
+                merged_session.extend(session_spec.clone());
                 match merged_session.get("subject_id") {
                     Some(Value::String(subject_id)) if subject_id == &challenge.subject_id => {}
                     Some(Value::String(_)) => {
@@ -1815,11 +2217,11 @@ pub fn init() -> HashMap<String, Value> {
                 let session = create_manual_session(&merged_session, effective_session_ttl)
                     .map_err(IntentError::type_error)?;
                 let session = prepare_request_aware_manual_session(&args[1], session);
-                let session_cookie =
-                    build_signed_session_cookie(&config, &session.id, options.as_ref())
-                        .map_err(IntentError::type_error)?;
+                let session_cookie = build_signed_session_cookie(&config, &session.id, None)
+                    .map_err(IntentError::type_error)?;
                 let cleared_challenge_cookie =
-                    build_cleared_auth_challenge_cookie(&config).map_err(IntentError::type_error)?;
+                    build_cleared_auth_challenge_cookie(&config, options.as_ref())
+                        .map_err(IntentError::type_error)?;
                 let response =
                     add_set_cookie_header(&args[0], &session_cookie).map_err(IntentError::type_error)?;
                 let response = add_set_cookie_header(&response, &cleared_challenge_cookie)
@@ -1842,12 +2244,13 @@ pub fn init() -> HashMap<String, Value> {
 
     // @ntnt cancel_auth_challenge
     // @module std/auth
-    // @signature cancel_auth_challenge(response: Response, req: Request) -> Response
+    // @signature cancel_auth_challenge(response: Response, req: Request, options?: Map) -> Response
     // Cancel the current auth challenge and clear the challenge cookie.
     //
     // Use this when a staged auth flow is abandoned, fails, or needs to be reset.
     // @param response The Response map to attach the clearing cookie to
     // @param req The current HTTP request
+    // @param options Optional cookie overrides matching the challenge cookie path/settings
     // @returns Response with the challenge cookie cleared
     // @see_also begin_auth_challenge, current_auth_challenge, complete_auth_challenge
     // @since v0.4.9
@@ -1858,12 +2261,12 @@ pub fn init() -> HashMap<String, Value> {
         Value::NativeFunction {
             name: "cancel_auth_challenge".to_string(),
             arity: 2,
-            max_arity: 2,
+            max_arity: 3,
             requires: None,
             func: |args| {
-                if args.len() != 2 {
+                if args.len() < 2 || args.len() > 3 {
                     return Err(IntentError::type_error(
-                        "[auth] cancel_auth_challenge() requires response and request".to_string(),
+                        "[auth] cancel_auth_challenge() requires response, request, and optional options".to_string(),
                     ));
                 }
 
@@ -1874,8 +2277,23 @@ pub fn init() -> HashMap<String, Value> {
                     )
                 })?;
 
-                let cleared_cookie =
-                    build_cleared_auth_challenge_cookie(&config).map_err(IntentError::type_error)?;
+                validate_http_request_arg("cancel_auth_challenge", &args[1])?;
+                let options = match args.get(2) {
+                    Some(Value::Map(map)) => Some(map.clone()),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] cancel_auth_challenge() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => None,
+                };
+
+                let cleared_cookie = build_cleared_auth_challenge_cookie(
+                    &config,
+                    options.as_ref(),
+                )
+                .map_err(IntentError::type_error)?;
                 let response =
                     add_set_cookie_header(&args[0], &cleared_cookie).map_err(IntentError::type_error)?;
 
@@ -3738,6 +4156,168 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt create_local_user
+    // @module std/auth
+    // @signature create_local_user(identifier: String, password: String, options?: Map) -> Result<Map, String>
+    // Create an auth-owned local identity and password credential.
+    //
+    // This is a primitive for provisioning local accounts without app-owned
+    // credential tables. Email is the default identifier kind. Options may include
+    // `identifier_kind`, `state`, `must_change_password`, `metadata`, and `id`.
+    // App profile fields, roles, orgs, and session claims remain app-owned.
+    // Local identity/credential provisioning currently supports the memory and
+    // SQLite auth stores; PostgreSQL and Redis fail closed until their local-auth
+    // record families are implemented.
+    // @param identifier Local login identifier; email by default
+    // @param password Plaintext initial password to hash and store
+    // @param options Optional map with identifier/account-state settings
+    // @returns Ok(map) with safe local user metadata, or Err(message)
+    // @error RuntimeError ~ "Auth not initialized" fix: "Call enable_auth(...) before creating local users"
+    // @see_also bootstrap_local_user, verify_local_password, local_sign_in
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #security
+    // @example create_local_user("admin@example.com", password, map { "state": "password_change_required" }) ~ "Provision a local user"
+    module.insert(
+        "create_local_user".to_string(),
+        Value::NativeFunction {
+            name: "create_local_user".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] create_local_user() requires identifier, password, and optional options"
+                            .to_string(),
+                    ));
+                }
+                let _config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before create_local_user()."
+                            .to_string(),
+                    )
+                })?;
+                let identifier = match &args[0] {
+                    Value::String(identifier) => identifier.as_str(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] create_local_user() identifier must be a string, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+                let password = match &args[1] {
+                    Value::String(password) => password.as_str(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] create_local_user() password must be a string, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+                let options = match args.get(2) {
+                    Some(Value::Map(map)) => Some(map),
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] create_local_user() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => None,
+                };
+                let identifier_kind = local_options_identifier_kind(options, "create_local_user")?;
+                let (state, must_change_password, metadata_json, id) =
+                    local_creation_options(options)?;
+
+                match create_local_user_record(
+                    identifier_kind,
+                    identifier,
+                    password,
+                    state,
+                    must_change_password,
+                    metadata_json,
+                    id,
+                ) {
+                    Ok(creation) => Ok(Value::ok(local_user_creation_to_value(creation))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
+    // @ntnt bootstrap_local_user
+    // @module std/auth
+    // @signature bootstrap_local_user(options?: Map) -> Result<Map, String>
+    // Create the initial bootstrap local account exactly once.
+    //
+    // Reads `email`/`identifier` and `password` from the options map, or from
+    // `NTNT_AUTH_BOOTSTRAP_EMAIL` and `NTNT_AUTH_BOOTSTRAP_PASSWORD` by default.
+    // If the identity already exists, it returns `created: false` and does not
+    // replace the stored credential, preventing env-configured bootstrap passwords
+    // from becoming a recurring password-reset path on restart. Local bootstrap
+    // state currently supports the memory and SQLite auth stores; PostgreSQL and
+    // Redis fail closed until their local-auth record families are implemented.
+    // @param options Optional map with `email` or `identifier`, `password`, `identifier_kind`, `identifier_env`, and `password_env`
+    // @returns Ok(map) with safe local user metadata and `created`, or Err(message)
+    // @error RuntimeError ~ "requires email/password" fix: "Pass options or set bootstrap env vars"
+    // @see_also create_local_user, verify_local_password, local_sign_in
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #bootstrap, #security
+    // @example bootstrap_local_user(map { "email": get_env("ADMIN_EMAIL")?, "password": get_env("ADMIN_PASSWORD")? }) ~ "Create first admin credential"
+    module.insert(
+        "bootstrap_local_user".to_string(),
+        Value::NativeFunction {
+            name: "bootstrap_local_user".to_string(),
+            arity: 0,
+            max_arity: 1,
+            requires: None,
+            func: |args| {
+                if args.len() > 1 {
+                    return Err(IntentError::type_error(
+                        "[auth] bootstrap_local_user() accepts optional options".to_string(),
+                    ));
+                }
+                let _config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before bootstrap_local_user()."
+                            .to_string(),
+                    )
+                })?;
+                let empty = HashMap::new();
+                let options = match args.first() {
+                    Some(Value::Map(map)) => map,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] bootstrap_local_user() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => &empty,
+                };
+                let identifier_kind = local_options_identifier_kind(Some(options), "bootstrap_local_user")?;
+                let identifier = bootstrap_option_string(
+                    options,
+                    &["identifier", "email"],
+                    "identifier_env",
+                    "NTNT_AUTH_BOOTSTRAP_EMAIL",
+                    "identifier/email",
+                )?;
+                let password = bootstrap_option_string(
+                    options,
+                    &["password"],
+                    "password_env",
+                    "NTNT_AUTH_BOOTSTRAP_PASSWORD",
+                    "password",
+                )?;
+
+                match bootstrap_local_user_record(identifier_kind, &identifier, &password) {
+                    Ok(creation) => Ok(Value::ok(local_user_creation_to_value(creation))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
     // @ntnt verify_local_password
     // @module std/auth
     // @signature verify_local_password(identifier: String, password: String, options?: Map) -> Result<Map, String>
@@ -3751,7 +4331,10 @@ pub fn init() -> HashMap<String, Value> {
     // and locked accounts all return the same invalid-credentials error to avoid
     // account-state or identity enumeration. Corrupted or unsupported stored hashes
     // return a generic operational auth error without backend parser details after
-    // running the same dummy verification work used for absent credentials. Bootstrap,
+    // running the same dummy verification work used for absent credentials. Local
+    // identity/credential lookup currently supports the memory and SQLite auth
+    // stores; PostgreSQL and Redis fail closed until their local-auth record
+    // families are implemented. Bootstrap,
     // pending-setup, and password-change-required identities can verify credentials,
     // but the returned payload forces `must_change_password: true` so callers do not
     // accidentally treat setup-required accounts as fully active sessions.
@@ -3834,6 +4417,115 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt local_sign_in
+    // @module std/auth
+    // @signature local_sign_in(response: Response, req: Request, credentials: Map, session?: Map, options?: Map) -> Result<Response, String>
+    // Verify local credentials and complete or stage local sign-in.
+    //
+    // Active users are signed in through the same request-aware session completion
+    // path as `sign_in_session(...)`, including session rotation and request-derived
+    // metadata capture. Setup-required users (bootstrap, pending setup, or password
+    // change required) receive an auth challenge cookie instead of a full session.
+    // Invalid credentials return `Err("Invalid local credentials")` without setting
+    // cookies. Local identity/credential lookup currently supports the memory and
+    // SQLite auth stores; PostgreSQL and Redis fail closed until their local-auth
+    // record families are implemented.
+    // @param response Response to attach the session or challenge cookie to
+    // @param req Current HTTP request
+    // @param credentials Map with `email` or `identifier`, `password`, and optional `identifier_kind`
+    // @param session Optional app-owned session data such as `claims`, `data`, `name`, or `picture`
+    // @param options Optional map with `session_ttl`, `challenge_kind`, `challenge_ttl`, and cookie overrides (`cookie_path`, `cookie_domain`, `cookie_secure`, `cookie_http_only`, `cookie_same_site`, `cookie_max_age`)
+    // @returns Ok(Response) with a session/challenge cookie, or Err(message)
+    // @error TypeError ~ "request must be an HTTP request map" fix: "Pass the current route request as the second argument"
+    // @see_also create_local_user, bootstrap_local_user, verify_local_password, sign_in_session
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #session, #security
+    // @example local_sign_in(redirect("/admin"), req, map { "email": email, "password": password }, map { "claims": app_claims }) ~ "Verify and sign in local user"
+    module.insert(
+        "local_sign_in".to_string(),
+        Value::NativeFunction {
+            name: "local_sign_in".to_string(),
+            arity: 3,
+            max_arity: 5,
+            requires: None,
+            func: |args| {
+                if args.len() < 3 || args.len() > 5 {
+                    return Err(IntentError::type_error(
+                        "[auth] local_sign_in() requires response, request, credentials, optional session, and optional options"
+                            .to_string(),
+                    ));
+                }
+                let config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before local_sign_in()."
+                            .to_string(),
+                    )
+                })?;
+                validate_http_request_arg("local_sign_in", &args[1])?;
+                let credentials = match &args[2] {
+                    Value::Map(map) => map,
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] local_sign_in() credentials must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+                let (identifier_kind, identifier, password) = local_sign_in_credentials(credentials)?;
+                let (app_session, options) = local_sign_in_options(args)?;
+                let verified = match verify_local_password_record(&identifier_kind, &identifier, &password) {
+                    Ok(verified) => verified,
+                    Err(message) => return Ok(Value::err(Value::String(message))),
+                };
+                let verified_value = verified_local_password_to_value(verified);
+                let verified_map = match verified_value {
+                    Value::Map(map) => map,
+                    _ => {
+                        return Err(IntentError::runtime_error(
+                            "[auth] local_sign_in() verified credential payload was invalid"
+                                .to_string(),
+                        ))
+                    }
+                };
+
+                if should_stage_local_sign_in(&verified_map) {
+                    return stage_local_sign_in(
+                        &args[0],
+                        &verified_map,
+                        &app_session,
+                        options.as_ref(),
+                        &config,
+                    )
+                    .map(|response| Value::ok(response));
+                }
+
+                let session_ttl = match options.as_ref().and_then(|m| m.get("session_ttl")) {
+                    Some(Value::Int(i)) => *i,
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] local_sign_in() session_ttl must be an int, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => config.session_ttl,
+                };
+                let effective_session_ttl =
+                    session_ttl.min(config.max_session_ttl.unwrap_or(session_ttl));
+                let session_spec = build_local_session_spec(&verified_map, &app_session);
+                let session = create_manual_session(&session_spec, effective_session_ttl)
+                    .map_err(IntentError::type_error)?;
+                persist_request_aware_manual_session(
+                    &args[0],
+                    &args[1],
+                    session,
+                    options.as_ref(),
+                    &config,
+                )
+                .map(Value::ok)
+            },
+        },
+    );
+
     // @ntnt sign_in_session
     // @module std/auth
     // @signature sign_in_session(response: Response, req: Request, session: Map, options?: Map) -> Response
@@ -3854,7 +4546,7 @@ pub fn init() -> HashMap<String, Value> {
     // @param response The Response map to attach the session cookie to
     // @param req The current HTTP request
     // @param session Session data map, including required `subject_id`
-    // @param options Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+    // @param options Optional map with `session_ttl` and cookie override keys (`cookie_path`, `cookie_domain`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
     // @returns Response with a persisted session and Set-Cookie header
     // @error TypeError ~ "request must be an HTTP request map" fix: "Call sign_in_session(response, req, session, options?) from a route handler and pass the current req"
     // @see_also sign_out_session, current_session, rotate_session
@@ -3942,7 +4634,7 @@ pub fn init() -> HashMap<String, Value> {
     // session fixation while preserving the existing session payload.
     // @param response The Response map to attach the rotated cookie to
     // @param req The current HTTP request
-    // @param options Optional cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
+    // @param options Optional cookie override keys (`cookie_path`, `cookie_domain`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`, `cookie_max_age`)
     // @returns Response with the rotated session cookie
     // @see_also sign_in_session, sign_out_session, current_session
     // @since v0.4.9
@@ -4009,7 +4701,7 @@ pub fn init() -> HashMap<String, Value> {
     // built-in redirect handler.
     // @param response The Response map to attach the clearing cookie to
     // @param req The current HTTP request
-    // @param options Optional cookie override keys (`cookie_path`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
+    // @param options Optional cookie override keys (`cookie_path`, `cookie_domain`, `cookie_same_site`, `cookie_secure`, `cookie_http_only`)
     // @returns Response with the auth cookie cleared
     // @see_also sign_in_session, rotate_session, current_user
     // @since v0.4.9
@@ -4350,15 +5042,40 @@ mod tests {
         cleanup_expired_oauth_state_records, consume_auth_challenge_record,
         consume_exchange_token_record, consume_oauth_state_record,
         delete_all_session_records_for_user, delete_session_record, extend_session_record_expiry,
-        get_auth_challenge_record, get_refreshable_session_record, get_session_record,
-        list_session_records_for_user, migrate_session_record, store_auth_challenge_record,
-        store_exchange_token_record, store_oauth_state_record, store_session_record,
-        update_session_record_data, update_session_record_tokens, OAUTH_STATE_TTL,
+        get_auth_challenge_record, get_local_identity_by_id_record, get_refreshable_session_record,
+        get_session_record, list_session_records_for_user, migrate_session_record,
+        store_auth_challenge_record, store_exchange_token_record, store_oauth_state_record,
+        store_session_record, update_session_record_data, update_session_record_tokens,
+        OAUTH_STATE_TTL,
     };
     use super::*;
 
     static AUTH_TEST_MUTEX: std::sync::LazyLock<std::sync::Mutex<()>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.as_ref() {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
 
     fn reset_auth_test_state() {
         let mut store = SESSION_STORE.lock().unwrap();
@@ -4382,6 +5099,30 @@ mod tests {
         }
     }
 
+    fn result_ok_value(value: Value) -> Value {
+        let Value::EnumValue {
+            enum_name,
+            variant,
+            values,
+        } = value
+        else {
+            panic!("expected Result::Ok, got {value:?}");
+        };
+        assert_eq!(enum_name, "Result");
+        assert_eq!(variant, "Ok");
+        values
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("missing Result::Ok payload"))
+    }
+
+    fn result_ok_map(value: Value) -> HashMap<String, Value> {
+        match result_ok_value(value) {
+            Value::Map(map) => map,
+            other => panic!("expected Result::Ok(Map), got {other:?}"),
+        }
+    }
+
     fn result_err_string(value: Value) -> String {
         let Value::EnumValue {
             enum_name,
@@ -4399,6 +5140,20 @@ mod tests {
         }
     }
 
+    fn assert_map_string(map: &HashMap<String, Value>, key: &str, expected: &str) {
+        match map.get(key) {
+            Some(Value::String(actual)) => assert_eq!(actual, expected),
+            other => panic!("expected {key} string {expected:?}, got {other:?}"),
+        }
+    }
+
+    fn assert_map_bool(map: &HashMap<String, Value>, key: &str, expected: bool) {
+        match map.get(key) {
+            Some(Value::Bool(actual)) => assert_eq!(*actual, expected),
+            other => panic!("expected {key} bool {expected}, got {other:?}"),
+        }
+    }
+
     fn cookie_header_from_response(response: &Value) -> String {
         let cookies = cookie_headers_from_response(response);
         cookies
@@ -4407,7 +5162,22 @@ mod tests {
             .unwrap_or_else(|| panic!("missing Set-Cookie header"))
     }
 
+    fn set_cookie_header_from_response(response: &Value) -> String {
+        let cookies = set_cookie_headers_from_response(response);
+        cookies
+            .first()
+            .cloned()
+            .unwrap_or_else(|| panic!("missing Set-Cookie header"))
+    }
+
     fn cookie_headers_from_response(response: &Value) -> Vec<String> {
+        set_cookie_headers_from_response(response)
+            .into_iter()
+            .map(|s| s.split(';').next().unwrap().to_string())
+            .collect()
+    }
+
+    fn set_cookie_headers_from_response(response: &Value) -> Vec<String> {
         let headers = match response {
             Value::Map(map) => match map.get("headers") {
                 Some(Value::Map(headers)) => headers,
@@ -4423,11 +5193,11 @@ mod tests {
             .unwrap_or_else(|| panic!("missing Set-Cookie header"));
 
         match cookie {
-            Value::String(s) => vec![s.split(';').next().unwrap().to_string()],
+            Value::String(s) => vec![s.to_string()],
             Value::Array(values) => values
                 .iter()
                 .map(|value| match value {
-                    Value::String(s) => s.split(';').next().unwrap().to_string(),
+                    Value::String(s) => s.to_string(),
                     other => panic!("expected cookie string in array, got {:?}", other),
                 })
                 .collect(),
@@ -6944,6 +7714,872 @@ mod tests {
 
         let fetched = get_session_by_id(&session.id).expect("session should exist");
         assert_eq!(fetched.expires_at, session.expires_at);
+    }
+
+    #[test]
+    fn test_create_local_user_and_verify_password_round_trip() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+        let verify_local_password = module_fn(&module, "verify_local_password");
+
+        let created = result_ok_map(
+            create_local_user(&[
+                Value::String("Alice@Example.COM".to_string()),
+                Value::String("correct horse battery staple".to_string()),
+            ])
+            .unwrap(),
+        );
+        match created.get("state") {
+            Some(Value::String(state)) => assert_eq!(state, "active"),
+            other => panic!("expected active state, got {:?}", other),
+        }
+        match created.get("email") {
+            Some(Value::String(email)) => assert_eq!(email, "Alice@Example.COM"),
+            other => panic!("expected email, got {:?}", other),
+        }
+
+        let verified = result_ok_map(
+            verify_local_password(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("correct horse battery staple".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_map_string(&verified, "state", "active");
+        assert_map_bool(&verified, "must_change_password", false);
+        assert!(!verified.contains_key("password_hash"));
+    }
+
+    #[test]
+    fn test_create_local_user_rejects_caller_supplied_id_collision_without_overwrite() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+        let verify_local_password = module_fn(&module, "verify_local_password");
+
+        result_ok_map(
+            create_local_user(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("original password".to_string()),
+                Value::Map(HashMap::from([(
+                    "id".to_string(),
+                    Value::String("stable-local-user-id".to_string()),
+                )])),
+            ])
+            .unwrap(),
+        );
+
+        let collision_error = result_err_string(
+            create_local_user(&[
+                Value::String("bob@example.com".to_string()),
+                Value::String("replacement password".to_string()),
+                Value::Map(HashMap::from([(
+                    "id".to_string(),
+                    Value::String("stable-local-user-id".to_string()),
+                )])),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(collision_error, "[auth] local identity id already exists");
+
+        let stored = get_local_identity_by_id_record("stable-local-user-id")
+            .unwrap()
+            .expect("original identity should remain stored");
+        assert_eq!(stored.identifier_normalized, "alice@example.com");
+        assert_eq!(stored.identifier, "alice@example.com");
+
+        let verified_original = result_ok_map(
+            verify_local_password(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("original password".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_map_string(&verified_original, "email", "alice@example.com");
+
+        let bob_error = result_err_string(
+            verify_local_password(&[
+                Value::String("bob@example.com".to_string()),
+                Value::String("replacement password".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(bob_error, "Invalid local credentials");
+    }
+
+    #[test]
+    fn test_create_local_user_rolls_back_identity_when_credential_write_fails() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        {
+            let conn_guard = SQLITE_CONN.lock().unwrap();
+            let conn = conn_guard.as_ref().expect("SQLite should be initialized");
+            conn.execute("DROP TABLE auth_local_credentials", [])
+                .expect("test setup should remove credentials table");
+        }
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+
+        let error = result_err_string(
+            create_local_user(&[
+                Value::String("partial@example.com".to_string()),
+                Value::String("will not be stored".to_string()),
+                Value::Map(HashMap::from([(
+                    "id".to_string(),
+                    Value::String("partial-local-user-id".to_string()),
+                )])),
+            ])
+            .unwrap(),
+        );
+        assert!(
+            error.starts_with("[auth] failed to store local credential"),
+            "unexpected error: {error}"
+        );
+
+        assert!(
+            get_local_identity_by_id_record("partial-local-user-id")
+                .unwrap()
+                .is_none(),
+            "failed local user creation must not leave an identity without credentials"
+        );
+    }
+
+    #[test]
+    fn test_bootstrap_local_user_is_one_time_and_forces_password_change() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        let verify_local_password = module_fn(&module, "verify_local_password");
+
+        let first = result_ok_map(
+            bootstrap_local_user(&[Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("Admin@Example.COM".to_string()),
+                ),
+                (
+                    "password".to_string(),
+                    Value::String("temporary bootstrap password".to_string()),
+                ),
+            ]))])
+            .unwrap(),
+        );
+        assert_map_bool(&first, "created", true);
+        assert_map_string(&first, "state", "bootstrap");
+        assert_map_bool(&first, "must_change_password", true);
+
+        let second = result_ok_map(
+            bootstrap_local_user(&[Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("admin@example.com".to_string()),
+                ),
+                (
+                    "password".to_string(),
+                    Value::String("should not replace original".to_string()),
+                ),
+            ]))])
+            .unwrap(),
+        );
+        assert_map_bool(&second, "created", false);
+
+        let verified_original = result_ok_map(
+            verify_local_password(&[
+                Value::String("admin@example.com".to_string()),
+                Value::String("temporary bootstrap password".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_map_bool(&verified_original, "must_change_password", true);
+
+        let changed_error = result_err_string(
+            verify_local_password(&[
+                Value::String("admin@example.com".to_string()),
+                Value::String("should not replace original".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(changed_error, "Invalid local credentials");
+    }
+
+    #[test]
+    fn test_bootstrap_local_user_rejects_empty_password_from_env() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let _email_env = EnvVarGuard::set("NTNT_AUTH_BOOTSTRAP_EMAIL", "admin@example.com");
+        let _password_env = EnvVarGuard::set("NTNT_AUTH_BOOTSTRAP_PASSWORD", "");
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        let err = bootstrap_local_user(&[]).unwrap_err();
+        assert!(format!("{}", err).contains(
+            "[auth] bootstrap_local_user() NTNT_AUTH_BOOTSTRAP_PASSWORD env var must not be empty"
+        ));
+    }
+
+    #[test]
+    fn test_bootstrap_local_user_record_rejects_empty_password() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+
+        let error = match bootstrap_local_user_record("email", "admin@example.com", "") {
+            Ok(_) => panic!("expected empty bootstrap password to fail"),
+            Err(error) => error,
+        };
+        assert_eq!(error, "[auth] local password must not be empty");
+    }
+
+    #[test]
+    fn test_bootstrap_local_user_rejects_second_bootstrap_identifier() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        let verify_local_password = module_fn(&module, "verify_local_password");
+
+        result_ok_map(
+            bootstrap_local_user(&[Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("admin@example.com".to_string()),
+                ),
+                (
+                    "password".to_string(),
+                    Value::String("first bootstrap password".to_string()),
+                ),
+            ]))])
+            .unwrap(),
+        );
+
+        let second_error = result_err_string(
+            bootstrap_local_user(&[Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("second-admin@example.com".to_string()),
+                ),
+                (
+                    "password".to_string(),
+                    Value::String("second bootstrap password".to_string()),
+                ),
+            ]))])
+            .unwrap(),
+        );
+        assert_eq!(second_error, "[auth] bootstrap local user already exists");
+
+        let verified_original = result_ok_map(
+            verify_local_password(&[
+                Value::String("admin@example.com".to_string()),
+                Value::String("first bootstrap password".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_map_bool(&verified_original, "must_change_password", true);
+
+        let second_verify_error = result_err_string(
+            verify_local_password(&[
+                Value::String("second-admin@example.com".to_string()),
+                Value::String("second bootstrap password".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(second_verify_error, "Invalid local credentials");
+    }
+
+    #[test]
+    fn test_local_sign_in_creates_request_aware_session_for_active_user() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+        let local_sign_in = module_fn(&module, "local_sign_in");
+        let current_session = module_fn(&module, "current_session");
+
+        result_ok_map(
+            create_local_user(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("let me in".to_string()),
+            ])
+            .unwrap(),
+        );
+
+        let signed_in = result_ok_value(
+            local_sign_in(&[
+                redirect_response("/admin", None),
+                request_with_cookie_and_security_headers(""),
+                Value::Map(HashMap::from([
+                    (
+                        "email".to_string(),
+                        Value::String("alice@example.com".to_string()),
+                    ),
+                    (
+                        "password".to_string(),
+                        Value::String("let me in".to_string()),
+                    ),
+                ])),
+                Value::Map(HashMap::from([(
+                    "claims".to_string(),
+                    Value::Map(HashMap::from([(
+                        "role".to_string(),
+                        Value::String("admin".to_string()),
+                    )])),
+                )])),
+            ])
+            .unwrap(),
+        );
+
+        let cookie = cookie_header_from_response(&signed_in);
+        assert!(cookie.starts_with("ntnt_session="));
+        let session_id = get_session_id_from_request(&request_with_cookie(&cookie))
+            .expect("session cookie should verify");
+        let session = get_session_by_id(&session_id).expect("session should be persisted");
+        assert!(session.user_id.starts_with("local:"));
+        assert_eq!(session.email.as_deref(), Some("alice@example.com"));
+        assert_eq!(session.device_name.as_deref(), Some("Mac · Safari"));
+        assert!(session.user_agent_hash.is_some());
+        assert!(session.last_ip_hash.is_some());
+
+        match current_session(&[request_with_cookie(&cookie)]).unwrap() {
+            Value::EnumValue {
+                variant, values, ..
+            } => {
+                assert_eq!(variant, "Some");
+                let session_map = match values.first() {
+                    Some(Value::Map(map)) => map,
+                    other => panic!("expected session map, got {:?}", other),
+                };
+                match session_map.get("data") {
+                    Some(Value::Map(data)) => assert_map_string(data, "role", "admin"),
+                    other => panic!("expected session data, got {:?}", other),
+                }
+            }
+            other => panic!("expected Some(session), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_local_sign_in_accepts_case_insensitive_email_alias_identifier_kind() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+        let local_sign_in = module_fn(&module, "local_sign_in");
+
+        result_ok_map(
+            create_local_user(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("let me in".to_string()),
+            ])
+            .unwrap(),
+        );
+
+        let signed_in = result_ok_value(
+            local_sign_in(&[
+                redirect_response("/admin", None),
+                request_with_cookie_and_security_headers(""),
+                Value::Map(HashMap::from([
+                    (
+                        "identifier_kind".to_string(),
+                        Value::String(" Email ".to_string()),
+                    ),
+                    (
+                        "email".to_string(),
+                        Value::String("alice@example.com".to_string()),
+                    ),
+                    (
+                        "password".to_string(),
+                        Value::String("let me in".to_string()),
+                    ),
+                ])),
+            ])
+            .unwrap(),
+        );
+
+        assert!(cookie_header_from_response(&signed_in).starts_with("ntnt_session="));
+    }
+
+    #[test]
+    fn test_local_sign_in_treats_single_options_map_as_options() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+        let local_sign_in = module_fn(&module, "local_sign_in");
+
+        result_ok_map(
+            create_local_user(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("let me in".to_string()),
+            ])
+            .unwrap(),
+        );
+
+        let signed_in = result_ok_value(
+            local_sign_in(&[
+                redirect_response("/admin", None),
+                request_with_cookie_and_security_headers(""),
+                Value::Map(HashMap::from([
+                    (
+                        "email".to_string(),
+                        Value::String("alice@example.com".to_string()),
+                    ),
+                    (
+                        "password".to_string(),
+                        Value::String("let me in".to_string()),
+                    ),
+                ])),
+                Value::Map(HashMap::from([
+                    (
+                        "cookie_path".to_string(),
+                        Value::String("/admin".to_string()),
+                    ),
+                    (
+                        "cookie_domain".to_string(),
+                        Value::String("Example.COM".to_string()),
+                    ),
+                    ("cookie_secure".to_string(), Value::Bool(false)),
+                ])),
+            ])
+            .unwrap(),
+        );
+
+        let set_cookie = set_cookie_header_from_response(&signed_in);
+        assert!(set_cookie.starts_with("ntnt_session="));
+        assert!(
+            set_cookie.contains("Path=/admin"),
+            "single optional map should be interpreted as auth options: {set_cookie}"
+        );
+        assert!(set_cookie.contains("Domain=example.com"));
+        assert!(!set_cookie.contains("; Secure"));
+    }
+
+    #[test]
+    fn test_local_sign_in_rejects_mixed_single_session_options_map() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let local_sign_in = module_fn(&module, "local_sign_in");
+
+        let err = local_sign_in(&[
+            redirect_response("/admin", None),
+            request_with_cookie_and_security_headers(""),
+            Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("alice@example.com".to_string()),
+                ),
+                (
+                    "password".to_string(),
+                    Value::String("let me in".to_string()),
+                ),
+            ])),
+            Value::Map(HashMap::from([
+                (
+                    "claims".to_string(),
+                    Value::Map(HashMap::from([(
+                        "role".to_string(),
+                        Value::String("admin".to_string()),
+                    )])),
+                ),
+                (
+                    "cookie_path".to_string(),
+                    Value::String("/admin".to_string()),
+                ),
+            ])),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err)
+            .contains("[auth] local_sign_in() optional map mixes session data and auth options"));
+    }
+
+    #[test]
+    fn test_local_sign_in_rejects_invalid_cookie_domain() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+        let local_sign_in = module_fn(&module, "local_sign_in");
+
+        result_ok_map(
+            create_local_user(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("let me in".to_string()),
+            ])
+            .unwrap(),
+        );
+
+        let err = local_sign_in(&[
+            redirect_response("/admin", None),
+            request_with_cookie_and_security_headers(""),
+            Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("alice@example.com".to_string()),
+                ),
+                (
+                    "password".to_string(),
+                    Value::String("let me in".to_string()),
+                ),
+            ])),
+            Value::Map(HashMap::from([(
+                "cookie_domain".to_string(),
+                Value::String("example.com; HttpOnly=false".to_string()),
+            )])),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err).contains("[auth] cookie_domain contains invalid characters"));
+    }
+
+    #[test]
+    fn test_local_sign_in_rejects_empty_cookie_domain() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+        let local_sign_in = module_fn(&module, "local_sign_in");
+
+        result_ok_map(
+            create_local_user(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("let me in".to_string()),
+            ])
+            .unwrap(),
+        );
+
+        let err = local_sign_in(&[
+            redirect_response("/admin", None),
+            request_with_cookie_and_security_headers(""),
+            Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("alice@example.com".to_string()),
+                ),
+                (
+                    "password".to_string(),
+                    Value::String("let me in".to_string()),
+                ),
+            ])),
+            Value::Map(HashMap::from([(
+                "cookie_domain".to_string(),
+                Value::String("   ".to_string()),
+            )])),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err).contains("[auth] cookie_domain must not be empty"));
+    }
+
+    #[test]
+    fn test_local_sign_in_rejects_invalid_credentials_without_session_or_challenge_cookie() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let create_local_user = module_fn(&module, "create_local_user");
+        let local_sign_in = module_fn(&module, "local_sign_in");
+        let current_auth_challenge = module_fn(&module, "current_auth_challenge");
+        let current_session = module_fn(&module, "current_session");
+
+        result_ok_map(
+            create_local_user(&[
+                Value::String("alice@example.com".to_string()),
+                Value::String("correct password".to_string()),
+            ])
+            .unwrap(),
+        );
+
+        let error = result_err_string(
+            local_sign_in(&[
+                redirect_response("/admin", None),
+                request_with_cookie_and_security_headers(""),
+                Value::Map(HashMap::from([
+                    (
+                        "email".to_string(),
+                        Value::String("alice@example.com".to_string()),
+                    ),
+                    (
+                        "password".to_string(),
+                        Value::String("wrong password".to_string()),
+                    ),
+                ])),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(error, "Invalid local credentials");
+
+        let req = request_with_cookie("");
+        match current_session(&[req.clone()]).unwrap() {
+            Value::EnumValue { variant, .. } => assert_eq!(variant, "None"),
+            other => panic!("expected None session, got {:?}", other),
+        }
+        match current_auth_challenge(&[req]).unwrap() {
+            Value::EnumValue { variant, .. } => assert_eq!(variant, "None"),
+            other => panic!("expected None challenge, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_local_sign_in_rejects_empty_password_before_verification() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let local_sign_in = module_fn(&module, "local_sign_in");
+        let err = local_sign_in(&[
+            redirect_response("/admin", None),
+            request_with_cookie_and_security_headers(""),
+            Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("alice@example.com".to_string()),
+                ),
+                ("password".to_string(), Value::String("".to_string())),
+            ])),
+        ])
+        .unwrap_err();
+
+        assert!(format!("{}", err).contains("[auth] local_sign_in() password must not be empty"));
+    }
+
+    #[test]
+    fn test_local_sign_in_stages_bootstrap_user_instead_of_full_session() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        let local_sign_in = module_fn(&module, "local_sign_in");
+        let complete_auth_challenge = module_fn(&module, "complete_auth_challenge");
+        let current_auth_challenge = module_fn(&module, "current_auth_challenge");
+        let current_session = module_fn(&module, "current_session");
+
+        result_ok_map(
+            bootstrap_local_user(&[Value::Map(HashMap::from([
+                (
+                    "email".to_string(),
+                    Value::String("admin@example.com".to_string()),
+                ),
+                (
+                    "password".to_string(),
+                    Value::String("temp password".to_string()),
+                ),
+            ]))])
+            .unwrap(),
+        );
+
+        let cookie_overrides = HashMap::from([
+            (
+                "cookie_path".to_string(),
+                Value::String("/admin/setup".to_string()),
+            ),
+            (
+                "cookie_domain".to_string(),
+                Value::String("Example.COM".to_string()),
+            ),
+            ("cookie_secure".to_string(), Value::Bool(false)),
+        ]);
+
+        let staged = result_ok_value(
+            local_sign_in(&[
+                redirect_response("/admin/setup", None),
+                request_with_cookie_and_security_headers(""),
+                Value::Map(HashMap::from([
+                    (
+                        "email".to_string(),
+                        Value::String("admin@example.com".to_string()),
+                    ),
+                    (
+                        "password".to_string(),
+                        Value::String("temp password".to_string()),
+                    ),
+                ])),
+                Value::Map(HashMap::from([
+                    (
+                        "claims".to_string(),
+                        Value::Map(HashMap::from([(
+                            "role".to_string(),
+                            Value::String("bootstrap-admin".to_string()),
+                        )])),
+                    ),
+                    (
+                        "data".to_string(),
+                        Value::Map(HashMap::from([(
+                            "tenant".to_string(),
+                            Value::String("acme".to_string()),
+                        )])),
+                    ),
+                ])),
+                Value::Map(cookie_overrides.clone()),
+            ])
+            .unwrap(),
+        );
+
+        let set_cookie = set_cookie_header_from_response(&staged);
+        assert!(set_cookie.starts_with("ntnt_session_challenge="));
+        assert!(
+            set_cookie.contains("Path=/admin/setup"),
+            "challenge cookie should honor local_sign_in cookie_path override: {set_cookie}"
+        );
+        assert!(set_cookie.contains("Domain=example.com"));
+        assert!(!set_cookie.contains("; Secure"));
+        let cookie = cookie_header_from_response(&staged);
+        let req = request_with_cookie(&cookie);
+
+        match current_auth_challenge(&[req.clone()]).unwrap() {
+            Value::EnumValue {
+                variant, values, ..
+            } => {
+                assert_eq!(variant, "Some");
+                let challenge_map = match values.first() {
+                    Some(Value::Map(map)) => map,
+                    other => panic!("expected challenge map, got {:?}", other),
+                };
+                assert_map_string(challenge_map, "kind", "password_change_required");
+            }
+            other => panic!("expected Some(challenge), got {:?}", other),
+        }
+
+        match current_session(&[req.clone()]).unwrap() {
+            Value::EnumValue { variant, .. } => assert_eq!(variant, "None"),
+            other => panic!("expected None session, got {:?}", other),
+        }
+
+        let completed = complete_auth_challenge(&[
+            redirect_response("/admin", None),
+            req,
+            Value::Map(HashMap::from([(
+                "claims".to_string(),
+                Value::Map(HashMap::from([(
+                    "role".to_string(),
+                    Value::String("completed-admin".to_string()),
+                )])),
+            )])),
+            Value::Map(cookie_overrides),
+        ])
+        .unwrap();
+        let completed_cookies = set_cookie_headers_from_response(&completed);
+        let session_cookie = completed_cookies
+            .iter()
+            .find(|cookie| cookie.starts_with("ntnt_session="))
+            .unwrap_or_else(|| {
+                panic!(
+                    "complete_auth_challenge should attach a full session cookie: {completed_cookies:?}"
+                )
+            });
+        assert!(
+            session_cookie.contains("Path=/"),
+            "full session cookie should use the configured session cookie path, not the staged challenge path: {session_cookie}"
+        );
+        assert!(
+            !session_cookie.contains("Path=/admin/setup"),
+            "full session cookie must not inherit the staged challenge cookie path: {session_cookie}"
+        );
+        let session_cookie_header = session_cookie
+            .split(';')
+            .next()
+            .unwrap_or_else(|| panic!("missing session cookie pair: {session_cookie}"));
+        match current_session(&[request_with_cookie(session_cookie_header)]).unwrap() {
+            Value::EnumValue {
+                variant, values, ..
+            } => {
+                assert_eq!(variant, "Some");
+                let session_map = match values.first() {
+                    Some(Value::Map(map)) => map,
+                    other => panic!("expected session map, got {:?}", other),
+                };
+                match session_map.get("data") {
+                    Some(Value::Map(data)) => {
+                        assert_map_string(data, "role", "completed-admin");
+                        assert_map_string(data, "tenant", "acme");
+                    }
+                    other => panic!(
+                        "complete_auth_challenge should preserve staged session data, got {:?}",
+                        other
+                    ),
+                }
+            }
+            other => panic!("expected completed staged session, got {:?}", other),
+        }
+        let cleared_challenge_cookie = completed_cookies
+            .iter()
+            .find(|cookie| cookie.starts_with("ntnt_session_challenge=;"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "complete_auth_challenge should clear the staged challenge cookie: {completed_cookies:?}"
+                )
+            });
+        assert!(
+            cleared_challenge_cookie.contains("Path=/admin/setup"),
+            "cleared challenge cookie should preserve the challenge cookie path override: {cleared_challenge_cookie}"
+        );
+        assert!(cleared_challenge_cookie.contains("Domain=example.com"));
+        assert!(cleared_challenge_cookie.contains("Max-Age=0"));
+    }
+
+    #[test]
+    fn test_cancel_auth_challenge_clears_cookie_with_overrides() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let cancel_auth_challenge = module_fn(&module, "cancel_auth_challenge");
+        let cancelled = cancel_auth_challenge(&[
+            redirect_response("/login", None),
+            request_with_cookie(""),
+            Value::Map(HashMap::from([
+                (
+                    "cookie_path".to_string(),
+                    Value::String("/admin/setup".to_string()),
+                ),
+                ("cookie_secure".to_string(), Value::Bool(false)),
+                ("cookie_max_age".to_string(), Value::Int(999)),
+            ])),
+        ])
+        .unwrap();
+
+        let set_cookie = set_cookie_header_from_response(&cancelled);
+        assert!(set_cookie.starts_with("ntnt_session_challenge=;"));
+        assert!(
+            set_cookie.contains("Path=/admin/setup"),
+            "cancel_auth_challenge should clear the same challenge cookie path: {set_cookie}"
+        );
+        assert!(set_cookie.contains("Max-Age=0"));
+        assert!(!set_cookie.contains("Max-Age=999"));
+        assert!(!set_cookie.contains("; Secure"));
     }
 
     #[test]

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -341,6 +341,17 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     )
     .map_err(|e| format!("Failed to create auth_local_credentials table: {}", e))?;
 
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS auth_local_bootstrap_state (
+            key TEXT PRIMARY KEY,
+            local_user_id TEXT NOT NULL UNIQUE,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY(local_user_id) REFERENCES auth_local_identities(id) ON DELETE CASCADE
+        )",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_local_bootstrap_state table: {}", e))?;
+
     let mut sqlite_conn = SQLITE_CONN.lock().unwrap();
     *sqlite_conn = Some(conn);
     Ok(())

--- a/src/stdlib/auth/cookies.rs
+++ b/src/stdlib/auth/cookies.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 pub(super) struct AuthCookieSettings {
     pub(super) name: String,
     pub(super) path: String,
+    pub(super) domain: Option<String>,
     pub(super) same_site: String,
     pub(super) secure: bool,
     pub(super) http_only: bool,
@@ -91,6 +92,36 @@ fn validate_cookie_path(path: &str) -> std::result::Result<String, String> {
     Ok(path.to_string())
 }
 
+fn validate_cookie_domain(domain: &str) -> std::result::Result<String, String> {
+    let domain = domain.trim();
+    if domain.is_empty() {
+        return Err("[auth] cookie_domain must not be empty".to_string());
+    }
+    if domain.chars().any(|ch| {
+        ch.is_control() || ch.is_whitespace() || matches!(ch, ';' | ',' | '/' | ':' | '=')
+    }) {
+        return Err("[auth] cookie_domain contains invalid characters".to_string());
+    }
+
+    let host = domain.trim_start_matches('.');
+    if host.is_empty() || !host.chars().any(|ch| ch.is_ascii_alphanumeric()) {
+        return Err("[auth] cookie_domain must contain a host name".to_string());
+    }
+    for label in host.split('.') {
+        if label.is_empty()
+            || label.starts_with('-')
+            || label.ends_with('-')
+            || !label
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+        {
+            return Err("[auth] cookie_domain must be a valid host name".to_string());
+        }
+    }
+
+    Ok(domain.to_ascii_lowercase())
+}
+
 pub(super) fn normalize_cookie_same_site(value: &str) -> std::result::Result<String, String> {
     match value.to_ascii_lowercase().as_str() {
         "lax" => Ok("Lax".to_string()),
@@ -150,6 +181,10 @@ fn auth_cookie_settings(
     Ok(AuthCookieSettings {
         name: validate_cookie_name(&config.cookie_name)?,
         path: validate_cookie_path(&get_string("cookie_path")?.unwrap_or_else(|| "/".to_string()))?,
+        domain: get_string("cookie_domain")?
+            .as_deref()
+            .map(validate_cookie_domain)
+            .transpose()?,
         same_site: normalize_cookie_same_site(
             &get_string("cookie_same_site")?.unwrap_or_else(|| config.cookie_same_site.clone()),
         )?,
@@ -170,6 +205,10 @@ fn build_auth_cookie_string(value: &str, settings: &AuthCookieSettings) -> Strin
     }
     if settings.secure {
         cookie.push_str("; Secure");
+    }
+    if let Some(domain) = &settings.domain {
+        cookie.push_str("; Domain=");
+        cookie.push_str(domain);
     }
 
     cookie
@@ -216,8 +255,9 @@ pub(super) fn build_signed_auth_challenge_cookie(
     config: &AuthConfig,
     challenge_id: &str,
     ttl: i64,
+    overrides: Option<&HashMap<String, Value>>,
 ) -> std::result::Result<String, String> {
-    let mut settings = auth_cookie_settings(config, ttl.max(0), None)?;
+    let mut settings = auth_cookie_settings(config, ttl.max(0), overrides)?;
     settings.name = auth_challenge_cookie_name(config)?;
     let signed_challenge_id = sign_session_id(challenge_id, &config.session_secret);
     Ok(build_auth_cookie_string(&signed_challenge_id, &settings))
@@ -225,8 +265,14 @@ pub(super) fn build_signed_auth_challenge_cookie(
 
 pub(super) fn build_cleared_auth_challenge_cookie(
     config: &AuthConfig,
+    overrides: Option<&HashMap<String, Value>>,
 ) -> std::result::Result<String, String> {
-    let mut settings = auth_cookie_settings(config, 0, None)?;
+    let sanitized_overrides = overrides.map(|map| {
+        let mut sanitized = map.clone();
+        sanitized.remove("cookie_max_age");
+        sanitized
+    });
+    let mut settings = auth_cookie_settings(config, 0, sanitized_overrides.as_ref())?;
     settings.name = auth_challenge_cookie_name(config)?;
     Ok(build_auth_cookie_string("", &settings))
 }

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -1,11 +1,13 @@
 use crate::interpreter::Value;
-use argon2::password_hash::Error as PasswordHashError;
+use argon2::password_hash::{Error as PasswordHashError, PasswordHasher, SaltString};
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use std::collections::HashMap;
 
 use super::storage::{
-    get_local_credential_secret_record, get_local_identity_by_identifier_record,
-    normalize_local_identifier, LocalAccountState, LocalCredentialSecret, LocalIdentity,
+    get_bootstrap_local_user_id_record, get_local_credential_secret_record,
+    get_local_identity_by_id_record, get_local_identity_by_identifier_record,
+    normalize_local_identifier, provision_local_user_record, store_bootstrap_local_user_id_record,
+    LocalAccountState, LocalCredentialSecret, LocalIdentity,
 };
 
 const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
@@ -19,6 +21,12 @@ const DUMMY_LOCAL_ARGON2_PASSWORD_HASH: &str =
 pub(in crate::stdlib::auth) struct VerifiedLocalPassword {
     identity: LocalIdentity,
     credential: LocalCredentialSecret,
+}
+
+pub(in crate::stdlib::auth) struct LocalUserCreation {
+    identity: LocalIdentity,
+    must_change_password: bool,
+    created: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,6 +50,146 @@ impl CredentialPasswordAlgorithm {
             Self::Argon2 => "argon2id",
         }
     }
+}
+
+pub(in crate::stdlib::auth) fn create_local_user_record(
+    identifier_kind: &str,
+    identifier: &str,
+    password: &str,
+    state: LocalAccountState,
+    must_change_password: bool,
+    metadata_json: String,
+    id: Option<String>,
+) -> std::result::Result<LocalUserCreation, String> {
+    if password.is_empty() {
+        return Err("[auth] local password must not be empty".to_string());
+    }
+
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier_normalized = normalize_local_identifier(&kind, identifier)?;
+
+    let local_user_id = match id {
+        Some(id) => {
+            let id = id.trim().to_string();
+            if id.is_empty() {
+                return Err("[auth] local identity id must not be empty".to_string());
+            }
+            id
+        }
+        None => uuid::Uuid::new_v4().to_string(),
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    let identity = LocalIdentity {
+        id: local_user_id,
+        identifier_kind: kind,
+        identifier: identifier.to_string(),
+        identifier_normalized,
+        created_at: now,
+        updated_at: now,
+        state,
+        metadata_json,
+    };
+    let credential =
+        hash_local_password_for_identity(&identity.id, password, must_change_password, now)?;
+
+    provision_local_user_record(&identity, &credential, false)?;
+
+    Ok(LocalUserCreation {
+        identity,
+        must_change_password,
+        created: true,
+    })
+}
+
+pub(in crate::stdlib::auth) fn bootstrap_local_user_record(
+    identifier_kind: &str,
+    identifier: &str,
+    password: &str,
+) -> std::result::Result<LocalUserCreation, String> {
+    if password.is_empty() {
+        return Err("[auth] local password must not be empty".to_string());
+    }
+
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier_normalized = normalize_local_identifier(&kind, identifier)?;
+
+    if let Some(bootstrap_id) = get_bootstrap_local_user_id_record()? {
+        if let Some(identity) = get_local_identity_by_id_record(&bootstrap_id)? {
+            if identity.identifier_kind == kind
+                && identity.identifier_normalized == identifier_normalized
+            {
+                return Ok(LocalUserCreation {
+                    must_change_password: matches!(
+                        identity.state,
+                        LocalAccountState::Bootstrap
+                            | LocalAccountState::PendingSetup
+                            | LocalAccountState::PasswordChangeRequired
+                    ),
+                    identity,
+                    created: false,
+                });
+            }
+        }
+        return Err("[auth] bootstrap local user already exists".to_string());
+    }
+
+    if let Some(identity) = get_local_identity_by_identifier_record(&kind, &identifier_normalized)?
+    {
+        store_bootstrap_local_user_id_record(&identity.id)?;
+        return Ok(LocalUserCreation {
+            must_change_password: matches!(
+                identity.state,
+                LocalAccountState::Bootstrap
+                    | LocalAccountState::PendingSetup
+                    | LocalAccountState::PasswordChangeRequired
+            ),
+            identity,
+            created: false,
+        });
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let identity = LocalIdentity {
+        id: uuid::Uuid::new_v4().to_string(),
+        identifier_kind: kind,
+        identifier: identifier.to_string(),
+        identifier_normalized,
+        created_at: now,
+        updated_at: now,
+        state: LocalAccountState::Bootstrap,
+        metadata_json: "{}".to_string(),
+    };
+    let credential = hash_local_password_for_identity(&identity.id, password, true, now)?;
+    provision_local_user_record(&identity, &credential, true)?;
+
+    Ok(LocalUserCreation {
+        identity,
+        must_change_password: true,
+        created: true,
+    })
+}
+
+fn hash_local_password_for_identity(
+    local_user_id: &str,
+    password: &str,
+    must_change_password: bool,
+    now: i64,
+) -> std::result::Result<LocalCredentialSecret, String> {
+    let salt = SaltString::generate(&mut argon2::password_hash::rand_core::OsRng);
+    let password_hash = Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map_err(|_| "[auth] failed to hash local password".to_string())?
+        .to_string();
+
+    Ok(LocalCredentialSecret {
+        local_user_id: local_user_id.to_string(),
+        password_hash,
+        password_hash_algorithm: "argon2id".to_string(),
+        password_hash_params_json: "{}".to_string(),
+        password_changed_at: now,
+        must_change_password,
+    })
 }
 
 pub(in crate::stdlib::auth) fn verify_local_password_record(
@@ -86,7 +234,9 @@ pub(in crate::stdlib::auth) fn verify_local_password_record(
             password_matches
         }
         Err(err) => {
-            let _ = verify_all_dummy_local_passwords(password);
+            if let Err(dummy_err) = verify_all_dummy_local_passwords(password) {
+                return Err(dummy_err);
+            }
             return Err(err);
         }
     };
@@ -140,7 +290,7 @@ fn verify_dummy_local_password(
         password_changed_at: 0,
         must_change_password: false,
     };
-    let _ = verify_credential_password(&credential, password)?;
+    let (_password_matches, _algorithm) = verify_credential_password(&credential, password)?;
     Ok(())
 }
 
@@ -170,6 +320,50 @@ fn verify_argon2_password(
         Err(PasswordHashError::Password) => Ok(false),
         Err(_) => Err(INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH.to_string()),
     }
+}
+
+pub(in crate::stdlib::auth) fn local_user_creation_to_value(creation: LocalUserCreation) -> Value {
+    let mut map = HashMap::from([
+        (
+            "subject_id".to_string(),
+            Value::String(creation.identity.id.clone()),
+        ),
+        (
+            "id".to_string(),
+            Value::String(creation.identity.id.clone()),
+        ),
+        ("provider".to_string(), Value::String("local".to_string())),
+        (
+            "identifier_kind".to_string(),
+            Value::String(creation.identity.identifier_kind.clone()),
+        ),
+        (
+            "identifier".to_string(),
+            Value::String(creation.identity.identifier.clone()),
+        ),
+        (
+            "identifier_normalized".to_string(),
+            Value::String(creation.identity.identifier_normalized.clone()),
+        ),
+        (
+            "state".to_string(),
+            Value::String(creation.identity.state.as_str().to_string()),
+        ),
+        (
+            "must_change_password".to_string(),
+            Value::Bool(creation.must_change_password),
+        ),
+        ("created".to_string(), Value::Bool(creation.created)),
+    ]);
+
+    if creation.identity.identifier_kind == "email" {
+        map.insert(
+            "email".to_string(),
+            Value::String(creation.identity.identifier.clone()),
+        );
+    }
+
+    Value::Map(map)
 }
 
 pub(in crate::stdlib::auth) fn verified_local_password_to_value(

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -1,5 +1,7 @@
-// Local-auth storage intentionally includes write-side helpers before the
-// public create/reset/bootstrap flows land in later DD-062 slices.
+// Local-auth storage owns the explicit record families for DD-062 local
+// credentials. The current public surface covers identity provisioning,
+// bootstrap, password verification, and request-aware sign-in; reset/TOTP
+// enrollment records remain reserved for later slices.
 #![cfg_attr(not(test), allow(dead_code))]
 
 use super::*;
@@ -95,7 +97,7 @@ pub(in crate::stdlib::auth) struct LocalIdentity {
     pub(in crate::stdlib::auth) metadata_json: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(in crate::stdlib::auth) struct LocalCredentialSecret {
     pub(in crate::stdlib::auth) local_user_id: String,
     pub(in crate::stdlib::auth) password_hash: String,
@@ -103,6 +105,19 @@ pub(in crate::stdlib::auth) struct LocalCredentialSecret {
     pub(in crate::stdlib::auth) password_hash_params_json: String,
     pub(in crate::stdlib::auth) password_changed_at: i64,
     pub(in crate::stdlib::auth) must_change_password: bool,
+}
+
+impl std::fmt::Debug for LocalCredentialSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalCredentialSecret")
+            .field("local_user_id", &self.local_user_id)
+            .field("password_hash", &"[REDACTED]")
+            .field("password_hash_algorithm", &self.password_hash_algorithm)
+            .field("password_hash_params_json", &"[REDACTED]")
+            .field("password_changed_at", &self.password_changed_at)
+            .field("must_change_password", &self.must_change_password)
+            .finish()
+    }
 }
 
 pub(in crate::stdlib::auth) fn normalize_local_identifier(
@@ -138,6 +153,7 @@ pub(in crate::stdlib::auth) struct LocalAuthMemoryStore {
     identities_by_id: HashMap<String, LocalIdentity>,
     identity_id_by_lookup_key: HashMap<String, String>,
     credential_secrets_by_local_user_id: HashMap<String, LocalCredentialSecret>,
+    bootstrap_local_user_id: Option<String>,
 }
 
 impl LocalAuthMemoryStore {
@@ -200,17 +216,7 @@ impl LocalAuthMemoryStore {
         &mut self,
         credential: LocalCredentialSecret,
     ) -> std::result::Result<(), String> {
-        if credential.local_user_id.trim().is_empty() {
-            return Err("[auth] local credential local_user_id must not be empty".to_string());
-        }
-        if credential.password_hash.trim().is_empty() {
-            return Err("[auth] local credential password_hash must not be empty".to_string());
-        }
-        if credential.password_hash_algorithm.trim().is_empty() {
-            return Err(
-                "[auth] local credential password_hash_algorithm must not be empty".to_string(),
-            );
-        }
+        validate_local_credential_secret(&credential, None)?;
         if !self
             .identities_by_id
             .contains_key(&credential.local_user_id)
@@ -232,6 +238,66 @@ impl LocalAuthMemoryStore {
             .credential_secrets_by_local_user_id
             .get(local_user_id)
             .cloned())
+    }
+
+    pub(in crate::stdlib::auth) fn get_bootstrap_local_user_id(
+        &self,
+    ) -> std::result::Result<Option<String>, String> {
+        Ok(self.bootstrap_local_user_id.clone())
+    }
+
+    pub(in crate::stdlib::auth) fn store_bootstrap_local_user_id(
+        &mut self,
+        local_user_id: &str,
+    ) -> std::result::Result<(), String> {
+        if local_user_id.trim().is_empty() {
+            return Err("[auth] bootstrap local user id must not be empty".to_string());
+        }
+        if let Some(existing_id) = &self.bootstrap_local_user_id {
+            if existing_id != local_user_id {
+                return Err("[auth] bootstrap local user already exists".to_string());
+            }
+        }
+        self.bootstrap_local_user_id = Some(local_user_id.to_string());
+        Ok(())
+    }
+
+    pub(in crate::stdlib::auth) fn provision_user(
+        &mut self,
+        identity: LocalIdentity,
+        credential: LocalCredentialSecret,
+        mark_bootstrap: bool,
+    ) -> std::result::Result<(), String> {
+        let identity = normalize_local_identity_for_storage(identity)?;
+        validate_local_credential_secret(&credential, Some(&identity.id))?;
+        if self.identities_by_id.contains_key(&identity.id) {
+            return Err("[auth] local identity id already exists".to_string());
+        }
+        let lookup_key =
+            local_identity_lookup_key(&identity.identifier_kind, &identity.identifier_normalized)?;
+        if self.identity_id_by_lookup_key.contains_key(&lookup_key) {
+            return Err(format!(
+                "[auth] local identity already exists for {}",
+                identity.identifier_kind
+            ));
+        }
+        if mark_bootstrap {
+            if let Some(existing_id) = &self.bootstrap_local_user_id {
+                if existing_id != &identity.id {
+                    return Err("[auth] bootstrap local user already exists".to_string());
+                }
+            }
+        }
+
+        self.identity_id_by_lookup_key
+            .insert(lookup_key, identity.id.clone());
+        self.credential_secrets_by_local_user_id
+            .insert(credential.local_user_id.clone(), credential);
+        if mark_bootstrap {
+            self.bootstrap_local_user_id = Some(identity.id.clone());
+        }
+        self.identities_by_id.insert(identity.id.clone(), identity);
+        Ok(())
     }
 }
 
@@ -257,6 +323,55 @@ fn normalize_local_identity_for_storage(
     Ok(identity)
 }
 
+fn validate_local_credential_secret(
+    credential: &LocalCredentialSecret,
+    expected_local_user_id: Option<&str>,
+) -> std::result::Result<(), String> {
+    if credential.local_user_id.trim().is_empty() {
+        return Err("[auth] local credential local_user_id must not be empty".to_string());
+    }
+    if let Some(expected) = expected_local_user_id {
+        if credential.local_user_id != expected {
+            return Err(
+                "[auth] local credential must reference the provisioned local identity".to_string(),
+            );
+        }
+    }
+    if credential.password_hash.trim().is_empty() {
+        return Err("[auth] local credential password_hash must not be empty".to_string());
+    }
+    if credential.password_hash_algorithm.trim().is_empty() {
+        return Err(
+            "[auth] local credential password_hash_algorithm must not be empty".to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub(in crate::stdlib::auth) fn provision_local_user_record(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+    mark_bootstrap: bool,
+) -> std::result::Result<(), String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE.lock().unwrap().local_auth.provision_user(
+            identity.clone(),
+            credential.clone(),
+            mark_bootstrap,
+        ),
+        AuthStorageBackend::Sqlite => {
+            provision_local_user_sqlite(identity, credential, mark_bootstrap)
+        }
+        AuthStorageBackend::Postgres => {
+            Err("[auth] local user provisioning is not implemented for PostgreSQL yet".to_string())
+        }
+        AuthStorageBackend::Redis => Err(
+            "[auth] local user provisioning is not implemented for Redis/Valkey yet".to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
 pub(in crate::stdlib::auth) fn store_local_identity_record(
     identity: &LocalIdentity,
 ) -> std::result::Result<(), String> {
@@ -317,25 +432,6 @@ pub(in crate::stdlib::auth) fn get_local_identity_by_identifier_record(
     }
 }
 
-pub(in crate::stdlib::auth) fn store_local_credential_secret_record(
-    credential: &LocalCredentialSecret,
-) -> std::result::Result<(), String> {
-    match active_auth_storage_backend() {
-        AuthStorageBackend::Memory => SESSION_STORE
-            .lock()
-            .unwrap()
-            .local_auth
-            .store_credential_secret(credential.clone()),
-        AuthStorageBackend::Sqlite => store_local_credential_secret_sqlite(credential),
-        AuthStorageBackend::Postgres => {
-            Err("[auth] local credential storage is not implemented for PostgreSQL yet".to_string())
-        }
-        AuthStorageBackend::Redis => Err(
-            "[auth] local credential storage is not implemented for Redis/Valkey yet".to_string(),
-        ),
-    }
-}
-
 pub(in crate::stdlib::auth) fn get_local_credential_secret_record(
     local_user_id: &str,
 ) -> std::result::Result<Option<LocalCredentialSecret>, String> {
@@ -355,6 +451,190 @@ pub(in crate::stdlib::auth) fn get_local_credential_secret_record(
     }
 }
 
+#[cfg(test)]
+pub(in crate::stdlib::auth) fn store_local_credential_secret_record(
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .store_credential_secret(credential.clone()),
+        AuthStorageBackend::Sqlite => store_local_credential_secret_sqlite(credential),
+        AuthStorageBackend::Postgres => {
+            Err("[auth] local credential storage is not implemented for PostgreSQL yet".to_string())
+        }
+        AuthStorageBackend::Redis => Err(
+            "[auth] local credential storage is not implemented for Redis/Valkey yet".to_string(),
+        ),
+    }
+}
+
+pub(in crate::stdlib::auth) fn get_bootstrap_local_user_id_record(
+) -> std::result::Result<Option<String>, String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .get_bootstrap_local_user_id(),
+        AuthStorageBackend::Sqlite => get_bootstrap_local_user_id_sqlite(),
+        AuthStorageBackend::Postgres => Err(
+            "[auth] bootstrap local user lookup is not implemented for PostgreSQL yet".to_string(),
+        ),
+        AuthStorageBackend::Redis => Err(
+            "[auth] bootstrap local user lookup is not implemented for Redis/Valkey yet"
+                .to_string(),
+        ),
+    }
+}
+
+pub(in crate::stdlib::auth) fn store_bootstrap_local_user_id_record(
+    local_user_id: &str,
+) -> std::result::Result<(), String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .store_bootstrap_local_user_id(local_user_id),
+        AuthStorageBackend::Sqlite => store_bootstrap_local_user_id_sqlite(local_user_id),
+        AuthStorageBackend::Postgres => Err(
+            "[auth] bootstrap local user storage is not implemented for PostgreSQL yet".to_string(),
+        ),
+        AuthStorageBackend::Redis => Err(
+            "[auth] bootstrap local user storage is not implemented for Redis/Valkey yet"
+                .to_string(),
+        ),
+    }
+}
+
+fn insert_local_identity_sqlite(
+    conn: &rusqlite::Connection,
+    identity: &LocalIdentity,
+) -> std::result::Result<(), String> {
+    conn.execute(
+        "INSERT INTO auth_local_identities
+         (id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        rusqlite::params![
+            identity.id,
+            identity.identifier_kind,
+            identity.identifier,
+            identity.identifier_normalized,
+            identity.created_at,
+            identity.updated_at,
+            identity.state.as_str(),
+            identity.metadata_json,
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store local identity: {}", e))?;
+    Ok(())
+}
+
+fn insert_local_credential_secret_sqlite(
+    conn: &rusqlite::Connection,
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    conn.execute(
+        "INSERT INTO auth_local_credentials
+         (local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![
+            credential.local_user_id,
+            credential.password_hash,
+            credential.password_hash_algorithm,
+            credential.password_hash_params_json,
+            credential.password_changed_at,
+            if credential.must_change_password { 1 } else { 0 },
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
+    Ok(())
+}
+
+fn bootstrap_local_user_id_sqlite_conn(
+    conn: &rusqlite::Connection,
+) -> std::result::Result<Option<String>, String> {
+    conn.query_row(
+        "SELECT local_user_id FROM auth_local_bootstrap_state WHERE key = 'bootstrap'",
+        [],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(|e| format!("[auth] failed to lookup bootstrap local user: {}", e))
+}
+
+fn provision_local_user_sqlite(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+    mark_bootstrap: bool,
+) -> std::result::Result<(), String> {
+    let identity = normalize_local_identity_for_storage(identity.clone())?;
+    validate_local_credential_secret(credential, Some(&identity.id))?;
+    let mut conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
+    let tx = conn
+        .transaction()
+        .map_err(|e| format!("[auth] failed to provision local user: {}", e))?;
+
+    if get_local_identity_by_id_sqlite_conn(&tx, &identity.id)?.is_some() {
+        return Err("[auth] local identity id already exists".to_string());
+    }
+    if get_local_identity_by_identifier_sqlite_conn(
+        &tx,
+        &identity.identifier_kind,
+        &identity.identifier_normalized,
+    )?
+    .is_some()
+    {
+        return Err(format!(
+            "[auth] local identity already exists for {}",
+            identity.identifier_kind
+        ));
+    }
+    if mark_bootstrap && bootstrap_local_user_id_sqlite_conn(&tx)?.is_some() {
+        return Err("[auth] bootstrap local user already exists".to_string());
+    }
+
+    insert_local_identity_sqlite(&tx, &identity)?;
+    insert_local_credential_secret_sqlite(&tx, credential)?;
+    if mark_bootstrap {
+        tx.execute(
+            "INSERT INTO auth_local_bootstrap_state (key, local_user_id, created_at)
+             VALUES ('bootstrap', ?1, ?2)",
+            rusqlite::params![identity.id, chrono::Utc::now().timestamp()],
+        )
+        .map_err(|e| format!("[auth] failed to store bootstrap local user: {}", e))?;
+    }
+    tx.commit()
+        .map_err(|e| format!("[auth] failed to provision local user: {}", e))?;
+    Ok(())
+}
+
+fn local_identity_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<LocalIdentity> {
+    let state: String = row.get(6)?;
+    let state = LocalAccountState::from_str(&state).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            6,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+    Ok(LocalIdentity {
+        id: row.get(0)?,
+        identifier_kind: row.get(1)?,
+        identifier: row.get(2)?,
+        identifier_normalized: row.get(3)?,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+        state,
+        metadata_json: row.get(7)?,
+    })
+}
+
+#[cfg(test)]
 fn store_local_identity_sqlite(identity: &LocalIdentity) -> std::result::Result<(), String> {
     let identity = normalize_local_identity_for_storage(identity.clone())?;
     let conn_guard = SQLITE_CONN.lock().unwrap();
@@ -385,30 +665,10 @@ fn store_local_identity_sqlite(identity: &LocalIdentity) -> std::result::Result<
     Ok(())
 }
 
-fn local_identity_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<LocalIdentity> {
-    let state: String = row.get(6)?;
-    let state = LocalAccountState::from_str(&state).map_err(|e| {
-        rusqlite::Error::FromSqlConversionFailure(
-            6,
-            rusqlite::types::Type::Text,
-            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
-        )
-    })?;
-    Ok(LocalIdentity {
-        id: row.get(0)?,
-        identifier_kind: row.get(1)?,
-        identifier: row.get(2)?,
-        identifier_normalized: row.get(3)?,
-        created_at: row.get(4)?,
-        updated_at: row.get(5)?,
-        state,
-        metadata_json: row.get(7)?,
-    })
-}
-
-fn get_local_identity_by_id_sqlite(id: &str) -> std::result::Result<Option<LocalIdentity>, String> {
-    let conn_guard = SQLITE_CONN.lock().unwrap();
-    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+fn get_local_identity_by_id_sqlite_conn(
+    conn: &rusqlite::Connection,
+    id: &str,
+) -> std::result::Result<Option<LocalIdentity>, String> {
     conn.query_row(
         "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
          FROM auth_local_identities
@@ -420,12 +680,17 @@ fn get_local_identity_by_id_sqlite(id: &str) -> std::result::Result<Option<Local
     .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))
 }
 
-fn get_local_identity_by_identifier_sqlite(
+fn get_local_identity_by_id_sqlite(id: &str) -> std::result::Result<Option<LocalIdentity>, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    get_local_identity_by_id_sqlite_conn(conn, id)
+}
+
+fn get_local_identity_by_identifier_sqlite_conn(
+    conn: &rusqlite::Connection,
     identifier_kind: &str,
     identifier_normalized: &str,
 ) -> std::result::Result<Option<LocalIdentity>, String> {
-    let conn_guard = SQLITE_CONN.lock().unwrap();
-    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
     let kind = identifier_kind.trim().to_ascii_lowercase();
     let normalized = identifier_normalized.trim().to_ascii_lowercase();
     conn.query_row(
@@ -439,6 +704,16 @@ fn get_local_identity_by_identifier_sqlite(
     .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))
 }
 
+fn get_local_identity_by_identifier_sqlite(
+    identifier_kind: &str,
+    identifier_normalized: &str,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    get_local_identity_by_identifier_sqlite_conn(conn, identifier_kind, identifier_normalized)
+}
+
+#[cfg(test)]
 fn store_local_credential_secret_sqlite(
     credential: &LocalCredentialSecret,
 ) -> std::result::Result<(), String> {
@@ -493,6 +768,31 @@ fn get_local_credential_secret_sqlite(
     .map_err(|e| format!("[auth] failed to lookup local credential: {}", e))
 }
 
+fn get_bootstrap_local_user_id_sqlite() -> std::result::Result<Option<String>, String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    bootstrap_local_user_id_sqlite_conn(conn)
+}
+
+fn store_bootstrap_local_user_id_sqlite(local_user_id: &str) -> std::result::Result<(), String> {
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    let inserted = conn
+        .execute(
+            "INSERT OR IGNORE INTO auth_local_bootstrap_state (key, local_user_id, created_at)
+             VALUES ('bootstrap', ?1, ?2)",
+            rusqlite::params![local_user_id, chrono::Utc::now().timestamp()],
+        )
+        .map_err(|e| format!("[auth] failed to store bootstrap local user: {}", e))?;
+    if inserted == 0 {
+        let existing = bootstrap_local_user_id_sqlite_conn(conn)?;
+        if existing.as_deref() != Some(local_user_id) {
+            return Err("[auth] bootstrap local user already exists".to_string());
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -541,6 +841,26 @@ mod tests {
             store.get_credential_secret("local-user-1").unwrap(),
             Some(credential)
         );
+    }
+
+    #[test]
+    fn test_local_credential_secret_debug_redacts_hash_material() {
+        let credential = LocalCredentialSecret {
+            local_user_id: "local-user-1".to_string(),
+            password_hash: "argon2$fixture-hash-value".to_string(),
+            password_hash_algorithm: "argon2id".to_string(),
+            password_hash_params_json: "{\"salt\":\"fixture-salt\"}".to_string(),
+            password_changed_at: 101,
+            must_change_password: false,
+        };
+
+        let formatted = format!("{:?}", credential);
+        assert!(formatted.contains("LocalCredentialSecret"));
+        assert!(formatted.contains("local-user-1"));
+        assert!(formatted.contains("argon2id"));
+        assert!(formatted.contains("[REDACTED]"));
+        assert!(!formatted.contains("super-secret-hash"));
+        assert!(!formatted.contains("secret-salt"));
     }
 
     #[test]

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -3,14 +3,15 @@ use super::*;
 mod local;
 
 pub(super) use local::{
-    get_local_credential_secret_record, get_local_identity_by_identifier_record,
-    normalize_local_identifier, LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret,
-    LocalIdentity,
+    get_bootstrap_local_user_id_record, get_local_credential_secret_record,
+    get_local_identity_by_id_record, get_local_identity_by_identifier_record,
+    normalize_local_identifier, provision_local_user_record, store_bootstrap_local_user_id_record,
+    LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
 };
 #[cfg(test)]
 pub(super) use local::{
-    get_local_identity_by_id_record, local_auth_record_fallback_policy,
-    store_local_credential_secret_record, store_local_identity_record, LocalAuthRecordKind,
+    local_auth_record_fallback_policy, store_local_credential_secret_record,
+    store_local_identity_record, LocalAuthRecordKind,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3807,6 +3807,48 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
         }
         "std/auth" => {
             sig!(
+                "create_local_user",
+                [
+                    "identifier" => Type::String,
+                    "password" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(2)
+            );
+            sig!(
+                "bootstrap_local_user",
+                [
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(0)
+            );
+            sig!(
                 "verify_local_password",
                 [
                     "identifier" => Type::String,
@@ -3827,6 +3869,116 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                     ],
                 },
                 required(2)
+            );
+            sig!(
+                "sign_in_session",
+                [
+                    "response" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "req" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "session" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Map {
+                    key_type: Box::new(Type::String),
+                    value_type: Box::new(Type::Any),
+                },
+                required(3)
+            );
+            sig!(
+                "complete_auth_challenge",
+                [
+                    "response" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "req" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "session" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Map {
+                    key_type: Box::new(Type::String),
+                    value_type: Box::new(Type::Any),
+                },
+                required(2)
+            );
+            sig!(
+                "cancel_auth_challenge",
+                [
+                    "response" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "req" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Map {
+                    key_type: Box::new(Type::String),
+                    value_type: Box::new(Type::Any),
+                },
+                required(2)
+            );
+            sig!(
+                "local_sign_in",
+                [
+                    "response" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "req" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "credentials" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "session" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(3)
             );
         }
         "std/crypto" => {
@@ -4213,6 +4365,90 @@ mod tests {
         assert_eq!(errs.len(), 1);
         assert!(errs[0].message.contains("expected String"));
         assert!(errs[0].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_local_user_creation_signatures_check_args() {
+        let errs = check_errors(
+            r#"
+            import { create_local_user, bootstrap_local_user } from "std/auth"
+            create_local_user(42, "pw")
+            bootstrap_local_user(42)
+            "#,
+        );
+        assert_eq!(errs.len(), 2);
+        assert!(errs[0].message.contains("expected String"));
+        assert!(errs[0].message.contains("got Int"));
+        assert!(errs[1].message.contains("expected Map"));
+        assert!(errs[1].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_sign_in_session_signature_requires_request_aware_shape() {
+        let errs = check_errors(
+            r#"
+            import { sign_in_session } from "std/auth"
+            sign_in_session(map {}, 42, map { "subject_id": "user-1" })
+            "#,
+        );
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].message.contains("expected Map"));
+        assert!(errs[0].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_sign_in_session_rejects_old_pre_request_shape() {
+        let errs = check_errors(
+            r#"
+            import { sign_in_session } from "std/auth"
+            sign_in_session(map {}, map { "subject_id": "user-1" })
+            "#,
+        );
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].message.contains("sign_in_session"));
+        assert!(errs[0].message.contains("expects 3"));
+    }
+
+    #[test]
+    fn test_std_auth_auth_challenge_signatures_check_args() {
+        let errs = check_errors(
+            r#"
+            import { complete_auth_challenge, cancel_auth_challenge } from "std/auth"
+            complete_auth_challenge(map {}, 42)
+            cancel_auth_challenge(map {}, map {}, 42)
+            "#,
+        );
+        assert_eq!(errs.len(), 2);
+        assert!(errs[0].message.contains("expected Map"));
+        assert!(errs[0].message.contains("got Int"));
+        assert!(errs[1].message.contains("expected Map"));
+        assert!(errs[1].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_local_sign_in_signature_checks_request_aware_shape() {
+        let errs = check_errors(
+            r#"
+            import { local_sign_in } from "std/auth"
+            local_sign_in(map {}, 42, map { "identifier": "admin@example.com", "password": "pw" })
+            "#,
+        );
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].message.contains("expected Map"));
+        assert!(errs[0].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_local_sign_in_signature_requires_credentials() {
+        let errs = check_errors(
+            r#"
+            import { local_sign_in } from "std/auth"
+            local_sign_in(map {}, map {})
+            "#,
+        );
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].message.contains("local_sign_in"));
+        assert!(errs[0].message.contains("expects 3"));
     }
 
     // ── Scope nesting ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- update DD-043/DD-062 for the local-auth/Auth Excellence baseline and deferred reset/TOTP scope
- add memory/SQLite local user provisioning, one-time bootstrap state, and request-aware `local_sign_in(...)`
- stage setup-required local sign-ins through auth challenges and preserve staged app session data when completing the challenge
- wire docs/typechecker/generated stdlib reference for the new `std/auth` surface

## Safety / architecture notes
- local identity/credential lookup is memory/SQLite only; PostgreSQL/Redis local-auth record families fail closed until implemented
- local credential APIs return safe metadata only; password hashes/params remain internal and redacted from debug output
- create/bootstrap provisioning is atomic for memory/SQLite and rejects empty passwords / duplicate bootstrap state
- per-call `cookie_name` overrides remain unsupported and are no longer advertised for `local_sign_in(...)`
- password reset and TOTP enrollment remain intentionally deferred

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --lib test_local_sign_in_stages_bootstrap_user_instead_of_full_session -- --test-threads=1 --nocapture`
- `cargo test --lib complete_auth_challenge -- --test-threads=1 --nocapture`
- `cargo test --lib local_sign_in -- --test-threads=1 --nocapture`
- `cargo test --lib auth_challenge -- --test-threads=1 --nocapture`
- `cargo test auth -- --test-threads=1 --nocapture` *(Postgres/Redis contract tests visibly skipped because `NTNT_AUTH_TEST_POSTGRES_URL` / `NTNT_AUTH_TEST_REDIS_URL` are unset)*
- `cargo check --all-targets`
- `cargo build --profile dev-release`
- `./target/dev-release/ntnt docs --generate`
- `./target/dev-release/ntnt docs --validate`
- `cargo build --release --locked`
- static diff scan: `STATIC_SCAN_CLEAN` (`diff_chars=178899`, `nonbenign_findings=0`)

## Diff size note
Final local diff before commit: `11 files changed, 2830 insertions(+), 229 deletions(-)`. The bulk is tests, generated stdlib docs/typechecker wiring, request-aware local sign-in/challenge handling, and atomic local provisioning.