### PR TITLE
auth: add local bootstrap provisioning

### DIFF
--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -53,8 +53,8 @@ If a capability is security-sensitive lifecycle state that every app otherwise r
 
 ### What's Still Missing (the gap to "best ever")
 - [ ] Complete first-class local email/password/TOTP credential lifecycle owned by `std/auth`
-- [ ] Bootstrap/setup, password-reset, and TOTP enrollment stores with fail-closed fallback semantics
-- [ ] Optional local credential sign-in/reference flow that composes verified local credentials with the existing request-aware session-completion path
+- [ ] Setup-completion, password-reset, and TOTP enrollment stores with fail-closed fallback semantics
+- [ ] Optional local credential sign-in/reference flow, only if explicit `verify_local_password(...)` + `sign_in_session(...)` composition proves too repetitive
 - [ ] Admin/arbitrary-user session APIs (`list_sessions(user_id)`, `revoke_session(session_id)`, `revoke_all_sessions(user_id)`) distinct from current-user helpers
 - [ ] Security event storage and suspicious-activity policy actions (`warn`, `challenge`, `revoke`)
 - [ ] Fully behavioral remember-me support (`remember_ttl`, request capture, cookie/session TTL selection)
@@ -302,7 +302,9 @@ Current pressure points:
 ### Phase 9 — First-Class Local Auth
 **Goal:** Make `std/auth` world-class not only for OAuth/session plumbing, but also for the extremely common app shape of **local email + password + TOTP auth**.
 
-**Current baseline on `main`:** local identity/credential storage and `verify_local_password(...)` exist, and manual session completion is already request-aware through `sign_in_session(response, req, session, options?)`. The next implementation slice should not recreate PR #99's broad `local_sign_in` wrapper. Prefer a narrow bootstrap/setup primitive first, then compose login explicitly with `verify_local_password(...)` + `sign_in_session(...)` until a higher-level helper is proven necessary.
+**Current PR #100 slice:** PR #100 adds a narrow `bootstrap_local_user(identifier, password, options?)` provisioning primitive on top of the existing local identity/credential storage. It stores the auth-owned local identity and credential atomically for memory/SQLite, returns only a safe bootstrap user payload, marks the account `bootstrap` with `must_change_password: true`, and intentionally does not add a public `local_sign_in(...)` wrapper or any cookie/challenge/session semantic changes.
+
+**Current baseline after this slice:** local identity/credential storage, `verify_local_password(...)`, `bootstrap_local_user(...)`, generated docs, typechecker signatures, and request-aware manual session completion exist. The next implementation work should compose these primitives explicitly until a higher-level local sign-in helper is proven necessary.
 
 **Why this must exist:** the current `std/auth` surface is strong at sessions, cookies, staged auth challenges, OAuth/OIDC, TOTP primitives, sign-in/sign-out helpers, and protected-route handling. But a normal local admin/app flow still requires developers to build and own a mini auth system beside it:
 
@@ -369,8 +371,10 @@ A later `enable_local_auth(...)` convenience wrapper is acceptable only if it de
 - [x] Store password hashes in auth-owned tables rather than pushing that responsibility to apps
 - [x] Define a lean durable local-user/account shape: identity + auth state first, not a full profile platform
 - [x] Support account states needed by real flows: bootstrap/pending setup/active/disabled/locked/password-change-required
-- [ ] Support bootstrap account creation from config/env for the common admin-panel case
-- [ ] Ensure bootstrap credentials force rotation/setup instead of becoming a permanent production secret path
+- [x] Add public bootstrap provisioning through `bootstrap_local_user(...)` as the first narrow setup primitive
+- [x] Store bootstrap identity + credential atomically for memory/SQLite so a credential-write failure cannot orphan the identity row
+- [ ] Support config/env-driven bootstrap seeding for the common admin-panel deployment case
+- [ ] Ensure bootstrap credentials force rotation/setup completion instead of becoming a permanent production secret path
 - [x] Add memory/SQLite contract tests by default
 - [ ] Add Postgres/Redis local-auth contract tests in required backend CI
 
@@ -497,7 +501,7 @@ For template cleanup specifically, the biggest early wins were:
 
 Those are now shipped. The next big win is local email/password/TOTP auth, but only if it lands as a coherent subsystem with storage/test discipline rather than another layer of helpers.
 
-**2026-04-27 correction:** PR #99 attempted bootstrap plus a broad request-aware `local_sign_in(...)` helper and came out too large for this slice. The replacement sequence is docs/status cleanup first, then a much smaller runtime PR. The next runtime batch should target bootstrap/setup provisioning only, reuse existing `verify_local_password(...)`, `sign_in_session(...)`, and staged-auth primitives, and avoid cookie/challenge/session semantic changes unless they are strictly required.
+**2026-04-27 / PR #100 status:** PR #100 is the replacement slice: DD/status cleanup plus `bootstrap_local_user(...)` only. It deliberately leaves out the scrapped PR #99 surface area: no public `local_sign_in(...)`, no cookie-domain or challenge-cookie changes, no new session semantics, no TOTP enrollment, no password reset, and no Postgres/Redis local credential backend implementation. The next runtime batch should start from the post-PR100 baseline and remain similarly narrow.
 
 | Order | Delivery Wave | Feature Bundle | Why This Order |
 |-------|---------------|----------------|----------------|
@@ -617,12 +621,17 @@ Those are now shipped. The next big win is local email/password/TOTP auth, but o
 **Value:** prevents the local-auth wave from undoing the architecture cleanup.
 
 #### Wave 9 — First-Class Local Auth
-**Ships:**
+**Shipped so far:**
 - local identity and credential store
-- request-aware email/password sign-in
+- `verify_local_password(...)`
+- `bootstrap_local_user(...)` as a narrow bootstrap/setup provisioning primitive
+- atomic memory/SQLite identity+credential writes for bootstrap provisioning
+
+**Remaining:**
+- request-aware email/password reference flow if explicit composition is not enough
 - staged first-login / forced-password-change / TOTP enrollment
 - password reset token lifecycle
-- local-auth backend contract tests
+- Postgres/Redis local-auth backend contract tests
 - template migration away from custom local auth persistence
 
 **Value:** closes the gap between great auth primitives and great auth architecture.
@@ -659,9 +668,9 @@ This table tracks the intended competitive posture after the v0.4.9 auth work an
 | Suspicious activity policy | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Behavioral remember-me TTL | ❌ | ✅ | ✅ | ◐ | ✅ | ✅ |
 | TOTP/MFA primitives | ✅ | ✅ | ❌ | ❌¹ | ❌ | ❌³ |
-| First-class local email/password/TOTP lifecycle | ❌ | ✅ | ❌ | ❌ | ◐ | ✅ |
+| First-class local email/password/TOTP lifecycle | ◐ | ✅ | ❌ | ❌ | ◐ | ✅ |
 | Auth-owned password reset tokens | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Bootstrap admin local auth | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Bootstrap admin/local setup provisioning | ◐ | ✅ | ❌ | ❌ | ❌ | ✅ |
 | Safari ITP workaround | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Zero-config setup | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Auto route registration / auth route prefixing | ◐ | ✅ | ✅⁴ | ❌ | ❌ | ✅ |

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -3,7 +3,7 @@
 **Status:** In Progress
 **Author:** Larri
 **Date:** 2026-03-20
-**Branch:** `main` through v0.4.9; `feat/local-auth-blueprint` carries the next planning pass for first-class local auth and architecture discipline
+**Branch:** `main` through v0.4.9; next local-auth work should branch from `origin/main` in small slices
 
 ---
 
@@ -52,9 +52,9 @@ If a capability is security-sensitive lifecycle state that every app otherwise r
 - [x] API key validation, Turnstile CAPTCHA verification, OAuth token introspection, client credentials grant, and OIDC discovery
 
 ### What's Still Missing (the gap to "best ever")
-- [ ] First-class local email/password/TOTP credential lifecycle owned by `std/auth`
-- [ ] Auth-owned local credential/reset/TOTP enrollment stores with fail-closed fallback semantics
-- [ ] First-class local credential sign-in helper that feeds verified local credentials into the existing request-aware session-completion path
+- [ ] Complete first-class local email/password/TOTP credential lifecycle owned by `std/auth`
+- [ ] Bootstrap/setup, password-reset, and TOTP enrollment stores with fail-closed fallback semantics
+- [ ] Optional local credential sign-in/reference flow that composes verified local credentials with the existing request-aware session-completion path
 - [ ] Admin/arbitrary-user session APIs (`list_sessions(user_id)`, `revoke_session(session_id)`, `revoke_all_sessions(user_id)`) distinct from current-user helpers
 - [ ] Security event storage and suspicious-activity policy actions (`warn`, `challenge`, `revoke`)
 - [ ] Fully behavioral remember-me support (`remember_ttl`, request capture, cookie/session TTL selection)
@@ -302,6 +302,8 @@ Current pressure points:
 ### Phase 9 — First-Class Local Auth
 **Goal:** Make `std/auth` world-class not only for OAuth/session plumbing, but also for the extremely common app shape of **local email + password + TOTP auth**.
 
+**Current baseline on `main`:** local identity/credential storage and `verify_local_password(...)` exist, and manual session completion is already request-aware through `sign_in_session(response, req, session, options?)`. The next implementation slice should not recreate PR #99's broad `local_sign_in` wrapper. Prefer a narrow bootstrap/setup primitive first, then compose login explicitly with `verify_local_password(...)` + `sign_in_session(...)` until a higher-level helper is proven necessary.
+
 **Why this must exist:** the current `std/auth` surface is strong at sessions, cookies, staged auth challenges, OAuth/OIDC, TOTP primitives, sign-in/sign-out helpers, and protected-route handling. But a normal local admin/app flow still requires developers to build and own a mini auth system beside it:
 
 - local user/credential table
@@ -362,14 +364,15 @@ A later `enable_local_auth(...)` convenience wrapper is acceptable only if it de
 **Exit criterion:** the storage and module homes for local auth are obvious before the first credential table/helper is implemented.
 
 #### Phase 9B — Local Identity and Credential Store
-- [ ] Add first-class local credential storage owned by `std/auth`
-- [ ] Support a generic local subject + identifier model; ship email as the first documented identifier preset with normalization rules, not as the only possible local-auth identity shape
-- [ ] Store password hashes in auth-owned tables rather than pushing that responsibility to apps
-- [ ] Define a lean durable local-user/account shape: identity + auth state first, not a full profile platform
-- [ ] Support account states needed by real flows: bootstrap/pending setup/active/disabled/locked/password-change-required
+- [x] Add first-class local credential storage owned by `std/auth`
+- [x] Support a generic local subject + identifier model; ship email as the first documented identifier preset with normalization rules, not as the only possible local-auth identity shape
+- [x] Store password hashes in auth-owned tables rather than pushing that responsibility to apps
+- [x] Define a lean durable local-user/account shape: identity + auth state first, not a full profile platform
+- [x] Support account states needed by real flows: bootstrap/pending setup/active/disabled/locked/password-change-required
 - [ ] Support bootstrap account creation from config/env for the common admin-panel case
 - [ ] Ensure bootstrap credentials force rotation/setup instead of becoming a permanent production secret path
-- [ ] Add memory/SQLite contract tests by default and Postgres/Redis contract tests in required backend CI
+- [x] Add memory/SQLite contract tests by default
+- [ ] Add Postgres/Redis local-auth contract tests in required backend CI
 
 #### Phase 9C — Request-Aware Local Sign-In Flow
 
@@ -377,8 +380,8 @@ A later `enable_local_auth(...)` convenience wrapper is acceptable only if it de
 
 Because this lands before 0.4.9 is released, the old pre-release `sign_in_session(response, session, options?)` shape should not be kept as a compatibility shim. Callers must migrate by passing the route `req` as the second argument; otherwise local/manual auth would silently miss rotation, existing-session migration, and request metadata capture.
 
-- [ ] Add built-in email/password verification through `std/auth`
-- [ ] Use the existing request-aware session-completion primitive from the local sign-in path so it can rotate/migrate existing sessions and capture request metadata
+- [x] Add built-in email/password verification through `std/auth` via `verify_local_password(...)`
+- [ ] Use the existing request-aware session-completion primitive from any local sign-in/reference path so it can rotate/migrate existing sessions and capture request metadata
 - [ ] Reuse the same session cookie, session TTL, sliding/max-lifetime, metadata, and revocation semantics as OAuth-backed sign-in
 - [ ] Reuse staged auth challenge primitives for local login continuation instead of inventing a second pending-auth model
 - [ ] Support straightforward local sign-in that upgrades into a real auth session with app-supplied claims/session data
@@ -493,6 +496,8 @@ For template cleanup specifically, the biggest early wins were:
 3. staged-auth challenge primitives
 
 Those are now shipped. The next big win is local email/password/TOTP auth, but only if it lands as a coherent subsystem with storage/test discipline rather than another layer of helpers.
+
+**2026-04-27 correction:** PR #99 attempted bootstrap plus a broad request-aware `local_sign_in(...)` helper and came out too large for this slice. The replacement sequence is docs/status cleanup first, then a much smaller runtime PR. The next runtime batch should target bootstrap/setup provisioning only, reuse existing `verify_local_password(...)`, `sign_in_session(...)`, and staged-auth primitives, and avoid cookie/challenge/session semantic changes unless they are strictly required.
 
 | Order | Delivery Wave | Feature Bundle | Why This Order |
 |-------|---------------|----------------|----------------|

--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -1,6 +1,6 @@
 # DD-062: First-Class Local Email/Password/TOTP Auth in `std/auth`
 
-**Status:** Draft / implementation blueprint
+**Status:** In progress / implementation blueprint
 **Parent:** DD-043 Phase 9 — First-Class Local Auth
 **Target:** v0.4.x auth roadmap after the v0.4.9 DD-043 foundation
 
@@ -68,6 +68,10 @@ DD-062 is the detailed child plan for DD-043 Phase 9.
 Current 0.4.9 baseline: the shared manual/staged session completion path is already request-aware. `sign_in_session(response, req, session, options?)` and `complete_auth_challenge(response, req, session?, options?)` rotate/migrate existing sessions and capture request-derived metadata. Local auth should consume that path rather than introduce its own session creation semantics.
 
 This is an intentional 0.4.9 pre-release API correction, not a compatibility surface to preserve. The migration path is explicit: insert the current route `req` as the second argument wherever old branch code called `sign_in_session(response, session, options?)`.
+
+Current local-auth baseline on `main`: local identity/credential records, password-secret verification, email normalization, account states, safe `verify_local_password(...)` payloads, and memory/SQLite coverage already exist. Bootstrap provisioning, setup completion, TOTP enrollment storage, password reset, Postgres/Redis local-auth contracts, and template migration remain open.
+
+PR #99 proved that combining bootstrap plus a broad `local_sign_in(...)` wrapper creates too much code and too many duplicated session/challenge semantics for one slice. The immediate replacement should be small: update docs/status first, then add bootstrap/setup provisioning as a narrow runtime PR that composes the existing primitives.
 
 | DD-043 Phase | DD-062 Section | Purpose |
 |---|---|---|
@@ -350,12 +354,14 @@ This table should become implementation comments and contract tests, not just do
 
 **Baseline:** request-aware manual session completion already exists in 0.4.9 branch work. This phase should wire local credential verification into that primitive, not design a new cookie/session attachment path.
 
+**Lean path after PR #99:** do not add a public `local_sign_in(...)` helper until the explicit composition path is insufficient. For now, custom login handlers should call `verify_local_password(...)` and then `sign_in_session(response, req, session, options?)` with app-owned claims/session data. Setup-required flows should use the staged-auth primitives directly until the setup/TOTP flow shape is small and stable.
+
 - [x] Add local password verification through `std/auth`
-- [ ] Add local sign-in domain operation that delegates to `sign_in_session(response, req, session, options?)` or the same internal primitive
-- [ ] Rotate/migrate existing sessions on successful local login
-- [ ] Capture `device_name`, `user_agent_hash`, and `last_ip_hash` from request metadata
-- [ ] Apply configured session TTL, max lifetime, sliding expiry, cookie policy, and remember-me behavior
-- [ ] Return staged continuation when TOTP/setup/password-change is required
+- [ ] Decide whether a public local sign-in domain operation is still needed after explicit composition and bootstrap/setup primitives land
+- [x] Rotate/migrate existing sessions on successful local login when composed through `sign_in_session(...)`
+- [x] Capture `device_name`, `user_agent_hash`, and `last_ip_hash` from request metadata when composed through `sign_in_session(...)`
+- [x] Apply configured session TTL, max lifetime, sliding expiry, and cookie policy when composed through `sign_in_session(...)`
+- [ ] Add remember-me behavior and staged continuation once setup/TOTP flows are implemented
 - [ ] Add tests proving local login does not lose session metadata compared with OAuth login
 
 ### Phase 3 — First Login, Forced Password Change, and TOTP Enrollment
@@ -462,11 +468,12 @@ Treat local auth as the next practical `std/auth` simplification step, but do no
 The right implementation order is:
 
 1. architecture/storage/test preflight
-2. local identity and credential store
-3. request-aware local sign-in
-4. staged setup/TOTP
-5. password reset
-6. template migration
-7. contract/docs/CI ratchet
+2. local identity and credential store — baseline shipped on `main`
+3. bootstrap/setup provisioning — next small runtime slice
+4. request-aware local sign-in/reference flow only if explicit composition remains too repetitive
+5. staged setup/TOTP
+6. password reset
+7. template migration
+8. contract/docs/CI ratchet
 
 If `std/auth` can own OAuth well but still cannot cleanly own a normal local admin login, the library remains incomplete in a way users feel immediately. If it owns local auth with the same discipline as OAuth/session/challenge state, it becomes genuinely hard to beat.

--- a/design-docs/dd-062-local-email-password-totp-auth.md
+++ b/design-docs/dd-062-local-email-password-totp-auth.md
@@ -69,9 +69,9 @@ Current 0.4.9 baseline: the shared manual/staged session completion path is alre
 
 This is an intentional 0.4.9 pre-release API correction, not a compatibility surface to preserve. The migration path is explicit: insert the current route `req` as the second argument wherever old branch code called `sign_in_session(response, session, options?)`.
 
-Current local-auth baseline on `main`: local identity/credential records, password-secret verification, email normalization, account states, safe `verify_local_password(...)` payloads, and memory/SQLite coverage already exist. Bootstrap provisioning, setup completion, TOTP enrollment storage, password reset, Postgres/Redis local-auth contracts, and template migration remain open.
+Current local-auth baseline after PR #100: local identity/credential records, password-secret verification, email normalization, account states, safe `verify_local_password(...)` payloads, `bootstrap_local_user(...)` provisioning, atomic memory/SQLite bootstrap identity+credential writes, generated docs, typechecker signatures, and memory/SQLite coverage exist. Setup completion, TOTP enrollment storage, password reset, config/env bootstrap seeding, Postgres/Redis local-auth contracts, and template migration remain open.
 
-PR #99 proved that combining bootstrap plus a broad `local_sign_in(...)` wrapper creates too much code and too many duplicated session/challenge semantics for one slice. The immediate replacement should be small: update docs/status first, then add bootstrap/setup provisioning as a narrow runtime PR that composes the existing primitives.
+PR #100 is intentionally the small replacement slice after PR #99 was scrapped: it adds bootstrap provisioning only and does not carry forward the broad `local_sign_in(...)` wrapper, cookie/challenge changes, or new session semantics from that spike. Future work should continue composing the existing primitives explicitly until a higher-level helper is proven necessary.
 
 | DD-043 Phase | DD-062 Section | Purpose |
 |---|---|---|
@@ -181,25 +181,18 @@ These should be intentionally small. App profile and authorization data should r
 
 ### Local sign-in/session helpers
 
-The built-in local sign-in route can be enough for simple apps, but custom login forms need a safe lower-level helper.
-
-The helper must be request-aware. A shape in this family is acceptable:
+Custom login forms should first use the explicit composition path:
 
 ```ntnt
-local_sign_in(req, response, map {
-    "email": email,
-    "password": password,
-    "remember_me": remember_me
+let verified = verify_local_password(email, password)?
+return sign_in_session(response, req, map {
+    "subject_id": verified["subject_id"],
+    "email": verified["email"],
+    "claims": app_claims_for_local_user(verified)
 })
 ```
 
-It should return either:
-
-- a completed signed-in response, or
-- a staged-auth continuation response for TOTP/setup/password-change, or
-- a safe auth error result
-
-It must delegate to request-aware `sign_in_session(response, req, session, options?)` or the same internal session-completion primitive so local login receives OAuth-equivalent rotation, metadata capture, cookie, TTL, and lifecycle behavior. It should not directly create sessions, attach cookies, or bypass the shared completion path.
+That is the current direction after PR #100. A public `local_sign_in(...)` helper is intentionally **not** part of this slice; PR #99 showed that adding it too early duplicates session/challenge semantics and bloats the change. If a later helper is added, it must be request-aware and delegate to `sign_in_session(response, req, session, options?)` or the same internal session-completion primitive so local login receives OAuth-equivalent rotation, metadata capture, cookie, TTL, and lifecycle behavior. It must not directly create sessions, attach cookies, or bypass the shared completion path.
 
 ### Password reset helpers
 
@@ -342,7 +335,9 @@ This table should become implementation comments and contract tests, not just do
 - [x] Create credential-secret storage and verification helpers
 - [x] Normalize email lookup rules and document them
 - [x] Add account states: bootstrap, pending setup, active, disabled, locked, password-change-required
-- [ ] Support bootstrap account creation from config/env
+- [x] Add public bootstrap provisioning through `bootstrap_local_user(...)` with safe bootstrap user payloads
+- [x] Store bootstrap identity + credential atomically for memory/SQLite
+- [ ] Support config/env-driven bootstrap seeding for the common admin-panel deployment case
 - [ ] Force bootstrap credential rotation/setup completion according to config
 - [x] Add memory/SQLite contract tests by default
 - [ ] Add Postgres/Redis contract coverage in backend CI
@@ -354,7 +349,7 @@ This table should become implementation comments and contract tests, not just do
 
 **Baseline:** request-aware manual session completion already exists in 0.4.9 branch work. This phase should wire local credential verification into that primitive, not design a new cookie/session attachment path.
 
-**Lean path after PR #99:** do not add a public `local_sign_in(...)` helper until the explicit composition path is insufficient. For now, custom login handlers should call `verify_local_password(...)` and then `sign_in_session(response, req, session, options?)` with app-owned claims/session data. Setup-required flows should use the staged-auth primitives directly until the setup/TOTP flow shape is small and stable.
+**Post-PR100 lean path:** do not add a public `local_sign_in(...)` helper until the explicit composition path is insufficient. For now, custom login handlers should call `verify_local_password(...)` and then `sign_in_session(response, req, session, options?)` with app-owned claims/session data. Setup-required flows should use the staged-auth primitives directly until the setup/TOTP flow shape is small and stable.
 
 - [x] Add local password verification through `std/auth`
 - [ ] Decide whether a public local sign-in domain operation is still needed after explicit composition and bootstrap/setup primitives land
@@ -469,11 +464,12 @@ The right implementation order is:
 
 1. architecture/storage/test preflight
 2. local identity and credential store — baseline shipped on `main`
-3. bootstrap/setup provisioning — next small runtime slice
-4. request-aware local sign-in/reference flow only if explicit composition remains too repetitive
-5. staged setup/TOTP
-6. password reset
-7. template migration
-8. contract/docs/CI ratchet
+3. bootstrap/setup provisioning — PR #100 adds `bootstrap_local_user(...)` as the narrow runtime slice
+4. first-login/setup completion and forced password rotation
+5. request-aware local sign-in/reference flow only if explicit composition remains too repetitive
+6. staged setup/TOTP
+7. password reset
+8. template migration
+9. contract/docs/CI ratchet
 
 If `std/auth` can own OAuth well but still cannot cleanly own a normal local admin login, the library remains incomplete in a way users feel immediately. If it owns local auth with the same discipline as OAuth/session/challenge state, it becomes genuinely hard to beat.

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1827,6 +1827,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`auth_me`](#authme) | Return current user as JSON for SPAs. |
 | [`auth_start`](#authstart) | Handle OAuth login start - redirects to the provider's authorization page. |
 | [`begin_auth_challenge`](#beginauthchallenge) | Persist a pending auth challenge and attach the challenge cookie. |
+| [`bootstrap_local_user`](#bootstraplocaluser) | Provision an initial local credential record for app setup flows. |
 | [`cancel_auth_challenge`](#cancelauthchallenge) | Cancel the current auth challenge and clear the challenge cookie. |
 | [`complete_auth_challenge`](#completeauthchallenge) | Upgrade the current auth challenge into a full authenticated session. |
 | [`create_session_from_oauth`](#createsessionfromoauth) | Create a session from OAuth user info and tokens. |
@@ -2030,6 +2031,42 @@ begin_auth_challenge(redirect("/admin/verify"), map { "subject_id": user.id, "ki
 ```
 
 **See also:** `current_auth_challenge`, `complete_auth_challenge`, `cancel_auth_challenge`
+
+*Since v0.4.9*
+
+---
+
+#### `bootstrap_local_user`
+
+```ntnt
+bootstrap_local_user(identifier: String, password: String, options?: Map) -> Result<Map, String>
+```
+
+Provision an initial local credential record for app setup flows.
+
+The helper normalizes the identifier (email by default), rejects an existing local identity with the same normalized identifier, stores an auth-owned local identity plus password credential, and returns the same safe local user payload shape as `verify_local_password(...)`. The bootstrapped account starts in `bootstrap` state with `must_change_password: true` so app-owned setup code can force rotation before granting regular access. It never exposes passwords, password hashes, hash parameters, credentials, secrets, or tokens.
+
+**Parameters:**
+
+- `identifier` — The local setup identifier. Email is the default identifier kind.
+- `password` — The temporary plaintext password to hash and store
+- `options` — Optional map with `identifier_kind` (default `"email"`)
+
+**Returns:** Ok(map) with safe local user fields; Err(message) on duplicate, invalid input, or unsupported storage backend
+
+**Examples:**
+
+```ntnt
+let user = bootstrap_local_user("admin@example.com", setup_password)?  // Provision a first setup user
+sign_in_session(redirect("/setup"), req, map { "subject_id": user["subject_id"], "email": user["email"] })  // Sign in the setup user with request-aware session handling
+```
+
+**Errors:**
+
+- **RuntimeError**: Auth not initialized — *Fix: Call enable_auth(...) during app startup before bootstrapping local credentials*
+- **TypeError**: identifier must be a string — *Fix: Pass the setup email/identifier as a string*
+
+**See also:** `verify_local_password`, `sign_in_session`
 
 *Since v0.4.9*
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -70,7 +70,9 @@ use guards::validate_auth_challenge_kind;
 pub use guards::{
     enforce_auth_for_request, get_protected_paths, register_protected_paths, reset_protected_paths,
 };
-use local::{verified_local_password_to_value, verify_local_password_record};
+use local::{
+    bootstrap_local_user_record, verified_local_password_to_value, verify_local_password_record,
+};
 use oauth::extract_user_info;
 pub use oauth::{
     client_credentials_grant, decode_id_token, exchange_code_for_tokens, fetch_oidc_discovery,
@@ -3738,6 +3740,98 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt bootstrap_local_user
+    // @module std/auth
+    // @signature bootstrap_local_user(identifier: String, password: String, options?: Map) -> Result<Map, String>
+    // Provision an initial local credential record for app setup flows.
+    //
+    // The helper normalizes the identifier (email by default), rejects an existing
+    // local identity with the same normalized identifier, stores an auth-owned
+    // local identity plus password credential, and returns the same safe local
+    // user payload shape as `verify_local_password(...)`. The bootstrapped
+    // account starts in `bootstrap` state with `must_change_password: true` so
+    // app-owned setup code can force rotation before granting regular access.
+    // It never exposes passwords, password hashes, hash parameters, credentials,
+    // secrets, or tokens.
+    // @param identifier The local setup identifier. Email is the default identifier kind.
+    // @param password The temporary plaintext password to hash and store
+    // @param options Optional map with `identifier_kind` (default `"email"`)
+    // @returns Ok(map) with safe local user fields; Err(message) on duplicate, invalid input, or unsupported storage backend
+    // @error RuntimeError ~ "Auth not initialized" fix: "Call enable_auth(...) during app startup before bootstrapping local credentials"
+    // @error TypeError ~ "identifier must be a string" fix: "Pass the setup email/identifier as a string"
+    // @see_also verify_local_password, sign_in_session
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #security
+    // @example let user = bootstrap_local_user("admin@example.com", setup_password)? ~ "Provision a first setup user"
+    // @example sign_in_session(redirect("/setup"), req, map { "subject_id": user["subject_id"], "email": user["email"] }) ~ "Sign in the setup user with request-aware session handling"
+    module.insert(
+        "bootstrap_local_user".to_string(),
+        Value::NativeFunction {
+            name: "bootstrap_local_user".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] bootstrap_local_user() requires identifier, password, and optional options"
+                            .to_string(),
+                    ));
+                }
+
+                let _config = get_auth_config().ok_or_else(|| {
+                    IntentError::runtime_error(
+                        "[auth] Auth not initialized. Call enable_auth() before bootstrap_local_user()."
+                            .to_string(),
+                    )
+                })?;
+
+                let identifier = match &args[0] {
+                    Value::String(s) => s.as_str(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] bootstrap_local_user() identifier must be a string, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+                let password = match &args[1] {
+                    Value::String(s) => s.as_str(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] bootstrap_local_user() password must be a string, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+                let identifier_kind = match args.get(2) {
+                    Some(Value::Map(map)) => match map.get("identifier_kind") {
+                        Some(Value::String(kind)) => kind.as_str(),
+                        Some(other) => {
+                            return Err(IntentError::type_error(format!(
+                                "[auth] bootstrap_local_user() identifier_kind must be a string, got {}",
+                                other.type_name()
+                            )))
+                        }
+                        None => "email",
+                    },
+                    Some(other) => {
+                        return Err(IntentError::type_error(format!(
+                            "[auth] bootstrap_local_user() options must be a map, got {}",
+                            other.type_name()
+                        )))
+                    }
+                    None => "email",
+                };
+
+                match bootstrap_local_user_record(identifier_kind, identifier, password) {
+                    Ok(verified) => Ok(Value::ok(verified_local_password_to_value(verified))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
     // @ntnt verify_local_password
     // @module std/auth
     // @signature verify_local_password(identifier: String, password: String, options?: Map) -> Result<Map, String>
@@ -4396,6 +4490,23 @@ mod tests {
         match values.first() {
             Some(Value::String(message)) => message.clone(),
             other => panic!("unexpected Result::Err payload: {other:?}"),
+        }
+    }
+
+    fn result_ok_map(value: Value) -> HashMap<String, Value> {
+        let Value::EnumValue {
+            enum_name,
+            variant,
+            values,
+        } = value
+        else {
+            panic!("expected Result::Ok, got {value:?}");
+        };
+        assert_eq!(enum_name, "Result");
+        assert_eq!(variant, "Ok");
+        match values.first() {
+            Some(Value::Map(map)) => map.clone(),
+            other => panic!("unexpected Result::Ok payload: {other:?}"),
         }
     }
 
@@ -5901,6 +6012,171 @@ mod tests {
                 assert!(!message.contains("password hash"));
             }
         }
+    }
+
+    #[test]
+    fn test_bootstrap_local_user_native_helper_provisions_safe_setup_user() {
+        use super::storage::{
+            get_local_credential_secret_record, get_local_identity_by_identifier_record,
+            LocalAccountState,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let module = init();
+            let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+            let bootstrapped = result_ok_map(
+                bootstrap_local_user(&[
+                    Value::String(" Bootstrap@Example.COM ".to_string()),
+                    Value::String("temporary bootstrap password".to_string()),
+                ])
+                .unwrap(),
+            );
+
+            let local_user_id = match bootstrapped.get("local_user_id") {
+                Some(Value::String(id)) => id.clone(),
+                other => panic!("unexpected local_user_id payload: {other:?}"),
+            };
+            match bootstrapped.get("subject_id") {
+                Some(Value::String(subject_id)) => assert_eq!(subject_id, &local_user_id),
+                other => panic!("unexpected subject_id payload: {other:?}"),
+            }
+            match bootstrapped.get("provider") {
+                Some(Value::String(provider)) => assert_eq!(provider, "local"),
+                other => panic!("unexpected provider payload: {other:?}"),
+            }
+            match bootstrapped.get("email") {
+                Some(Value::String(email)) => assert_eq!(email, "Bootstrap@Example.COM"),
+                other => panic!("unexpected email payload: {other:?}"),
+            }
+            match bootstrapped.get("identifier_normalized") {
+                Some(Value::String(identifier)) => assert_eq!(identifier, "bootstrap@example.com"),
+                other => panic!("unexpected identifier_normalized payload: {other:?}"),
+            }
+            match bootstrapped.get("state") {
+                Some(Value::String(state)) => assert_eq!(state, "bootstrap"),
+                other => panic!("unexpected state payload: {other:?}"),
+            }
+            match bootstrapped.get("must_change_password") {
+                Some(Value::Bool(value)) => assert!(*value),
+                other => panic!("unexpected must_change_password payload: {other:?}"),
+            }
+            for secret_key in [
+                "password",
+                "password_hash",
+                "password_hash_algorithm",
+                "password_hash_params_json",
+                "credential",
+                "secret",
+                "token",
+            ] {
+                assert!(
+                    !bootstrapped.contains_key(secret_key),
+                    "bootstrap payload must not expose {secret_key}"
+                );
+            }
+
+            let stored_identity =
+                get_local_identity_by_identifier_record("email", "bootstrap@example.com")
+                    .unwrap()
+                    .expect("bootstrap should store a local identity");
+            assert_eq!(stored_identity.id, local_user_id);
+            assert_eq!(stored_identity.state, LocalAccountState::Bootstrap);
+            let credential = get_local_credential_secret_record(&stored_identity.id)
+                .unwrap()
+                .expect("bootstrap should store a local credential secret");
+            assert_ne!(credential.password_hash, "temporary bootstrap password");
+            assert!(!credential.password_hash.trim().is_empty());
+            assert!(credential.must_change_password);
+
+            let verify_local_password = module_fn(&module, "verify_local_password");
+            let verified = result_ok_map(
+                verify_local_password(&[
+                    Value::String("bootstrap@example.com".to_string()),
+                    Value::String("temporary bootstrap password".to_string()),
+                ])
+                .unwrap(),
+            );
+            match verified.get("local_user_id") {
+                Some(Value::String(id)) => assert_eq!(id, &stored_identity.id),
+                other => panic!("unexpected verified local_user_id payload: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_bootstrap_local_user_rejects_duplicate_and_invalid_inputs() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        bootstrap_local_user(&[
+            Value::String("admin@example.com".to_string()),
+            Value::String("temporary bootstrap password".to_string()),
+        ])
+        .unwrap();
+
+        let duplicate = result_err_string(
+            bootstrap_local_user(&[
+                Value::String(" Admin@Example.com ".to_string()),
+                Value::String("temporary bootstrap password".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert!(
+            duplicate.contains("already exists"),
+            "unexpected duplicate error: {duplicate}"
+        );
+
+        let invalid_email = result_err_string(
+            bootstrap_local_user(&[
+                Value::String("not-an-email".to_string()),
+                Value::String("temporary bootstrap password".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert!(
+            invalid_email.contains("must contain @"),
+            "unexpected invalid-email error: {invalid_email}"
+        );
+
+        let empty_password = result_err_string(
+            bootstrap_local_user(&[
+                Value::String("new@example.com".to_string()),
+                Value::String("   ".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert!(
+            empty_password.contains("password must not be empty"),
+            "unexpected empty-password error: {empty_password}"
+        );
+    }
+
+    #[test]
+    fn test_bootstrap_local_user_requires_auth_initialization() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        let err = bootstrap_local_user(&[
+            Value::String("admin@example.com".to_string()),
+            Value::String("password".to_string()),
+        ])
+        .expect_err("bootstrap_local_user should require initialized auth");
+        assert!(
+            err.to_string().contains("enable_auth"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -5584,6 +5584,120 @@ mod tests {
     }
 
     #[test]
+    fn test_local_identity_and_credential_atomic_store_rejects_invalid_credential_without_orphaning_memory_and_sqlite(
+    ) {
+        use super::storage::{
+            get_local_credential_secret_record, get_local_identity_by_identifier_record,
+            store_local_identity_and_credential_record, LocalAccountState, LocalCredentialSecret,
+            LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let identity = LocalIdentity {
+                id: "local-user-atomic-failure".to_string(),
+                identifier_kind: "email".to_string(),
+                identifier: "atomic@example.com".to_string(),
+                identifier_normalized: "atomic@example.com".to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state: LocalAccountState::Bootstrap,
+                metadata_json: "{}".to_string(),
+            };
+            let invalid_credential = LocalCredentialSecret {
+                local_user_id: identity.id.clone(),
+                password_hash: "".to_string(),
+                password_hash_algorithm: "bcrypt".to_string(),
+                password_hash_params_json: "{}".to_string(),
+                password_changed_at: 101,
+                must_change_password: true,
+            };
+
+            let err = store_local_identity_and_credential_record(&identity, &invalid_credential)
+                .expect_err("atomic store should reject invalid credentials");
+            assert!(
+                err.contains("password_hash"),
+                "unexpected invalid credential error: {err}"
+            );
+            assert_eq!(
+                get_local_identity_by_identifier_record("email", "atomic@example.com").unwrap(),
+                None,
+                "failed atomic store must not leave an orphaned identity"
+            );
+            assert_eq!(
+                get_local_credential_secret_record("local-user-atomic-failure").unwrap(),
+                None,
+                "failed atomic store must not leave a credential"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sqlite_atomic_local_identity_and_credential_store_rolls_back_identity_on_credential_failure(
+    ) {
+        use super::storage::{
+            get_local_identity_by_identifier_record, store_local_identity_and_credential_record,
+            LocalAccountState, LocalCredentialSecret, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        {
+            let conn_guard = SQLITE_CONN.lock().unwrap();
+            let conn = conn_guard.as_ref().expect("SQLite should be initialized");
+            conn.execute(
+                "CREATE TRIGGER fail_local_credential_insert
+                 BEFORE INSERT ON auth_local_credentials
+                 BEGIN
+                     SELECT RAISE(ABORT, 'forced local credential failure');
+                 END",
+                [],
+            )
+            .expect("test trigger should be installed");
+        }
+
+        let identity = LocalIdentity {
+            id: "local-user-sqlite-atomic".to_string(),
+            identifier_kind: "email".to_string(),
+            identifier: "sqlite-atomic@example.com".to_string(),
+            identifier_normalized: "sqlite-atomic@example.com".to_string(),
+            created_at: 100,
+            updated_at: 100,
+            state: LocalAccountState::Bootstrap,
+            metadata_json: "{}".to_string(),
+        };
+        let credential = LocalCredentialSecret {
+            local_user_id: identity.id.clone(),
+            password_hash: "bcrypt$hash".to_string(),
+            password_hash_algorithm: "bcrypt".to_string(),
+            password_hash_params_json: "{}".to_string(),
+            password_changed_at: 101,
+            must_change_password: true,
+        };
+
+        let err = store_local_identity_and_credential_record(&identity, &credential)
+            .expect_err("credential failure should abort the atomic store");
+        assert!(
+            err.contains("forced local credential failure"),
+            "unexpected SQLite credential failure: {err}"
+        );
+        assert_eq!(
+            get_local_identity_by_identifier_record("email", "sqlite-atomic@example.com").unwrap(),
+            None,
+            "SQLite transaction failure must roll back the identity insert"
+        );
+    }
+
+    #[test]
     fn test_local_credential_store_rejects_missing_identity_memory_and_sqlite() {
         use super::storage::{store_local_credential_secret_record, LocalCredentialSecret};
 

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 
 use super::storage::{
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
-    normalize_local_identifier, store_local_credential_secret_record, store_local_identity_record,
-    LocalAccountState, LocalCredentialSecret, LocalIdentity,
+    normalize_local_identifier, store_local_identity_and_credential_record, LocalAccountState,
+    LocalCredentialSecret, LocalIdentity,
 };
 
 const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
@@ -62,8 +62,7 @@ pub(in crate::stdlib::auth) fn bootstrap_local_user_record(
         must_change_password: true,
     };
 
-    store_local_identity_record(&identity)?;
-    store_local_credential_secret_record(&credential)?;
+    store_local_identity_and_credential_record(&identity, &credential)?;
 
     Ok(VerifiedLocalPassword {
         identity,

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -5,7 +5,8 @@ use std::collections::HashMap;
 
 use super::storage::{
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
-    normalize_local_identifier, LocalAccountState, LocalCredentialSecret, LocalIdentity,
+    normalize_local_identifier, store_local_credential_secret_record, store_local_identity_record,
+    LocalAccountState, LocalCredentialSecret, LocalIdentity,
 };
 
 const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
@@ -19,6 +20,55 @@ const DUMMY_LOCAL_ARGON2_PASSWORD_HASH: &str =
 pub(in crate::stdlib::auth) struct VerifiedLocalPassword {
     identity: LocalIdentity,
     credential: LocalCredentialSecret,
+}
+
+pub(in crate::stdlib::auth) fn bootstrap_local_user_record(
+    identifier_kind: &str,
+    identifier: &str,
+    password: &str,
+) -> std::result::Result<VerifiedLocalPassword, String> {
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier = identifier.trim();
+    let identifier_normalized = normalize_local_identifier(&kind, identifier)?;
+
+    if password.trim().is_empty() {
+        return Err("[auth] local bootstrap password must not be empty".to_string());
+    }
+
+    if get_local_identity_by_identifier_record(&kind, &identifier_normalized)?.is_some() {
+        return Err(format!("[auth] local identity already exists for {}", kind));
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let identity = LocalIdentity {
+        id: format!("local:{}", uuid::Uuid::new_v4()),
+        identifier_kind: kind,
+        identifier: identifier.to_string(),
+        identifier_normalized,
+        created_at: now,
+        updated_at: now,
+        state: LocalAccountState::Bootstrap,
+        metadata_json: "{}".to_string(),
+    };
+    let credential = LocalCredentialSecret {
+        local_user_id: identity.id.clone(),
+        password_hash: bcrypt::hash(password, bcrypt::DEFAULT_COST)
+            .map_err(|_| "[auth] failed to hash local bootstrap password".to_string())?,
+        password_hash_algorithm: CredentialPasswordAlgorithm::Bcrypt
+            .storage_name()
+            .to_string(),
+        password_hash_params_json: "{}".to_string(),
+        password_changed_at: now,
+        must_change_password: true,
+    };
+
+    store_local_identity_record(&identity)?;
+    store_local_credential_secret_record(&credential)?;
+
+    Ok(VerifiedLocalPassword {
+        identity,
+        credential,
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -182,6 +232,10 @@ pub(in crate::stdlib::auth) fn verified_local_password_to_value(
         ),
         (
             "id".to_string(),
+            Value::String(verified.identity.id.clone()),
+        ),
+        (
+            "local_user_id".to_string(),
             Value::String(verified.identity.id.clone()),
         ),
         ("provider".to_string(), Value::String("local".to_string())),

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -200,17 +200,7 @@ impl LocalAuthMemoryStore {
         &mut self,
         credential: LocalCredentialSecret,
     ) -> std::result::Result<(), String> {
-        if credential.local_user_id.trim().is_empty() {
-            return Err("[auth] local credential local_user_id must not be empty".to_string());
-        }
-        if credential.password_hash.trim().is_empty() {
-            return Err("[auth] local credential password_hash must not be empty".to_string());
-        }
-        if credential.password_hash_algorithm.trim().is_empty() {
-            return Err(
-                "[auth] local credential password_hash_algorithm must not be empty".to_string(),
-            );
-        }
+        validate_local_credential_secret_for_storage(&credential)?;
         if !self
             .identities_by_id
             .contains_key(&credential.local_user_id)
@@ -221,6 +211,45 @@ impl LocalAuthMemoryStore {
         }
         self.credential_secrets_by_local_user_id
             .insert(credential.local_user_id.clone(), credential);
+        Ok(())
+    }
+
+    pub(in crate::stdlib::auth) fn store_identity_and_credential(
+        &mut self,
+        identity: LocalIdentity,
+        credential: LocalCredentialSecret,
+    ) -> std::result::Result<(), String> {
+        let identity = normalize_local_identity_for_storage(identity)?;
+        validate_local_credential_secret_for_storage(&credential)?;
+        validate_local_identity_credential_pair(&identity, &credential)?;
+
+        let lookup_key =
+            local_identity_lookup_key(&identity.identifier_kind, &identity.identifier_normalized)?;
+        if let Some(existing_id) = self.identity_id_by_lookup_key.get(&lookup_key) {
+            if existing_id != &identity.id {
+                return Err(format!(
+                    "[auth] local identity identifier already exists for {}",
+                    identity.identifier_kind
+                ));
+            }
+        }
+
+        if let Some(previous) = self.identities_by_id.get(&identity.id) {
+            let previous_lookup_key = local_identity_lookup_key(
+                &previous.identifier_kind,
+                &previous.identifier_normalized,
+            )?;
+            if previous_lookup_key != lookup_key {
+                self.identity_id_by_lookup_key.remove(&previous_lookup_key);
+            }
+        }
+
+        self.identity_id_by_lookup_key
+            .insert(lookup_key, identity.id.clone());
+        self.identities_by_id
+            .insert(identity.id.clone(), identity.clone());
+        self.credential_secrets_by_local_user_id
+            .insert(identity.id, credential);
         Ok(())
     }
 
@@ -257,6 +286,33 @@ fn normalize_local_identity_for_storage(
     Ok(identity)
 }
 
+fn validate_local_credential_secret_for_storage(
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    if credential.local_user_id.trim().is_empty() {
+        return Err("[auth] local credential local_user_id must not be empty".to_string());
+    }
+    if credential.password_hash.trim().is_empty() {
+        return Err("[auth] local credential password_hash must not be empty".to_string());
+    }
+    if credential.password_hash_algorithm.trim().is_empty() {
+        return Err(
+            "[auth] local credential password_hash_algorithm must not be empty".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_local_identity_credential_pair(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    if credential.local_user_id != identity.id {
+        return Err("[auth] local credential must reference the paired local identity".to_string());
+    }
+    Ok(())
+}
+
 pub(in crate::stdlib::auth) fn store_local_identity_record(
     identity: &LocalIdentity,
 ) -> std::result::Result<(), String> {
@@ -273,6 +329,30 @@ pub(in crate::stdlib::auth) fn store_local_identity_record(
         AuthStorageBackend::Redis => {
             Err("[auth] local identity storage is not implemented for Redis/Valkey yet".to_string())
         }
+    }
+}
+
+pub(in crate::stdlib::auth) fn store_local_identity_and_credential_record(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .store_identity_and_credential(identity.clone(), credential.clone()),
+        AuthStorageBackend::Sqlite => {
+            store_local_identity_and_credential_sqlite(identity, credential)
+        }
+        AuthStorageBackend::Postgres => Err(
+            "[auth] local identity and credential storage is not implemented for PostgreSQL yet"
+                .to_string(),
+        ),
+        AuthStorageBackend::Redis => Err(
+            "[auth] local identity and credential storage is not implemented for Redis/Valkey yet"
+                .to_string(),
+        ),
     }
 }
 
@@ -385,6 +465,69 @@ fn store_local_identity_sqlite(identity: &LocalIdentity) -> std::result::Result<
     Ok(())
 }
 
+fn store_local_identity_and_credential_sqlite(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    let identity = normalize_local_identity_for_storage(identity.clone())?;
+    validate_local_credential_secret_for_storage(credential)?;
+    validate_local_identity_credential_pair(&identity, credential)?;
+
+    let mut conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
+    let tx = conn
+        .transaction()
+        .map_err(|e| format!("[auth] failed to begin local bootstrap transaction: {}", e))?;
+
+    tx.execute(
+        "INSERT INTO auth_local_identities
+         (id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(id) DO UPDATE SET
+            identifier_kind = excluded.identifier_kind,
+            identifier = excluded.identifier,
+            identifier_normalized = excluded.identifier_normalized,
+            updated_at = excluded.updated_at,
+            state = excluded.state,
+            metadata_json = excluded.metadata_json",
+        rusqlite::params![
+            identity.id,
+            identity.identifier_kind,
+            identity.identifier,
+            identity.identifier_normalized,
+            identity.created_at,
+            identity.updated_at,
+            identity.state.as_str(),
+            identity.metadata_json,
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store local identity: {}", e))?;
+
+    tx.execute(
+        "INSERT INTO auth_local_credentials
+         (local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(local_user_id) DO UPDATE SET
+            password_hash = excluded.password_hash,
+            password_hash_algorithm = excluded.password_hash_algorithm,
+            password_hash_params_json = excluded.password_hash_params_json,
+            password_changed_at = excluded.password_changed_at,
+            must_change_password = excluded.must_change_password",
+        rusqlite::params![
+            credential.local_user_id,
+            credential.password_hash,
+            credential.password_hash_algorithm,
+            credential.password_hash_params_json,
+            credential.password_changed_at,
+            if credential.must_change_password { 1 } else { 0 },
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
+
+    tx.commit()
+        .map_err(|e| format!("[auth] failed to commit local bootstrap transaction: {}", e))
+}
+
 fn local_identity_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<LocalIdentity> {
     let state: String = row.get(6)?;
     let state = LocalAccountState::from_str(&state).map_err(|e| {
@@ -442,6 +585,7 @@ fn get_local_identity_by_identifier_sqlite(
 fn store_local_credential_secret_sqlite(
     credential: &LocalCredentialSecret,
 ) -> std::result::Result<(), String> {
+    validate_local_credential_secret_for_storage(credential)?;
     let conn_guard = SQLITE_CONN.lock().unwrap();
     let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
     conn.execute(

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -4,12 +4,13 @@ mod local;
 
 pub(super) use local::{
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
-    normalize_local_identifier, store_local_credential_secret_record, store_local_identity_record,
-    LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
+    normalize_local_identifier, store_local_identity_and_credential_record, LocalAccountState,
+    LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
 };
 #[cfg(test)]
 pub(super) use local::{
-    get_local_identity_by_id_record, local_auth_record_fallback_policy, LocalAuthRecordKind,
+    get_local_identity_by_id_record, local_auth_record_fallback_policy,
+    store_local_credential_secret_record, store_local_identity_record, LocalAuthRecordKind,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -4,13 +4,12 @@ mod local;
 
 pub(super) use local::{
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
-    normalize_local_identifier, LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret,
-    LocalIdentity,
+    normalize_local_identifier, store_local_credential_secret_record, store_local_identity_record,
+    LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
 };
 #[cfg(test)]
 pub(super) use local::{
-    get_local_identity_by_id_record, local_auth_record_fallback_policy,
-    store_local_credential_secret_record, store_local_identity_record, LocalAuthRecordKind,
+    get_local_identity_by_id_record, local_auth_record_fallback_policy, LocalAuthRecordKind,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3807,6 +3807,28 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
         }
         "std/auth" => {
             sig!(
+                "bootstrap_local_user",
+                [
+                    "identifier" => Type::String,
+                    "password" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(2)
+            );
+            sig!(
                 "verify_local_password",
                 [
                     "identifier" => Type::String,
@@ -4208,6 +4230,19 @@ mod tests {
             r#"
             import { verify_local_password } from "std/auth"
             verify_local_password(42, "pw")
+            "#,
+        );
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].message.contains("expected String"));
+        assert!(errs[0].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_bootstrap_local_user_signature_checks_args() {
+        let errs = check_errors(
+            r#"
+            import { bootstrap_local_user } from "std/auth"
+            bootstrap_local_user(42, "pw")
             "#,
         );
         assert_eq!(errs.len(), 1);


### PR DESCRIPTION
## Summary
- Updates DD-043/DD-062 after closing PR #99 as an oversized local-auth spike.
- Adds the focused runtime slice for `std/auth.bootstrap_local_user(...)`: provision an initial local identity + password credential using existing auth storage/password primitives.
- Keeps this PR intentionally narrow: no `local_sign_in(...)`, no session/cookie/challenge semantic changes, no password reset/TOTP enrollment, and no PostgreSQL/Redis local credential backend implementation.
- Regenerates `docs/STDLIB_REFERENCE.md` for the new public helper.

## Code shape
- `bootstrap_local_user(identifier, password, options?) -> Result<Map, String>`
- Supports existing memory + SQLite local identity/credential storage paths.
- Uses an atomic identity+credential write boundary for bootstrap provisioning; SQLite wraps both writes in one transaction and memory validates both records before mutating state.
- Returns only safe user payload fields (`subject_id`, `local_user_id`, provider/identifier/state metadata); never exposes password material, hash params, credential secrets, tokens, or connection strings.
- Bootstrap users start in `bootstrap` state with `must_change_password: true`.

## Review follow-up
- Addressed Greptile P1: `bootstrap_local_user` no longer performs separate identity then credential writes. It now uses `store_local_identity_and_credential_record(...)`.
- Added regression coverage for invalid credential rejection without orphaning identity state across memory/SQLite.
- Added SQLite rollback coverage using a forced credential insert failure to prove the identity insert is rolled back.
- Greptile’s P2 description mismatch was stale from the earlier docs-only PR body; this PR body now describes the runtime files/code scope.

## Validation
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --locked --lib test_local_identity_and_credential_atomic_store_rejects_invalid_credential_without_orphaning_memory_and_sqlite -- --test-threads=1 --nocapture`
- `cargo test --locked --lib test_sqlite_atomic_local_identity_and_credential_store_rolls_back_identity_on_credential_failure -- --test-threads=1 --nocapture`
- `cargo test --locked --lib bootstrap_local_user -- --test-threads=1 --nocapture`
- `cargo test --locked auth -- --test-threads=1 --nocapture`
- `cargo test --locked --all-targets`
- `cargo run --locked -- docs --generate`
- `cargo run --locked -- docs --validate`

## Known validation note
- `cargo clippy --locked --all-targets -- -D warnings` is not currently clean on this branch. The first failure is in existing `build.rs` style warnings (`collapsible_if`, `manual_strip`); opportunistically fixing those exposes a larger repo-wide set of pre-existing clippy-deny warnings outside this DD-043 slice. I left those out of this focused PR rather than turning it into a clippy cleanup grab bag.
