### PR TITLE
auth: add local TOTP enrollment helpers

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -86,6 +86,7 @@ Apply this section to any change touching `src/stdlib/auth.rs`, `src/stdlib/auth
 - Does local login use request-aware `sign_in_session(response, req, session, options?)` or the same internal completion primitive instead of creating a weaker parallel session path?
 - Are reset tokens hash-stored, TTL-bound, one-time-use, and replay-tested?
 - Is TOTP enrollment durable account state, not only pending challenge metadata?
+- Do TOTP verification helpers avoid local-identity/MFA-status enumeration by using one generic failure for not-found, disabled/locked, not-enabled, missing-secret, malformed metadata, and wrong-code cases, with dummy verification on unavailable-state paths?
 - Is the email/SMS delivery boundary explicit (`std/auth` issues/validates tokens and URLs; apps/plugins deliver messages)?
 - Does the template integration delete custom auth persistence instead of wrapping it?
 

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -48,6 +48,7 @@ Everything below is merged or intended as the current v0.4.9 baseline:
 - Current-user session management: `user_sessions(req)`, `logout_all(req, keep_current)`
 - Staged auth challenge primitives: `begin_auth_challenge()`, `current_auth_challenge()`, `complete_auth_challenge()`, `cancel_auth_challenge()`
 - TOTP primitives: `totp_secret()`, `verify_totp()`, `totp_uri()`
+- Local TOTP helpers: `begin_totp_enrollment(...)`, `confirm_totp_enrollment(...)`, `verify_local_totp(...)`, `totp_status(...)`, `reset_totp(...)`
 - Route/API protection: `require_auth()` middleware/path/request helper with HTML redirect vs API 401 behavior
 - Bearer-token/resource-server helpers: `oauth_validate(...)`, `oauth_introspect(...)`
 - Built-in login page with configurable title/logo/copy/provider buttons
@@ -117,12 +118,12 @@ Goal: make the extension seam explicit and safe without inventing a full RBAC sy
 
 Goal: make TOTP a real local-auth extension path without requiring template-owned TOTP tables.
 
-- [ ] Add TOTP enrollment helpers around the existing primitives, e.g. `begin_totp_enrollment(...)`, `confirm_totp_enrollment(...)`, `totp_status(...)`, `reset_totp(...)`
-- [ ] Store TOTP enrollment state under the reserved auth metadata namespace on the local identity, unless implementation proves a separate auth-owned record is necessary
-- [ ] Keep TOTP secrets server-side only and absent from safe payloads/current-user/template data
-- [ ] Use staged auth challenges for password → TOTP and setup-required continuations
-- [ ] Ensure protected-route/API access is not granted until required setup/TOTP steps complete
-- [ ] Add tests for enrollment, verification, reset/re-enrollment, disabled/locked account rejection, and no-secret leakage
+- [x] Add TOTP enrollment helpers around the existing primitives: `begin_totp_enrollment(...)`, `confirm_totp_enrollment(...)`, `verify_local_totp(...)`, `totp_status(...)`, `reset_totp(...)`
+- [x] Store TOTP enrollment state under the reserved auth metadata namespace on the local identity
+- [x] Keep TOTP secrets server-side and absent from safe payloads/current-user/template data; only one-time setup URI material is returned by enrollment
+- [x] Document staged auth challenge composition for password → TOTP and setup-required continuations
+- [x] Ensure examples do not grant protected-route/API access until required setup/TOTP steps complete
+- [x] Add tests for enrollment, verification, reset/re-enrollment, disabled/locked account rejection, and no-secret leakage
 
 ### PR 3 — Password Reset Essentials
 
@@ -172,6 +173,7 @@ Everything below is explicitly deferred. It may be valuable later, but it is not
 Only if real apps prove the final-sprint primitives are insufficient:
 
 - Dedicated TOTP enrollment storage instead of reserved local-user metadata
+- TOTP failed-attempt throttling and last-used-step replay tracking if apps need std/auth-owned lockout policy
 - Dedicated local-account profile/admin APIs
 - Higher-level `local_sign_in(...)` wrapper if explicit composition proves too verbose
 - `enable_local_auth(...)` convenience preset

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1751,6 +1751,75 @@ fn login(req) {
 
 Session claims, roles, profiles, and organization membership stay app-owned; local auth only owns credential lifecycle state and safe verification/setup results.
 
+### Local TOTP Enrollment and Verification
+
+Use the local TOTP helpers when an app needs MFA without maintaining its own TOTP table. `begin_totp_enrollment(...)` stores pending secret material under the reserved `auth.totp` metadata namespace and returns an `otpauth://` setup URI for QR-code display. `confirm_totp_enrollment(...)`, `verify_local_totp(...)`, `totp_status(...)`, and `reset_totp(...)` return secret-free status maps; safe user payloads never expose pending or confirmed TOTP secrets.
+
+The setup URI is secret-bearing because authenticator apps need it to enroll. Render it only in the setup response; do not log it, persist it in app metadata, cache it, or expose it through API responses unrelated to setup.
+
+For login, keep password-verified users in a staged auth challenge until TOTP verification succeeds. Do not call `sign_in_session(...)` for a TOTP-required account until the second factor is complete. Pair TOTP routes with the app's normal rate limiting/backoff; `verify_local_totp(...)` verifies the code but does not own account lockout policy.
+
+```ntnt
+import {
+    begin_auth_challenge,
+    begin_totp_enrollment,
+    complete_auth_challenge,
+    confirm_totp_enrollment,
+    current_auth_challenge,
+    current_user,
+    sign_in_session,
+    totp_status,
+    verify_local_password,
+    verify_local_totp
+} from "std/auth"
+import { html, parse_form, redirect } from "std/http/server"
+
+fn start_totp_setup(req) {
+    let user = current_user(req) otherwise return redirect("/login")
+    let setup = begin_totp_enrollment(user["email"], map { "issuer": "Admin" })?
+    return html(template("totp_setup.html", map { "uri": setup["uri"] }))
+}
+
+fn finish_totp_setup(req) {
+    let user = current_user(req) otherwise return redirect("/login")
+    let form = parse_form(req)
+    confirm_totp_enrollment(user["email"], form["code"] ?? "")?
+    return redirect("/admin/security")
+}
+
+fn login(req) {
+    let form = parse_form(req)
+    let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")?
+    let mfa = totp_status(form["email"] ?? "")?
+
+    if mfa["enabled"] {
+        return begin_auth_challenge(redirect("/login/totp"), map {
+            "subject_id": verified["subject_id"],
+            "kind": "mfa_pending",
+            "data": map { "email": verified["email"] }
+        })
+    }
+
+    return sign_in_session(redirect("/admin"), req, map {
+        "subject_id": verified["subject_id"],
+        "email": verified["email"]
+    })
+}
+
+fn finish_totp_login(req) {
+    let challenge = current_auth_challenge(req) otherwise return redirect("/login")
+    if challenge["kind"] != "mfa_pending" { return redirect("/login") }
+    let form = parse_form(req)
+    let email = challenge["data"]["email"] ?? ""
+    verify_local_totp(email, form["code"] ?? "")?
+
+    return complete_auth_challenge(redirect("/admin"), req, map {
+        "subject_id": challenge["subject_id"],
+        "email": email
+    })
+}
+```
+
 ### Local Metadata and Group Authorization
 
 Use `local_user(...)` and `update_local_user_metadata(...)` from trusted server-side code to read/update app-owned local identity metadata without creating a parallel auth model. Metadata is namespaced: `auth.*` is reserved for `std/auth` lifecycle helpers, while app data should live under namespaces such as `app` or `template`. Safe local-user payloads omit reserved auth metadata so TOTP/reset internals do not leak into templates or API responses.

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1827,9 +1827,11 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`auth_me`](#authme) | Return current user as JSON for SPAs. |
 | [`auth_start`](#authstart) | Handle OAuth login start - redirects to the provider's authorization page. |
 | [`begin_auth_challenge`](#beginauthchallenge) | Persist a pending auth challenge and attach the challenge cookie. |
+| [`begin_totp_enrollment`](#begintotpenrollment) | Start TOTP enrollment for a local identity and return one-time setup material. |
 | [`bootstrap_local_user`](#bootstraplocaluser) | Provision an initial local credential record for app setup flows. |
 | [`cancel_auth_challenge`](#cancelauthchallenge) | Cancel the current auth challenge and clear the challenge cookie. |
 | [`complete_auth_challenge`](#completeauthchallenge) | Upgrade the current auth challenge into a full authenticated session. |
+| [`confirm_totp_enrollment`](#confirmtotpenrollment) | Confirm a pending local TOTP enrollment using a code from the authenticator app. |
 | [`create_session_from_oauth`](#createsessionfromoauth) | Create a session from OAuth user info and tokens. |
 | [`csrf_field`](#csrffield) | Get an HTML hidden input field with the CSRF token. |
 | [`csrf_token`](#csrftoken) | Get the CSRF token for the current session. |
@@ -1855,6 +1857,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`oauth_start`](#oauthstart) | Generate an OAuth authorization URL for manual flow control. |
 | [`oauth_validate`](#oauthvalidate) | Validate an incoming bearer token (for APIs acting as resource servers). |
 | [`require_auth`](#requireauth) | Protect routes with the configured auth session. |
+| [`reset_totp`](#resettotp) | Clear a local user's pending or confirmed TOTP enrollment. |
 | [`rotate_session`](#rotatesession) | Rotate the current session ID and attach the new auth cookie to a response. |
 | [`session_data`](#sessiondata) | Get custom data stored in the current session. |
 | [`sessions_cleanup`](#sessionscleanup) | Clean up expired sessions, auth challenges, OAuth states, and exchange tokens from the session store. |
@@ -1863,12 +1866,14 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`sign_in_session`](#signinsession) | Persist a request-aware session and attach the auth cookie to an existing response. |
 | [`sign_out_session`](#signoutsession) | Revoke the current session and attach a clearing auth cookie to a response. |
 | [`totp_secret`](#totpsecret) | Generate a new TOTP secret for MFA setup. |
+| [`totp_status`](#totpstatus) | Read a local user's safe TOTP enrollment status. |
 | [`totp_uri`](#totpuri) | Generate an otpauth:// URI for QR codes. |
 | [`update_local_user_metadata`](#updatelocalusermetadata) | Merge or replace app-owned local identity metadata and return a safe payload. |
 | [`user_sessions`](#usersessions) | Get all active sessions for the current user. |
 | [`validate_csrf`](#validatecsrf) | Validate CSRF token on state-changing requests (POST, PUT, DELETE, PATCH). |
 | [`verify_csrf`](#verifycsrf) | Verify a CSRF token against the session's token. |
 | [`verify_local_password`](#verifylocalpassword) | Verify a local credential record and return a safe auth user payload. |
+| [`verify_local_totp`](#verifylocaltotp) | Verify a local user's confirmed TOTP code without exposing the stored secret. |
 | [`verify_totp`](#verifytotp) | Verify a TOTP code against a secret. |
 
 #### `auth_callback`
@@ -2040,6 +2045,35 @@ begin_auth_challenge(redirect("/admin/verify"), map { "subject_id": user.id, "ki
 
 ---
 
+#### `begin_totp_enrollment`
+
+```ntnt
+begin_totp_enrollment(identifier: String, options?: Map) -> Result<Map, String>
+```
+
+Start TOTP enrollment for a local identity and return one-time setup material.
+
+Generates a new TOTP secret, stores it under std/auth-owned local identity metadata (`auth.totp.pending_secret`), and returns safe status fields plus an `otpauth://` URI for QR-code setup. The raw secret is not returned as a standalone field and is never exposed through `local_user(...)`, `current_user(...)`, or `totp_status(...)`. The setup URI itself is secret-bearing; render it only in the setup response and do not log, cache, or persist it.
+
+**Parameters:**
+
+- `identifier` — The local user identifier. Email is the default identifier kind.
+- `options` — Optional map with `identifier_kind`, `issuer`, and `label`
+
+**Returns:** Ok(map) with pending TOTP status and setup `uri`; Err(message) on invalid identity/state/storage
+
+**Examples:**
+
+```ntnt
+begin_totp_enrollment("admin@example.com", map { "issuer": "Admin" })?  // Create TOTP setup URI
+```
+
+**See also:** `confirm_totp_enrollment`, `totp_status`, `verify_local_totp`, `reset_totp`
+
+*Since v0.4.9*
+
+---
+
 #### `bootstrap_local_user`
 
 ```ntnt
@@ -2131,6 +2165,36 @@ complete_auth_challenge(redirect("/admin"), req, map { "claims": app_claims_for_
 ```
 
 **See also:** `begin_auth_challenge`, `current_auth_challenge`, `cancel_auth_challenge`, `sign_in_session`
+
+*Since v0.4.9*
+
+---
+
+#### `confirm_totp_enrollment`
+
+```ntnt
+confirm_totp_enrollment(identifier: String, code: String, options?: Map) -> Result<Map, String>
+```
+
+Confirm a pending local TOTP enrollment using a code from the authenticator app.
+
+Moves `auth.totp.pending_secret` to std/auth-owned confirmed secret metadata only after the submitted code verifies. Returned status is secret-free and safe to use in setup flows.
+
+**Parameters:**
+
+- `identifier` — The local user identifier. Email is the default identifier kind.
+- `code` — The 6-digit TOTP code from the authenticator app
+- `options` — Optional map with `identifier_kind`
+
+**Returns:** Ok(map) with confirmed TOTP status; Err(message) on missing pending setup or invalid code
+
+**Examples:**
+
+```ntnt
+confirm_totp_enrollment("admin@example.com", form["code"] ?? "")?  // Finish TOTP setup
+```
+
+**See also:** `begin_totp_enrollment`, `verify_local_totp`, `totp_status`, `reset_totp`
 
 *Since v0.4.9*
 
@@ -2882,6 +2946,35 @@ require_auth("/admin/*")  // Protect all admin file routes
 
 ---
 
+#### `reset_totp`
+
+```ntnt
+reset_totp(identifier: String, options?: Map) -> Result<Map, String>
+```
+
+Clear a local user's pending or confirmed TOTP enrollment.
+
+Removes only std/auth-owned `auth.totp` metadata and preserves app-owned metadata namespaces.
+
+**Parameters:**
+
+- `identifier` — The local user identifier. Email is the default identifier kind.
+- `options` — Optional map with `identifier_kind`
+
+**Returns:** Ok(map) with disabled TOTP status; Err(message) on invalid identity/state/storage
+
+**Examples:**
+
+```ntnt
+reset_totp("admin@example.com")?  // Remove TOTP enrollment
+```
+
+**See also:** `begin_totp_enrollment`, `confirm_totp_enrollment`, `totp_status`
+
+*Since v0.4.9*
+
+---
+
 #### `rotate_session`
 
 ```ntnt
@@ -3119,6 +3212,35 @@ totp_secret()  // => "JBSWY3DPEHPK3PXP..."  // Generate secret
 
 ---
 
+#### `totp_status`
+
+```ntnt
+totp_status(identifier: String, options?: Map) -> Result<Map, String>
+```
+
+Read a local user's safe TOTP enrollment status.
+
+Returns status booleans and display metadata only. It never includes pending or confirmed TOTP secret material.
+
+**Parameters:**
+
+- `identifier` — The local user identifier. Email is the default identifier kind.
+- `options` — Optional map with `identifier_kind`
+
+**Returns:** Ok(map) with safe TOTP status; Err(message) on invalid identity/storage
+
+**Examples:**
+
+```ntnt
+totp_status("admin@example.com")?  // Check whether TOTP is enabled
+```
+
+**See also:** `begin_totp_enrollment`, `confirm_totp_enrollment`, `verify_local_totp`, `reset_totp`
+
+*Since v0.4.9*
+
+---
+
 #### `totp_uri`
 
 ```ntnt
@@ -3301,6 +3423,36 @@ sign_in_session(redirect("/admin"), req, map { "subject_id": verified["subject_i
 - **TypeError**: identifier must be a string — *Fix: Pass the submitted email/identifier as a string*
 
 **See also:** `sign_in_session`, `current_session`
+
+*Since v0.4.9*
+
+---
+
+#### `verify_local_totp`
+
+```ntnt
+verify_local_totp(identifier: String, code: String, options?: Map) -> Result<Map, String>
+```
+
+Verify a local user's confirmed TOTP code without exposing the stored secret.
+
+Use after `verify_local_password(...)` in staged login flows. Apps should keep the user in an auth challenge until this helper succeeds, then complete the challenge with `complete_auth_challenge(...)` or sign in through `sign_in_session(...)`. Pair TOTP endpoints with app rate limiting/backoff; this helper verifies codes but does not own account lockout policy.
+
+**Parameters:**
+
+- `identifier` — The local user identifier. Email is the default identifier kind.
+- `code` — The 6-digit TOTP code from the authenticator app
+- `options` — Optional map with `identifier_kind`
+
+**Returns:** Ok(map) with `verified: true` and safe TOTP status; Err(message) on invalid code or unavailable TOTP
+
+**Examples:**
+
+```ntnt
+verify_local_totp("admin@example.com", form["code"] ?? "")?  // Verify second factor
+```
+
+**See also:** `begin_auth_challenge`, `complete_auth_challenge`, `totp_status`
 
 *Since v0.4.9*
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -5133,7 +5133,7 @@ pub fn init() -> HashMap<String, Value> {
                     }
                 };
 
-                Ok(Value::Bool(verify_totp_code(&secret, &code, "")))
+                Ok(Value::Bool(verify_totp_code(&secret, &code, "", "NTNT")))
             },
         },
     );
@@ -5217,6 +5217,13 @@ mod tests {
         match map.get(key) {
             Some(Value::Bool(value)) => assert_eq!(*value, expected, "unexpected {key}"),
             other => panic!("expected {key} bool, got {other:?}"),
+        }
+    }
+
+    fn map_int(map: &HashMap<String, Value>, key: &str) -> i64 {
+        match map.get(key) {
+            Some(Value::Int(value)) => *value,
+            other => panic!("expected {key} int, got {other:?}"),
         }
     }
 
@@ -7366,6 +7373,8 @@ mod tests {
             );
             assert_map_bool(&enrollment, "pending", true);
             assert_map_bool(&enrollment, "enabled", false);
+            let enrollment_created_at = map_int(&enrollment, "created_at");
+            assert!(enrollment_created_at > 0);
             assert!(
                 !enrollment.contains_key("secret"),
                 "begin_totp_enrollment must not expose the raw secret field"
@@ -7423,6 +7432,7 @@ mod tests {
             );
             assert_map_bool(&confirmed, "enabled", true);
             assert_map_bool(&confirmed, "pending", false);
+            assert_eq!(map_int(&confirmed, "created_at"), enrollment_created_at);
             assert_no_totp_secret_material(&Value::Map(confirmed.clone()), &pending_secret);
 
             let verified = result_ok_map(
@@ -7439,6 +7449,7 @@ mod tests {
                 totp_status(&[Value::String("totp@example.com".to_string())]).unwrap(),
             );
             assert_map_bool(&status, "enabled", true);
+            assert_eq!(map_int(&status, "created_at"), enrollment_created_at);
             assert_no_totp_secret_material(&Value::Map(status.clone()), &pending_secret);
 
             let signed_in = sign_in_session(&[
@@ -7465,6 +7476,10 @@ mod tests {
             );
             assert_map_bool(&active_reenrollment, "enabled", true);
             assert_map_bool(&active_reenrollment, "pending", true);
+            assert_eq!(
+                map_int(&active_reenrollment, "created_at"),
+                enrollment_created_at
+            );
 
             let reset = result_ok_map(
                 reset_totp(&[Value::String("totp@example.com".to_string())]).unwrap(),

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -7555,7 +7555,7 @@ mod tests {
                 ])
                 .unwrap(),
             );
-            assert!(verify_error.contains("cannot manage TOTP"));
+            assert_eq!(verify_error, "Invalid local TOTP code");
 
             let status_error =
                 result_err_string(totp_status(&[Value::String(email.to_string())]).unwrap());
@@ -7564,6 +7564,84 @@ mod tests {
             let reset_error =
                 result_err_string(reset_totp(&[Value::String(email.to_string())]).unwrap());
             assert!(reset_error.contains("cannot manage TOTP"));
+        }
+    }
+
+    #[test]
+    fn test_verify_local_totp_uses_generic_errors_for_unavailable_or_disabled_mfa() {
+        use super::storage::{store_local_identity_record, LocalAccountState, LocalIdentity};
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        for (id, email, state, metadata_json) in [
+            (
+                "local-user-no-totp",
+                "no-totp@example.com",
+                LocalAccountState::Active,
+                "{}",
+            ),
+            (
+                "local-user-missing-secret",
+                "missing-secret@example.com",
+                LocalAccountState::Active,
+                "{\"auth\":{\"totp\":{\"enabled\":true,\"issuer\":\"Admin\"}}}",
+            ),
+            (
+                "local-user-malformed-totp",
+                "malformed-totp@example.com",
+                LocalAccountState::Active,
+                "{\"auth\":{\"totp\":\"not-a-map\"}}",
+            ),
+            (
+                "local-user-disabled-totp",
+                "disabled-totp@example.com",
+                LocalAccountState::Disabled,
+                "{}",
+            ),
+            (
+                "local-user-locked-totp",
+                "locked-totp@example.com",
+                LocalAccountState::Locked,
+                "{}",
+            ),
+        ] {
+            store_local_identity_record(&LocalIdentity {
+                id: id.to_string(),
+                identifier_kind: "email".to_string(),
+                identifier: email.to_string(),
+                identifier_normalized: email.to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state,
+                metadata_json: metadata_json.to_string(),
+            })
+            .unwrap();
+        }
+
+        let module = init();
+        let verify_local_totp = module_fn(&module, "verify_local_totp");
+
+        for email in [
+            "unknown@example.com",
+            "no-totp@example.com",
+            "missing-secret@example.com",
+            "malformed-totp@example.com",
+            "disabled-totp@example.com",
+            "locked-totp@example.com",
+        ] {
+            let message = result_err_string(
+                verify_local_totp(&[
+                    Value::String(email.to_string()),
+                    Value::String("000000".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(
+                message, "Invalid local TOTP code",
+                "unexpected error for {email}"
+            );
         }
     }
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -71,9 +71,10 @@ pub use guards::{
     enforce_auth_for_request, get_protected_paths, register_protected_paths, reset_protected_paths,
 };
 use local::{
-    bootstrap_local_user_record, local_identity_to_safe_value, local_user_record,
-    set_local_password_record, update_local_user_metadata_record, verified_local_password_to_value,
-    verify_local_password_record,
+    begin_totp_enrollment_record, bootstrap_local_user_record, confirm_totp_enrollment_record,
+    local_identity_to_safe_value, local_user_record, reset_totp_record, set_local_password_record,
+    totp_status_record, update_local_user_metadata_record, verified_local_password_to_value,
+    verify_local_password_record, verify_local_totp_record,
 };
 use oauth::extract_user_info;
 pub use oauth::{
@@ -734,6 +735,74 @@ fn parse_local_metadata_update_options(options: Option<&Value>) -> Result<(Strin
             other.type_name()
         ))),
         None => Ok(("email".to_string(), false)),
+    }
+}
+
+fn require_auth_initialized_for(function_name: &str) -> Result<()> {
+    get_auth_config().map(|_| ()).ok_or_else(|| {
+        IntentError::runtime_error(format!(
+            "[auth] Auth not initialized. Call enable_auth() before {}().",
+            function_name
+        ))
+    })
+}
+
+fn string_arg<'a>(
+    function_name: &str,
+    args: &'a [Value],
+    index: usize,
+    name: &str,
+) -> Result<&'a str> {
+    match args.get(index) {
+        Some(Value::String(value)) => Ok(value.as_str()),
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() {} must be a string, got {}",
+            function_name,
+            name,
+            other.type_name()
+        ))),
+        None => Err(IntentError::type_error(format!(
+            "[auth] {}() missing required {}",
+            function_name, name
+        ))),
+    }
+}
+
+fn parse_totp_options(
+    function_name: &str,
+    options: Option<&Value>,
+) -> Result<(String, Option<String>, Option<String>)> {
+    match options {
+        Some(Value::Map(map)) => {
+            let identifier_kind = optional_string_option(map, "identifier_kind", function_name)?
+                .unwrap_or_else(|| "email".to_string());
+            let issuer = optional_string_option(map, "issuer", function_name)?;
+            let label = optional_string_option(map, "label", function_name)?;
+            Ok((identifier_kind, issuer, label))
+        }
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() options must be a map, got {}",
+            function_name,
+            other.type_name()
+        ))),
+        None => Ok(("email".to_string(), None, None)),
+    }
+}
+
+fn optional_string_option(
+    map: &HashMap<String, Value>,
+    key: &str,
+    function_name: &str,
+) -> Result<Option<String>> {
+    match map.get(key) {
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() {} must be a string, got {}",
+            function_name,
+            key,
+            other.type_name()
+        ))),
+        None => Ok(None),
     }
 }
 
@@ -4356,6 +4425,212 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt begin_totp_enrollment
+    // @module std/auth
+    // @signature begin_totp_enrollment(identifier: String, options?: Map) -> Result<Map, String>
+    // Start TOTP enrollment for a local identity and return one-time setup material.
+    //
+    // Generates a new TOTP secret, stores it under std/auth-owned local identity metadata (`auth.totp.pending_secret`),
+    // and returns safe status fields plus an `otpauth://` URI for QR-code setup. The raw secret is not returned as a
+    // standalone field and is never exposed through `local_user(...)`, `current_user(...)`, or `totp_status(...)`.
+    // The setup URI itself is secret-bearing; render it only in the setup response and do not log, cache, or persist it.
+    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param options Optional map with `identifier_kind`, `issuer`, and `label`
+    // @returns Ok(map) with pending TOTP status and setup `uri`; Err(message) on invalid identity/state/storage
+    // @see_also confirm_totp_enrollment, totp_status, verify_local_totp, reset_totp
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #mfa, #totp
+    // @example begin_totp_enrollment("admin@example.com", map { "issuer": "Admin" })? ~ "Create TOTP setup URI"
+    module.insert(
+        "begin_totp_enrollment".to_string(),
+        Value::NativeFunction {
+            name: "begin_totp_enrollment".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] begin_totp_enrollment() requires identifier and optional options"
+                            .to_string(),
+                    ));
+                }
+                require_auth_initialized_for("begin_totp_enrollment")?;
+                let identifier = string_arg("begin_totp_enrollment", args, 0, "identifier")?;
+                let (identifier_kind, issuer, label) =
+                    parse_totp_options("begin_totp_enrollment", args.get(1))?;
+                match begin_totp_enrollment_record(
+                    &identifier_kind,
+                    identifier,
+                    issuer.as_deref(),
+                    label.as_deref(),
+                ) {
+                    Ok(status) => Ok(Value::ok(Value::Map(status))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
+    // @ntnt confirm_totp_enrollment
+    // @module std/auth
+    // @signature confirm_totp_enrollment(identifier: String, code: String, options?: Map) -> Result<Map, String>
+    // Confirm a pending local TOTP enrollment using a code from the authenticator app.
+    //
+    // Moves `auth.totp.pending_secret` to std/auth-owned confirmed secret metadata only after the submitted code
+    // verifies. Returned status is secret-free and safe to use in setup flows.
+    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param code The 6-digit TOTP code from the authenticator app
+    // @param options Optional map with `identifier_kind`
+    // @returns Ok(map) with confirmed TOTP status; Err(message) on missing pending setup or invalid code
+    // @see_also begin_totp_enrollment, verify_local_totp, totp_status, reset_totp
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #mfa, #totp
+    // @example confirm_totp_enrollment("admin@example.com", form["code"] ?? "")? ~ "Finish TOTP setup"
+    module.insert(
+        "confirm_totp_enrollment".to_string(),
+        Value::NativeFunction {
+            name: "confirm_totp_enrollment".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] confirm_totp_enrollment() requires identifier, code, and optional options"
+                            .to_string(),
+                    ));
+                }
+                require_auth_initialized_for("confirm_totp_enrollment")?;
+                let identifier = string_arg("confirm_totp_enrollment", args, 0, "identifier")?;
+                let code = string_arg("confirm_totp_enrollment", args, 1, "code")?;
+                let (identifier_kind, _, _) =
+                    parse_totp_options("confirm_totp_enrollment", args.get(2))?;
+                match confirm_totp_enrollment_record(&identifier_kind, identifier, code) {
+                    Ok(status) => Ok(Value::ok(Value::Map(status))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
+    // @ntnt verify_local_totp
+    // @module std/auth
+    // @signature verify_local_totp(identifier: String, code: String, options?: Map) -> Result<Map, String>
+    // Verify a local user's confirmed TOTP code without exposing the stored secret.
+    //
+    // Use after `verify_local_password(...)` in staged login flows. Apps should keep the user in an auth challenge
+    // until this helper succeeds, then complete the challenge with `complete_auth_challenge(...)` or sign in through
+    // `sign_in_session(...)`. Pair TOTP endpoints with app rate limiting/backoff; this helper verifies codes but does
+    // not own account lockout policy.
+    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param code The 6-digit TOTP code from the authenticator app
+    // @param options Optional map with `identifier_kind`
+    // @returns Ok(map) with `verified: true` and safe TOTP status; Err(message) on invalid code or unavailable TOTP
+    // @see_also begin_auth_challenge, complete_auth_challenge, totp_status
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #mfa, #totp
+    // @example verify_local_totp("admin@example.com", form["code"] ?? "")? ~ "Verify second factor"
+    module.insert(
+        "verify_local_totp".to_string(),
+        Value::NativeFunction {
+            name: "verify_local_totp".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] verify_local_totp() requires identifier, code, and optional options"
+                            .to_string(),
+                    ));
+                }
+                require_auth_initialized_for("verify_local_totp")?;
+                let identifier = string_arg("verify_local_totp", args, 0, "identifier")?;
+                let code = string_arg("verify_local_totp", args, 1, "code")?;
+                let (identifier_kind, _, _) = parse_totp_options("verify_local_totp", args.get(2))?;
+                match verify_local_totp_record(&identifier_kind, identifier, code) {
+                    Ok(status) => Ok(Value::ok(Value::Map(status))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
+    // @ntnt totp_status
+    // @module std/auth
+    // @signature totp_status(identifier: String, options?: Map) -> Result<Map, String>
+    // Read a local user's safe TOTP enrollment status.
+    //
+    // Returns status booleans and display metadata only. It never includes pending or confirmed TOTP secret material.
+    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param options Optional map with `identifier_kind`
+    // @returns Ok(map) with safe TOTP status; Err(message) on invalid identity/storage
+    // @see_also begin_totp_enrollment, confirm_totp_enrollment, verify_local_totp, reset_totp
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #mfa, #totp
+    // @example totp_status("admin@example.com")? ~ "Check whether TOTP is enabled"
+    module.insert(
+        "totp_status".to_string(),
+        Value::NativeFunction {
+            name: "totp_status".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] totp_status() requires identifier and optional options".to_string(),
+                    ));
+                }
+                require_auth_initialized_for("totp_status")?;
+                let identifier = string_arg("totp_status", args, 0, "identifier")?;
+                let (identifier_kind, _, _) = parse_totp_options("totp_status", args.get(1))?;
+                match totp_status_record(&identifier_kind, identifier) {
+                    Ok(status) => Ok(Value::ok(Value::Map(status))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
+    // @ntnt reset_totp
+    // @module std/auth
+    // @signature reset_totp(identifier: String, options?: Map) -> Result<Map, String>
+    // Clear a local user's pending or confirmed TOTP enrollment.
+    //
+    // Removes only std/auth-owned `auth.totp` metadata and preserves app-owned metadata namespaces.
+    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param options Optional map with `identifier_kind`
+    // @returns Ok(map) with disabled TOTP status; Err(message) on invalid identity/state/storage
+    // @see_also begin_totp_enrollment, confirm_totp_enrollment, totp_status
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #mfa, #totp
+    // @example reset_totp("admin@example.com")? ~ "Remove TOTP enrollment"
+    module.insert(
+        "reset_totp".to_string(),
+        Value::NativeFunction {
+            name: "reset_totp".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] reset_totp() requires identifier and optional options".to_string(),
+                    ));
+                }
+                require_auth_initialized_for("reset_totp")?;
+                let identifier = string_arg("reset_totp", args, 0, "identifier")?;
+                let (identifier_kind, _, _) = parse_totp_options("reset_totp", args.get(1))?;
+                match reset_totp_record(&identifier_kind, identifier) {
+                    Ok(status) => Ok(Value::ok(Value::Map(status))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
     // @ntnt sign_in_session
     // @module std/auth
     // @signature sign_in_session(response: Response, req: Request, session: Map, options?: Map) -> Response
@@ -4935,6 +5210,42 @@ mod tests {
         match values.first() {
             Some(Value::Map(map)) => map.clone(),
             other => panic!("unexpected Result::Ok payload: {other:?}"),
+        }
+    }
+
+    fn assert_map_bool(map: &HashMap<String, Value>, key: &str, expected: bool) {
+        match map.get(key) {
+            Some(Value::Bool(value)) => assert_eq!(*value, expected, "unexpected {key}"),
+            other => panic!("expected {key} bool, got {other:?}"),
+        }
+    }
+
+    fn assert_no_totp_secret_material(value: &Value, secret: &str) {
+        match value {
+            Value::String(s) => assert!(
+                !s.contains(secret),
+                "string value unexpectedly exposed TOTP secret material"
+            ),
+            Value::Array(values) => {
+                for item in values {
+                    assert_no_totp_secret_material(item, secret);
+                }
+            }
+            Value::Map(map) => {
+                for (key, item) in map {
+                    assert!(
+                        key != "secret" && key != "pending_secret",
+                        "safe payload unexpectedly exposed TOTP secret key {key}"
+                    );
+                    assert_no_totp_secret_material(item, secret);
+                }
+            }
+            Value::EnumValue { values, .. } => {
+                for item in values {
+                    assert_no_totp_secret_material(item, secret);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -6994,6 +7305,250 @@ mod tests {
                 .unwrap();
             assert!(stored.metadata_json.contains("\"theme\":\"light\""));
             assert!(stored.metadata_json.contains("server-only"));
+        }
+    }
+
+    #[test]
+    fn test_totp_enrollment_helpers_round_trip_memory_and_sqlite_without_secret_leakage() {
+        use super::storage::{
+            get_local_identity_by_identifier_record, store_local_credential_secret_record,
+            store_local_identity_record, LocalAccountState, LocalCredentialSecret, LocalIdentity,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            store_local_identity_record(&LocalIdentity {
+                id: "local-user-totp".to_string(),
+                identifier_kind: "email".to_string(),
+                identifier: "Totp@Example.COM".to_string(),
+                identifier_normalized: "totp@example.com".to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state: LocalAccountState::Active,
+                metadata_json: r#"{"app":{"theme":"dark"}}"#.to_string(),
+            })
+            .unwrap();
+            store_local_credential_secret_record(&LocalCredentialSecret {
+                local_user_id: "local-user-totp".to_string(),
+                password_hash: bcrypt::hash("totp password", 4).unwrap(),
+                password_hash_algorithm: "bcrypt".to_string(),
+                password_hash_params_json: "{}".to_string(),
+                password_changed_at: 101,
+                must_change_password: false,
+            })
+            .unwrap();
+
+            let module = init();
+            let begin_totp_enrollment = module_fn(&module, "begin_totp_enrollment");
+            let confirm_totp_enrollment = module_fn(&module, "confirm_totp_enrollment");
+            let verify_local_totp = module_fn(&module, "verify_local_totp");
+            let totp_status = module_fn(&module, "totp_status");
+            let reset_totp = module_fn(&module, "reset_totp");
+            let local_user = module_fn(&module, "local_user");
+            let sign_in_session = module_fn(&module, "sign_in_session");
+            let current_user = module_fn(&module, "current_user");
+
+            let enrollment = result_ok_map(
+                begin_totp_enrollment(&[
+                    Value::String("totp@example.com".to_string()),
+                    Value::Map(HashMap::from([(
+                        "issuer".to_string(),
+                        Value::String("Example Admin".to_string()),
+                    )])),
+                ])
+                .unwrap(),
+            );
+            assert_map_bool(&enrollment, "pending", true);
+            assert_map_bool(&enrollment, "enabled", false);
+            assert!(
+                !enrollment.contains_key("secret"),
+                "begin_totp_enrollment must not expose the raw secret field"
+            );
+            match enrollment.get("uri") {
+                Some(Value::String(uri)) => assert!(uri.starts_with("otpauth://totp/")),
+                other => panic!("expected setup uri, got {other:?}"),
+            }
+
+            let safe_user = result_ok_map(
+                local_user(&[Value::String("totp@example.com".to_string())]).unwrap(),
+            );
+
+            let stored = get_local_identity_by_identifier_record("email", "totp@example.com")
+                .unwrap()
+                .unwrap();
+            assert!(stored.metadata_json.contains("pending_secret"));
+            let pending_secret = serde_json::from_str::<serde_json::Value>(&stored.metadata_json)
+                .unwrap()["auth"]["totp"]["pending_secret"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            assert_no_totp_secret_material(&Value::Map(safe_user.clone()), &pending_secret);
+
+            let bad_code = result_err_string(
+                confirm_totp_enrollment(&[
+                    Value::String("totp@example.com".to_string()),
+                    Value::String("000000".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert!(bad_code.contains("Invalid local TOTP code"));
+
+            let secret_bytes = Secret::Encoded(pending_secret.clone())
+                .to_bytes()
+                .expect("test secret should decode");
+            let totp = TOTP::new(
+                TotpAlgorithm::SHA1,
+                6,
+                1,
+                30,
+                secret_bytes,
+                Some("Example Admin".to_string()),
+                "totp@example.com".to_string(),
+            )
+            .expect("test TOTP should construct");
+            let valid_code = totp.generate_current().expect("test code should generate");
+
+            let confirmed = result_ok_map(
+                confirm_totp_enrollment(&[
+                    Value::String("totp@example.com".to_string()),
+                    Value::String(valid_code.clone()),
+                ])
+                .unwrap(),
+            );
+            assert_map_bool(&confirmed, "enabled", true);
+            assert_map_bool(&confirmed, "pending", false);
+            assert_no_totp_secret_material(&Value::Map(confirmed.clone()), &pending_secret);
+
+            let verified = result_ok_map(
+                verify_local_totp(&[
+                    Value::String("totp@example.com".to_string()),
+                    Value::String(valid_code),
+                ])
+                .unwrap(),
+            );
+            assert_map_bool(&verified, "verified", true);
+            assert_map_bool(&verified, "enabled", true);
+
+            let status = result_ok_map(
+                totp_status(&[Value::String("totp@example.com".to_string())]).unwrap(),
+            );
+            assert_map_bool(&status, "enabled", true);
+            assert_no_totp_secret_material(&Value::Map(status.clone()), &pending_secret);
+
+            let signed_in = sign_in_session(&[
+                redirect_response("/admin", None),
+                request_with_cookie(""),
+                Value::Map(HashMap::from([
+                    (
+                        "subject_id".to_string(),
+                        Value::String("local-user-totp".to_string()),
+                    ),
+                    (
+                        "email".to_string(),
+                        Value::String("totp@example.com".to_string()),
+                    ),
+                ])),
+            ])
+            .unwrap();
+            let cookie = cookie_header_from_response(&signed_in);
+            let current_user_value = current_user(&[request_with_cookie(&cookie)]).unwrap();
+            assert_no_totp_secret_material(&current_user_value, &pending_secret);
+
+            let active_reenrollment = result_ok_map(
+                begin_totp_enrollment(&[Value::String("totp@example.com".to_string())]).unwrap(),
+            );
+            assert_map_bool(&active_reenrollment, "enabled", true);
+            assert_map_bool(&active_reenrollment, "pending", true);
+
+            let reset = result_ok_map(
+                reset_totp(&[Value::String("totp@example.com".to_string())]).unwrap(),
+            );
+            assert_map_bool(&reset, "enabled", false);
+            assert_map_bool(&reset, "pending", false);
+
+            let after_reset = get_local_identity_by_identifier_record("email", "totp@example.com")
+                .unwrap()
+                .unwrap();
+            assert!(!after_reset.metadata_json.contains("totp"));
+            assert!(after_reset.metadata_json.contains("theme"));
+
+            let reenrollment = result_ok_map(
+                begin_totp_enrollment(&[Value::String("totp@example.com".to_string())]).unwrap(),
+            );
+            assert_map_bool(&reenrollment, "pending", true);
+            assert_map_bool(&reenrollment, "enabled", false);
+        }
+    }
+
+    #[test]
+    fn test_totp_helpers_reject_disabled_and_locked_local_accounts() {
+        use super::storage::{store_local_identity_record, LocalAccountState, LocalIdentity};
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        for (email, state) in [
+            ("disabled@example.com", LocalAccountState::Disabled),
+            ("locked@example.com", LocalAccountState::Locked),
+        ] {
+            store_local_identity_record(&LocalIdentity {
+                id: format!("local-user-{email}"),
+                identifier_kind: "email".to_string(),
+                identifier: email.to_string(),
+                identifier_normalized: email.to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state,
+                metadata_json: "{}".to_string(),
+            })
+            .unwrap();
+        }
+
+        let module = init();
+        let begin_totp_enrollment = module_fn(&module, "begin_totp_enrollment");
+        let confirm_totp_enrollment = module_fn(&module, "confirm_totp_enrollment");
+        let verify_local_totp = module_fn(&module, "verify_local_totp");
+        let totp_status = module_fn(&module, "totp_status");
+        let reset_totp = module_fn(&module, "reset_totp");
+
+        for email in ["disabled@example.com", "locked@example.com"] {
+            let begin_error = result_err_string(
+                begin_totp_enrollment(&[Value::String(email.to_string())]).unwrap(),
+            );
+            assert!(begin_error.contains("cannot manage TOTP"));
+
+            let confirm_error = result_err_string(
+                confirm_totp_enrollment(&[
+                    Value::String(email.to_string()),
+                    Value::String("000000".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert!(confirm_error.contains("cannot manage TOTP"));
+
+            let verify_error = result_err_string(
+                verify_local_totp(&[
+                    Value::String(email.to_string()),
+                    Value::String("000000".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert!(verify_error.contains("cannot manage TOTP"));
+
+            let status_error =
+                result_err_string(totp_status(&[Value::String(email.to_string())]).unwrap());
+            assert!(status_error.contains("cannot manage TOTP"));
+
+            let reset_error =
+                result_err_string(reset_totp(&[Value::String(email.to_string())]).unwrap());
+            assert!(reset_error.contains("cannot manage TOTP"));
         }
     }
 

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -11,8 +11,10 @@ use super::storage::{
 };
 
 const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
+const INVALID_LOCAL_TOTP_CODE: &str = "Invalid local TOTP code";
 const INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH: &str =
     "[auth] local credential hash is invalid or unsupported";
+const DUMMY_LOCAL_TOTP_SECRET: &str = "JBSWY3DPEHPK3PXP";
 const DUMMY_LOCAL_BCRYPT_PASSWORD_HASH: &str =
     "$2b$12$.yG5RREnsakkWw6jeYfJNOxZnY6SGO22Ce8jBqKkvXnbV/2Hm3h.y";
 const DUMMY_LOCAL_ARGON2_PASSWORD_HASH: &str =
@@ -158,18 +160,43 @@ pub(in crate::stdlib::auth) fn verify_local_totp_record(
     identifier: &str,
     code: &str,
 ) -> std::result::Result<HashMap<String, Value>, String> {
-    let identity = local_user_record(identifier_kind, identifier)?;
-    ensure_totp_manageable_identity(&identity)?;
-    let metadata = local_metadata_to_value_map(&identity.metadata_json)?;
-    let totp = auth_totp_metadata(&metadata)?;
-    if !bool_field(&totp, "enabled").unwrap_or(false) {
-        return Err("[auth] local TOTP is not enabled".to_string());
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier_normalized = match normalize_local_identifier(&kind, identifier.trim()) {
+        Ok(identifier_normalized) => identifier_normalized,
+        Err(_) => return invalid_local_totp_result(code),
+    };
+
+    let identity = match get_local_identity_by_identifier_record(&kind, &identifier_normalized) {
+        Ok(Some(identity)) => identity,
+        Ok(None) => return invalid_local_totp_result(code),
+        Err(err) => {
+            verify_dummy_local_totp(code);
+            return Err(err);
+        }
+    };
+
+    if matches!(
+        identity.state,
+        LocalAccountState::Disabled | LocalAccountState::Locked
+    ) {
+        return invalid_local_totp_result(code);
     }
-    let secret = string_field(&totp, "secret")
-        .ok_or_else(|| "[auth] local TOTP enrollment is missing secret material".to_string())?;
+
+    let metadata = match local_metadata_to_value_map(&identity.metadata_json) {
+        Ok(metadata) => metadata,
+        Err(_) => return invalid_local_totp_result(code),
+    };
+    let totp = match auth_totp_metadata(&metadata) {
+        Ok(totp) => totp,
+        Err(_) => return invalid_local_totp_result(code),
+    };
+    let secret = match string_field(&totp, "secret") {
+        Some(secret) if bool_field(&totp, "enabled").unwrap_or(false) => secret,
+        _ => return invalid_local_totp_result(code),
+    };
     let issuer = string_field(&totp, "issuer").unwrap_or_else(|| "NTNT".to_string());
     if !super::verify_totp_code(&secret, code, &identity.identifier, &issuer) {
-        return Err("Invalid local TOTP code".to_string());
+        return Err(INVALID_LOCAL_TOTP_CODE.to_string());
     }
     let mut status = totp_status_from_identity(&identity)?;
     status.insert("verified".to_string(), Value::Bool(true));
@@ -229,6 +256,15 @@ fn clean_totp_display_value(
         return Err("[auth] TOTP issuer/label must not be empty".to_string());
     }
     Ok(cleaned.to_string())
+}
+
+fn verify_dummy_local_totp(code: &str) {
+    let _ = super::verify_totp_code(DUMMY_LOCAL_TOTP_SECRET, code, "__dummy__", "NTNT");
+}
+
+fn invalid_local_totp_result<T>(code: &str) -> std::result::Result<T, String> {
+    verify_dummy_local_totp(code);
+    Err(INVALID_LOCAL_TOTP_CODE.to_string())
 }
 
 fn ensure_totp_manageable_identity(identity: &LocalIdentity) -> std::result::Result<(), String> {

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -65,6 +65,144 @@ pub(in crate::stdlib::auth) fn update_local_user_metadata_record(
     .ok_or_else(|| "[auth] local user not found".to_string())
 }
 
+pub(in crate::stdlib::auth) fn begin_totp_enrollment_record(
+    identifier_kind: &str,
+    identifier: &str,
+    issuer: Option<&str>,
+    label: Option<&str>,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier_normalized = normalize_local_identifier(&kind, identifier.trim())?;
+    let secret = super::generate_totp_secret();
+    let issuer = clean_totp_display_value(issuer, "NTNT")?;
+    let now = chrono::Utc::now().timestamp();
+
+    let updated_identity =
+        update_local_identity_by_identifier_record(&kind, &identifier_normalized, |identity| {
+            ensure_totp_manageable_identity(identity)?;
+            let label = clean_totp_display_value(label, identity.identifier.as_str())?;
+            let mut metadata = local_metadata_to_value_map(&identity.metadata_json)?;
+            let mut totp = auth_totp_metadata(&metadata)?;
+            let enabled = bool_field(&totp, "enabled").unwrap_or(false);
+            totp.insert("enabled".to_string(), Value::Bool(enabled));
+            totp.insert("pending".to_string(), Value::Bool(true));
+            totp.insert("pending_secret".to_string(), Value::String(secret.clone()));
+            totp.insert("issuer".to_string(), Value::String(issuer.clone()));
+            totp.insert("label".to_string(), Value::String(label));
+            totp.insert("updated_at".to_string(), Value::Int(now));
+            if !totp.contains_key("created_at") {
+                totp.insert("created_at".to_string(), Value::Int(now));
+            }
+            set_auth_totp_metadata(&mut metadata, Some(totp))?;
+            identity.metadata_json = local_metadata_to_json_string(&metadata)?;
+            identity.updated_at = now;
+            Ok(())
+        })?
+        .ok_or_else(|| "[auth] local user not found".to_string())?;
+
+    let mut status = totp_status_from_identity(&updated_identity)?;
+    let label =
+        string_field(&status, "label").unwrap_or_else(|| updated_identity.identifier.clone());
+    let uri = super::get_totp_uri(&secret, &label, &issuer)?;
+    status.insert("uri".to_string(), Value::String(uri));
+    Ok(status)
+}
+
+pub(in crate::stdlib::auth) fn confirm_totp_enrollment_record(
+    identifier_kind: &str,
+    identifier: &str,
+    code: &str,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier_normalized = normalize_local_identifier(&kind, identifier.trim())?;
+    let now = chrono::Utc::now().timestamp();
+    let updated_identity =
+        update_local_identity_by_identifier_record(&kind, &identifier_normalized, |identity| {
+            ensure_totp_manageable_identity(identity)?;
+            let mut metadata = local_metadata_to_value_map(&identity.metadata_json)?;
+            let totp = auth_totp_metadata(&metadata)?;
+            let pending_secret = string_field(&totp, "pending_secret")
+                .ok_or_else(|| "[auth] no pending local TOTP enrollment".to_string())?;
+            if !super::verify_totp_code(&pending_secret, code, &identity.identifier) {
+                return Err("Invalid local TOTP code".to_string());
+            }
+            let issuer = string_field(&totp, "issuer").unwrap_or_else(|| "NTNT".to_string());
+            let label = string_field(&totp, "label").unwrap_or_else(|| identity.identifier.clone());
+            let required = bool_field(&totp, "required").unwrap_or(false);
+            set_auth_totp_metadata(
+                &mut metadata,
+                Some(HashMap::from([
+                    ("enabled".to_string(), Value::Bool(true)),
+                    ("pending".to_string(), Value::Bool(false)),
+                    ("required".to_string(), Value::Bool(required)),
+                    ("secret".to_string(), Value::String(pending_secret)),
+                    ("issuer".to_string(), Value::String(issuer)),
+                    ("label".to_string(), Value::String(label)),
+                    ("confirmed_at".to_string(), Value::Int(now)),
+                    ("updated_at".to_string(), Value::Int(now)),
+                ])),
+            )?;
+            identity.metadata_json = local_metadata_to_json_string(&metadata)?;
+            identity.updated_at = now;
+            Ok(())
+        })?
+        .ok_or_else(|| "[auth] local user not found".to_string())?;
+
+    totp_status_from_identity(&updated_identity)
+}
+
+pub(in crate::stdlib::auth) fn verify_local_totp_record(
+    identifier_kind: &str,
+    identifier: &str,
+    code: &str,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    let identity = local_user_record(identifier_kind, identifier)?;
+    ensure_totp_manageable_identity(&identity)?;
+    let metadata = local_metadata_to_value_map(&identity.metadata_json)?;
+    let totp = auth_totp_metadata(&metadata)?;
+    if !bool_field(&totp, "enabled").unwrap_or(false) {
+        return Err("[auth] local TOTP is not enabled".to_string());
+    }
+    let secret = string_field(&totp, "secret")
+        .ok_or_else(|| "[auth] local TOTP enrollment is missing secret material".to_string())?;
+    if !super::verify_totp_code(&secret, code, &identity.identifier) {
+        return Err("Invalid local TOTP code".to_string());
+    }
+    let mut status = totp_status_from_identity(&identity)?;
+    status.insert("verified".to_string(), Value::Bool(true));
+    Ok(status)
+}
+
+pub(in crate::stdlib::auth) fn totp_status_record(
+    identifier_kind: &str,
+    identifier: &str,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    let identity = local_user_record(identifier_kind, identifier)?;
+    ensure_totp_manageable_identity(&identity)?;
+    totp_status_from_identity(&identity)
+}
+
+pub(in crate::stdlib::auth) fn reset_totp_record(
+    identifier_kind: &str,
+    identifier: &str,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier_normalized = normalize_local_identifier(&kind, identifier.trim())?;
+    let now = chrono::Utc::now().timestamp();
+    let updated_identity =
+        update_local_identity_by_identifier_record(&kind, &identifier_normalized, |identity| {
+            ensure_totp_manageable_identity(identity)?;
+            let mut metadata = local_metadata_to_value_map(&identity.metadata_json)?;
+            set_auth_totp_metadata(&mut metadata, None)?;
+            identity.metadata_json = local_metadata_to_json_string(&metadata)?;
+            identity.updated_at = now;
+            Ok(())
+        })?
+        .ok_or_else(|| "[auth] local user not found".to_string())?;
+
+    totp_status_from_identity(&updated_identity)
+}
+
 fn reject_reserved_local_metadata_namespaces(
     metadata: &HashMap<String, Value>,
 ) -> std::result::Result<(), String> {
@@ -77,6 +215,146 @@ fn reject_reserved_local_metadata_namespaces(
         }
     }
     Ok(())
+}
+
+fn clean_totp_display_value(
+    value: Option<&str>,
+    default: &str,
+) -> std::result::Result<String, String> {
+    let cleaned = value.unwrap_or(default).trim();
+    if cleaned.is_empty() {
+        return Err("[auth] TOTP issuer/label must not be empty".to_string());
+    }
+    Ok(cleaned.to_string())
+}
+
+fn ensure_totp_manageable_identity(identity: &LocalIdentity) -> std::result::Result<(), String> {
+    if matches!(
+        identity.state,
+        LocalAccountState::Disabled | LocalAccountState::Locked
+    ) {
+        return Err("[auth] local user cannot manage TOTP in current state".to_string());
+    }
+    Ok(())
+}
+
+fn auth_totp_metadata(
+    metadata: &HashMap<String, Value>,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    match metadata.get("auth") {
+        Some(Value::Map(auth)) => match auth.get("totp") {
+            Some(Value::Map(totp)) => Ok(totp.clone()),
+            Some(_) => Err("[auth] local TOTP metadata must be a map".to_string()),
+            None => Ok(HashMap::new()),
+        },
+        Some(_) => Err("[auth] local auth metadata must be a map".to_string()),
+        None => Ok(HashMap::new()),
+    }
+}
+
+fn set_auth_totp_metadata(
+    metadata: &mut HashMap<String, Value>,
+    totp: Option<HashMap<String, Value>>,
+) -> std::result::Result<(), String> {
+    let mut auth = match metadata.remove("auth") {
+        Some(Value::Map(auth)) => auth,
+        Some(_) => return Err("[auth] local auth metadata must be a map".to_string()),
+        None => HashMap::new(),
+    };
+
+    match totp {
+        Some(totp) => {
+            auth.insert("totp".to_string(), Value::Map(totp));
+            metadata.insert("auth".to_string(), Value::Map(auth));
+        }
+        None => {
+            auth.remove("totp");
+            if !auth.is_empty() {
+                metadata.insert("auth".to_string(), Value::Map(auth));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn bool_field(map: &HashMap<String, Value>, key: &str) -> Option<bool> {
+    match map.get(key) {
+        Some(Value::Bool(value)) => Some(*value),
+        _ => None,
+    }
+}
+
+fn int_field(map: &HashMap<String, Value>, key: &str) -> Option<i64> {
+    match map.get(key) {
+        Some(Value::Int(value)) => Some(*value),
+        _ => None,
+    }
+}
+
+fn string_field(map: &HashMap<String, Value>, key: &str) -> Option<String> {
+    match map.get(key) {
+        Some(Value::String(value)) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn totp_status_from_identity(
+    identity: &LocalIdentity,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    let metadata = local_metadata_to_value_map(&identity.metadata_json)?;
+    let totp = auth_totp_metadata(&metadata)?;
+    let enabled = bool_field(&totp, "enabled").unwrap_or(false);
+    let pending = bool_field(&totp, "pending").unwrap_or(false);
+    let required = bool_field(&totp, "required").unwrap_or(false);
+
+    let mut status = HashMap::from([
+        ("subject_id".to_string(), Value::String(identity.id.clone())),
+        ("id".to_string(), Value::String(identity.id.clone())),
+        (
+            "local_user_id".to_string(),
+            Value::String(identity.id.clone()),
+        ),
+        (
+            "identifier_kind".to_string(),
+            Value::String(identity.identifier_kind.clone()),
+        ),
+        (
+            "identifier".to_string(),
+            Value::String(identity.identifier.clone()),
+        ),
+        (
+            "identifier_normalized".to_string(),
+            Value::String(identity.identifier_normalized.clone()),
+        ),
+        (
+            "state".to_string(),
+            Value::String(identity.state.as_str().to_string()),
+        ),
+        ("enabled".to_string(), Value::Bool(enabled)),
+        ("pending".to_string(), Value::Bool(pending)),
+        ("required".to_string(), Value::Bool(required)),
+    ]);
+
+    if identity.identifier_kind == "email" {
+        status.insert(
+            "email".to_string(),
+            Value::String(identity.identifier.clone()),
+        );
+    }
+    if let Some(issuer) = string_field(&totp, "issuer") {
+        status.insert("issuer".to_string(), Value::String(issuer));
+    }
+    if let Some(label) = string_field(&totp, "label") {
+        status.insert("label".to_string(), Value::String(label));
+    }
+    for key in ["created_at", "updated_at", "confirmed_at"] {
+        if let Some(value) = int_field(&totp, key) {
+            status.insert(key.to_string(), Value::Int(value));
+        }
+    }
+
+    Ok(status)
 }
 
 fn local_metadata_to_value_map(

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -123,12 +123,13 @@ pub(in crate::stdlib::auth) fn confirm_totp_enrollment_record(
             let totp = auth_totp_metadata(&metadata)?;
             let pending_secret = string_field(&totp, "pending_secret")
                 .ok_or_else(|| "[auth] no pending local TOTP enrollment".to_string())?;
-            if !super::verify_totp_code(&pending_secret, code, &identity.identifier) {
-                return Err("Invalid local TOTP code".to_string());
-            }
             let issuer = string_field(&totp, "issuer").unwrap_or_else(|| "NTNT".to_string());
             let label = string_field(&totp, "label").unwrap_or_else(|| identity.identifier.clone());
             let required = bool_field(&totp, "required").unwrap_or(false);
+            let created_at = int_field(&totp, "created_at").unwrap_or(now);
+            if !super::verify_totp_code(&pending_secret, code, &identity.identifier, &issuer) {
+                return Err("Invalid local TOTP code".to_string());
+            }
             set_auth_totp_metadata(
                 &mut metadata,
                 Some(HashMap::from([
@@ -138,6 +139,7 @@ pub(in crate::stdlib::auth) fn confirm_totp_enrollment_record(
                     ("secret".to_string(), Value::String(pending_secret)),
                     ("issuer".to_string(), Value::String(issuer)),
                     ("label".to_string(), Value::String(label)),
+                    ("created_at".to_string(), Value::Int(created_at)),
                     ("confirmed_at".to_string(), Value::Int(now)),
                     ("updated_at".to_string(), Value::Int(now)),
                 ])),
@@ -165,7 +167,8 @@ pub(in crate::stdlib::auth) fn verify_local_totp_record(
     }
     let secret = string_field(&totp, "secret")
         .ok_or_else(|| "[auth] local TOTP enrollment is missing secret material".to_string())?;
-    if !super::verify_totp_code(&secret, code, &identity.identifier) {
+    let issuer = string_field(&totp, "issuer").unwrap_or_else(|| "NTNT".to_string());
+    if !super::verify_totp_code(&secret, code, &identity.identifier, &issuer) {
         return Err("Invalid local TOTP code".to_string());
     }
     let mut status = totp_status_from_identity(&identity)?;

--- a/src/stdlib/auth/primitives.rs
+++ b/src/stdlib/auth/primitives.rs
@@ -97,8 +97,8 @@ pub fn get_totp_uri(
 }
 
 /// Verify a TOTP code
-pub fn verify_totp_code(secret: &str, code: &str, email: &str) -> bool {
-    match create_totp(secret, email, "NTNT") {
+pub fn verify_totp_code(secret: &str, code: &str, email: &str, issuer: &str) -> bool {
+    match create_totp(secret, email, issuer) {
         Ok(totp) => totp.check_current(code).unwrap_or(false),
         Err(_) => false,
     }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3909,6 +3909,113 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                 required(3)
             );
             sig!(
+                "begin_totp_enrollment",
+                [
+                    "identifier" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(1)
+            );
+            sig!(
+                "confirm_totp_enrollment",
+                [
+                    "identifier" => Type::String,
+                    "code" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(2)
+            );
+            sig!(
+                "verify_local_totp",
+                [
+                    "identifier" => Type::String,
+                    "code" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(2)
+            );
+            sig!(
+                "totp_status",
+                [
+                    "identifier" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(1)
+            );
+            sig!(
+                "reset_totp",
+                [
+                    "identifier" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(1)
+            );
+            sig!(
                 "verify_local_password",
                 [
                     "identifier" => Type::String,
@@ -4393,6 +4500,39 @@ mod tests {
         assert_eq!(errs.len(), 1);
         assert!(errs[0].message.contains("expected String"));
         assert!(errs[0].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_totp_helper_signatures_check_args() {
+        let errs = check_errors(
+            r#"
+            import { begin_totp_enrollment, confirm_totp_enrollment, verify_local_totp, totp_status, reset_totp } from "std/auth"
+            begin_totp_enrollment(42)
+            confirm_totp_enrollment("admin@example.com", 123456)
+            verify_local_totp("admin@example.com", 123456)
+            totp_status(42)
+            reset_totp(42)
+            "#,
+        );
+        assert_eq!(errs.len(), 5);
+        assert!(errs
+            .iter()
+            .all(|err| err.message.contains("expected String")));
+    }
+
+    #[test]
+    fn test_std_auth_totp_helper_signatures_allow_options() {
+        let errs = check_errors(
+            r#"
+            import { begin_totp_enrollment, confirm_totp_enrollment, verify_local_totp, totp_status, reset_totp } from "std/auth"
+            let setup = begin_totp_enrollment("admin@example.com", map { "issuer": "Admin", "label": "admin@example.com" })
+            let confirmed = confirm_totp_enrollment("admin@example.com", "123456", map { "identifier_kind": "email" })
+            let verified = verify_local_totp("admin@example.com", "123456", map { "identifier_kind": "email" })
+            let status = totp_status("admin@example.com", map { "identifier_kind": "email" })
+            let reset = reset_totp("admin@example.com", map { "identifier_kind": "email" })
+            "#,
+        );
+        assert!(errs.is_empty(), "unexpected diagnostics: {errs:?}");
     }
 
     // ── Scope nesting ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements DD-043 PR 2: Strong TOTP Support for local auth.

- Adds local TOTP lifecycle helpers:
  - `begin_totp_enrollment(identifier, options?)`
  - `confirm_totp_enrollment(identifier, code, options?)`
  - `verify_local_totp(identifier, code, options?)`
  - `totp_status(identifier, options?)`
  - `reset_totp(identifier, options?)`
- Stores TOTP lifecycle state under reserved auth-owned local identity metadata (`auth.totp`) instead of requiring template-owned TOTP tables.
- Keeps pending/confirmed TOTP secrets out of safe payloads (`local_user`, `totp_status`, `current_user`); enrollment returns only one-time setup URI material for QR display.
- Preserves active TOTP during re-enrollment: starting a new enrollment leaves `enabled=true` while `pending=true`, avoiding a password-only downgrade window.
- Rejects disabled/locked local accounts consistently across TOTP helpers.
- Adds typechecker signatures and user-facing docs for staged password → TOTP challenge composition.
- Marks DD-043 PR2 complete and records attempt throttling/replay tracking as future policy if apps need std/auth-owned lockout.

## Test Plan

- Red/green TDD for new TOTP helpers:
  - `cargo test totp -- --nocapture`
- Targeted auth suite:
  - `cargo test auth -- --test-threads=1`
- Full suite:
  - `cargo test`
- Pre-push/core checks:
  - `cargo fmt`
  - `cargo fmt -- --check`
  - `cargo build --profile dev-release`
  - `./target/dev-release/ntnt docs --generate`
  - `git diff --check`
  - `./target/dev-release/ntnt validate examples/`
  - `./target/dev-release/ntnt lint examples/`

Notes:
- Example validation passes with existing warnings in examples/collections_demo.tnt.
- Example lint passes with existing warnings/suggestions; no new lint errors.
- Local auth backend contract env vars are set in this environment, so auth contract tests exercised configured live backends as well as memory/SQLite.

## Review

- Ran delegated security/code review before push.
- Fixed first-pass findings around active re-enrollment, disabled/locked status, current-user leakage tests, unsafe docs examples, setup URI handling guidance, and TOTP throttling/replay policy deferral.
- Second-pass review found no remaining Bucket 1/2/3 findings.

## Known Limitations / Deferrals

- `verify_local_totp(...)` verifies codes but does not own failed-attempt throttling, lockout policy, or last-used-step replay tracking. DD-043 now records that as a future std/auth refinement if real apps need it centralized; apps should wrap TOTP routes with their normal rate limiting/backoff today.
