### PR TITLE
auth: add local password reset helpers

### DIFF
--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1699,7 +1699,7 @@ fn get(req) {
 
 Boundary rule: use `std/auth` for auth flows, sessions, CSRF, current-user helpers, and TOTP. Use `std/crypto` for generic crypto helpers like `uuid`, `hash_password`, and `verify_password`.
 
-Full OAuth, session management, CSRF, JWT, TOTP, and local credential bootstrap, setup completion, and verification support.
+Full OAuth, session management, CSRF, JWT, TOTP, and local credential bootstrap, setup completion, password reset, and verification support.
 
 ### Local Credential Bootstrap and Setup Completion
 
@@ -1750,6 +1750,43 @@ fn login(req) {
 ```
 
 Session claims, roles, profiles, and organization membership stay app-owned; local auth only owns credential lifecycle state and safe verification/setup results.
+
+### Local Password Reset
+
+Use `issue_password_reset(...)` and `consume_password_reset(...)` for reset links instead of storing reset state in app metadata or generic auth challenges. Issuance stores only a hashed verifier plus selector in auth-owned reset-token storage. The raw `selector.verifier` token is returned once so the app can email it or render a setup link. Missing, malformed, disabled, locked, and expired accounts/tokens use generic responses to avoid account enumeration.
+
+```ntnt
+import { consume_password_reset, issue_password_reset, sign_in_session } from "std/auth"
+import { parse_form, redirect } from "std/http/server"
+
+fn request_password_reset(req) {
+    let form = parse_form(req)
+    let reset = issue_password_reset(form["email"] ?? "")?
+
+    // Only present for an existing resettable local user. Still show the same UI either way.
+    if reset["token"] != None {
+        send_reset_email(form["email"] ?? "", reset["token"])
+    }
+
+    return redirect("/password-reset/sent")
+}
+
+fn finish_password_reset(req) {
+    let form = parse_form(req)
+    let user = consume_password_reset(
+        form["token"] ?? "",
+        form["new_password"] ?? ""
+    )?
+
+    return sign_in_session(redirect("/admin"), req, map {
+        "subject_id": user["subject_id"],
+        "email": user["email"],
+        "claims": app_claims_for_local_user(user)
+    })
+}
+```
+
+Reset tokens are one-time records. Never log the returned token, store it in `local_user.metadata`, or echo it through unrelated API responses. If a token is missing, expired, malformed, replayed, or has a wrong verifier, `consume_password_reset(...)` returns the same `Err("Invalid password reset token")`.
 
 ### Local TOTP Enrollment and Verification
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1753,7 +1753,7 @@ Session claims, roles, profiles, and organization membership stay app-owned; loc
 
 ### Local Password Reset
 
-Use `issue_password_reset(...)` and `consume_password_reset(...)` for reset links instead of storing reset state in app metadata or generic auth challenges. Issuance stores only a hashed verifier plus selector in auth-owned reset-token storage. The raw `selector.verifier` token is returned once so the app can email it or render a setup link. Missing, malformed, disabled, locked, and expired accounts/tokens use generic responses to avoid account enumeration.
+Use `issue_password_reset(...)` and `consume_password_reset(...)` for reset links instead of storing reset state in app metadata or generic auth challenges. Issuance stores only a hashed verifier plus selector in auth-owned reset-token storage for resettable local identities. The raw `selector.verifier` token is returned once so the app can email it or render a setup link; syntactically valid requests receive the same response shape whether or not a matching account exists. Missing, malformed, disabled, locked, and expired accounts/tokens use generic responses/errors to avoid account enumeration.
 
 ```ntnt
 import { consume_password_reset, issue_password_reset, sign_in_session } from "std/auth"
@@ -1763,7 +1763,8 @@ fn request_password_reset(req) {
     let form = parse_form(req)
     let reset = issue_password_reset(form["email"] ?? "")?
 
-    // Only present for an existing resettable local user. Still show the same UI either way.
+    // `token` is present for valid-shaped requests, not as an account-existence signal.
+    // Keep the same UI either way; send the link out-of-band if configured.
     if reset["token"] != None {
         send_reset_email(form["email"] ?? "", reset["token"])
     }

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2539,7 +2539,7 @@ The helper normalizes the identifier (email by default), stores only a hashed ve
 - `identifier` — The local user identifier. Email is the default identifier kind.
 - `options` — Optional map with `identifier_kind` and `ttl_seconds` (default 3600)
 
-**Returns:** Ok(map) with `status: "accepted"`; existing accounts also include `token`, `selector`, `created_at`, and `expires_at`
+**Returns:** Ok(map) with `status: "accepted"`; syntactically valid reset requests also include `token`, `selector`, `created_at`, and `expires_at` without revealing whether a matching account exists
 
 **Examples:**
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2532,7 +2532,7 @@ issue_password_reset(identifier: String, options?: Map) -> Result<Map, String>
 
 Issue a one-time password reset token for a local identity.
 
-The helper normalizes the identifier (email by default), stores only a hashed verifier with an opaque selector, and returns deliverable token material only when the local identity exists and can receive a reset. Missing, malformed, disabled, or locked identities return a generic accepted payload without token material so callers can show the same response without account enumeration. Store or send the returned `token` out-of-band; std/auth never stores the raw token.
+The helper normalizes the identifier (email by default), stores only a hashed verifier with an opaque selector, and returns syntactically valid token material for valid-shaped requests so response shape does not reveal account existence. Only resettable local identities have the selector/verifier persisted; dummy token material for missing, disabled, or locked identities later fails with the same generic consume error. Malformed identifiers or non-positive TTLs return a generic accepted payload without token material. Store or send the returned `token` out-of-band; std/auth never stores the raw token.
 
 **Parameters:**
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1832,6 +1832,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`cancel_auth_challenge`](#cancelauthchallenge) | Cancel the current auth challenge and clear the challenge cookie. |
 | [`complete_auth_challenge`](#completeauthchallenge) | Upgrade the current auth challenge into a full authenticated session. |
 | [`confirm_totp_enrollment`](#confirmtotpenrollment) | Confirm a pending local TOTP enrollment using a code from the authenticator app. |
+| [`consume_password_reset`](#consumepasswordreset) | Consume a one-time password reset token and rotate the local password. |
 | [`create_session_from_oauth`](#createsessionfromoauth) | Create a session from OAuth user info and tokens. |
 | [`csrf_field`](#csrffield) | Get an HTML hidden input field with the CSRF token. |
 | [`csrf_token`](#csrftoken) | Get the CSRF token for the current session. |
@@ -1842,6 +1843,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`get_session`](#getsession) | Get the current session from the request. |
 | [`get_user`](#getuser) | Get the current authenticated user from the request. |
 | [`has_group`](#hasgroup) | Check app-owned group IDs from authenticated session data. |
+| [`issue_password_reset`](#issuepasswordreset) | Issue a one-time password reset token for a local identity. |
 | [`jwt_decode`](#jwtdecode) | Decode a JWT token WITHOUT verifying the signature. |
 | [`jwt_sign`](#jwtsign) | Create a signed JWT token from claims. |
 | [`jwt_verify`](#jwtverify) | Verify a JWT token and return its claims. |
@@ -2200,6 +2202,35 @@ confirm_totp_enrollment("admin@example.com", form["code"] ?? "")?  // Finish TOT
 
 ---
 
+#### `consume_password_reset`
+
+```ntnt
+consume_password_reset(token: String, new_password: String) -> Result<Map, String>
+```
+
+Consume a one-time password reset token and rotate the local password.
+
+Valid tokens are consumed atomically, verified against the stored hash, and then used to replace the local credential, transition the identity to `active`, and clear `must_change_password`. Missing, malformed, expired, replayed, and wrong-verifier tokens all return the same generic error. Returned payloads are safe local auth user maps and never expose password hashes, token hashes, raw token material, credentials, or secrets.
+
+**Parameters:**
+
+- `token` — The `selector.verifier` token returned by `issue_password_reset(...)`
+- `new_password` — Replacement plaintext password to hash and store
+
+**Returns:** Ok(map) with safe local user fields; Err(message) for invalid/expired/replayed tokens or storage failure
+
+**Examples:**
+
+```ntnt
+let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "")?  // Finish a password reset
+```
+
+**See also:** `issue_password_reset`, `verify_local_password`, `sign_in_session`
+
+*Since v0.4.9*
+
+---
+
 #### `create_session_from_oauth`
 
 ```ntnt
@@ -2488,6 +2519,35 @@ has_group(current_session(req)?, ["admins", "owners"])  // Check any accepted gr
 ```
 
 **See also:** `require_auth`, `current_session`, `sign_in_session`
+
+*Since v0.4.9*
+
+---
+
+#### `issue_password_reset`
+
+```ntnt
+issue_password_reset(identifier: String, options?: Map) -> Result<Map, String>
+```
+
+Issue a one-time password reset token for a local identity.
+
+The helper normalizes the identifier (email by default), stores only a hashed verifier with an opaque selector, and returns deliverable token material only when the local identity exists and can receive a reset. Missing, malformed, disabled, or locked identities return a generic accepted payload without token material so callers can show the same response without account enumeration. Store or send the returned `token` out-of-band; std/auth never stores the raw token.
+
+**Parameters:**
+
+- `identifier` — The local user identifier. Email is the default identifier kind.
+- `options` — Optional map with `identifier_kind` and `ttl_seconds` (default 3600)
+
+**Returns:** Ok(map) with `status: "accepted"`; existing accounts also include `token`, `selector`, `created_at`, and `expires_at`
+
+**Examples:**
+
+```ntnt
+let reset = issue_password_reset(form["email"] ?? "")?  // Begin password reset without account enumeration
+```
+
+**See also:** `consume_password_reset`, `verify_local_password`, `set_local_password`
 
 *Since v0.4.9*
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -4373,7 +4373,7 @@ pub fn init() -> HashMap<String, Value> {
     // Store or send the returned `token` out-of-band; std/auth never stores the raw token.
     // @param identifier The local user identifier. Email is the default identifier kind.
     // @param options Optional map with `identifier_kind` and `ttl_seconds` (default 3600)
-    // @returns Ok(map) with `status: "accepted"`; existing accounts also include `token`, `selector`, `created_at`, and `expires_at`
+    // @returns Ok(map) with `status: "accepted"`; syntactically valid reset requests also include `token`, `selector`, `created_at`, and `expires_at` without revealing whether a matching account exists
     // @see_also consume_password_reset, verify_local_password, set_local_password
     // @since v0.4.9
     // @tags #auth, #local-auth, #password-reset, #security
@@ -7490,10 +7490,20 @@ mod tests {
                 issue_password_reset(&[Value::String("missing@example.com".to_string())]).unwrap(),
             );
             assert_eq!(map_string(&missing_user, "status"), "accepted");
+            let missing_token = map_string(&missing_user, "token");
+            let missing_selector = map_string(&missing_user, "selector");
             assert!(
-                !missing_user.contains_key("token") && !missing_user.contains_key("selector"),
-                "missing-account reset issuance must not fabricate deliverable token material"
+                missing_token.starts_with(&format!("{missing_selector}.")),
+                "missing-account issuance should preserve response shape without storing a usable token"
             );
+            let missing_consume = result_err_string(
+                consume_password_reset(&[
+                    Value::String(missing_token),
+                    Value::String("missing account reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(missing_consume, "Invalid password reset token");
 
             result_ok_map(
                 bootstrap_local_user(&[
@@ -7528,23 +7538,33 @@ mod tests {
                 issue_password_reset(&[Value::String("expire@example.com".to_string())]).unwrap(),
             );
             let wrong_selector = map_string(&wrong_verifier_issue, "selector");
+            let wrong_verifier_token = format!("{wrong_selector}.definitely-wrong-verifier");
             let wrong_verifier = result_err_string(
                 consume_password_reset(&[
-                    Value::String(format!("{wrong_selector}.definitely-wrong-verifier")),
+                    Value::String(wrong_verifier_token),
                     Value::String("wrong verifier password".to_string()),
                 ])
                 .unwrap(),
             );
             assert_eq!(wrong_verifier, "Invalid password reset token");
 
-            let still_old_password = result_ok_map(
-                verify_local_password(&[
-                    Value::String("expire@example.com".to_string()),
-                    Value::String("temporary reset password".to_string()),
+            let valid_after_wrong_verifier = result_ok_map(
+                consume_password_reset(&[
+                    Value::String(map_string(&wrong_verifier_issue, "token")),
+                    Value::String("valid after wrong verifier".to_string()),
                 ])
                 .unwrap(),
             );
-            assert_eq!(map_string(&still_old_password, "state"), "bootstrap");
+            assert_eq!(map_string(&valid_after_wrong_verifier, "state"), "active");
+
+            let rotated_password = result_ok_map(
+                verify_local_password(&[
+                    Value::String("expire@example.com".to_string()),
+                    Value::String("valid after wrong verifier".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(map_string(&rotated_password, "state"), "active");
         }
     }
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -7288,6 +7288,10 @@ mod tests {
                 "token should include its selector prefix for lookup"
             );
             assert!(map_int(&issued, "expires_at") > map_int(&issued, "created_at"));
+            let sibling_issued = result_ok_map(
+                issue_password_reset(&[Value::String("reset@example.com".to_string())]).unwrap(),
+            );
+            let sibling_token = map_string(&sibling_issued, "token");
             for secret_key in [
                 "password",
                 "password_hash",
@@ -7381,6 +7385,15 @@ mod tests {
                 .unwrap(),
             );
             assert_eq!(replay, "Invalid password reset token");
+
+            let sibling_replay = result_err_string(
+                consume_password_reset(&[
+                    Value::String(sibling_token),
+                    Value::String("sibling reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(sibling_replay, "Invalid password reset token");
         }
     }
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -7296,6 +7296,7 @@ mod tests {
                 "credential",
                 "secret",
                 "token_hash",
+                "local_user_id",
             ] {
                 assert!(
                     !issued.contains_key(secret_key),
@@ -7384,6 +7385,91 @@ mod tests {
     }
 
     #[test]
+    fn test_password_reset_consume_is_atomic_when_sqlite_credential_write_fails() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        let issue_password_reset = module_fn(&module, "issue_password_reset");
+        let consume_password_reset = module_fn(&module, "consume_password_reset");
+        let verify_local_password = module_fn(&module, "verify_local_password");
+
+        result_ok_map(
+            bootstrap_local_user(&[
+                Value::String("atomic-reset@example.com".to_string()),
+                Value::String("temporary reset password".to_string()),
+            ])
+            .unwrap(),
+        );
+        let issued = result_ok_map(
+            issue_password_reset(&[Value::String("atomic-reset@example.com".to_string())]).unwrap(),
+        );
+        let token = map_string(&issued, "token");
+
+        {
+            let conn_guard = SQLITE_CONN.lock().unwrap();
+            let conn = conn_guard.as_ref().expect("SQLite should be initialized");
+            conn.execute(
+                "CREATE TRIGGER fail_password_reset_credential_update
+                 BEFORE UPDATE ON auth_local_credentials
+                 BEGIN
+                     SELECT RAISE(ABORT, 'forced password reset credential failure');
+                 END",
+                [],
+            )
+            .expect("test trigger should be installed");
+        }
+
+        let failed = result_err_string(
+            consume_password_reset(&[
+                Value::String(token.clone()),
+                Value::String("rotated by reset".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert!(
+            failed.contains("forced password reset credential failure"),
+            "unexpected storage failure message: {failed}"
+        );
+
+        let old_password_still_valid = result_ok_map(
+            verify_local_password(&[
+                Value::String("atomic-reset@example.com".to_string()),
+                Value::String("temporary reset password".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(map_string(&old_password_still_valid, "state"), "bootstrap");
+
+        {
+            let conn_guard = SQLITE_CONN.lock().unwrap();
+            let conn = conn_guard.as_ref().expect("SQLite should be initialized");
+            conn.execute("DROP TRIGGER fail_password_reset_credential_update", [])
+                .expect("test trigger should be dropped");
+        }
+
+        let consumed = result_ok_map(
+            consume_password_reset(&[
+                Value::String(token),
+                Value::String("rotated by reset".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(map_string(&consumed, "state"), "active");
+
+        let new_password = result_ok_map(
+            verify_local_password(&[
+                Value::String("atomic-reset@example.com".to_string()),
+                Value::String("rotated by reset".to_string()),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(map_string(&new_password, "state"), "active");
+    }
+
+    #[test]
     fn test_password_reset_helpers_use_generic_responses_for_missing_expired_and_malformed_tokens()
     {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
@@ -7423,15 +7509,11 @@ mod tests {
                 ])
                 .unwrap(),
             );
-            let expired_token = map_string(&expired_issue, "token");
-            let expired = result_err_string(
-                consume_password_reset(&[
-                    Value::String(expired_token),
-                    Value::String("expired reset password".to_string()),
-                ])
-                .unwrap(),
+            assert_eq!(map_string(&expired_issue, "status"), "accepted");
+            assert!(
+                !expired_issue.contains_key("token") && !expired_issue.contains_key("selector"),
+                "zero-ttl reset issuance must not return unstored token material"
             );
-            assert_eq!(expired, "Invalid password reset token");
 
             let malformed = result_err_string(
                 consume_password_reset(&[

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -72,8 +72,9 @@ pub use guards::{
 };
 use local::{
     begin_totp_enrollment_record, bootstrap_local_user_record, confirm_totp_enrollment_record,
-    local_identity_to_safe_value, local_user_record, reset_totp_record, set_local_password_record,
-    totp_status_record, update_local_user_metadata_record, verified_local_password_to_value,
+    consume_password_reset_record, issue_password_reset_record, local_identity_to_safe_value,
+    local_user_record, reset_totp_record, set_local_password_record, totp_status_record,
+    update_local_user_metadata_record, verified_local_password_to_value,
     verify_local_password_record, verify_local_totp_record,
 };
 use oauth::extract_user_info;
@@ -765,6 +766,36 @@ fn string_arg<'a>(
             "[auth] {}() missing required {}",
             function_name, name
         ))),
+    }
+}
+
+fn parse_password_reset_issue_options(
+    function_name: &str,
+    options: Option<&Value>,
+) -> Result<(String, Option<i64>)> {
+    match options {
+        Some(Value::Map(map)) => {
+            let identifier_kind = optional_string_option(map, "identifier_kind", function_name)?
+                .unwrap_or_else(|| "email".to_string());
+            let ttl_seconds = match map.get("ttl_seconds") {
+                Some(Value::Int(value)) => Some(*value),
+                Some(other) => {
+                    return Err(IntentError::type_error(format!(
+                        "[auth] {}() ttl_seconds must be an int, got {}",
+                        function_name,
+                        other.type_name()
+                    )))
+                }
+                None => None,
+            };
+            Ok((identifier_kind, ttl_seconds))
+        }
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() options must be a map, got {}",
+            function_name,
+            other.type_name()
+        ))),
+        None => Ok(("email".to_string(), None)),
     }
 }
 
@@ -4329,6 +4360,93 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt issue_password_reset
+    // @module std/auth
+    // @signature issue_password_reset(identifier: String, options?: Map) -> Result<Map, String>
+    // Issue a one-time password reset token for a local identity.
+    //
+    // The helper normalizes the identifier (email by default), stores only a hashed
+    // verifier with an opaque selector, and returns deliverable token material only
+    // when the local identity exists and can receive a reset. Missing, malformed,
+    // disabled, or locked identities return a generic accepted payload without token
+    // material so callers can show the same response without account enumeration.
+    // Store or send the returned `token` out-of-band; std/auth never stores the raw token.
+    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param options Optional map with `identifier_kind` and `ttl_seconds` (default 3600)
+    // @returns Ok(map) with `status: "accepted"`; existing accounts also include `token`, `selector`, `created_at`, and `expires_at`
+    // @see_also consume_password_reset, verify_local_password, set_local_password
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #password-reset, #security
+    // @example let reset = issue_password_reset(form["email"] ?? "")? ~ "Begin password reset without account enumeration"
+    module.insert(
+        "issue_password_reset".to_string(),
+        Value::NativeFunction {
+            name: "issue_password_reset".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] issue_password_reset() requires identifier and optional options"
+                            .to_string(),
+                    ));
+                }
+                require_auth_initialized_for("issue_password_reset")?;
+                let identifier = string_arg("issue_password_reset", args, 0, "identifier")?;
+                let (identifier_kind, ttl_seconds) =
+                    parse_password_reset_issue_options("issue_password_reset", args.get(1))?;
+                match issue_password_reset_record(&identifier_kind, identifier, ttl_seconds) {
+                    Ok(payload) => Ok(Value::ok(Value::Map(payload))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
+    // @ntnt consume_password_reset
+    // @module std/auth
+    // @signature consume_password_reset(token: String, new_password: String) -> Result<Map, String>
+    // Consume a one-time password reset token and rotate the local password.
+    //
+    // Valid tokens are consumed atomically, verified against the stored hash, and
+    // then used to replace the local credential, transition the identity to `active`,
+    // and clear `must_change_password`. Missing, malformed, expired, replayed, and
+    // wrong-verifier tokens all return the same generic error. Returned payloads are
+    // safe local auth user maps and never expose password hashes, token hashes, raw
+    // token material, credentials, or secrets.
+    // @param token The `selector.verifier` token returned by `issue_password_reset(...)`
+    // @param new_password Replacement plaintext password to hash and store
+    // @returns Ok(map) with safe local user fields; Err(message) for invalid/expired/replayed tokens or storage failure
+    // @see_also issue_password_reset, verify_local_password, sign_in_session
+    // @since v0.4.9
+    // @tags #auth, #local-auth, #password-reset, #security
+    // @example let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "")? ~ "Finish a password reset"
+    module.insert(
+        "consume_password_reset".to_string(),
+        Value::NativeFunction {
+            name: "consume_password_reset".to_string(),
+            arity: 2,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.len() != 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] consume_password_reset() requires token and new_password"
+                            .to_string(),
+                    ));
+                }
+                require_auth_initialized_for("consume_password_reset")?;
+                let token = string_arg("consume_password_reset", args, 0, "token")?;
+                let new_password = string_arg("consume_password_reset", args, 1, "new_password")?;
+                match consume_password_reset_record(token, new_password) {
+                    Ok(verified) => Ok(Value::ok(verified_local_password_to_value(verified))),
+                    Err(message) => Ok(Value::err(Value::String(message))),
+                }
+            },
+        },
+    );
+
     // @ntnt verify_local_password
     // @module std/auth
     // @signature verify_local_password(identifier: String, password: String, options?: Map) -> Result<Map, String>
@@ -5224,6 +5342,13 @@ mod tests {
         match map.get(key) {
             Some(Value::Int(value)) => *value,
             other => panic!("expected {key} int, got {other:?}"),
+        }
+    }
+
+    fn map_string(map: &HashMap<String, Value>, key: &str) -> String {
+        match map.get(key) {
+            Some(Value::String(value)) => value.clone(),
+            other => panic!("expected {key} string, got {other:?}"),
         }
     }
 
@@ -7117,6 +7242,227 @@ mod tests {
                 Some(Value::Bool(value)) => assert!(!*value),
                 other => panic!("unexpected verified must_change_password payload: {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn test_password_reset_helpers_issue_consume_and_reject_replay_memory_and_sqlite() {
+        use super::storage::{
+            get_local_credential_secret_record, get_local_identity_by_identifier_record,
+            LocalAccountState,
+        };
+
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let module = init();
+            let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+            let issue_password_reset = module_fn(&module, "issue_password_reset");
+            let consume_password_reset = module_fn(&module, "consume_password_reset");
+            let verify_local_password = module_fn(&module, "verify_local_password");
+
+            result_ok_map(
+                bootstrap_local_user(&[
+                    Value::String(" Reset@Example.COM ".to_string()),
+                    Value::String("temporary reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+
+            let issued = result_ok_map(
+                issue_password_reset(&[Value::String(" reset@example.com ".to_string())]).unwrap(),
+            );
+            let token = map_string(&issued, "token");
+            let selector = map_string(&issued, "selector");
+            assert!(
+                token.len() >= 64,
+                "reset token should have high-entropy material"
+            );
+            assert!(
+                token.starts_with(&format!("{selector}.")),
+                "token should include its selector prefix for lookup"
+            );
+            assert!(map_int(&issued, "expires_at") > map_int(&issued, "created_at"));
+            for secret_key in [
+                "password",
+                "password_hash",
+                "password_hash_algorithm",
+                "password_hash_params_json",
+                "credential",
+                "secret",
+                "token_hash",
+            ] {
+                assert!(
+                    !issued.contains_key(secret_key),
+                    "issue_password_reset payload must not expose {secret_key}"
+                );
+            }
+
+            let stored_identity =
+                get_local_identity_by_identifier_record("email", "reset@example.com")
+                    .unwrap()
+                    .expect("reset identity should be stored");
+            assert_eq!(stored_identity.state, LocalAccountState::Bootstrap);
+            assert!(
+                !stored_identity.metadata_json.contains(&token),
+                "raw reset token must not be stored in local identity metadata"
+            );
+            assert!(
+                !stored_identity.metadata_json.contains("token_hash"),
+                "reset token hashes belong in reset-token storage, not metadata"
+            );
+
+            let consumed = result_ok_map(
+                consume_password_reset(&[
+                    Value::String(token.clone()),
+                    Value::String("rotated by reset".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(map_string(&consumed, "local_user_id"), stored_identity.id);
+            match consumed.get("state") {
+                Some(Value::String(state)) => assert_eq!(state, "active"),
+                other => panic!("unexpected reset state payload: {other:?}"),
+            }
+            match consumed.get("must_change_password") {
+                Some(Value::Bool(value)) => assert!(!*value),
+                other => panic!("unexpected reset must_change_password payload: {other:?}"),
+            }
+            for secret_key in [
+                "password",
+                "password_hash",
+                "password_hash_algorithm",
+                "password_hash_params_json",
+                "credential",
+                "secret",
+                "token",
+                "selector",
+                "token_hash",
+            ] {
+                assert!(
+                    !consumed.contains_key(secret_key),
+                    "consume_password_reset payload must not expose {secret_key}"
+                );
+            }
+
+            let old_password = result_err_string(
+                verify_local_password(&[
+                    Value::String("reset@example.com".to_string()),
+                    Value::String("temporary reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(old_password, "Invalid local credentials");
+
+            let verified = result_ok_map(
+                verify_local_password(&[
+                    Value::String("reset@example.com".to_string()),
+                    Value::String("rotated by reset".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(map_string(&verified, "local_user_id"), stored_identity.id);
+            let rotated_credential = get_local_credential_secret_record(&stored_identity.id)
+                .unwrap()
+                .expect("reset credential should be stored");
+            assert!(!rotated_credential.must_change_password);
+
+            let replay = result_err_string(
+                consume_password_reset(&[
+                    Value::String(token),
+                    Value::String("replay reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(replay, "Invalid password reset token");
+        }
+    }
+
+    #[test]
+    fn test_password_reset_helpers_use_generic_responses_for_missing_expired_and_malformed_tokens()
+    {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let module = init();
+            let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+            let issue_password_reset = module_fn(&module, "issue_password_reset");
+            let consume_password_reset = module_fn(&module, "consume_password_reset");
+            let verify_local_password = module_fn(&module, "verify_local_password");
+
+            let missing_user = result_ok_map(
+                issue_password_reset(&[Value::String("missing@example.com".to_string())]).unwrap(),
+            );
+            assert_eq!(map_string(&missing_user, "status"), "accepted");
+            assert!(
+                !missing_user.contains_key("token") && !missing_user.contains_key("selector"),
+                "missing-account reset issuance must not fabricate deliverable token material"
+            );
+
+            result_ok_map(
+                bootstrap_local_user(&[
+                    Value::String("expire@example.com".to_string()),
+                    Value::String("temporary reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            let expired_issue = result_ok_map(
+                issue_password_reset(&[
+                    Value::String("expire@example.com".to_string()),
+                    Value::Map(HashMap::from([("ttl_seconds".to_string(), Value::Int(0))])),
+                ])
+                .unwrap(),
+            );
+            let expired_token = map_string(&expired_issue, "token");
+            let expired = result_err_string(
+                consume_password_reset(&[
+                    Value::String(expired_token),
+                    Value::String("expired reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(expired, "Invalid password reset token");
+
+            let malformed = result_err_string(
+                consume_password_reset(&[
+                    Value::String("not-a-valid-reset-token".to_string()),
+                    Value::String("malformed reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(malformed, "Invalid password reset token");
+
+            let wrong_verifier_issue = result_ok_map(
+                issue_password_reset(&[Value::String("expire@example.com".to_string())]).unwrap(),
+            );
+            let wrong_selector = map_string(&wrong_verifier_issue, "selector");
+            let wrong_verifier = result_err_string(
+                consume_password_reset(&[
+                    Value::String(format!("{wrong_selector}.definitely-wrong-verifier")),
+                    Value::String("wrong verifier password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(wrong_verifier, "Invalid password reset token");
+
+            let still_old_password = result_ok_map(
+                verify_local_password(&[
+                    Value::String("expire@example.com".to_string()),
+                    Value::String("temporary reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(map_string(&still_old_password, "state"), "bootstrap");
         }
     }
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -4366,11 +4366,13 @@ pub fn init() -> HashMap<String, Value> {
     // Issue a one-time password reset token for a local identity.
     //
     // The helper normalizes the identifier (email by default), stores only a hashed
-    // verifier with an opaque selector, and returns deliverable token material only
-    // when the local identity exists and can receive a reset. Missing, malformed,
-    // disabled, or locked identities return a generic accepted payload without token
-    // material so callers can show the same response without account enumeration.
-    // Store or send the returned `token` out-of-band; std/auth never stores the raw token.
+    // verifier with an opaque selector, and returns syntactically valid token material
+    // for valid-shaped requests so response shape does not reveal account existence.
+    // Only resettable local identities have the selector/verifier persisted; dummy
+    // token material for missing, disabled, or locked identities later fails with the
+    // same generic consume error. Malformed identifiers or non-positive TTLs return
+    // a generic accepted payload without token material. Store or send the returned
+    // `token` out-of-band; std/auth never stores the raw token.
     // @param identifier The local user identifier. Email is the default identifier kind.
     // @param options Optional map with `identifier_kind` and `ttl_seconds` (default 3600)
     // @returns Ok(map) with `status: "accepted"`; syntactically valid reset requests also include `token`, `selector`, `created_at`, and `expires_at` without revealing whether a matching account exists

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -7400,6 +7400,66 @@ mod tests {
     }
 
     #[test]
+    fn test_set_local_password_revokes_outstanding_password_reset_tokens() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let module = init();
+            let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+            let issue_password_reset = module_fn(&module, "issue_password_reset");
+            let consume_password_reset = module_fn(&module, "consume_password_reset");
+            let set_local_password = module_fn(&module, "set_local_password");
+            let verify_local_password = module_fn(&module, "verify_local_password");
+
+            result_ok_map(
+                bootstrap_local_user(&[
+                    Value::String("manual-rotate@example.com".to_string()),
+                    Value::String("temporary reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            let issued = result_ok_map(
+                issue_password_reset(&[Value::String("manual-rotate@example.com".to_string())])
+                    .unwrap(),
+            );
+            let token = map_string(&issued, "token");
+
+            let rotated = result_ok_map(
+                set_local_password(&[
+                    Value::String("manual-rotate@example.com".to_string()),
+                    Value::String("temporary reset password".to_string()),
+                    Value::String("manually rotated password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(map_string(&rotated, "state"), "active");
+
+            let stale_reset = result_err_string(
+                consume_password_reset(&[
+                    Value::String(token),
+                    Value::String("attacker chosen reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(stale_reset, "Invalid password reset token");
+
+            let current_password_still_valid = result_ok_map(
+                verify_local_password(&[
+                    Value::String("manual-rotate@example.com".to_string()),
+                    Value::String("manually rotated password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(map_string(&current_password_still_valid, "state"), "active");
+        }
+    }
+
+    #[test]
     fn test_password_reset_consume_is_atomic_when_sqlite_credential_write_fails() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         reset_auth_test_state();

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -341,6 +341,30 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     )
     .map_err(|e| format!("Failed to create auth_local_credentials table: {}", e))?;
 
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS auth_local_password_reset_tokens (
+            selector TEXT PRIMARY KEY,
+            local_user_id TEXT NOT NULL,
+            token_hash TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL,
+            FOREIGN KEY(local_user_id) REFERENCES auth_local_identities(id) ON DELETE CASCADE
+        )",
+        [],
+    )
+    .map_err(|e| {
+        format!(
+            "Failed to create auth_local_password_reset_tokens table: {}",
+            e
+        )
+    })?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_auth_local_password_reset_tokens_expires ON auth_local_password_reset_tokens(expires_at)",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_local_password_reset_tokens index: {}", e))?;
+
     let mut sqlite_conn = SQLITE_CONN.lock().unwrap();
     *sqlite_conn = Some(conn);
     Ok(())

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -365,6 +365,12 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     )
     .map_err(|e| format!("Failed to create auth_local_password_reset_tokens index: {}", e))?;
 
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_auth_local_password_reset_tokens_user ON auth_local_password_reset_tokens(local_user_id)",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_local_password_reset_tokens user index: {}", e))?;
+
     let mut sqlite_conn = SQLITE_CONN.lock().unwrap();
     *sqlite_conn = Some(conn);
     Ok(())

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -1,17 +1,23 @@
 use crate::interpreter::Value;
 use argon2::password_hash::Error as PasswordHashError;
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
+use base64::Engine;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
 use super::storage::{
-    get_local_credential_secret_record, get_local_identity_by_identifier_record,
+    consume_local_password_reset_token_record, get_local_credential_secret_record,
+    get_local_identity_by_id_record, get_local_identity_by_identifier_record,
     normalize_local_identifier, store_local_identity_and_credential_record,
-    update_local_identity_by_identifier_record, LocalAccountState, LocalCredentialSecret,
-    LocalIdentity,
+    store_local_password_reset_token_record, update_local_identity_by_identifier_record,
+    LocalAccountState, LocalCredentialSecret, LocalIdentity, LocalPasswordResetToken,
 };
 
 const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
 const INVALID_LOCAL_TOTP_CODE: &str = "Invalid local TOTP code";
+const INVALID_PASSWORD_RESET_TOKEN: &str = "Invalid password reset token";
+const DEFAULT_PASSWORD_RESET_TTL_SECONDS: i64 = 60 * 60;
 const INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH: &str =
     "[auth] local credential hash is invalid or unsupported";
 const DUMMY_LOCAL_TOTP_SECRET: &str = "JBSWY3DPEHPK3PXP";
@@ -559,6 +565,126 @@ pub(in crate::stdlib::auth) fn set_local_password_record(
         identity,
         credential,
     })
+}
+
+pub(in crate::stdlib::auth) fn issue_password_reset_record(
+    identifier_kind: &str,
+    identifier: &str,
+    ttl_seconds: Option<i64>,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    let ttl_seconds = ttl_seconds.unwrap_or(DEFAULT_PASSWORD_RESET_TTL_SECONDS);
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier_normalized = match normalize_local_identifier(&kind, identifier.trim()) {
+        Ok(identifier_normalized) => identifier_normalized,
+        Err(_) => return Ok(password_reset_accepted_response()),
+    };
+
+    let Some(identity) = get_local_identity_by_identifier_record(&kind, &identifier_normalized)?
+    else {
+        return Ok(password_reset_accepted_response());
+    };
+    if matches!(
+        identity.state,
+        LocalAccountState::Disabled | LocalAccountState::Locked
+    ) {
+        return Ok(password_reset_accepted_response());
+    }
+
+    let selector = random_urlsafe_token(16);
+    let verifier = random_urlsafe_token(32);
+    let token = format!("{selector}.{verifier}");
+    let now = chrono::Utc::now().timestamp();
+    let expires_at = now.saturating_add(ttl_seconds.max(0));
+    if expires_at > now {
+        store_local_password_reset_token_record(&LocalPasswordResetToken {
+            selector: selector.clone(),
+            local_user_id: identity.id.clone(),
+            token_hash: hash_password_reset_verifier(&verifier),
+            created_at: now,
+            expires_at,
+        })?;
+    }
+
+    Ok(HashMap::from([
+        ("status".to_string(), Value::String("accepted".to_string())),
+        ("selector".to_string(), Value::String(selector)),
+        ("token".to_string(), Value::String(token)),
+        ("local_user_id".to_string(), Value::String(identity.id)),
+        ("created_at".to_string(), Value::Int(now)),
+        ("expires_at".to_string(), Value::Int(expires_at)),
+    ]))
+}
+
+pub(in crate::stdlib::auth) fn consume_password_reset_record(
+    token: &str,
+    new_password: &str,
+) -> std::result::Result<VerifiedLocalPassword, String> {
+    if new_password.trim().is_empty() {
+        return Err("[auth] local password must not be empty".to_string());
+    }
+
+    let Some((selector, verifier)) = token.split_once('.') else {
+        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
+    };
+    if selector.trim().is_empty() || verifier.trim().is_empty() || token.split('.').count() != 2 {
+        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let Some(reset_token) = consume_local_password_reset_token_record(selector, now)? else {
+        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
+    };
+    let submitted_hash = hash_password_reset_verifier(verifier);
+    if !super::constant_time_compare(&reset_token.token_hash, &submitted_hash) {
+        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
+    }
+
+    let identity = get_local_identity_by_id_record(&reset_token.local_user_id)?
+        .ok_or_else(|| INVALID_PASSWORD_RESET_TOKEN.to_string())?;
+    if matches!(
+        identity.state,
+        LocalAccountState::Disabled | LocalAccountState::Locked
+    ) {
+        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let identity = LocalIdentity {
+        updated_at: now,
+        state: LocalAccountState::Active,
+        ..identity
+    };
+    let credential = LocalCredentialSecret {
+        local_user_id: identity.id.clone(),
+        password_hash: bcrypt::hash(new_password, bcrypt::DEFAULT_COST)
+            .map_err(|_| "[auth] failed to hash local password".to_string())?,
+        password_hash_algorithm: CredentialPasswordAlgorithm::Bcrypt
+            .storage_name()
+            .to_string(),
+        password_hash_params_json: "{}".to_string(),
+        password_changed_at: now,
+        must_change_password: false,
+    };
+
+    store_local_identity_and_credential_record(&identity, &credential)?;
+    Ok(VerifiedLocalPassword {
+        identity,
+        credential,
+    })
+}
+
+fn password_reset_accepted_response() -> HashMap<String, Value> {
+    HashMap::from([("status".to_string(), Value::String("accepted".to_string()))])
+}
+
+fn random_urlsafe_token(byte_count: usize) -> String {
+    let mut bytes = vec![0_u8; byte_count];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn hash_password_reset_verifier(verifier: &str) -> String {
+    hex::encode(Sha256::digest(verifier.as_bytes()))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -579,17 +579,6 @@ pub(in crate::stdlib::auth) fn issue_password_reset_record(
         Err(_) => return Ok(password_reset_accepted_response()),
     };
 
-    let Some(identity) = get_local_identity_by_identifier_record(&kind, &identifier_normalized)?
-    else {
-        return Ok(password_reset_accepted_response());
-    };
-    if matches!(
-        identity.state,
-        LocalAccountState::Disabled | LocalAccountState::Locked
-    ) {
-        return Ok(password_reset_accepted_response());
-    }
-
     let now = chrono::Utc::now().timestamp();
     let expires_at = now.saturating_add(ttl_seconds.max(0));
     if expires_at <= now {
@@ -599,21 +588,26 @@ pub(in crate::stdlib::auth) fn issue_password_reset_record(
     let selector = random_urlsafe_token(16);
     let verifier = random_urlsafe_token(32);
     let token = format!("{selector}.{verifier}");
-    store_local_password_reset_token_record(&LocalPasswordResetToken {
-        selector: selector.clone(),
-        local_user_id: identity.id.clone(),
-        token_hash: hash_password_reset_verifier(&verifier),
-        created_at: now,
-        expires_at,
-    })?;
 
-    Ok(HashMap::from([
-        ("status".to_string(), Value::String("accepted".to_string())),
-        ("selector".to_string(), Value::String(selector)),
-        ("token".to_string(), Value::String(token)),
-        ("created_at".to_string(), Value::Int(now)),
-        ("expires_at".to_string(), Value::Int(expires_at)),
-    ]))
+    if let Some(identity) = get_local_identity_by_identifier_record(&kind, &identifier_normalized)?
+    {
+        if !matches!(
+            identity.state,
+            LocalAccountState::Disabled | LocalAccountState::Locked
+        ) {
+            store_local_password_reset_token_record(&LocalPasswordResetToken {
+                selector: selector.clone(),
+                local_user_id: identity.id.clone(),
+                token_hash: hash_password_reset_verifier(&verifier),
+                created_at: now,
+                expires_at,
+            })?;
+        }
+    }
+
+    Ok(password_reset_token_response(
+        selector, token, now, expires_at,
+    ))
 }
 
 pub(in crate::stdlib::auth) fn consume_password_reset_record(
@@ -633,23 +627,24 @@ pub(in crate::stdlib::auth) fn consume_password_reset_record(
 
     let now = chrono::Utc::now().timestamp();
     let submitted_hash = hash_password_reset_verifier(verifier);
-    let credential = LocalCredentialSecret {
-        local_user_id: String::new(),
-        password_hash: bcrypt::hash(new_password, bcrypt::DEFAULT_COST)
-            .map_err(|_| "[auth] failed to hash local password".to_string())?,
-        password_hash_algorithm: CredentialPasswordAlgorithm::Bcrypt
-            .storage_name()
-            .to_string(),
-        password_hash_params_json: "{}".to_string(),
-        password_changed_at: now,
-        must_change_password: false,
-    };
     let Some((identity, credential)) =
         consume_local_password_reset_token_and_store_credential_record(
             selector,
             &submitted_hash,
-            &credential,
             now,
+            |local_user_id| {
+                Ok(LocalCredentialSecret {
+                    local_user_id: local_user_id.to_string(),
+                    password_hash: bcrypt::hash(new_password, bcrypt::DEFAULT_COST)
+                        .map_err(|_| "[auth] failed to hash local password".to_string())?,
+                    password_hash_algorithm: CredentialPasswordAlgorithm::Bcrypt
+                        .storage_name()
+                        .to_string(),
+                    password_hash_params_json: "{}".to_string(),
+                    password_changed_at: now,
+                    must_change_password: false,
+                })
+            },
         )?
     else {
         return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
@@ -662,6 +657,21 @@ pub(in crate::stdlib::auth) fn consume_password_reset_record(
 
 fn password_reset_accepted_response() -> HashMap<String, Value> {
     HashMap::from([("status".to_string(), Value::String("accepted".to_string()))])
+}
+
+fn password_reset_token_response(
+    selector: String,
+    token: String,
+    created_at: i64,
+    expires_at: i64,
+) -> HashMap<String, Value> {
+    HashMap::from([
+        ("status".to_string(), Value::String("accepted".to_string())),
+        ("selector".to_string(), Value::String(selector)),
+        ("token".to_string(), Value::String(token)),
+        ("created_at".to_string(), Value::Int(created_at)),
+        ("expires_at".to_string(), Value::Int(expires_at)),
+    ])
 }
 
 fn random_urlsafe_token(byte_count: usize) -> String {

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -7,8 +7,8 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
 use super::storage::{
-    consume_local_password_reset_token_record, get_local_credential_secret_record,
-    get_local_identity_by_id_record, get_local_identity_by_identifier_record,
+    consume_local_password_reset_token_and_store_credential_record,
+    get_local_credential_secret_record, get_local_identity_by_identifier_record,
     normalize_local_identifier, store_local_identity_and_credential_record,
     store_local_password_reset_token_record, update_local_identity_by_identifier_record,
     LocalAccountState, LocalCredentialSecret, LocalIdentity, LocalPasswordResetToken,
@@ -590,26 +590,27 @@ pub(in crate::stdlib::auth) fn issue_password_reset_record(
         return Ok(password_reset_accepted_response());
     }
 
+    let now = chrono::Utc::now().timestamp();
+    let expires_at = now.saturating_add(ttl_seconds.max(0));
+    if expires_at <= now {
+        return Ok(password_reset_accepted_response());
+    }
+
     let selector = random_urlsafe_token(16);
     let verifier = random_urlsafe_token(32);
     let token = format!("{selector}.{verifier}");
-    let now = chrono::Utc::now().timestamp();
-    let expires_at = now.saturating_add(ttl_seconds.max(0));
-    if expires_at > now {
-        store_local_password_reset_token_record(&LocalPasswordResetToken {
-            selector: selector.clone(),
-            local_user_id: identity.id.clone(),
-            token_hash: hash_password_reset_verifier(&verifier),
-            created_at: now,
-            expires_at,
-        })?;
-    }
+    store_local_password_reset_token_record(&LocalPasswordResetToken {
+        selector: selector.clone(),
+        local_user_id: identity.id.clone(),
+        token_hash: hash_password_reset_verifier(&verifier),
+        created_at: now,
+        expires_at,
+    })?;
 
     Ok(HashMap::from([
         ("status".to_string(), Value::String("accepted".to_string())),
         ("selector".to_string(), Value::String(selector)),
         ("token".to_string(), Value::String(token)),
-        ("local_user_id".to_string(), Value::String(identity.id)),
         ("created_at".to_string(), Value::Int(now)),
         ("expires_at".to_string(), Value::Int(expires_at)),
     ]))
@@ -631,31 +632,9 @@ pub(in crate::stdlib::auth) fn consume_password_reset_record(
     }
 
     let now = chrono::Utc::now().timestamp();
-    let Some(reset_token) = consume_local_password_reset_token_record(selector, now)? else {
-        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
-    };
     let submitted_hash = hash_password_reset_verifier(verifier);
-    if !super::constant_time_compare(&reset_token.token_hash, &submitted_hash) {
-        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
-    }
-
-    let identity = get_local_identity_by_id_record(&reset_token.local_user_id)?
-        .ok_or_else(|| INVALID_PASSWORD_RESET_TOKEN.to_string())?;
-    if matches!(
-        identity.state,
-        LocalAccountState::Disabled | LocalAccountState::Locked
-    ) {
-        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
-    }
-
-    let now = chrono::Utc::now().timestamp();
-    let identity = LocalIdentity {
-        updated_at: now,
-        state: LocalAccountState::Active,
-        ..identity
-    };
     let credential = LocalCredentialSecret {
-        local_user_id: identity.id.clone(),
+        local_user_id: String::new(),
         password_hash: bcrypt::hash(new_password, bcrypt::DEFAULT_COST)
             .map_err(|_| "[auth] failed to hash local password".to_string())?,
         password_hash_algorithm: CredentialPasswordAlgorithm::Bcrypt
@@ -665,8 +644,16 @@ pub(in crate::stdlib::auth) fn consume_password_reset_record(
         password_changed_at: now,
         must_change_password: false,
     };
-
-    store_local_identity_and_credential_record(&identity, &credential)?;
+    let Some((identity, credential)) =
+        consume_local_password_reset_token_and_store_credential_record(
+            selector,
+            &submitted_hash,
+            &credential,
+            now,
+        )?
+    else {
+        return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
+    };
     Ok(VerifiedLocalPassword {
         identity,
         credential,

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -10,6 +10,7 @@ use super::storage::{
     consume_local_password_reset_token_and_store_credential_record,
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
     normalize_local_identifier, store_local_identity_and_credential_record,
+    store_local_identity_and_credential_revoke_password_resets_record,
     store_local_password_reset_token_record, update_local_identity_by_identifier_record,
     LocalAccountState, LocalCredentialSecret, LocalIdentity, LocalPasswordResetToken,
 };
@@ -559,7 +560,7 @@ pub(in crate::stdlib::auth) fn set_local_password_record(
         must_change_password: false,
     };
 
-    store_local_identity_and_credential_record(&identity, &credential)?;
+    store_local_identity_and_credential_revoke_password_resets_record(&identity, &credential)?;
 
     Ok(VerifiedLocalPassword {
         identity,

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -313,26 +313,30 @@ impl LocalAuthMemoryStore {
         Ok(())
     }
 
-    pub(in crate::stdlib::auth) fn consume_password_reset_token_and_store_credential(
+    pub(in crate::stdlib::auth) fn consume_password_reset_token_and_store_credential<F>(
         &mut self,
         selector: &str,
         token_hash: &str,
-        credential: LocalCredentialSecret,
         now: i64,
-    ) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String> {
-        let Some(reset_token) = self.password_reset_tokens_by_selector.remove(selector) else {
+        credential_builder: F,
+    ) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String>
+    where
+        F: FnOnce(&str) -> std::result::Result<LocalCredentialSecret, String>,
+    {
+        let Some(reset_token) = self
+            .password_reset_tokens_by_selector
+            .get(selector)
+            .cloned()
+        else {
             return Ok(None);
         };
-        if reset_token.expires_at <= now
-            || !constant_time_compare(&reset_token.token_hash, token_hash)
-        {
+        if reset_token.expires_at <= now {
+            self.password_reset_tokens_by_selector.remove(selector);
             return Ok(None);
         }
-        let credential = LocalCredentialSecret {
-            local_user_id: reset_token.local_user_id.clone(),
-            ..credential
-        };
-        validate_local_credential_secret_for_storage(&credential)?;
+        if !constant_time_compare(&reset_token.token_hash, token_hash) {
+            return Ok(None);
+        }
         let Some(identity) = self
             .identities_by_id
             .get(&reset_token.local_user_id)
@@ -346,12 +350,15 @@ impl LocalAuthMemoryStore {
         ) {
             return Ok(None);
         }
+        let credential = credential_builder(&reset_token.local_user_id)?;
+        validate_local_credential_secret_for_storage(&credential)?;
         let identity = LocalIdentity {
             updated_at: now,
             state: LocalAccountState::Active,
             ..identity
         };
         self.store_identity_and_credential(identity.clone(), credential.clone())?;
+        self.password_reset_tokens_by_selector.remove(selector);
         Ok(Some((identity, credential)))
     }
 }
@@ -593,12 +600,15 @@ pub(in crate::stdlib::auth) fn store_local_password_reset_token_record(
     }
 }
 
-pub(in crate::stdlib::auth) fn consume_local_password_reset_token_and_store_credential_record(
+pub(in crate::stdlib::auth) fn consume_local_password_reset_token_and_store_credential_record<F>(
     selector: &str,
     token_hash: &str,
-    credential: &LocalCredentialSecret,
     now: i64,
-) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String> {
+    credential_builder: F,
+) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String>
+where
+    F: FnOnce(&str) -> std::result::Result<LocalCredentialSecret, String>,
+{
     match active_auth_storage_backend() {
         AuthStorageBackend::Memory => SESSION_STORE
             .lock()
@@ -607,12 +617,15 @@ pub(in crate::stdlib::auth) fn consume_local_password_reset_token_and_store_cred
             .consume_password_reset_token_and_store_credential(
                 selector,
                 token_hash,
-                credential.clone(),
                 now,
+                credential_builder,
             ),
         AuthStorageBackend::Sqlite => {
             consume_local_password_reset_token_and_store_credential_sqlite(
-                selector, token_hash, credential, now,
+                selector,
+                token_hash,
+                now,
+                credential_builder,
             )
         }
         AuthStorageBackend::Postgres => {
@@ -920,12 +933,15 @@ fn store_local_password_reset_token_sqlite(
     Ok(())
 }
 
-fn consume_local_password_reset_token_and_store_credential_sqlite(
+fn consume_local_password_reset_token_and_store_credential_sqlite<F>(
     selector: &str,
     token_hash: &str,
-    credential: &LocalCredentialSecret,
     now: i64,
-) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String> {
+    credential_builder: F,
+) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String>
+where
+    F: FnOnce(&str) -> std::result::Result<LocalCredentialSecret, String>,
+{
     let mut conn_guard = SQLITE_CONN.lock().unwrap();
     let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
     let tx = conn.transaction().map_err(|e| {
@@ -963,14 +979,17 @@ fn consume_local_password_reset_token_and_store_credential_sqlite(
         return Ok(None);
     };
 
-    tx.execute(
-        "DELETE FROM auth_local_password_reset_tokens WHERE selector = ?1",
-        rusqlite::params![selector],
-    )
-    .map_err(|e| format!("[auth] failed to delete password reset token: {}", e))?;
-
-    if reset_token.expires_at <= now || !constant_time_compare(&reset_token.token_hash, token_hash)
-    {
+    if reset_token.expires_at <= now {
+        tx.execute(
+            "DELETE FROM auth_local_password_reset_tokens WHERE selector = ?1",
+            rusqlite::params![selector],
+        )
+        .map_err(|e| {
+            format!(
+                "[auth] failed to delete expired password reset token: {}",
+                e
+            )
+        })?;
         tx.commit().map_err(|e| {
             format!(
                 "[auth] failed to commit password reset consume transaction: {}",
@@ -979,10 +998,16 @@ fn consume_local_password_reset_token_and_store_credential_sqlite(
         })?;
         return Ok(None);
     }
-    let credential = LocalCredentialSecret {
-        local_user_id: reset_token.local_user_id.clone(),
-        ..credential.clone()
-    };
+    if !constant_time_compare(&reset_token.token_hash, token_hash) {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    let credential = credential_builder(&reset_token.local_user_id)?;
     validate_local_credential_secret_for_storage(&credential)?;
 
     let Some(identity) = tx
@@ -1049,6 +1074,11 @@ fn consume_local_password_reset_token_and_store_credential_sqlite(
         ],
     )
     .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
+    tx.execute(
+        "DELETE FROM auth_local_password_reset_tokens WHERE selector = ?1",
+        rusqlite::params![selector],
+    )
+    .map_err(|e| format!("[auth] failed to delete password reset token: {}", e))?;
     tx.commit().map_err(|e| {
         format!(
             "[auth] failed to commit password reset consume transaction: {}",

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -313,18 +313,46 @@ impl LocalAuthMemoryStore {
         Ok(())
     }
 
-    pub(in crate::stdlib::auth) fn consume_password_reset_token(
+    pub(in crate::stdlib::auth) fn consume_password_reset_token_and_store_credential(
         &mut self,
         selector: &str,
+        token_hash: &str,
+        credential: LocalCredentialSecret,
         now: i64,
-    ) -> std::result::Result<Option<LocalPasswordResetToken>, String> {
-        let Some(token) = self.password_reset_tokens_by_selector.remove(selector) else {
+    ) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String> {
+        let Some(reset_token) = self.password_reset_tokens_by_selector.remove(selector) else {
             return Ok(None);
         };
-        if token.expires_at <= now {
+        if reset_token.expires_at <= now
+            || !constant_time_compare(&reset_token.token_hash, token_hash)
+        {
             return Ok(None);
         }
-        Ok(Some(token))
+        let credential = LocalCredentialSecret {
+            local_user_id: reset_token.local_user_id.clone(),
+            ..credential
+        };
+        validate_local_credential_secret_for_storage(&credential)?;
+        let Some(identity) = self
+            .identities_by_id
+            .get(&reset_token.local_user_id)
+            .cloned()
+        else {
+            return Ok(None);
+        };
+        if matches!(
+            identity.state,
+            LocalAccountState::Disabled | LocalAccountState::Locked
+        ) {
+            return Ok(None);
+        }
+        let identity = LocalIdentity {
+            updated_at: now,
+            state: LocalAccountState::Active,
+            ..identity
+        };
+        self.store_identity_and_credential(identity.clone(), credential.clone())?;
+        Ok(Some((identity, credential)))
     }
 }
 
@@ -565,24 +593,34 @@ pub(in crate::stdlib::auth) fn store_local_password_reset_token_record(
     }
 }
 
-pub(in crate::stdlib::auth) fn consume_local_password_reset_token_record(
+pub(in crate::stdlib::auth) fn consume_local_password_reset_token_and_store_credential_record(
     selector: &str,
+    token_hash: &str,
+    credential: &LocalCredentialSecret,
     now: i64,
-) -> std::result::Result<Option<LocalPasswordResetToken>, String> {
+) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String> {
     match active_auth_storage_backend() {
         AuthStorageBackend::Memory => SESSION_STORE
             .lock()
             .unwrap()
             .local_auth
-            .consume_password_reset_token(selector, now),
-        AuthStorageBackend::Sqlite => consume_local_password_reset_token_sqlite(selector, now),
-        AuthStorageBackend::Postgres => Err(
-            "[auth] password reset token lookup is not implemented for PostgreSQL yet".to_string(),
-        ),
-        AuthStorageBackend::Redis => Err(
-            "[auth] password reset token lookup is not implemented for Redis/Valkey yet"
-                .to_string(),
-        ),
+            .consume_password_reset_token_and_store_credential(
+                selector,
+                token_hash,
+                credential.clone(),
+                now,
+            ),
+        AuthStorageBackend::Sqlite => {
+            consume_local_password_reset_token_and_store_credential_sqlite(
+                selector, token_hash, credential, now,
+            )
+        }
+        AuthStorageBackend::Postgres => {
+            Err("[auth] password reset consume is not implemented for PostgreSQL yet".to_string())
+        }
+        AuthStorageBackend::Redis => {
+            Err("[auth] password reset consume is not implemented for Redis/Valkey yet".to_string())
+        }
     }
 }
 
@@ -882,20 +920,22 @@ fn store_local_password_reset_token_sqlite(
     Ok(())
 }
 
-fn consume_local_password_reset_token_sqlite(
+fn consume_local_password_reset_token_and_store_credential_sqlite(
     selector: &str,
+    token_hash: &str,
+    credential: &LocalCredentialSecret,
     now: i64,
-) -> std::result::Result<Option<LocalPasswordResetToken>, String> {
+) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String> {
     let mut conn_guard = SQLITE_CONN.lock().unwrap();
     let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
     let tx = conn.transaction().map_err(|e| {
         format!(
-            "[auth] failed to begin password reset token consume transaction: {}",
+            "[auth] failed to begin password reset consume transaction: {}",
             e
         )
     })?;
 
-    let token = tx
+    let Some(reset_token) = tx
         .query_row(
             "SELECT selector, local_user_id, token_hash, created_at, expires_at
              FROM auth_local_password_reset_tokens
@@ -912,21 +952,111 @@ fn consume_local_password_reset_token_sqlite(
             },
         )
         .optional()
-        .map_err(|e| format!("[auth] failed to lookup password reset token: {}", e))?;
+        .map_err(|e| format!("[auth] failed to lookup password reset token: {}", e))?
+    else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
 
     tx.execute(
         "DELETE FROM auth_local_password_reset_tokens WHERE selector = ?1",
         rusqlite::params![selector],
     )
     .map_err(|e| format!("[auth] failed to delete password reset token: {}", e))?;
+
+    if reset_token.expires_at <= now || !constant_time_compare(&reset_token.token_hash, token_hash)
+    {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    let credential = LocalCredentialSecret {
+        local_user_id: reset_token.local_user_id.clone(),
+        ..credential.clone()
+    };
+    validate_local_credential_secret_for_storage(&credential)?;
+
+    let Some(identity) = tx
+        .query_row(
+            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+             FROM auth_local_identities
+             WHERE id = ?1",
+            rusqlite::params![reset_token.local_user_id],
+            local_identity_from_row,
+        )
+        .optional()
+        .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))?
+    else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+    if matches!(
+        identity.state,
+        LocalAccountState::Disabled | LocalAccountState::Locked
+    ) {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+
+    let identity = normalize_local_identity_for_storage(LocalIdentity {
+        updated_at: now,
+        state: LocalAccountState::Active,
+        ..identity
+    })?;
+    tx.execute(
+        "UPDATE auth_local_identities
+         SET updated_at = ?2, state = ?3
+         WHERE id = ?1",
+        rusqlite::params![identity.id, identity.updated_at, identity.state.as_str()],
+    )
+    .map_err(|e| format!("[auth] failed to update local identity: {}", e))?;
+    tx.execute(
+        "INSERT INTO auth_local_credentials
+         (local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(local_user_id) DO UPDATE SET
+            password_hash = excluded.password_hash,
+            password_hash_algorithm = excluded.password_hash_algorithm,
+            password_hash_params_json = excluded.password_hash_params_json,
+            password_changed_at = excluded.password_changed_at,
+            must_change_password = excluded.must_change_password",
+        rusqlite::params![
+            credential.local_user_id,
+            credential.password_hash,
+            credential.password_hash_algorithm,
+            credential.password_hash_params_json,
+            credential.password_changed_at,
+            if credential.must_change_password { 1 } else { 0 },
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
     tx.commit().map_err(|e| {
         format!(
-            "[auth] failed to commit password reset token consume transaction: {}",
+            "[auth] failed to commit password reset consume transaction: {}",
             e
         )
     })?;
 
-    Ok(token.filter(|token| token.expires_at > now))
+    Ok(Some((identity, credential.clone())))
 }
 
 #[cfg(test)]

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -358,7 +358,8 @@ impl LocalAuthMemoryStore {
             ..identity
         };
         self.store_identity_and_credential(identity.clone(), credential.clone())?;
-        self.password_reset_tokens_by_selector.remove(selector);
+        self.password_reset_tokens_by_selector
+            .retain(|_, token| token.local_user_id != reset_token.local_user_id);
         Ok(Some((identity, credential)))
     }
 }
@@ -1075,10 +1076,10 @@ where
     )
     .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
     tx.execute(
-        "DELETE FROM auth_local_password_reset_tokens WHERE selector = ?1",
-        rusqlite::params![selector],
+        "DELETE FROM auth_local_password_reset_tokens WHERE local_user_id = ?1",
+        rusqlite::params![reset_token.local_user_id],
     )
-    .map_err(|e| format!("[auth] failed to delete password reset token: {}", e))?;
+    .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
     tx.commit().map_err(|e| {
         format!(
             "[auth] failed to commit password reset consume transaction: {}",

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -254,6 +254,15 @@ impl LocalAuthMemoryStore {
         identity: LocalIdentity,
         credential: LocalCredentialSecret,
     ) -> std::result::Result<(), String> {
+        self.store_identity_and_credential_with_reset_revocation(identity, credential, false)
+    }
+
+    pub(in crate::stdlib::auth) fn store_identity_and_credential_with_reset_revocation(
+        &mut self,
+        identity: LocalIdentity,
+        credential: LocalCredentialSecret,
+        revoke_password_resets: bool,
+    ) -> std::result::Result<(), String> {
         let identity = normalize_local_identity_for_storage(identity)?;
         validate_local_credential_secret_for_storage(&credential)?;
         validate_local_identity_credential_pair(&identity, &credential)?;
@@ -284,7 +293,11 @@ impl LocalAuthMemoryStore {
         self.identities_by_id
             .insert(identity.id.clone(), identity.clone());
         self.credential_secrets_by_local_user_id
-            .insert(identity.id, credential);
+            .insert(identity.id.clone(), credential);
+        if revoke_password_resets {
+            self.password_reset_tokens_by_selector
+                .retain(|_, token| token.local_user_id != identity.id);
+        }
         Ok(())
     }
 
@@ -454,14 +467,33 @@ pub(in crate::stdlib::auth) fn store_local_identity_and_credential_record(
     identity: &LocalIdentity,
     credential: &LocalCredentialSecret,
 ) -> std::result::Result<(), String> {
+    store_local_identity_and_credential_record_inner(identity, credential, false)
+}
+
+pub(in crate::stdlib::auth) fn store_local_identity_and_credential_revoke_password_resets_record(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    store_local_identity_and_credential_record_inner(identity, credential, true)
+}
+
+fn store_local_identity_and_credential_record_inner(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+    revoke_password_resets: bool,
+) -> std::result::Result<(), String> {
     match active_auth_storage_backend() {
         AuthStorageBackend::Memory => SESSION_STORE
             .lock()
             .unwrap()
             .local_auth
-            .store_identity_and_credential(identity.clone(), credential.clone()),
+            .store_identity_and_credential_with_reset_revocation(
+                identity.clone(),
+                credential.clone(),
+                revoke_password_resets,
+            ),
         AuthStorageBackend::Sqlite => {
-            store_local_identity_and_credential_sqlite(identity, credential)
+            store_local_identity_and_credential_sqlite(identity, credential, revoke_password_resets)
         }
         AuthStorageBackend::Postgres => Err(
             "[auth] local identity and credential storage is not implemented for PostgreSQL yet"
@@ -671,6 +703,7 @@ fn store_local_identity_sqlite(identity: &LocalIdentity) -> std::result::Result<
 fn store_local_identity_and_credential_sqlite(
     identity: &LocalIdentity,
     credential: &LocalCredentialSecret,
+    revoke_password_resets: bool,
 ) -> std::result::Result<(), String> {
     let identity = normalize_local_identity_for_storage(identity.clone())?;
     validate_local_credential_secret_for_storage(credential)?;
@@ -726,6 +759,14 @@ fn store_local_identity_and_credential_sqlite(
         ],
     )
     .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
+
+    if revoke_password_resets {
+        tx.execute(
+            "DELETE FROM auth_local_password_reset_tokens WHERE local_user_id = ?1",
+            rusqlite::params![identity.id],
+        )
+        .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
+    }
 
     tx.commit()
         .map_err(|e| format!("[auth] failed to commit local bootstrap transaction: {}", e))

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -106,6 +106,15 @@ pub(in crate::stdlib::auth) struct LocalCredentialSecret {
     pub(in crate::stdlib::auth) must_change_password: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::stdlib::auth) struct LocalPasswordResetToken {
+    pub(in crate::stdlib::auth) selector: String,
+    pub(in crate::stdlib::auth) local_user_id: String,
+    pub(in crate::stdlib::auth) token_hash: String,
+    pub(in crate::stdlib::auth) created_at: i64,
+    pub(in crate::stdlib::auth) expires_at: i64,
+}
+
 pub(in crate::stdlib::auth) fn normalize_local_identifier(
     identifier_kind: &str,
     identifier: &str,
@@ -139,6 +148,7 @@ pub(in crate::stdlib::auth) struct LocalAuthMemoryStore {
     identities_by_id: HashMap<String, LocalIdentity>,
     identity_id_by_lookup_key: HashMap<String, String>,
     credential_secrets_by_local_user_id: HashMap<String, LocalCredentialSecret>,
+    password_reset_tokens_by_selector: HashMap<String, LocalPasswordResetToken>,
 }
 
 impl LocalAuthMemoryStore {
@@ -287,6 +297,35 @@ impl LocalAuthMemoryStore {
             .get(local_user_id)
             .cloned())
     }
+
+    pub(in crate::stdlib::auth) fn store_password_reset_token(
+        &mut self,
+        token: LocalPasswordResetToken,
+    ) -> std::result::Result<(), String> {
+        validate_local_password_reset_token_for_storage(&token)?;
+        if !self.identities_by_id.contains_key(&token.local_user_id) {
+            return Err(
+                "[auth] password reset token must reference an existing local identity".to_string(),
+            );
+        }
+        self.password_reset_tokens_by_selector
+            .insert(token.selector.clone(), token);
+        Ok(())
+    }
+
+    pub(in crate::stdlib::auth) fn consume_password_reset_token(
+        &mut self,
+        selector: &str,
+        now: i64,
+    ) -> std::result::Result<Option<LocalPasswordResetToken>, String> {
+        let Some(token) = self.password_reset_tokens_by_selector.remove(selector) else {
+            return Ok(None);
+        };
+        if token.expires_at <= now {
+            return Ok(None);
+        }
+        Ok(Some(token))
+    }
 }
 
 fn local_identity_lookup_key(
@@ -324,6 +363,24 @@ fn validate_local_credential_secret_for_storage(
         return Err(
             "[auth] local credential password_hash_algorithm must not be empty".to_string(),
         );
+    }
+    Ok(())
+}
+
+fn validate_local_password_reset_token_for_storage(
+    token: &LocalPasswordResetToken,
+) -> std::result::Result<(), String> {
+    if token.selector.trim().is_empty() {
+        return Err("[auth] password reset token selector must not be empty".to_string());
+    }
+    if token.local_user_id.trim().is_empty() {
+        return Err("[auth] password reset token local_user_id must not be empty".to_string());
+    }
+    if token.token_hash.trim().is_empty() {
+        return Err("[auth] password reset token hash must not be empty".to_string());
+    }
+    if token.expires_at <= token.created_at {
+        return Err("[auth] password reset token expires_at must be after created_at".to_string());
     }
     Ok(())
 }
@@ -484,6 +541,47 @@ pub(in crate::stdlib::auth) fn get_local_credential_secret_record(
         }
         AuthStorageBackend::Redis => Err(
             "[auth] local credential lookup is not implemented for Redis/Valkey yet".to_string(),
+        ),
+    }
+}
+
+pub(in crate::stdlib::auth) fn store_local_password_reset_token_record(
+    token: &LocalPasswordResetToken,
+) -> std::result::Result<(), String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .store_password_reset_token(token.clone()),
+        AuthStorageBackend::Sqlite => store_local_password_reset_token_sqlite(token),
+        AuthStorageBackend::Postgres => Err(
+            "[auth] password reset token storage is not implemented for PostgreSQL yet".to_string(),
+        ),
+        AuthStorageBackend::Redis => Err(
+            "[auth] password reset token storage is not implemented for Redis/Valkey yet"
+                .to_string(),
+        ),
+    }
+}
+
+pub(in crate::stdlib::auth) fn consume_local_password_reset_token_record(
+    selector: &str,
+    now: i64,
+) -> std::result::Result<Option<LocalPasswordResetToken>, String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .consume_password_reset_token(selector, now),
+        AuthStorageBackend::Sqlite => consume_local_password_reset_token_sqlite(selector, now),
+        AuthStorageBackend::Postgres => Err(
+            "[auth] password reset token lookup is not implemented for PostgreSQL yet".to_string(),
+        ),
+        AuthStorageBackend::Redis => Err(
+            "[auth] password reset token lookup is not implemented for Redis/Valkey yet"
+                .to_string(),
         ),
     }
 }
@@ -755,6 +853,80 @@ fn get_local_credential_secret_sqlite(
     )
     .optional()
     .map_err(|e| format!("[auth] failed to lookup local credential: {}", e))
+}
+
+fn store_local_password_reset_token_sqlite(
+    token: &LocalPasswordResetToken,
+) -> std::result::Result<(), String> {
+    validate_local_password_reset_token_for_storage(token)?;
+    let conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
+    conn.execute(
+        "INSERT INTO auth_local_password_reset_tokens
+         (selector, local_user_id, token_hash, created_at, expires_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(selector) DO UPDATE SET
+            local_user_id = excluded.local_user_id,
+            token_hash = excluded.token_hash,
+            created_at = excluded.created_at,
+            expires_at = excluded.expires_at",
+        rusqlite::params![
+            token.selector,
+            token.local_user_id,
+            token.token_hash,
+            token.created_at,
+            token.expires_at,
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store password reset token: {}", e))?;
+    Ok(())
+}
+
+fn consume_local_password_reset_token_sqlite(
+    selector: &str,
+    now: i64,
+) -> std::result::Result<Option<LocalPasswordResetToken>, String> {
+    let mut conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
+    let tx = conn.transaction().map_err(|e| {
+        format!(
+            "[auth] failed to begin password reset token consume transaction: {}",
+            e
+        )
+    })?;
+
+    let token = tx
+        .query_row(
+            "SELECT selector, local_user_id, token_hash, created_at, expires_at
+             FROM auth_local_password_reset_tokens
+             WHERE selector = ?1",
+            rusqlite::params![selector],
+            |row| {
+                Ok(LocalPasswordResetToken {
+                    selector: row.get(0)?,
+                    local_user_id: row.get(1)?,
+                    token_hash: row.get(2)?,
+                    created_at: row.get(3)?,
+                    expires_at: row.get(4)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|e| format!("[auth] failed to lookup password reset token: {}", e))?;
+
+    tx.execute(
+        "DELETE FROM auth_local_password_reset_tokens WHERE selector = ?1",
+        rusqlite::params![selector],
+    )
+    .map_err(|e| format!("[auth] failed to delete password reset token: {}", e))?;
+    tx.commit().map_err(|e| {
+        format!(
+            "[auth] failed to commit password reset token consume transaction: {}",
+            e
+        )
+    })?;
+
+    Ok(token.filter(|token| token.expires_at > now))
 }
 
 #[cfg(test)]

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -3,8 +3,8 @@ use super::*;
 mod local;
 
 pub(super) use local::{
-    consume_local_password_reset_token_record, get_local_credential_secret_record,
-    get_local_identity_by_id_record, get_local_identity_by_identifier_record,
+    consume_local_password_reset_token_and_store_credential_record,
+    get_local_credential_secret_record, get_local_identity_by_identifier_record,
     normalize_local_identifier, store_local_identity_and_credential_record,
     store_local_password_reset_token_record, update_local_identity_by_identifier_record,
     LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
@@ -12,8 +12,8 @@ pub(super) use local::{
 };
 #[cfg(test)]
 pub(super) use local::{
-    local_auth_record_fallback_policy, store_local_credential_secret_record,
-    store_local_identity_record, LocalAuthRecordKind,
+    get_local_identity_by_id_record, local_auth_record_fallback_policy,
+    store_local_credential_secret_record, store_local_identity_record, LocalAuthRecordKind,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -3,15 +3,17 @@ use super::*;
 mod local;
 
 pub(super) use local::{
-    get_local_credential_secret_record, get_local_identity_by_identifier_record,
+    consume_local_password_reset_token_record, get_local_credential_secret_record,
+    get_local_identity_by_id_record, get_local_identity_by_identifier_record,
     normalize_local_identifier, store_local_identity_and_credential_record,
-    update_local_identity_by_identifier_record, LocalAccountState, LocalAuthMemoryStore,
-    LocalCredentialSecret, LocalIdentity,
+    store_local_password_reset_token_record, update_local_identity_by_identifier_record,
+    LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
+    LocalPasswordResetToken,
 };
 #[cfg(test)]
 pub(super) use local::{
-    get_local_identity_by_id_record, local_auth_record_fallback_policy,
-    store_local_credential_secret_record, store_local_identity_record, LocalAuthRecordKind,
+    local_auth_record_fallback_policy, store_local_credential_secret_record,
+    store_local_identity_record, LocalAuthRecordKind,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -6,6 +6,7 @@ pub(super) use local::{
     consume_local_password_reset_token_and_store_credential_record,
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
     normalize_local_identifier, store_local_identity_and_credential_record,
+    store_local_identity_and_credential_revoke_password_resets_record,
     store_local_password_reset_token_record, update_local_identity_by_identifier_record,
     LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
     LocalPasswordResetToken,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4016,6 +4016,44 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                 required(1)
             );
             sig!(
+                "issue_password_reset",
+                [
+                    "identifier" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(1)
+            );
+            sig!(
+                "consume_password_reset",
+                [
+                    "token" => Type::String,
+                    "new_password" => Type::String
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                }
+            );
+            sig!(
                 "verify_local_password",
                 [
                     "identifier" => Type::String,
@@ -4500,6 +4538,33 @@ mod tests {
         assert_eq!(errs.len(), 1);
         assert!(errs[0].message.contains("expected String"));
         assert!(errs[0].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_password_reset_signatures_check_args() {
+        let errs = check_errors(
+            r#"
+            import { issue_password_reset, consume_password_reset } from "std/auth"
+            issue_password_reset(42)
+            consume_password_reset("token", 123)
+            "#,
+        );
+        assert_eq!(errs.len(), 2);
+        assert!(errs
+            .iter()
+            .all(|err| err.message.contains("expected String")));
+    }
+
+    #[test]
+    fn test_std_auth_password_reset_signatures_allow_options() {
+        let errs = check_errors(
+            r#"
+            import { issue_password_reset, consume_password_reset } from "std/auth"
+            let issued = issue_password_reset("admin@example.com", map { "identifier_kind": "email", "ttl_seconds": 600 })
+            let consumed = consume_password_reset("selector.verifier", "new-password")
+            "#,
+        );
+        assert!(errs.is_empty(), "unexpected diagnostics: {errs:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add std/auth issue_password_reset and consume_password_reset helpers
- store reset selectors with hashed verifiers in explicit memory/SQLite local-auth reset-token storage
- rotate local credentials on consume, clear setup-required state, and reject replay/expired/malformed tokens generically
- add std/auth typechecker signatures and update generated/manual docs

## Verification
- cargo test --lib password_reset -- --nocapture
- cargo test
- cargo build --profile dev-release
- ./target/dev-release/ntnt docs --generate
- cargo fmt -- --check
- git diff --check