### PR TITLE
Fix binary multipart uploads

### DIFF
--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -6797,9 +6797,9 @@ parse_multipart(req: Request) -> Result<Map<String, Any>, String>
 
 Parse a multipart/form-data request body.
 
-Extracts fields and files from a multipart request. Text fields are returned as String values. File fields are returned as Maps with: `filename` (String), `content_type` (String), `size` (Int), and `data` (String - may be lossy for binary files).
+Extracts fields and files from a multipart request. Text fields are returned as String values. File fields are returned as Maps with: `filename` (String), `content_type` (String), `size` (Int), `data_bytes` (Array<Int>), and `data` (String - best-effort text compatibility field).
 
-Note: Binary file data passes through String conversion and may be lossy. For binary files, use `save_upload()` to write directly to disk.
+Binary file data is parsed from raw request bytes when available. Use `save_upload()` to write `data_bytes` directly to disk without UTF-8 loss.
 
 **Parameters:**
 
@@ -6952,7 +6952,7 @@ Security: Paths are validated to prevent directory traversal attacks. Relative p
 
 **Parameters:**
 
-- `file_field` — The file field Map from parse_multipart() with a `data` key.
+- `file_field` — The file field Map from parse_multipart() with `data_bytes` (or legacy `data`).
 - `path` — The filesystem path to save the file to (relative or absolute).
 
 **Returns:** Ok(Int) bytes written, or Err(String) on failure.

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -6799,11 +6799,11 @@ Parse a multipart/form-data request body.
 
 Extracts fields and files from a multipart request. Text fields are returned as String values. File fields are returned as Maps with: `filename` (String), `content_type` (String), `size` (Int), `data_bytes` (Array<Int>), and `data` (String - best-effort text compatibility field).
 
-Binary file data is parsed from raw request bytes when available. Use `save_upload()` to write `data_bytes` directly to disk without UTF-8 loss.
+Binary file data is parsed from raw request bytes when available. Runtime Request maps populate `body_bytes` for multipart/form-data requests and use an empty array for other content types to avoid unnecessary memory overhead. Use `save_upload()` to write `data_bytes` directly to disk without UTF-8 loss.
 
 **Parameters:**
 
-- `req` — The Request map with Content-Type header and body.
+- `req` — The Request map with Content-Type header and body/body_bytes.
 
 **Returns:** Ok(Map) with field names as keys, or Err(String) on parse failure.
 

--- a/src/stdlib/http_bridge.rs
+++ b/src/stdlib/http_bridge.rs
@@ -54,8 +54,10 @@ pub struct BridgeRequest {
     pub params: HashMap<String, String>,
     /// HTTP headers (lowercase keys)
     pub headers: HashMap<String, String>,
-    /// Request body as string
+    /// Request body as string (UTF-8 lossless when possible, lossy for binary bodies)
     pub body: String,
+    /// Raw request body bytes for binary-safe handlers such as multipart uploads
+    pub body_bytes: Vec<u8>,
     /// Unique request ID
     pub id: String,
     /// Client IP address
@@ -74,6 +76,15 @@ impl BridgeRequest {
         map.insert("url".to_string(), Value::String(self.url.clone()));
         map.insert("query".to_string(), Value::String(self.query.clone()));
         map.insert("body".to_string(), Value::String(self.body.clone()));
+        map.insert(
+            "body_bytes".to_string(),
+            Value::Array(
+                self.body_bytes
+                    .iter()
+                    .map(|byte| Value::Int(*byte as i64))
+                    .collect(),
+            ),
+        );
         map.insert("id".to_string(), Value::String(self.id.clone()));
         map.insert("ip".to_string(), Value::String(self.ip.clone()));
         map.insert("protocol".to_string(), Value::String(self.protocol.clone()));
@@ -271,6 +282,7 @@ mod tests {
                 .into_iter()
                 .collect(),
             body: "".to_string(),
+            body_bytes: Vec::new(),
             id: "req-123".to_string(),
             ip: "127.0.0.1".to_string(),
             protocol: "http".to_string(),
@@ -292,6 +304,10 @@ mod tests {
                     Some(Value::String(id)) => assert_eq!(id, "42"),
                     _ => panic!("Expected id param"),
                 }
+            }
+            match map.get("body_bytes") {
+                Some(Value::Array(bytes)) => assert!(bytes.is_empty()),
+                _ => panic!("Expected body_bytes array"),
             }
         } else {
             panic!("Expected Map");
@@ -391,6 +407,7 @@ mod tests {
             params: HashMap::new(),
             headers: HashMap::new(),
             body: "".to_string(),
+            body_bytes: Vec::new(),
             id: "1".to_string(),
             ip: "127.0.0.1".to_string(),
             protocol: "http".to_string(),

--- a/src/stdlib/http_bridge.rs
+++ b/src/stdlib/http_bridge.rs
@@ -66,6 +66,20 @@ pub struct BridgeRequest {
     pub protocol: String,
 }
 
+fn is_multipart_request(headers: &HashMap<String, String>) -> bool {
+    headers
+        .get("content-type")
+        .map(|content_type| {
+            content_type
+                .split(';')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .eq_ignore_ascii_case("multipart/form-data")
+        })
+        .unwrap_or(false)
+}
+
 impl BridgeRequest {
     /// Convert to NTNT Value for handler invocation
     pub fn to_value(&self) -> Value {
@@ -76,10 +90,15 @@ impl BridgeRequest {
         map.insert("url".to_string(), Value::String(self.url.clone()));
         map.insert("query".to_string(), Value::String(self.query.clone()));
         map.insert("body".to_string(), Value::String(self.body.clone()));
+        let exposed_body_bytes: &[u8] = if is_multipart_request(&self.headers) {
+            &self.body_bytes
+        } else {
+            &[]
+        };
         map.insert(
             "body_bytes".to_string(),
             Value::Array(
-                self.body_bytes
+                exposed_body_bytes
                     .iter()
                     .map(|byte| Value::Int(*byte as i64))
                     .collect(),
@@ -266,6 +285,57 @@ pub type SharedHandle = Arc<InterpreterHandle>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_bridge_request_exposes_body_bytes_only_for_multipart() {
+        let mut req = BridgeRequest {
+            method: "POST".to_string(),
+            path: "/upload".to_string(),
+            url: "/upload".to_string(),
+            query: "".to_string(),
+            query_params: HashMap::new(),
+            params: HashMap::new(),
+            headers: [("content-type".to_string(), "application/json".to_string())]
+                .into_iter()
+                .collect(),
+            body: "{}".to_string(),
+            body_bytes: vec![1, 2, 3],
+            id: "req-json".to_string(),
+            ip: "127.0.0.1".to_string(),
+            protocol: "http".to_string(),
+        };
+
+        let value = req.to_value();
+        match value {
+            Value::Map(map) => match map.get("body_bytes") {
+                Some(Value::Array(bytes)) => assert!(bytes.is_empty()),
+                other => panic!("Expected empty body_bytes array, got {:?}", other),
+            },
+            other => panic!("Expected Map, got {:?}", other),
+        }
+
+        req.headers.insert(
+            "content-type".to_string(),
+            "multipart/form-data; boundary=ntnt".to_string(),
+        );
+        let value = req.to_value();
+        match value {
+            Value::Map(map) => match map.get("body_bytes") {
+                Some(Value::Array(bytes)) => {
+                    let parsed: Vec<i64> = bytes
+                        .iter()
+                        .map(|value| match value {
+                            Value::Int(n) => *n,
+                            other => panic!("Expected Int byte, got {:?}", other),
+                        })
+                        .collect();
+                    assert_eq!(parsed, vec![1, 2, 3]);
+                }
+                other => panic!("Expected populated body_bytes array, got {:?}", other),
+            },
+            other => panic!("Expected Map, got {:?}", other),
+        }
+    }
 
     #[test]
     fn test_bridge_request_to_value() {

--- a/src/stdlib/http_server.rs
+++ b/src/stdlib/http_server.rs
@@ -1114,6 +1114,7 @@ pub fn request_to_value(
     request: &tiny_http::Request,
     params: HashMap<String, String>,
     body: String,
+    body_bytes: Vec<u8>,
 ) -> Value {
     let mut req_map: HashMap<String, Value> = HashMap::new();
 
@@ -1184,6 +1185,7 @@ pub fn request_to_value(
 
     // Body
     req_map.insert("body".to_string(), Value::String(body));
+    req_map.insert("body_bytes".to_string(), bytes_to_value_array(&body_bytes));
 
     // Client IP (from proxy headers or remote address)
     let ip = client_ip.unwrap_or_else(|| {
@@ -2365,11 +2367,11 @@ pub fn init() -> HashMap<String, Value> {
     //
     // Extracts fields and files from a multipart request. Text fields are returned
     // as String values. File fields are returned as Maps with: `filename` (String),
-    // `content_type` (String), `size` (Int), and `data` (String - may be lossy for
-    // binary files).
+    // `content_type` (String), `size` (Int), `data_bytes` (Array<Int>), and
+    // `data` (String - best-effort text compatibility field).
     //
-    // Note: Binary file data passes through String conversion and may be lossy.
-    // For binary files, use `save_upload()` to write directly to disk.
+    // Binary file data is parsed from raw request bytes when available. Use
+    // `save_upload()` to write `data_bytes` directly to disk without UTF-8 loss.
     // @param req The Request map with Content-Type header and body.
     // @returns Ok(Map) with field names as keys, or Err(String) on parse failure.
     // @see_also save_upload, parse_form
@@ -2392,13 +2394,32 @@ pub fn init() -> HashMap<String, Value> {
             func: |args| {
                 let (content_type, body) = match &args[0] {
                     Value::Map(map) => {
-                        let body = match map.get("body") {
-                            Some(Value::String(b)) => b.clone(),
-                            _ => {
-                                return Ok(Value::err(Value::String(
-                                    "Request has no body".to_string(),
-                                )))
-                            }
+                        let body = match map.get("body_bytes") {
+                            Some(value) => match value_array_to_bytes(value, "body_bytes") {
+                                Ok(bytes) => {
+                                    // Compatibility for tests/manual maps that include an empty
+                                    // body_bytes field but still carry the body as a String.
+                                    if bytes.is_empty() {
+                                        match map.get("body") {
+                                            Some(Value::String(b)) if !b.is_empty() => {
+                                                b.as_bytes().to_vec()
+                                            }
+                                            _ => bytes,
+                                        }
+                                    } else {
+                                        bytes
+                                    }
+                                }
+                                Err(e) => return Ok(Value::err(Value::String(e))),
+                            },
+                            None => match map.get("body") {
+                                Some(Value::String(b)) => b.as_bytes().to_vec(),
+                                _ => {
+                                    return Ok(Value::err(Value::String(
+                                        "Request has no body".to_string(),
+                                    )))
+                                }
+                            },
                         };
 
                         let content_type = match map.get("headers") {
@@ -2473,7 +2494,7 @@ pub fn init() -> HashMap<String, Value> {
     // Security: Paths are validated to prevent directory traversal attacks.
     // Relative paths are resolved from the current working directory.
     // Paths containing `..` are rejected for security.
-    // @param file_field The file field Map from parse_multipart() with a `data` key.
+    // @param file_field The file field Map from parse_multipart() with `data_bytes` (or legacy `data`).
     // @param path The filesystem path to save the file to (relative or absolute).
     // @returns Ok(Int) bytes written, or Err(String) on failure.
     // @see_also parse_multipart
@@ -2491,13 +2512,19 @@ pub fn init() -> HashMap<String, Value> {
             requires: None,
             func: |args| {
                 let data = match &args[0] {
-                    Value::Map(map) => match map.get("data") {
-                        Some(Value::String(d)) => d.clone(),
-                        _ => {
-                            return Ok(Value::err(Value::String(
-                                "File field has no data".to_string(),
-                            )))
-                        }
+                    Value::Map(map) => match map.get("data_bytes") {
+                        Some(value) => match value_array_to_bytes(value, "data_bytes") {
+                            Ok(bytes) => bytes,
+                            Err(e) => return Ok(Value::err(Value::String(e))),
+                        },
+                        None => match map.get("data") {
+                            Some(Value::String(d)) => d.as_bytes().to_vec(),
+                            _ => {
+                                return Ok(Value::err(Value::String(
+                                    "File field has no data".to_string(),
+                                )))
+                            }
+                        },
                     },
                     _ => {
                         return Err(IntentError::type_error(
@@ -2534,7 +2561,7 @@ pub fn init() -> HashMap<String, Value> {
                 }
 
                 // Write file to disk
-                match std::fs::write(&path, data.as_bytes()) {
+                match std::fs::write(&path, &data) {
                     Ok(()) => Ok(Value::ok(Value::Int(data.len() as i64))),
                     Err(e) => Ok(Value::err(Value::String(format!(
                         "Failed to save file: {}",
@@ -2581,87 +2608,144 @@ pub fn init() -> HashMap<String, Value> {
 
 /// Parse a multipart/form-data body into fields
 fn parse_multipart_body(
-    body: &str,
+    body: &[u8],
     boundary: &str,
 ) -> std::result::Result<HashMap<String, Value>, String> {
     let mut fields = HashMap::new();
-    let delimiter = format!("--{}", boundary);
-    let end_delimiter = format!("--{}--", boundary);
+    let delimiter = format!("--{}", boundary).into_bytes();
 
-    // Split body by boundary
-    let parts: Vec<&str> = body.split(&delimiter).collect();
+    if delimiter.len() <= 2 {
+        return Err("Invalid multipart boundary".to_string());
+    }
 
-    for part in parts {
-        let part = part.trim();
+    let mut cursor = 0usize;
+    while let Some(rel_start) = find_subslice(&body[cursor..], &delimiter) {
+        let mut part_start = cursor + rel_start + delimiter.len();
 
-        // Skip empty parts and the final delimiter
-        if part.is_empty() || part == "--" || part.starts_with("--") {
-            continue;
+        // Final boundary: --boundary--
+        if body.get(part_start..part_start + 2) == Some(b"--") {
+            break;
         }
 
-        // Split headers from content (separated by \r\n\r\n or \n\n)
-        let (headers_section, content) = if let Some(pos) = part.find("\r\n\r\n") {
-            (&part[..pos], &part[pos + 4..])
-        } else if let Some(pos) = part.find("\n\n") {
-            (&part[..pos], &part[pos + 2..])
-        } else {
-            continue;
+        // Each part starts after the boundary line ending.
+        if body.get(part_start..part_start + 2) == Some(b"\r\n") {
+            part_start += 2;
+        } else if body.get(part_start) == Some(&b'\n') {
+            part_start += 1;
+        }
+
+        let next_rel = match find_subslice(&body[part_start..], &delimiter) {
+            Some(pos) => pos,
+            None => break,
         };
+        let mut part_end = part_start + next_rel;
 
-        // Remove trailing boundary marker from content
-        let content = content
-            .trim_end_matches(&end_delimiter)
-            .trim_end_matches("\r\n")
-            .trim_end_matches('\n');
-
-        // Parse Content-Disposition header
-        let mut name: Option<String> = None;
-        let mut filename: Option<String> = None;
-        let mut content_type: Option<String> = None;
-
-        for line in headers_section.lines() {
-            let line = line.trim();
-            if line.to_lowercase().starts_with("content-disposition:") {
-                let disposition = &line["content-disposition:".len()..];
-                // Parse name="value" pairs
-                for part in disposition.split(';') {
-                    let part = part.trim();
-                    if part.starts_with("name=") {
-                        name = Some(part["name=".len()..].trim_matches('"').to_string());
-                    } else if part.starts_with("filename=") {
-                        // Sanitize filename to prevent path traversal and injection
-                        let raw_filename = part["filename=".len()..].trim_matches('"');
-                        filename = Some(sanitize_filename(raw_filename));
-                    }
-                }
-            } else if line.to_lowercase().starts_with("content-type:") {
-                content_type = Some(line["content-type:".len()..].trim().to_string());
-            }
+        // The CRLF immediately before the next boundary is framing, not file data.
+        if part_end >= 2 && &body[part_end - 2..part_end] == b"\r\n" {
+            part_end -= 2;
+        } else if part_end >= 1 && body[part_end - 1] == b'\n' {
+            part_end -= 1;
         }
 
-        // Add field to result
-        if let Some(field_name) = name {
-            if let Some(fname) = filename {
-                // File field
-                let mut file_map = HashMap::new();
-                file_map.insert("filename".to_string(), Value::String(fname));
-                file_map.insert(
-                    "content_type".to_string(),
-                    Value::String(
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    ),
-                );
-                file_map.insert("size".to_string(), Value::Int(content.len() as i64));
-                file_map.insert("data".to_string(), Value::String(content.to_string()));
-                fields.insert(field_name, Value::Map(file_map));
-            } else {
-                // Text field
-                fields.insert(field_name, Value::String(content.to_string()));
-            }
-        }
+        parse_multipart_part(&body[part_start..part_end], &mut fields)?;
+        cursor = part_start + next_rel;
     }
 
     Ok(fields)
+}
+
+fn parse_multipart_part(
+    part: &[u8],
+    fields: &mut HashMap<String, Value>,
+) -> std::result::Result<(), String> {
+    let (headers_section, content) = if let Some(pos) = find_subslice(part, b"\r\n\r\n") {
+        (&part[..pos], &part[pos + 4..])
+    } else if let Some(pos) = find_subslice(part, b"\n\n") {
+        (&part[..pos], &part[pos + 2..])
+    } else {
+        return Ok(());
+    };
+
+    let headers_text = String::from_utf8_lossy(headers_section);
+    let mut name: Option<String> = None;
+    let mut filename: Option<String> = None;
+    let mut content_type: Option<String> = None;
+
+    for line in headers_text.lines() {
+        let line = line.trim();
+        if line.to_lowercase().starts_with("content-disposition:") {
+            let disposition = &line["content-disposition:".len()..];
+            for part in disposition.split(';') {
+                let part = part.trim();
+                if part.starts_with("name=") {
+                    name = Some(part["name=".len()..].trim_matches('"').to_string());
+                } else if part.starts_with("filename=") {
+                    let raw_filename = part["filename=".len()..].trim_matches('"');
+                    filename = Some(sanitize_filename(raw_filename));
+                }
+            }
+        } else if line.to_lowercase().starts_with("content-type:") {
+            content_type = Some(line["content-type:".len()..].trim().to_string());
+        }
+    }
+
+    if let Some(field_name) = name {
+        if let Some(fname) = filename {
+            let mut file_map = HashMap::new();
+            file_map.insert("filename".to_string(), Value::String(fname));
+            file_map.insert(
+                "content_type".to_string(),
+                Value::String(
+                    content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
+                ),
+            );
+            file_map.insert("size".to_string(), Value::Int(content.len() as i64));
+            file_map.insert("data_bytes".to_string(), bytes_to_value_array(content));
+            file_map.insert(
+                "data".to_string(),
+                Value::String(String::from_utf8_lossy(content).to_string()),
+            );
+            fields.insert(field_name, Value::Map(file_map));
+        } else {
+            fields.insert(
+                field_name,
+                Value::String(String::from_utf8_lossy(content).to_string()),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn bytes_to_value_array(bytes: &[u8]) -> Value {
+    Value::Array(bytes.iter().map(|byte| Value::Int(*byte as i64)).collect())
+}
+
+fn value_array_to_bytes(value: &Value, key: &str) -> std::result::Result<Vec<u8>, String> {
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .enumerate()
+            .map(|(index, item)| match item {
+                Value::Int(n) if (0..=255).contains(n) => Ok(*n as u8),
+                Value::Int(n) => Err(format!("{}[{}] byte {} is outside 0..255", key, index, n)),
+                other => Err(format!(
+                    "{}[{}] must be an Int byte, got {:?}",
+                    key, index, other
+                )),
+            })
+            .collect(),
+        other => Err(format!("{} must be Array<Int>, got {:?}", key, other)),
+    }
 }
 
 /// Validate an upload path to prevent directory traversal attacks
@@ -2923,12 +3007,13 @@ pub fn process_request(
         }
     }
 
-    // Read the request body with size limit using take()
+    // Read the request body with size limit using take(). Keep raw bytes for
+    // multipart/file uploads; expose a best-effort String body for text routes.
     use std::io::Read;
-    let mut body_string = String::new();
+    let mut body_bytes = Vec::new();
     let mut limited_reader = request.as_reader().take((max_size + 1) as u64);
 
-    match limited_reader.read_to_string(&mut body_string) {
+    match limited_reader.read_to_end(&mut body_bytes) {
         Ok(n) => {
             if n > max_size {
                 return Err(IntentError::runtime_error(format!(
@@ -2945,9 +3030,10 @@ pub fn process_request(
             )));
         }
     }
+    let body_string = String::from_utf8_lossy(&body_bytes).to_string();
 
     // Create request value
-    let req_value = request_to_value(&request, params, body_string);
+    let req_value = request_to_value(&request, params, body_string, body_bytes);
 
     Ok((req_value, request))
 }
@@ -4505,6 +4591,82 @@ mod tests {
             headers.get("cache-control").is_none(),
             "Should not add duplicate lowercase cache-control"
         );
+    }
+
+    // ===========================================
+    // Multipart Upload Tests
+    // ===========================================
+
+    #[test]
+    fn test_parse_multipart_preserves_binary_file_bytes() {
+        let boundary = "ntnt-boundary";
+        let binary = vec![0, 159, 146, 150, 255, b'\r', b'\n', 1, 2, 3, b'-', b'-'];
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"title\"\r\n\r\n");
+        body.extend_from_slice(b"hello");
+        body.extend_from_slice(format!("\r\n--{}\r\n", boundary).as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"photo\"; filename=\"test.png\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
+        body.extend_from_slice(&binary);
+        body.extend_from_slice(format!("\r\n--{}--\r\n", boundary).as_bytes());
+
+        let fields = parse_multipart_body(&body, boundary).unwrap();
+        assert_eq!(fields.len(), 2);
+        assert_value_string(fields.get("title").unwrap(), "hello");
+
+        let file = match fields.get("photo") {
+            Some(Value::Map(map)) => map,
+            other => panic!("Expected photo file map, got {:?}", other),
+        };
+        assert_eq!(get_map_string(file, "filename"), "test.png");
+        assert_eq!(get_map_string(file, "content_type"), "image/png");
+        assert_eq!(get_map_int(file, "size"), binary.len() as i64);
+
+        let parsed_bytes =
+            value_array_to_bytes(file.get("data_bytes").unwrap(), "data_bytes").unwrap();
+        assert_eq!(parsed_bytes, binary);
+    }
+
+    #[test]
+    fn test_save_upload_writes_data_bytes_exactly() {
+        let binary = vec![0, 159, 146, 150, 255, b'\r', b'\n', 1, 2, 3];
+        let mut file_map = HashMap::new();
+        file_map.insert(
+            "filename".to_string(),
+            Value::String("upload.bin".to_string()),
+        );
+        file_map.insert("data_bytes".to_string(), bytes_to_value_array(&binary));
+
+        let path =
+            std::env::temp_dir().join(format!("ntnt-save-upload-{}.bin", uuid::Uuid::new_v4()));
+        let path_string = path.to_string_lossy().to_string();
+
+        let module = init();
+        let save_upload = match module.get("save_upload").unwrap() {
+            Value::NativeFunction { func, .. } => *func,
+            other => panic!("Expected save_upload native function, got {:?}", other),
+        };
+
+        let result = save_upload(&[Value::Map(file_map), Value::String(path_string)]).unwrap();
+        match result {
+            Value::EnumValue {
+                variant, values, ..
+            } => {
+                assert_eq!(variant, "Ok");
+                match values.first() {
+                    Some(Value::Int(n)) => assert_eq!(*n, binary.len() as i64),
+                    other => panic!("Expected byte count, got {:?}", other),
+                }
+            }
+            other => panic!("Expected Result::Ok, got {:?}", other),
+        }
+
+        let saved = std::fs::read(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(saved, binary);
     }
 
     // ===========================================

--- a/src/stdlib/http_server.rs
+++ b/src/stdlib/http_server.rs
@@ -1181,11 +1181,28 @@ pub fn request_to_value(
 
         headers.insert(field_lower, Value::String(value));
     }
+    let is_multipart = headers
+        .get("content-type")
+        .and_then(|value| match value {
+            Value::String(content_type) => Some(is_multipart_content_type(content_type)),
+            _ => None,
+        })
+        .unwrap_or(false);
     req_map.insert("headers".to_string(), Value::Map(headers));
 
-    // Body
+    // Body. Raw byte materialization is intentionally limited to multipart
+    // requests; converting every request body into Array<Int> is extremely
+    // expensive for JSON/form routes that never read it.
     req_map.insert("body".to_string(), Value::String(body));
-    req_map.insert("body_bytes".to_string(), bytes_to_value_array(&body_bytes));
+    let exposed_body_bytes = if is_multipart {
+        body_bytes.as_slice()
+    } else {
+        &[]
+    };
+    req_map.insert(
+        "body_bytes".to_string(),
+        bytes_to_value_array(exposed_body_bytes),
+    );
 
     // Client IP (from proxy headers or remote address)
     let ip = client_ip.unwrap_or_else(|| {
@@ -2370,9 +2387,11 @@ pub fn init() -> HashMap<String, Value> {
     // `content_type` (String), `size` (Int), `data_bytes` (Array<Int>), and
     // `data` (String - best-effort text compatibility field).
     //
-    // Binary file data is parsed from raw request bytes when available. Use
-    // `save_upload()` to write `data_bytes` directly to disk without UTF-8 loss.
-    // @param req The Request map with Content-Type header and body.
+    // Binary file data is parsed from raw request bytes when available. Runtime
+    // Request maps populate `body_bytes` for multipart/form-data requests and use
+    // an empty array for other content types to avoid unnecessary memory overhead.
+    // Use `save_upload()` to write `data_bytes` directly to disk without UTF-8 loss.
+    // @param req The Request map with Content-Type header and body/body_bytes.
     // @returns Ok(Map) with field names as keys, or Err(String) on parse failure.
     // @see_also save_upload, parse_form
     // @since v0.3.11
@@ -2606,6 +2625,15 @@ pub fn init() -> HashMap<String, Value> {
     module
 }
 
+fn is_multipart_content_type(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .eq_ignore_ascii_case("multipart/form-data")
+}
+
 /// Parse a multipart/form-data body into fields
 fn parse_multipart_body(
     body: &[u8],
@@ -2618,9 +2646,14 @@ fn parse_multipart_body(
         return Err("Invalid multipart boundary".to_string());
     }
 
-    let mut cursor = 0usize;
-    while let Some(rel_start) = find_subslice(&body[cursor..], &delimiter) {
-        let mut part_start = cursor + rel_start + delimiter.len();
+    let delimiter_table = build_kmp_table(&delimiter);
+    let mut boundary_pos = match find_multipart_boundary(body, &delimiter, &delimiter_table, 0) {
+        Some(pos) => pos,
+        None => return Ok(fields),
+    };
+
+    loop {
+        let mut part_start = boundary_pos + delimiter.len();
 
         // Final boundary: --boundary--
         if body.get(part_start..part_start + 2) == Some(b"--") {
@@ -2632,13 +2665,16 @@ fn parse_multipart_body(
             part_start += 2;
         } else if body.get(part_start) == Some(&b'\n') {
             part_start += 1;
+        } else {
+            return Err("Invalid multipart boundary framing".to_string());
         }
 
-        let next_rel = match find_subslice(&body[part_start..], &delimiter) {
-            Some(pos) => pos,
-            None => break,
-        };
-        let mut part_end = part_start + next_rel;
+        let next_boundary =
+            match find_multipart_boundary(body, &delimiter, &delimiter_table, part_start) {
+                Some(pos) => pos,
+                None => break,
+            };
+        let mut part_end = next_boundary;
 
         // The CRLF immediately before the next boundary is framing, not file data.
         if part_end >= 2 && &body[part_end - 2..part_end] == b"\r\n" {
@@ -2648,7 +2684,7 @@ fn parse_multipart_body(
         }
 
         parse_multipart_part(&body[part_start..part_end], &mut fields)?;
-        cursor = part_start + next_rel;
+        boundary_pos = next_boundary;
     }
 
     Ok(fields)
@@ -2717,13 +2753,82 @@ fn parse_multipart_part(
     Ok(())
 }
 
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() {
-        return Some(0);
+fn find_multipart_boundary(
+    body: &[u8],
+    delimiter: &[u8],
+    delimiter_table: &[usize],
+    from: usize,
+) -> Option<usize> {
+    let mut search_from = from;
+    while let Some(pos) = find_subslice_from(body, delimiter, delimiter_table, search_from) {
+        if is_multipart_boundary_at(body, delimiter, pos) {
+            return Some(pos);
+        }
+        search_from = pos + 1;
     }
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
+    None
+}
+
+fn is_multipart_boundary_at(body: &[u8], delimiter: &[u8], pos: usize) -> bool {
+    // Boundaries are delimiter lines: the first starts at byte 0, subsequent
+    // ones are preceded by LF (normally CRLF). A raw "--boundary" inside file
+    // content without line framing is just data.
+    if pos != 0 && body.get(pos.wrapping_sub(1)) != Some(&b'\n') {
+        return false;
+    }
+
+    let after = pos + delimiter.len();
+    body.get(after..after + 2) == Some(b"--")
+        || body.get(after..after + 2) == Some(b"\r\n")
+        || body.get(after) == Some(&b'\n')
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    let table = build_kmp_table(needle);
+    find_subslice_from(haystack, needle, &table, 0)
+}
+
+fn find_subslice_from(
+    haystack: &[u8],
+    needle: &[u8],
+    table: &[usize],
+    from: usize,
+) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(from.min(haystack.len()));
+    }
+    if from >= haystack.len() {
+        return None;
+    }
+
+    let mut matched = 0usize;
+    for (index, byte) in haystack.iter().enumerate().skip(from) {
+        while matched > 0 && *byte != needle[matched] {
+            matched = table[matched - 1];
+        }
+        if *byte == needle[matched] {
+            matched += 1;
+            if matched == needle.len() {
+                return Some(index + 1 - matched);
+            }
+        }
+    }
+    None
+}
+
+fn build_kmp_table(needle: &[u8]) -> Vec<usize> {
+    let mut table = vec![0; needle.len()];
+    let mut prefix_len = 0usize;
+    for index in 1..needle.len() {
+        while prefix_len > 0 && needle[index] != needle[prefix_len] {
+            prefix_len = table[prefix_len - 1];
+        }
+        if needle[index] == needle[prefix_len] {
+            prefix_len += 1;
+            table[index] = prefix_len;
+        }
+    }
+    table
 }
 
 fn bytes_to_value_array(bytes: &[u8]) -> Value {
@@ -4593,6 +4698,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_request_to_value_limits_body_bytes_to_multipart() {
+        let request = tiny_http::TestRequest::new()
+            .with_header("content-type: application/json".parse().unwrap())
+            .with_body("{}");
+        let (value, _request) = process_request(request.into(), HashMap::new()).unwrap();
+        match value {
+            Value::Map(map) => match map.get("body_bytes") {
+                Some(Value::Array(bytes)) => assert!(bytes.is_empty()),
+                other => panic!("Expected empty body_bytes array, got {:?}", other),
+            },
+            other => panic!("Expected request map, got {:?}", other),
+        }
+
+        let body = "--ntnt-boundary--\r\n";
+        let request = tiny_http::TestRequest::new()
+            .with_header(
+                "content-type: multipart/form-data; boundary=ntnt-boundary"
+                    .parse()
+                    .unwrap(),
+            )
+            .with_body(body);
+        let (value, _request) = process_request(request.into(), HashMap::new()).unwrap();
+        match value {
+            Value::Map(map) => match map.get("body_bytes") {
+                Some(Value::Array(bytes)) => assert_eq!(bytes.len(), body.as_bytes().len()),
+                other => panic!("Expected populated body_bytes array, got {:?}", other),
+            },
+            other => panic!("Expected request map, got {:?}", other),
+        }
+    }
+
     // ===========================================
     // Multipart Upload Tests
     // ===========================================
@@ -4600,7 +4737,10 @@ mod tests {
     #[test]
     fn test_parse_multipart_preserves_binary_file_bytes() {
         let boundary = "ntnt-boundary";
-        let binary = vec![0, 159, 146, 150, 255, b'\r', b'\n', 1, 2, 3, b'-', b'-'];
+        let mut binary = vec![0, 159, 146, 150, 255, b'\r', b'\n', 1, 2, 3, b'-', b'-'];
+        // A raw delimiter-looking sequence inside the file content must not split
+        // the part unless it is framed as a multipart boundary line.
+        binary.extend_from_slice(b"xx--ntnt-boundaryyy");
         let mut body = Vec::new();
         body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
         body.extend_from_slice(b"Content-Disposition: form-data; name=\"title\"\r\n\r\n");

--- a/src/stdlib/http_server.rs
+++ b/src/stdlib/http_server.rs
@@ -2677,9 +2677,9 @@ fn parse_multipart_body(
         let mut part_end = next_boundary;
 
         // The CRLF immediately before the next boundary is framing, not file data.
-        if part_end >= 2 && &body[part_end - 2..part_end] == b"\r\n" {
+        if part_end >= part_start + 2 && &body[part_end - 2..part_end] == b"\r\n" {
             part_end -= 2;
-        } else if part_end >= 1 && body[part_end - 1] == b'\n' {
+        } else if part_end > part_start && body[part_end - 1] == b'\n' {
             part_end -= 1;
         }
 
@@ -4768,6 +4768,13 @@ mod tests {
         let parsed_bytes =
             value_array_to_bytes(file.get("data_bytes").unwrap(), "data_bytes").unwrap();
         assert_eq!(parsed_bytes, binary);
+    }
+
+    #[test]
+    fn test_parse_multipart_handles_adjacent_boundaries_without_panic() {
+        let body = b"--X\r\n--X\r\n--X--\r\n";
+        let fields = parse_multipart_body(body, "X").expect("adjacent boundaries should parse");
+        assert!(fields.is_empty());
     }
 
     #[test]

--- a/src/stdlib/http_server_async.rs
+++ b/src/stdlib/http_server_async.rs
@@ -413,6 +413,7 @@ async fn axum_to_bridge_request(
         params,
         headers,
         body,
+        body_bytes: body_bytes.to_vec(),
         id: uuid::Uuid::new_v4().to_string(),
         ip: client_ip.unwrap_or_else(|| "unknown".to_string()),
         protocol: "http".to_string(),

--- a/src/stdlib/http_server_async.rs
+++ b/src/stdlib/http_server_async.rs
@@ -402,6 +402,22 @@ async fn axum_to_bridge_request(
     let body_bytes = axum::body::to_bytes(req.into_body(), 10 * 1024 * 1024)
         .await
         .map_err(|e| IntentError::runtime_error(format!("Failed to read body: {}", e)))?;
+    let is_multipart = headers
+        .get("content-type")
+        .map(|content_type| {
+            content_type
+                .split(';')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .eq_ignore_ascii_case("multipart/form-data")
+        })
+        .unwrap_or(false);
+    let raw_body_bytes = if is_multipart {
+        body_bytes.to_vec()
+    } else {
+        Vec::new()
+    };
     let body = String::from_utf8_lossy(&body_bytes).to_string();
 
     Ok(BridgeRequest {
@@ -413,7 +429,7 @@ async fn axum_to_bridge_request(
         params,
         headers,
         body,
-        body_bytes: body_bytes.to_vec(),
+        body_bytes: raw_body_bytes,
         id: uuid::Uuid::new_v4().to_string(),
         ip: client_ip.unwrap_or_else(|| "unknown".to_string()),
         protocol: "http".to_string(),

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3430,6 +3430,7 @@ impl TypeContext {
                 ("url".to_string(), Type::String),
                 ("query".to_string(), Type::String),
                 ("body".to_string(), Type::String),
+                ("body_bytes".to_string(), Type::Array(Box::new(Type::Int))),
                 ("id".to_string(), Type::String),
                 ("ip".to_string(), Type::String),
                 ("protocol".to_string(), Type::String),


### PR DESCRIPTION
## Summary

- Preserve raw request bytes alongside the existing string request body for sync and async HTTP server paths.
- Make `parse_multipart(req)` prefer `req.body_bytes` and parse multipart bodies byte-safely.
- Add `data_bytes: Array<Int>` to multipart file maps and make `save_upload()` write those bytes exactly, with legacy `data` fallback.
- Add regression tests for binary multipart parsing and exact `save_upload()` writes.
- Regenerate stdlib docs for the `parse_multipart` / `save_upload` behavior.

Closes #106.

## Verification

- `cargo build --profile dev-release`
- `cargo test --lib`
- `cargo test --test language_features_tests --test type_checker_tests --test cli_tests`
- `./target/dev-release/ntnt docs --generate`
- `cargo fmt -- --check`
- `git diff --check`
