### PR TITLE
feat(auth): complete local auth polish for 0.4.9

### DIFF
--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -1,9 +1,9 @@
 # DD-043: World-Class Auth — Making `std/auth` the Best stdlib Auth Ever
 
-**Status:** In Progress — Final Sprint
+**Status:** In Progress — 0.4.9 release polish
 **Author:** Larri
-**Date:** 2026-03-20 (slashed and sharpened 2026-04-28; WebAuthn/passkeys phase added 2026-04-29)
-**Branch:** `main` through v0.4.9; remaining v0.4.9 work is PR 3 + template proof; WebAuthn/passkeys are post-v0.4.9
+**Date:** 2026-03-20 (slashed and sharpened 2026-04-28; WebAuthn/passkeys phase added 2026-04-29; 0.4.9 auth polish updated 2026-05-29)
+**Branch:** `main` through v0.4.9; current polish branch: `feat/auth-049-local-backends-polish`; WebAuthn/passkeys are post-v0.4.9
 
 ---
 
@@ -52,17 +52,21 @@ Everything below is merged or intended as the current v0.4.9 baseline:
 - Route/API protection: `require_auth()` middleware/path/request helper with HTML redirect vs API 401 behavior
 - Bearer-token/resource-server helpers: `oauth_validate(...)`, `oauth_introspect(...)`
 - Built-in login page with configurable title/logo/copy/provider buttons
-- No WebAuthn/passkey support yet; that is intentionally post-v0.4.9, after PR 3 and the template integration proof
+- No WebAuthn/passkey support yet; that is intentionally post-v0.4.9, after the template integration proof
 - Configurable route prefixes, startup route logging, collision diagnostics
 - Auth health check endpoint, dev-only by default
 - Refresh-token rotation/preservation with provider-aware semantics
 - Safari ITP workaround through a two-phase exchange-token flow
-- Local identity/credential store owned by `std/auth`
-- `verify_local_password(identifier, password)` credential verification
+- Local identity/credential store owned by `std/auth` across memory, SQLite, PostgreSQL, and Redis/Valkey backends
+- Supported local `identifier_kind` values: `email` (default), `phone`, `username`, and `custom`
+- `verify_local_password(identifier, password, options?)` credential verification
 - `bootstrap_local_user(identifier, password, options?)` bootstrap provisioning
 - `set_local_password(identifier, current_password, new_password, options?)` password rotation/setup completion
+- `issue_password_reset(identifier, options?)` and `consume_password_reset(token, new_password, options?)` with hashed selector/verifier storage, TTL, one-time consume, replay rejection, and generic non-enumerating responses
+- Password reset session revocation is explicit: `consume_password_reset(..., map { "revoke_sessions": true })`; default is to preserve existing sessions
+- Standalone current-user session revocation UI can use `logout_all(req, keep_current)` for “log me out of all active sessions” flows
+- Local TOTP helpers use auth-owned local identity metadata, so the configured local identity backend carries TOTP state as well
 - Internal module split: config, cookies, providers, OAuth, guards, routes, request helpers, sessions, storage, primitives, utilities
-- Memory/SQLite coverage for local identity/credential paths; Postgres/Redis local credential backends are future unless explicitly implemented in the final sprint
 
 ---
 
@@ -93,7 +97,7 @@ Rules:
 
 ---
 
-## Remaining Work (Fast Path — 2-3 PRs)
+## Acceptance Work Still Open
 
 ### PR 1 — Metadata + Authorization Context Polish
 
@@ -130,13 +134,14 @@ Goal: make TOTP a real local-auth extension path without requiring template-owne
 
 Goal: ship reset password securely enough to use, without owning email delivery or account UI.
 
-- [ ] Add `issue_password_reset(identifier, options?) -> Result<PasswordReset, String>`
-- [ ] Add `consume_password_reset(token, new_password, options?) -> Result<PasswordResetResult, String>`
-- [ ] Store only token selectors/hashes, never raw tokens
-- [ ] Enforce TTL, one-time consume, replay rejection, and generic responses that do not enumerate accounts
-- [ ] Define reset consequences as explicit options/defaults: revoke sessions, force password change, clear/reset TOTP enrollment
-- [ ] Apps/plugins own email/SMS delivery; `std/auth` returns the token/safe URL material to deliver
-- [ ] Add memory/SQLite tests by default; clearly document/skip Postgres/Redis local reset support unless implemented
+- [x] Add `issue_password_reset(identifier, options?) -> Result<PasswordReset, String>`
+- [x] Add `consume_password_reset(token, new_password, options?) -> Result<PasswordResetResult, String>`
+- [x] Store only token selectors/hashes, never raw tokens
+- [x] Enforce TTL, one-time consume, replay rejection, and generic responses that do not enumerate accounts
+- [x] Define session revocation as an explicit reset option: default preserves sessions; `revoke_sessions: true` revokes active sessions after successful reset
+- [x] Apps/plugins own email/SMS delivery; `std/auth` returns the token/safe URL material to deliver
+- [x] Add local reset tests and backend contract coverage across memory, SQLite, PostgreSQL, and Redis/Valkey
+- Deferred post-v0.4.9 unless app/template pressure proves them: force-password-change-after-reset policy, TOTP reset-on-reset policy, and security-event emission
 
 ### Template Integration Proof
 
@@ -148,12 +153,13 @@ This may be a separate template-repo PR, but it is the real acceptance test.
 - [ ] Template protects both pages and API endpoints through `require_auth(...)` / group helpers
 - [ ] Template deletes parallel auth tables/state machines
 - [ ] The before/after diff is materially simpler
+- [x] `docs/AI_AGENT_GUIDE.md` includes a local auth quickstart showing login, reset, explicit reset-session revocation checkbox plumbing, and standalone `logout_all(...)` UI composition
 
 ---
 
 ## Post-v0.4.9 Phase — WebAuthn + Passkeys
 
-This phase is intentionally **after** PR 3, the template integration proof, and the v0.4.9 auth release. It should not delay 0.4.9. The goal is to add phishing-resistant WebAuthn/passkey primitives that compose with the same `std/auth` local identity, staged challenge, request-aware session, and route/API protection model.
+This phase is intentionally **after** the template integration proof and the v0.4.9 auth release. It should not delay 0.4.9. The goal is to add phishing-resistant WebAuthn/passkey primitives that compose with the same `std/auth` local identity, staged challenge, request-aware session, and route/API protection model.
 
 Design posture:
 
@@ -247,12 +253,13 @@ Non-goals for the first WebAuthn phase:
 The v0.4.9 final sprint is complete when:
 
 1. `std/auth` primitives are solid and composable for OAuth, local email/password, TOTP, password reset, pages, and API endpoints.
-2. Password reset tokens are hashed, TTL-bound, one-time, non-enumerating, and not app-reimplemented.
+2. Password reset tokens are hashed, TTL-bound, one-time, non-enumerating, and not app-reimplemented; reset-time session revocation is explicit and off by default.
 3. TOTP has first-class helper support and no template-owned TOTP model.
 4. Authorization context has a clean `group_ids` / claims handoff that apps can use for RBAC without `std/auth` owning RBAC.
 5. Local and OAuth sessions share lifecycle, cookie posture, rotation, metadata, and security behavior.
 6. Metadata is a deliberate extension seam with namespacing, safe payload rules, and no raw secrets.
-7. The template runs on `std/auth` models plus metadata/session-data extensions, with no parallel auth subsystem.
+7. Local auth works on the configured auth backend: memory, SQLite, PostgreSQL, or Redis/Valkey.
+8. The template runs on `std/auth` models plus metadata/session-data extensions, with no parallel auth subsystem.
 
 The WebAuthn/passkey phase is complete later when passkey registration, safe listing/revocation, passkey authentication, request-aware session completion, credential replay/counter protection, template UX, and browser-facing examples all work without creating a second user/session system.
 
@@ -272,7 +279,7 @@ Only if real apps prove the final-sprint primitives are insufficient:
 - Higher-level `local_sign_in(...)` wrapper if explicit composition proves too verbose
 - `enable_local_auth(...)` convenience preset
 - Built-in reset/setup/reference routes and pages
-- Full Postgres/Redis local-auth credential/reset/TOTP storage parity
+- Dedicated arbitrary-user admin session APIs beyond current-user `logout_all(...)`
 
 ### Advanced WebAuthn / Passkey Policy
 
@@ -297,8 +304,8 @@ After the first WebAuthn/passkey phase proves the primitive shape:
 ### Advanced Session Management
 
 - `list_sessions(user_id)` API for admin/arbitrary-user session lookup
-- `revoke_session(session_id)` and `revoke_all_sessions(user_id)` APIs
-- Password-change/account-disable hooks for session revocation
+- `revoke_session(session_id)` and arbitrary-user `revoke_all_sessions(user_id)` APIs
+- Password-change/account-disable hooks for session revocation beyond the explicit password-reset `revoke_sessions` option
 - Behavioral `remember_me` TTL selection beyond current plumbing
 - Device metadata management UI helpers
 
@@ -335,4 +342,4 @@ After the first WebAuthn/passkey phase proves the primitive shape:
 
 ---
 
-*Sharpened 2026-04-28. One DD, one roadmap. DD-062 retired. Final sprint keeps the secure essentials first-class — reset, TOTP, API/page protection, and authorization handoff — while pushing product/RBAC/platform bloat to Future Refinements. WebAuthn/passkeys added 2026-04-29 as a post-v0.4.9 phase after PR 3 and template proof.*
+*Sharpened 2026-04-28. One DD, one roadmap. DD-062 retired. Final sprint keeps the secure essentials first-class — reset, TOTP, API/page protection, local backend parity, and authorization handoff — while pushing product/RBAC/platform bloat to Future Refinements. WebAuthn/passkeys added 2026-04-29 as a post-v0.4.9 phase after template proof.*

--- a/design-docs/dd-059-auth-crypto-boundary.md
+++ b/design-docs/dd-059-auth-crypto-boundary.md
@@ -1,6 +1,6 @@
 # DD-059: Hard-Remove Generic Crypto Exports from `std/auth`
 
-## Status: implemented on branch / awaiting PR review
+## Status: implemented in the v0.4.9 baseline
 
 ## Problem
 `std/auth` should own authentication concerns, not generic crypto utilities.
@@ -19,7 +19,7 @@ After this change:
 - `hash_password` must be imported from `std/crypto`
 - `verify_password` must be imported from `std/crypto`
 - `uuid` remains in `std/crypto`
-- auth-owned helpers remain in `std/auth`
+- auth-owned helpers remain in `std/auth`, including local identity/credential lifecycle, password reset, TOTP, sessions, OAuth, CSRF, staged challenges, route/API protection, and current-user session management
 
 ## Explicitly In Scope vs Out of Scope
 **In scope**
@@ -77,7 +77,7 @@ One nearby repo, `larri-site-template`, still imports `totp_secret` / `verify_to
 - [x] Open PR with the DD, implementation, and audit context together
 
 ## Validation
-Implemented on branch `feat/dd-059-auth-crypto-boundary`.
+Implemented in the v0.4.9 auth baseline; original work happened on `feat/dd-059-auth-crypto-boundary`. Current 0.4.9 polish keeps the boundary intact while adding auth-owned local password/reset/TOTP features in `std/auth`.
 
 Validated behavior:
 - `hash_password` works from `std/crypto`
@@ -88,4 +88,4 @@ Validated behavior:
 ## Bottom Line
 Ship it.
 
-This is a small breaking change, but it is the right one: it removes the remaining generic crypto aliases from `std/auth` without dragging auth-specific helpers into unnecessary churn.
+This is a small breaking change, but it is the right one: it removes the remaining generic crypto aliases from `std/auth` without dragging auth-specific helpers into unnecessary churn. The added local-auth primitives do not reopen the generic-crypto boundary; they are auth lifecycle APIs, not generic hash/UUID utilities.

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1701,6 +1701,98 @@ Boundary rule: use `std/auth` for auth flows, sessions, CSRF, current-user helpe
 
 Full OAuth, session management, CSRF, JWT, TOTP, and local credential bootstrap, setup completion, password reset, and verification support.
 
+### Local Auth Quickstart
+
+The 0.4.9 local-auth path is intentionally explicit: `std/auth` owns credentials, reset tokens, TOTP state, sessions, cookies, CSRF, and route protection; the app owns the forms, delivery, roles, and policy copy. Local credentials and reset tokens are stored by the configured auth backend: memory, SQLite, PostgreSQL, or Redis/Valkey.
+
+Supported local identifier kinds are:
+
+- `email` — default; normalized case-insensitively.
+- `phone` — accepts digits plus common separators and stores a normalized E.164-ish string.
+- `username` — lowercase 3-64 character usernames using letters, digits, `_`, `-`, and `.`.
+- `custom` — app-defined opaque identifiers, trimmed and rejected if empty/control-bearing.
+
+```ntnt
+import {
+    bootstrap_local_user,
+    consume_password_reset,
+    enable_auth,
+    issue_password_reset,
+    logout_all,
+    require_auth,
+    sign_in_session,
+    update_local_user_metadata,
+    verify_local_password
+} from "std/auth"
+import { get_env } from "std/env"
+import { json, parse_form, redirect } from "std/http/server"
+
+enable_auth([], map {
+    "session_secret": get_env("SESSION_SECRET"),
+    "session_store": get_env("AUTH_STORE") ?? "sqlite:./auth.db",
+    "login_url": "/login",
+    "logout_url": "/"
+})
+
+fn create_invited_user(email, temporary_password) {
+    // Server-side/admin code. Apps decide who may call this.
+    let user = bootstrap_local_user(email, temporary_password, map {
+        "identifier_kind": "email"
+    })?
+    update_local_user_metadata(email, map {
+        "app": map { "group_ids": ["users"] }
+    })?
+    return user
+}
+
+fn post_login(req) {
+    let form = parse_form(req)
+    let verified = verify_local_password(form["email"] ?? "", form["password"] ?? "")?
+
+    return sign_in_session(redirect("/dashboard"), req, map {
+        "subject_id": verified["subject_id"],
+        "email": verified["email"],
+        "data": map { "group_ids": app_group_ids_for_local_user(verified) }
+    })
+}
+
+fn post_password_reset_request(req) {
+    let form = parse_form(req)
+    let reset = issue_password_reset(form["email"] ?? "")?
+
+    if reset["token"] != None {
+        // App-owned delivery. Do not log or persist the token.
+        send_reset_email(form["email"] ?? "", reset["token"])
+    }
+
+    return redirect("/password-reset/sent")
+}
+
+fn post_password_reset(req) {
+    let form = parse_form(req)
+    let user = consume_password_reset(
+        form["token"] ?? "",
+        form["new_password"] ?? "",
+        map { "revoke_sessions": form["logout_all_devices"] == "on" }
+    )?
+
+    return sign_in_session(redirect("/dashboard"), req, map {
+        "subject_id": user["subject_id"],
+        "email": user["email"]
+    })
+}
+
+fn post_logout_all(req) {
+    let auth_response = require_auth(req)
+    if typeof(auth_response) == "Map" { return auth_response }
+
+    // Use this behind UI like “log me out of all active sessions”.
+    return logout_all(req, false)
+}
+```
+
+Password reset does **not** revoke sessions by default. If the reset form has a “log me out of all active sessions” checkbox, pass `map { "revoke_sessions": true }` to `consume_password_reset(...)`. For a standalone account-security page, use `logout_all(req, keep_current)`; pass `false` to revoke every active session including the current one, or `true` to keep the current session and revoke the rest.
+
 ### Local Credential Bootstrap and Setup Completion
 
 `std/auth` owns local identity/credential lifecycle state. Use `bootstrap_local_user(...)` to provision a setup credential, then call `set_local_password(...)` with that current setup/forced-change credential plus a different replacement password to rotate it and clear setup-required state before granting regular access. Both helpers return only safe local-user metadata; they never expose passwords, password hashes, hash parameters, tokens, or raw credential records.
@@ -1776,7 +1868,8 @@ fn finish_password_reset(req) {
     let form = parse_form(req)
     let user = consume_password_reset(
         form["token"] ?? "",
-        form["new_password"] ?? ""
+        form["new_password"] ?? "",
+        map { "revoke_sessions": form["logout_all_devices"] == "on" }
     )?
 
     return sign_in_session(redirect("/admin"), req, map {
@@ -1787,7 +1880,7 @@ fn finish_password_reset(req) {
 }
 ```
 
-Reset tokens are one-time records. Never log the returned token, store it in `local_user.metadata`, or echo it through unrelated API responses. If a token is missing, expired, malformed, replayed, or has a wrong verifier, `consume_password_reset(...)` returns the same `Err("Invalid password reset token")`.
+Reset tokens are one-time records. Never log the returned token, store it in `local_user.metadata`, or echo it through unrelated API responses. If a token is missing, expired, malformed, replayed, or has a wrong verifier, `consume_password_reset(...)` returns the same `Err("Invalid password reset token")`. Existing sessions are preserved unless the app explicitly passes `map { "revoke_sessions": true }`; use that option for a reset-page checkbox like “log me out of all active sessions.”
 
 ### Local TOTP Enrollment and Verification
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2059,7 +2059,7 @@ Generates a new TOTP secret, stores it under std/auth-owned local identity metad
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
 - `options` — Optional map with `identifier_kind`, `issuer`, and `label`
 
 **Returns:** Ok(map) with pending TOTP status and setup `uri`; Err(message) on invalid identity/state/storage
@@ -2088,11 +2088,11 @@ The helper normalizes the identifier (email by default), rejects an existing loc
 
 **Parameters:**
 
-- `identifier` — The local setup identifier. Email is the default identifier kind.
+- `identifier` — The local setup identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
 - `password` — The temporary plaintext password to hash and store
-- `options` — Optional map with `identifier_kind` (default `"email"`)
+- `options` — Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`)
 
-**Returns:** Ok(map) with safe local user fields; Err(message) on duplicate, invalid input, or unsupported storage backend
+**Returns:** Ok(map) with safe local user fields; Err(message) on duplicate, invalid input, or storage backend failure
 
 **Examples:**
 
@@ -2184,7 +2184,7 @@ Moves `auth.totp.pending_secret` to std/auth-owned confirmed secret metadata onl
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
 - `code` — The 6-digit TOTP code from the authenticator app
 - `options` — Optional map with `identifier_kind`
 
@@ -2205,27 +2205,29 @@ confirm_totp_enrollment("admin@example.com", form["code"] ?? "")?  // Finish TOT
 #### `consume_password_reset`
 
 ```ntnt
-consume_password_reset(token: String, new_password: String) -> Result<Map, String>
+consume_password_reset(token: String, new_password: String, options?: Map) -> Result<Map, String>
 ```
 
 Consume a one-time password reset token and rotate the local password.
 
-Valid tokens are consumed atomically, verified against the stored hash, and then used to replace the local credential, transition the identity to `active`, and clear `must_change_password`. Missing, malformed, expired, replayed, and wrong-verifier tokens all return the same generic error. Returned payloads are safe local auth user maps and never expose password hashes, token hashes, raw token material, credentials, or secrets.
+Valid tokens are consumed atomically, verified against the stored hash, and then used to replace the local credential, transition the identity to `active`, and clear `must_change_password`. Missing, malformed, expired, replayed, and wrong-verifier tokens all return the same generic error. Returned payloads are safe local auth user maps and never expose password hashes, token hashes, raw token material, credentials, or secrets. Pass `map { "revoke_sessions": true }` to explicitly revoke that local user's existing sessions after a successful reset; by default, existing sessions are left active.
 
 **Parameters:**
 
 - `token` — The `selector.verifier` token returned by `issue_password_reset(...)`
 - `new_password` — Replacement plaintext password to hash and store
+- `options` — Optional map with `revoke_sessions` (default false)
 
-**Returns:** Ok(map) with safe local user fields; Err(message) for invalid/expired/replayed tokens or storage failure
+**Returns:** Ok(map) with safe local user fields and `revoked_sessions`; Err(message) for invalid/expired/replayed tokens or storage failure
 
 **Examples:**
 
 ```ntnt
-let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "")?  // Finish a password reset
+let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "")?  // Finish a password reset without revoking sessions
+let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "", map { "revoke_sessions": form["logout_all"] == "on" })?  // Finish a reset and explicitly revoke existing sessions from a checkbox
 ```
 
-**See also:** `issue_password_reset`, `verify_local_password`, `sign_in_session`
+**See also:** `issue_password_reset`, `verify_local_password`, `logout_all`, `sign_in_session`
 
 *Since v0.4.9*
 
@@ -2536,8 +2538,8 @@ The helper normalizes the identifier (email by default), stores only a hashed ve
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
-- `options` — Optional map with `identifier_kind` and `ttl_seconds` (default 3600)
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
+- `options` — Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`) and `ttl_seconds` (default 3600)
 
 **Returns:** Ok(map) with `status: "accepted"`; syntactically valid reset requests also include `token`, `selector`, `created_at`, and `expires_at` without revealing whether a matching account exists
 
@@ -2653,8 +2655,8 @@ Use this from trusted server-side setup/admin code when an app needs the local i
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
-- `options` — Optional map with `identifier_kind` (default `"email"`)
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
+- `options` — Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`)
 
 **Returns:** Ok(map) with safe local user fields and `metadata`; Err(message) when missing or unsupported
 
@@ -3018,7 +3020,7 @@ Removes only std/auth-owned `auth.totp` metadata and preserves app-owned metadat
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
 - `options` — Optional map with `identifier_kind`
 
 **Returns:** Ok(map) with disabled TOTP status; Err(message) on invalid identity/state/storage
@@ -3129,12 +3131,12 @@ The helper normalizes the identifier (email by default), loads the auth-owned lo
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
 - `current_password` — The current setup, forced-change, or active local password to verify before rotation
 - `new_password` — The replacement plaintext password to hash and store; it must differ from the current password
-- `options` — Optional map with `identifier_kind` (default `"email"`)
+- `options` — Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`)
 
-**Returns:** Ok(map) with safe local user fields; Err(message) on invalid credentials, invalid input, or unsupported storage backend
+**Returns:** Ok(map) with safe local user fields; Err(message) on invalid credentials, invalid input, or storage backend failure
 
 **Examples:**
 
@@ -3284,7 +3286,7 @@ Returns status booleans and display metadata only. It never includes pending or 
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
 - `options` — Optional map with `identifier_kind`
 
 **Returns:** Ok(map) with safe TOTP status; Err(message) on invalid identity/storage
@@ -3343,7 +3345,7 @@ By default this helper performs a top-level merge into `metadata_json` and prese
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
 - `metadata` — App-owned metadata map to merge or replace
 - `options` — Optional map with `identifier_kind` and `replace`
 
@@ -3466,7 +3468,7 @@ The helper normalizes the identifier (email by default), loads the auth-owned lo
 
 - `identifier` — The local login identifier. Email is the default identifier kind.
 - `password` — The plaintext password from the login form
-- `options` — Optional map with `identifier_kind` (default `"email"`)
+- `options` — Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`)
 
 **Returns:** Ok(map) with `subject_id`, `provider`, identifier fields, account `state`, and password-change metadata; Err(message) on invalid credentials or operational credential errors
 
@@ -3500,7 +3502,7 @@ Use after `verify_local_password(...)` in staged login flows. Apps should keep t
 
 **Parameters:**
 
-- `identifier` — The local user identifier. Email is the default identifier kind.
+- `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
 - `code` — The 6-digit TOTP code from the authenticator app
 - `options` — Optional map with `identifier_kind`
 

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -799,6 +799,29 @@ fn parse_password_reset_issue_options(
     }
 }
 
+fn parse_password_reset_consume_options(
+    function_name: &str,
+    options: Option<&Value>,
+) -> Result<bool> {
+    match options {
+        Some(Value::Map(map)) => match map.get("revoke_sessions") {
+            Some(Value::Bool(value)) => Ok(*value),
+            Some(other) => Err(IntentError::type_error(format!(
+                "[auth] {}() revoke_sessions must be a bool, got {}",
+                function_name,
+                other.type_name()
+            ))),
+            None => Ok(false),
+        },
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() options must be a map, got {}",
+            function_name,
+            other.type_name()
+        ))),
+        None => Ok(false),
+    }
+}
+
 fn parse_totp_options(
     function_name: &str,
     options: Option<&Value>,
@@ -3993,8 +4016,8 @@ pub fn init() -> HashMap<String, Value> {
     // local identity record and app-owned metadata without verifying a password.
     // Reserved `auth.*` metadata is kept server-side and omitted from the returned
     // payload; use dedicated std/auth helpers for stdlib-managed lifecycle state.
-    // @param identifier The local user identifier. Email is the default identifier kind.
-    // @param options Optional map with `identifier_kind` (default `"email"`)
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
+    // @param options Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`)
     // @returns Ok(map) with safe local user fields and `metadata`; Err(message) when missing or unsupported
     // @see_also update_local_user_metadata, verify_local_password
     // @since v0.4.9
@@ -4052,7 +4075,7 @@ pub fn init() -> HashMap<String, Value> {
     // preserves reserved `auth.*` namespaces for std/auth-managed lifecycle state.
     // Pass `map { "replace": true }` to replace app-visible metadata. Inputs may
     // not write `auth` or `auth.*` keys directly.
-    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param metadata App-owned metadata map to merge or replace
     // @param options Optional map with `identifier_kind` and `replace`
     // @returns Ok(map) with safe local user fields and metadata; Err(message) on missing user, reserved namespace, or unsupported backend
@@ -4174,10 +4197,10 @@ pub fn init() -> HashMap<String, Value> {
     // app-owned setup code can force rotation before granting regular access.
     // It never exposes passwords, password hashes, hash parameters, credentials,
     // secrets, or tokens.
-    // @param identifier The local setup identifier. Email is the default identifier kind.
+    // @param identifier The local setup identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param password The temporary plaintext password to hash and store
-    // @param options Optional map with `identifier_kind` (default `"email"`)
-    // @returns Ok(map) with safe local user fields; Err(message) on duplicate, invalid input, or unsupported storage backend
+    // @param options Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`)
+    // @returns Ok(map) with safe local user fields; Err(message) on duplicate, invalid input, or storage backend failure
     // @error RuntimeError ~ "Auth not initialized" fix: "Call enable_auth(...) during app startup before bootstrapping local credentials"
     // @error TypeError ~ "identifier must be a string" fix: "Pass the setup email/identifier as a string"
     // @see_also verify_local_password, sign_in_session
@@ -4266,11 +4289,11 @@ pub fn init() -> HashMap<String, Value> {
     // compose the resulting user through request-aware `sign_in_session(...)`. It
     // never exposes passwords, password hashes, hash parameters, credentials,
     // secrets, or tokens.
-    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param current_password The current setup, forced-change, or active local password to verify before rotation
     // @param new_password The replacement plaintext password to hash and store; it must differ from the current password
-    // @param options Optional map with `identifier_kind` (default `"email"`)
-    // @returns Ok(map) with safe local user fields; Err(message) on invalid credentials, invalid input, or unsupported storage backend
+    // @param options Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`)
+    // @returns Ok(map) with safe local user fields; Err(message) on invalid credentials, invalid input, or storage backend failure
     // @error RuntimeError ~ "Auth not initialized" fix: "Call enable_auth(...) during app startup before rotating local credentials"
     // @error TypeError ~ "identifier must be a string" fix: "Pass the setup email/identifier as a string"
     // @see_also bootstrap_local_user, verify_local_password, sign_in_session
@@ -4373,8 +4396,8 @@ pub fn init() -> HashMap<String, Value> {
     // same generic consume error. Malformed identifiers or non-positive TTLs return
     // a generic accepted payload without token material. Store or send the returned
     // `token` out-of-band; std/auth never stores the raw token.
-    // @param identifier The local user identifier. Email is the default identifier kind.
-    // @param options Optional map with `identifier_kind` and `ttl_seconds` (default 3600)
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
+    // @param options Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`) and `ttl_seconds` (default 3600)
     // @returns Ok(map) with `status: "accepted"`; syntactically valid reset requests also include `token`, `selector`, `created_at`, and `expires_at` without revealing whether a matching account exists
     // @see_also consume_password_reset, verify_local_password, set_local_password
     // @since v0.4.9
@@ -4408,7 +4431,7 @@ pub fn init() -> HashMap<String, Value> {
 
     // @ntnt consume_password_reset
     // @module std/auth
-    // @signature consume_password_reset(token: String, new_password: String) -> Result<Map, String>
+    // @signature consume_password_reset(token: String, new_password: String, options?: Map) -> Result<Map, String>
     // Consume a one-time password reset token and rotate the local password.
     //
     // Valid tokens are consumed atomically, verified against the stored hash, and
@@ -4416,33 +4439,48 @@ pub fn init() -> HashMap<String, Value> {
     // and clear `must_change_password`. Missing, malformed, expired, replayed, and
     // wrong-verifier tokens all return the same generic error. Returned payloads are
     // safe local auth user maps and never expose password hashes, token hashes, raw
-    // token material, credentials, or secrets.
+    // token material, credentials, or secrets. Pass `map { "revoke_sessions": true }`
+    // to explicitly revoke that local user's existing sessions after a successful reset;
+    // by default, existing sessions are left active.
     // @param token The `selector.verifier` token returned by `issue_password_reset(...)`
     // @param new_password Replacement plaintext password to hash and store
-    // @returns Ok(map) with safe local user fields; Err(message) for invalid/expired/replayed tokens or storage failure
-    // @see_also issue_password_reset, verify_local_password, sign_in_session
+    // @param options Optional map with `revoke_sessions` (default false)
+    // @returns Ok(map) with safe local user fields and `revoked_sessions`; Err(message) for invalid/expired/replayed tokens or storage failure
+    // @see_also issue_password_reset, verify_local_password, logout_all, sign_in_session
     // @since v0.4.9
     // @tags #auth, #local-auth, #password-reset, #security
-    // @example let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "")? ~ "Finish a password reset"
+    // @example let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "")? ~ "Finish a password reset without revoking sessions"
+    // @example let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "", map { "revoke_sessions": form["logout_all"] == "on" })? ~ "Finish a reset and explicitly revoke existing sessions from a checkbox"
     module.insert(
         "consume_password_reset".to_string(),
         Value::NativeFunction {
             name: "consume_password_reset".to_string(),
             arity: 2,
-            max_arity: 2,
+            max_arity: 3,
             requires: None,
             func: |args| {
-                if args.len() != 2 {
+                if args.len() < 2 || args.len() > 3 {
                     return Err(IntentError::type_error(
-                        "[auth] consume_password_reset() requires token and new_password"
+                        "[auth] consume_password_reset() requires token, new_password, and optional options"
                             .to_string(),
                     ));
                 }
                 require_auth_initialized_for("consume_password_reset")?;
                 let token = string_arg("consume_password_reset", args, 0, "token")?;
                 let new_password = string_arg("consume_password_reset", args, 1, "new_password")?;
-                match consume_password_reset_record(token, new_password) {
-                    Ok(verified) => Ok(Value::ok(verified_local_password_to_value(verified))),
+                let revoke_sessions =
+                    parse_password_reset_consume_options("consume_password_reset", args.get(2))?;
+                match consume_password_reset_record(token, new_password, revoke_sessions) {
+                    Ok((verified, revoked_sessions)) => {
+                        let mut value = verified_local_password_to_value(verified);
+                        if let Value::Map(ref mut map) = value {
+                            map.insert(
+                                "revoked_sessions".to_string(),
+                                Value::Int(revoked_sessions as i64),
+                            );
+                        }
+                        Ok(Value::ok(value))
+                    }
                     Err(message) => Ok(Value::err(Value::String(message))),
                 }
             },
@@ -4468,7 +4506,7 @@ pub fn init() -> HashMap<String, Value> {
     // accidentally treat setup-required accounts as fully active sessions.
     // @param identifier The local login identifier. Email is the default identifier kind.
     // @param password The plaintext password from the login form
-    // @param options Optional map with `identifier_kind` (default `"email"`)
+    // @param options Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`)
     // @returns Ok(map) with `subject_id`, `provider`, identifier fields, account `state`, and password-change metadata; Err(message) on invalid credentials or operational credential errors
     // @error RuntimeError ~ "Auth not initialized" fix: "Call enable_auth(...) during app startup before verifying local credentials"
     // @error TypeError ~ "identifier must be a string" fix: "Pass the submitted email/identifier as a string"
@@ -4554,7 +4592,7 @@ pub fn init() -> HashMap<String, Value> {
     // and returns safe status fields plus an `otpauth://` URI for QR-code setup. The raw secret is not returned as a
     // standalone field and is never exposed through `local_user(...)`, `current_user(...)`, or `totp_status(...)`.
     // The setup URI itself is secret-bearing; render it only in the setup response and do not log, cache, or persist it.
-    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param options Optional map with `identifier_kind`, `issuer`, and `label`
     // @returns Ok(map) with pending TOTP status and setup `uri`; Err(message) on invalid identity/state/storage
     // @see_also confirm_totp_enrollment, totp_status, verify_local_totp, reset_totp
@@ -4599,7 +4637,7 @@ pub fn init() -> HashMap<String, Value> {
     //
     // Moves `auth.totp.pending_secret` to std/auth-owned confirmed secret metadata only after the submitted code
     // verifies. Returned status is secret-free and safe to use in setup flows.
-    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param code The 6-digit TOTP code from the authenticator app
     // @param options Optional map with `identifier_kind`
     // @returns Ok(map) with confirmed TOTP status; Err(message) on missing pending setup or invalid code
@@ -4643,7 +4681,7 @@ pub fn init() -> HashMap<String, Value> {
     // until this helper succeeds, then complete the challenge with `complete_auth_challenge(...)` or sign in through
     // `sign_in_session(...)`. Pair TOTP endpoints with app rate limiting/backoff; this helper verifies codes but does
     // not own account lockout policy.
-    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param code The 6-digit TOTP code from the authenticator app
     // @param options Optional map with `identifier_kind`
     // @returns Ok(map) with `verified: true` and safe TOTP status; Err(message) on invalid code or unavailable TOTP
@@ -4683,7 +4721,7 @@ pub fn init() -> HashMap<String, Value> {
     // Read a local user's safe TOTP enrollment status.
     //
     // Returns status booleans and display metadata only. It never includes pending or confirmed TOTP secret material.
-    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param options Optional map with `identifier_kind`
     // @returns Ok(map) with safe TOTP status; Err(message) on invalid identity/storage
     // @see_also begin_totp_enrollment, confirm_totp_enrollment, verify_local_totp, reset_totp
@@ -4720,7 +4758,7 @@ pub fn init() -> HashMap<String, Value> {
     // Clear a local user's pending or confirmed TOTP enrollment.
     //
     // Removes only std/auth-owned `auth.totp` metadata and preserves app-owned metadata namespaces.
-    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param options Optional map with `identifier_kind`
     // @returns Ok(map) with disabled TOTP status; Err(message) on invalid identity/state/storage
     // @see_also begin_totp_enrollment, confirm_totp_enrollment, totp_status
@@ -5265,12 +5303,17 @@ pub fn init() -> HashMap<String, Value> {
 mod tests {
     use super::storage::{
         cleanup_expired_oauth_state_records, consume_auth_challenge_record,
-        consume_exchange_token_record, consume_oauth_state_record,
+        consume_exchange_token_record,
+        consume_local_password_reset_token_and_store_credential_record, consume_oauth_state_record,
         delete_all_session_records_for_user, delete_session_record, extend_session_record_expiry,
-        get_auth_challenge_record, get_refreshable_session_record, get_session_record,
-        list_session_records_for_user, migrate_session_record, store_auth_challenge_record,
-        store_exchange_token_record, store_oauth_state_record, store_session_record,
-        update_session_record_data, update_session_record_tokens, OAUTH_STATE_TTL,
+        get_auth_challenge_record, get_local_credential_secret_record,
+        get_local_identity_by_identifier_record, get_refreshable_session_record,
+        get_session_record, list_session_records_for_user, migrate_session_record,
+        store_auth_challenge_record, store_exchange_token_record,
+        store_local_identity_and_credential_record, store_local_password_reset_token_record,
+        store_oauth_state_record, store_session_record, update_session_record_data,
+        update_session_record_tokens, LocalAccountState, LocalCredentialSecret, LocalIdentity,
+        LocalPasswordResetToken, OAUTH_STATE_TTL,
     };
     use super::*;
 
@@ -5645,6 +5688,110 @@ mod tests {
         assert!(get_session_record(&rotated_session.id)
             .unwrap_or_else(|e| panic!("{} deleted session lookup should succeed: {}", label, e))
             .is_none());
+
+        let local_identity = LocalIdentity {
+            id: format!("local-user-{}", label),
+            identifier_kind: "username".to_string(),
+            identifier: format!("{}User", label),
+            identifier_normalized: format!("{}user", label),
+            created_at: now,
+            updated_at: now,
+            state: LocalAccountState::Active,
+            metadata_json: r#"{"app":{"group_ids":["admins"]}}"#.to_string(),
+        };
+        let local_credential = LocalCredentialSecret {
+            local_user_id: local_identity.id.clone(),
+            password_hash: format!("hash-{}", label),
+            password_hash_algorithm: "bcrypt".to_string(),
+            password_hash_params_json: "{}".to_string(),
+            password_changed_at: now,
+            must_change_password: false,
+        };
+        store_local_identity_and_credential_record(&local_identity, &local_credential)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{} local identity+credential store should succeed: {}",
+                    label, e
+                )
+            });
+        let stored_local_identity =
+            get_local_identity_by_identifier_record("username", &format!("{}user", label))
+                .unwrap_or_else(|e| panic!("{} local identity lookup should succeed: {}", label, e))
+                .unwrap_or_else(|| panic!("{} local identity should exist", label));
+        assert_eq!(stored_local_identity.id, local_identity.id);
+        assert_eq!(
+            stored_local_identity.metadata_json,
+            local_identity.metadata_json
+        );
+        let stored_local_credential = get_local_credential_secret_record(&local_identity.id)
+            .unwrap_or_else(|e| panic!("{} local credential lookup should succeed: {}", label, e))
+            .unwrap_or_else(|| panic!("{} local credential should exist", label));
+        assert_eq!(
+            stored_local_credential.password_hash,
+            local_credential.password_hash
+        );
+        let reset_token = LocalPasswordResetToken {
+            selector: format!("reset-selector-{}", label),
+            local_user_id: local_identity.id.clone(),
+            token_hash: format!("reset-hash-{}", label),
+            created_at: now,
+            expires_at: now + 3600,
+        };
+        store_local_password_reset_token_record(&reset_token).unwrap_or_else(|e| {
+            panic!(
+                "{} local password reset token store should succeed: {}",
+                label, e
+            )
+        });
+        let consumed_reset = consume_local_password_reset_token_and_store_credential_record(
+            &reset_token.selector,
+            &reset_token.token_hash,
+            now,
+            |local_user_id| {
+                Ok(LocalCredentialSecret {
+                    local_user_id: local_user_id.to_string(),
+                    password_hash: format!("hash-{}-rotated", label),
+                    password_hash_algorithm: "bcrypt".to_string(),
+                    password_hash_params_json: "{}".to_string(),
+                    password_changed_at: now + 1,
+                    must_change_password: false,
+                })
+            },
+        )
+        .unwrap_or_else(|e| {
+            panic!(
+                "{} local password reset consume should succeed: {}",
+                label, e
+            )
+        })
+        .unwrap_or_else(|| panic!("{} local password reset token should consume", label));
+        assert_eq!(consumed_reset.0.id, local_identity.id);
+        assert_eq!(
+            consumed_reset.1.password_hash,
+            format!("hash-{}-rotated", label)
+        );
+        assert!(
+            consume_local_password_reset_token_and_store_credential_record(
+                &reset_token.selector,
+                &reset_token.token_hash,
+                now,
+                |local_user_id| {
+                    Ok(LocalCredentialSecret {
+                        local_user_id: local_user_id.to_string(),
+                        password_hash: "unused".to_string(),
+                        password_hash_algorithm: "bcrypt".to_string(),
+                        password_hash_params_json: "{}".to_string(),
+                        password_changed_at: now + 2,
+                        must_change_password: false,
+                    })
+                },
+            )
+            .unwrap_or_else(|e| panic!(
+                "{} local password reset replay lookup should succeed: {}",
+                label, e
+            ))
+            .is_none()
+        );
 
         let oauth_state = OAuthState {
             state: format!("oauth-{}-active", label),
@@ -7324,6 +7471,26 @@ mod tests {
                 "reset token hashes belong in reset-token storage, not metadata"
             );
 
+            store_session_record(&Session {
+                id: "reset-default-keeps-session".to_string(),
+                user_id: stored_identity.id.clone(),
+                provider: "local".to_string(),
+                email: Some("reset@example.com".to_string()),
+                name: None,
+                picture: None,
+                raw_json: "{}".to_string(),
+                data_json: "{}".to_string(),
+                csrf_token: "csrf-reset-default-keeps-session".to_string(),
+                access_token: None,
+                refresh_token: None,
+                token_expires_at: None,
+                device_name: None,
+                user_agent_hash: None,
+                last_ip_hash: None,
+                created_at: chrono::Utc::now().timestamp(),
+                expires_at: chrono::Utc::now().timestamp() + 300,
+            })
+            .unwrap();
             let consumed = result_ok_map(
                 consume_password_reset(&[
                     Value::String(token.clone()),
@@ -7331,6 +7498,14 @@ mod tests {
                 ])
                 .unwrap(),
             );
+            assert_eq!(map_int(&consumed, "revoked_sessions"), 0);
+            assert!(
+                get_session_record("reset-default-keeps-session")
+                    .unwrap()
+                    .is_some(),
+                "password reset must keep existing sessions unless explicitly asked to revoke"
+            );
+            delete_session_record("reset-default-keeps-session").unwrap();
             assert_eq!(map_string(&consumed, "local_user_id"), stored_identity.id);
             match consumed.get("state") {
                 Some(Value::String(state)) => assert_eq!(state, "active"),
@@ -7396,6 +7571,49 @@ mod tests {
                 .unwrap(),
             );
             assert_eq!(sibling_replay, "Invalid password reset token");
+
+            let revoke_issued = result_ok_map(
+                issue_password_reset(&[Value::String("reset@example.com".to_string())]).unwrap(),
+            );
+            let revoke_token = map_string(&revoke_issued, "token");
+            store_session_record(&Session {
+                id: "reset-option-revokes-session".to_string(),
+                user_id: stored_identity.id.clone(),
+                provider: "local".to_string(),
+                email: Some("reset@example.com".to_string()),
+                name: None,
+                picture: None,
+                raw_json: "{}".to_string(),
+                data_json: "{}".to_string(),
+                csrf_token: "csrf-reset-option-revokes-session".to_string(),
+                access_token: None,
+                refresh_token: None,
+                token_expires_at: None,
+                device_name: None,
+                user_agent_hash: None,
+                last_ip_hash: None,
+                created_at: chrono::Utc::now().timestamp(),
+                expires_at: chrono::Utc::now().timestamp() + 300,
+            })
+            .unwrap();
+            let consumed_with_revoke = result_ok_map(
+                consume_password_reset(&[
+                    Value::String(revoke_token),
+                    Value::String("rotated and revoked sessions".to_string()),
+                    Value::Map(HashMap::from([(
+                        "revoke_sessions".to_string(),
+                        Value::Bool(true),
+                    )])),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(map_int(&consumed_with_revoke, "revoked_sessions"), 1);
+            assert!(
+                get_session_record("reset-option-revokes-session")
+                    .unwrap()
+                    .is_none(),
+                "explicit revoke_sessions option should revoke existing sessions"
+            );
         }
     }
 
@@ -8423,6 +8641,109 @@ mod tests {
             return;
         };
         run_auth_storage_contract_round_trip(store, "redis");
+    }
+
+    #[test]
+    fn test_redis_password_reset_consume_is_one_time_under_concurrency() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let Some(store) = auth_test_redis_store() else {
+            eprintln!(
+                "[auth-test] skipping Redis password reset concurrency test — set NTNT_AUTH_TEST_REDIS_URL"
+            );
+            return;
+        };
+        reset_auth_test_state();
+        init_test_auth(store);
+
+        let now = chrono::Utc::now().timestamp();
+        let identity = LocalIdentity {
+            id: format!("local-user-redis-concurrent-{now}"),
+            identifier_kind: "email".to_string(),
+            identifier: format!("redis-concurrent-{now}@example.com"),
+            identifier_normalized: format!("redis-concurrent-{now}@example.com"),
+            created_at: now,
+            updated_at: now,
+            state: LocalAccountState::Active,
+            metadata_json: "{}".to_string(),
+        };
+        let credential = LocalCredentialSecret {
+            local_user_id: identity.id.clone(),
+            password_hash: "hash-before-concurrent-reset".to_string(),
+            password_hash_algorithm: "bcrypt".to_string(),
+            password_hash_params_json: "{}".to_string(),
+            password_changed_at: now,
+            must_change_password: false,
+        };
+        store_local_identity_and_credential_record(&identity, &credential).unwrap();
+        let reset_token = LocalPasswordResetToken {
+            selector: format!("redis-concurrent-selector-{now}"),
+            local_user_id: identity.id.clone(),
+            token_hash: format!("redis-concurrent-token-hash-{now}"),
+            created_at: now,
+            expires_at: now + 3600,
+        };
+        store_local_password_reset_token_record(&reset_token).unwrap();
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let mut handles = Vec::new();
+        for index in 0..2 {
+            let barrier = barrier.clone();
+            let selector = reset_token.selector.clone();
+            let token_hash = reset_token.token_hash.clone();
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                consume_local_password_reset_token_and_store_credential_record(
+                    &selector,
+                    &token_hash,
+                    now,
+                    |local_user_id| {
+                        Ok(LocalCredentialSecret {
+                            local_user_id: local_user_id.to_string(),
+                            password_hash: format!("hash-after-concurrent-reset-{index}"),
+                            password_hash_algorithm: "bcrypt".to_string(),
+                            password_hash_params_json: "{}".to_string(),
+                            password_changed_at: now + index,
+                            must_change_password: false,
+                        })
+                    },
+                )
+            }));
+        }
+
+        let successes = handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .expect("redis consume thread should not panic")
+            })
+            .map(|result| result.expect("redis consume should not return storage error"))
+            .filter(|result| result.is_some())
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one concurrent Redis password reset consume should succeed"
+        );
+        assert!(
+            consume_local_password_reset_token_and_store_credential_record(
+                &reset_token.selector,
+                &reset_token.token_hash,
+                now,
+                |local_user_id| {
+                    Ok(LocalCredentialSecret {
+                        local_user_id: local_user_id.to_string(),
+                        password_hash: "unused-replay-hash".to_string(),
+                        password_hash_algorithm: "bcrypt".to_string(),
+                        password_hash_params_json: "{}".to_string(),
+                        password_changed_at: now + 10,
+                        must_change_password: false,
+                    })
+                },
+            )
+            .unwrap()
+            .is_none(),
+            "Redis password reset token should be gone after the successful consume"
+        );
     }
 
     #[test]

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -498,6 +498,69 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
         )
         .ok();
 
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS auth_local_identities (
+            id TEXT PRIMARY KEY,
+            identifier_kind TEXT NOT NULL,
+            identifier TEXT NOT NULL,
+            identifier_normalized TEXT NOT NULL,
+            created_at BIGINT NOT NULL,
+            updated_at BIGINT NOT NULL,
+            state TEXT NOT NULL,
+            metadata_json TEXT NOT NULL,
+            UNIQUE(identifier_kind, identifier_normalized)
+        )",
+            &[],
+        )
+        .map_err(|e| format!("Failed to create auth_local_identities table: {}", e))?;
+
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS auth_local_credentials (
+            local_user_id TEXT PRIMARY KEY REFERENCES auth_local_identities(id) ON DELETE CASCADE,
+            password_hash TEXT NOT NULL,
+            password_hash_algorithm TEXT NOT NULL,
+            password_hash_params_json TEXT NOT NULL,
+            password_changed_at BIGINT NOT NULL,
+            must_change_password BOOLEAN NOT NULL DEFAULT FALSE
+        )",
+            &[],
+        )
+        .map_err(|e| format!("Failed to create auth_local_credentials table: {}", e))?;
+
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS auth_local_password_reset_tokens (
+            selector TEXT PRIMARY KEY,
+            local_user_id TEXT NOT NULL REFERENCES auth_local_identities(id) ON DELETE CASCADE,
+            token_hash TEXT NOT NULL,
+            created_at BIGINT NOT NULL,
+            expires_at BIGINT NOT NULL
+        )",
+            &[],
+        )
+        .map_err(|e| {
+            format!(
+                "Failed to create auth_local_password_reset_tokens table: {}",
+                e
+            )
+        })?;
+
+    client
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_auth_local_password_reset_tokens_expires ON auth_local_password_reset_tokens(expires_at)",
+            &[],
+        )
+        .ok();
+
+    client
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_auth_local_password_reset_tokens_user ON auth_local_password_reset_tokens(local_user_id)",
+            &[],
+        )
+        .ok();
+
     // Store URL for later connections
     let mut pg_url = POSTGRES_URL.lock().unwrap();
     *pg_url = Some(url.to_string());

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -8,8 +8,9 @@ use std::collections::HashMap;
 
 use super::storage::{
     consume_local_password_reset_token_and_store_credential_record,
-    get_local_credential_secret_record, get_local_identity_by_identifier_record,
-    normalize_local_identifier, store_local_identity_and_credential_record,
+    delete_all_session_records_for_user, get_local_credential_secret_record,
+    get_local_identity_by_identifier_record, normalize_local_identifier,
+    store_local_identity_and_credential_record,
     store_local_identity_and_credential_revoke_password_resets_record,
     store_local_password_reset_token_record, update_local_identity_by_identifier_record,
     LocalAccountState, LocalCredentialSecret, LocalIdentity, LocalPasswordResetToken,
@@ -614,7 +615,8 @@ pub(in crate::stdlib::auth) fn issue_password_reset_record(
 pub(in crate::stdlib::auth) fn consume_password_reset_record(
     token: &str,
     new_password: &str,
-) -> std::result::Result<VerifiedLocalPassword, String> {
+    revoke_sessions: bool,
+) -> std::result::Result<(VerifiedLocalPassword, u64), String> {
     if new_password.trim().is_empty() {
         return Err("[auth] local password must not be empty".to_string());
     }
@@ -650,10 +652,18 @@ pub(in crate::stdlib::auth) fn consume_password_reset_record(
     else {
         return Err(INVALID_PASSWORD_RESET_TOKEN.to_string());
     };
-    Ok(VerifiedLocalPassword {
-        identity,
-        credential,
-    })
+    let revoked_sessions = if revoke_sessions {
+        delete_all_session_records_for_user(&identity.id, None)?
+    } else {
+        0
+    };
+    Ok((
+        VerifiedLocalPassword {
+            identity,
+            credential,
+        },
+        revoked_sessions,
+    ))
 }
 
 fn password_reset_accepted_response() -> HashMap<String, Value> {

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -2030,19 +2030,100 @@ fn store_local_password_reset_token_redis(
     }
     let token_key = redis_local_password_reset_key(&token.selector);
     let user_set_key = redis_local_password_reset_user_set_key(&token.local_user_id);
-    redis::pipe()
-        .atomic()
-        .cmd("SETEX")
-        .arg(&token_key)
-        .arg(ttl)
-        .arg(local_password_reset_token_to_json(token))
-        .ignore()
-        .cmd("SADD")
-        .arg(&user_set_key)
-        .arg(&token_key)
-        .ignore()
-        .query::<()>(&mut conn)
-        .map_err(|e| format!("Redis password reset token store error: {}", e))
+    redis::Script::new(
+        r#"
+        redis.call('SETEX', KEYS[1], ARGV[1], ARGV[2])
+        redis.call('SADD', KEYS[2], KEYS[1])
+
+        local current_ttl = redis.call('TTL', KEYS[2])
+        local token_ttl = tonumber(ARGV[1])
+        if current_ttl < token_ttl then
+            redis.call('EXPIRE', KEYS[2], token_ttl)
+        end
+
+        return 1
+        "#,
+    )
+    .key(&token_key)
+    .key(&user_set_key)
+    .arg(ttl)
+    .arg(local_password_reset_token_to_json(token))
+    .invoke::<i64>(&mut conn)
+    .map(|_| ())
+    .map_err(|e| format!("Redis password reset token store error: {}", e))
+}
+
+fn invoke_redis_password_reset_consume_script(
+    conn: &mut redis::Connection,
+    token_key: &str,
+    identity_key: &str,
+    credential_key: &str,
+    reset_set_key: &str,
+    now: i64,
+    token_hash: &str,
+    local_user_id: &str,
+    credential_json: &str,
+) -> std::result::Result<i64, String> {
+    redis::Script::new(
+        r#"
+        local token_json = redis.call('GET', KEYS[1])
+        if not token_json then
+            return 0
+        end
+
+        local token = cjson.decode(token_json)
+        if tonumber(token.expires_at) <= tonumber(ARGV[1]) then
+            redis.call('DEL', KEYS[1])
+            redis.call('SREM', KEYS[4], KEYS[1])
+            return 0
+        end
+
+        if token.token_hash ~= ARGV[2] or token.local_user_id ~= ARGV[3] then
+            return 0
+        end
+
+        local current_identity_json = redis.call('GET', KEYS[2])
+        if not current_identity_json then
+            return 0
+        end
+        local current_identity = cjson.decode(current_identity_json)
+        if current_identity.id ~= ARGV[3] then
+            return 0
+        end
+        if current_identity.state == 'disabled' or current_identity.state == 'locked' then
+            return 0
+        end
+
+        local current_lookup_key = 'ntnt:local_identity_lookup:' .. current_identity.identifier_kind .. ':' .. current_identity.identifier_normalized
+        local existing_id = redis.call('GET', current_lookup_key)
+        if existing_id and existing_id ~= ARGV[3] then
+            return -1
+        end
+
+        current_identity.state = 'active'
+        current_identity.updated_at = tonumber(ARGV[1])
+        redis.call('SET', KEYS[2], cjson.encode(current_identity))
+        redis.call('SET', current_lookup_key, ARGV[3])
+        redis.call('SET', KEYS[3], ARGV[4])
+
+        local reset_keys = redis.call('SMEMBERS', KEYS[4])
+        for _, key in ipairs(reset_keys) do
+            redis.call('DEL', key)
+        end
+        redis.call('DEL', KEYS[4])
+        return 1
+        "#,
+    )
+    .key(token_key)
+    .key(identity_key)
+    .key(credential_key)
+    .key(reset_set_key)
+    .arg(now)
+    .arg(token_hash)
+    .arg(local_user_id)
+    .arg(credential_json)
+    .invoke(conn)
+    .map_err(|e| format!("Redis password reset consume error: {}", e))
 }
 
 fn consume_local_password_reset_token_and_store_credential_redis<F>(
@@ -2106,57 +2187,19 @@ where
     })?;
 
     let identity_key = redis_local_identity_key(&identity.id);
-    let lookup_key =
-        redis_local_identity_lookup_key(&identity.identifier_kind, &identity.identifier_normalized);
     let credential_key = redis_local_credential_key(&credential.local_user_id);
     let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
-    let consumed: i64 = redis::Script::new(
-        r#"
-        local token_json = redis.call('GET', KEYS[1])
-        if not token_json then
-            return 0
-        end
-
-        local token = cjson.decode(token_json)
-        if tonumber(token.expires_at) <= tonumber(ARGV[1]) then
-            redis.call('DEL', KEYS[1])
-            redis.call('SREM', KEYS[4], KEYS[1])
-            return 0
-        end
-
-        if token.token_hash ~= ARGV[2] or token.local_user_id ~= ARGV[3] then
-            return 0
-        end
-
-        local existing_id = redis.call('GET', KEYS[5])
-        if existing_id and existing_id ~= ARGV[3] then
-            return -1
-        end
-
-        redis.call('SET', KEYS[2], ARGV[4])
-        redis.call('SET', KEYS[5], ARGV[3])
-        redis.call('SET', KEYS[3], ARGV[5])
-
-        local reset_keys = redis.call('SMEMBERS', KEYS[4])
-        for _, key in ipairs(reset_keys) do
-            redis.call('DEL', key)
-        end
-        redis.call('DEL', KEYS[4])
-        return 1
-        "#,
-    )
-    .key(&token_key)
-    .key(&identity_key)
-    .key(&credential_key)
-    .key(&reset_set_key)
-    .key(&lookup_key)
-    .arg(now)
-    .arg(token_hash)
-    .arg(&identity.id)
-    .arg(local_identity_to_json(&identity))
-    .arg(local_credential_to_json(&credential))
-    .invoke(&mut conn)
-    .map_err(|e| format!("Redis password reset consume error: {}", e))?;
+    let consumed = invoke_redis_password_reset_consume_script(
+        &mut conn,
+        &token_key,
+        &identity_key,
+        &credential_key,
+        &reset_set_key,
+        now,
+        token_hash,
+        &identity.id,
+        &local_credential_to_json(&credential),
+    )?;
 
     if consumed == -1 {
         return Err(format!(
@@ -2167,7 +2210,10 @@ where
     if consumed != 1 {
         return Ok(None);
     }
-    Ok(Some((identity, credential)))
+    let stored_identity = get_local_identity_by_id_redis(&identity.id)?.ok_or_else(|| {
+        "[auth] Redis password reset consumed token but local identity is missing".to_string()
+    })?;
+    Ok(Some((stored_identity, credential)))
 }
 
 #[cfg(test)]
@@ -2272,5 +2318,195 @@ mod tests {
 
         store.store_identity(first).unwrap();
         assert!(store.store_identity(second).is_err());
+    }
+
+    #[cfg(feature = "redis-tests")]
+    fn redis_test_connection() -> Option<redis::Connection> {
+        let url = std::env::var("NTNT_REDIS_TEST_URL")
+            .or_else(|_| std::env::var("REDIS_URL"))
+            .unwrap_or_else(|_| "redis://localhost:6379".to_string());
+        *REDIS_URL.lock().unwrap() = Some(url);
+        match redis_connection() {
+            Ok(mut conn) => {
+                let ping = redis::cmd("PING").query::<String>(&mut conn);
+                if let Err(err) = ping {
+                    eprintln!("skipping Redis local-auth test: Redis PING failed: {err}");
+                    return None;
+                }
+                Some(conn)
+            }
+            Err(err) => {
+                eprintln!("skipping Redis local-auth test: {err}");
+                None
+            }
+        }
+    }
+
+    #[cfg(feature = "redis-tests")]
+    fn unique_redis_test_suffix(name: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        format!("{name}-{nanos}")
+    }
+
+    #[cfg(feature = "redis-tests")]
+    fn redis_test_identity(id: &str) -> LocalIdentity {
+        LocalIdentity {
+            id: id.to_string(),
+            identifier_kind: "email".to_string(),
+            identifier: format!("{id}@example.test"),
+            identifier_normalized: format!("{id}@example.test"),
+            created_at: 100,
+            updated_at: 100,
+            state: LocalAccountState::Active,
+            metadata_json: "{}".to_string(),
+        }
+    }
+
+    #[cfg(feature = "redis-tests")]
+    fn redis_test_credential(local_user_id: &str) -> LocalCredentialSecret {
+        LocalCredentialSecret {
+            local_user_id: local_user_id.to_string(),
+            password_hash: "argon2$rotated-hash".to_string(),
+            password_hash_algorithm: "argon2id".to_string(),
+            password_hash_params_json: "{}".to_string(),
+            password_changed_at: 200,
+            must_change_password: false,
+        }
+    }
+
+    #[cfg(feature = "redis-tests")]
+    fn cleanup_redis_local_auth_keys(
+        conn: &mut redis::Connection,
+        identity: &LocalIdentity,
+        selectors: &[&str],
+    ) {
+        let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
+        let keys: Vec<String> = selectors
+            .iter()
+            .map(|selector| redis_local_password_reset_key(selector))
+            .chain([
+                redis_local_identity_key(&identity.id),
+                redis_local_identity_lookup_key(
+                    &identity.identifier_kind,
+                    &identity.identifier_normalized,
+                ),
+                redis_local_credential_key(&identity.id),
+                reset_set_key,
+            ])
+            .collect();
+        let _ = redis::cmd("DEL").arg(keys).query::<i64>(conn);
+    }
+
+    #[cfg(feature = "redis-tests")]
+    #[test]
+    fn test_redis_password_reset_user_index_expires_and_does_not_shorten() {
+        let Some(mut conn) = redis_test_connection() else {
+            return;
+        };
+        let suffix = unique_redis_test_suffix("reset-index-expiry");
+        let identity = redis_test_identity(&suffix);
+        let selector_long = format!("{suffix}-long");
+        let selector_short = format!("{suffix}-short");
+        cleanup_redis_local_auth_keys(&mut conn, &identity, &[&selector_long, &selector_short]);
+
+        store_local_identity_redis_with_connection(&mut conn, &identity).unwrap();
+        let now = chrono::Utc::now().timestamp();
+        store_local_password_reset_token_redis(&LocalPasswordResetToken {
+            selector: selector_long.clone(),
+            local_user_id: identity.id.clone(),
+            token_hash: "long-token-hash".to_string(),
+            created_at: now,
+            expires_at: now + 3600,
+        })
+        .unwrap();
+        let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
+        let ttl_after_long = redis::cmd("TTL")
+            .arg(&reset_set_key)
+            .query::<i64>(&mut conn)
+            .unwrap();
+        assert!(ttl_after_long > 0);
+
+        store_local_password_reset_token_redis(&LocalPasswordResetToken {
+            selector: selector_short.clone(),
+            local_user_id: identity.id.clone(),
+            token_hash: "short-token-hash".to_string(),
+            created_at: now,
+            expires_at: now + 60,
+        })
+        .unwrap();
+        let ttl_after_short = redis::cmd("TTL")
+            .arg(&reset_set_key)
+            .query::<i64>(&mut conn)
+            .unwrap();
+        assert!(
+            ttl_after_short >= 3500,
+            "shorter reset token TTL should not shorten the per-user reset index TTL: {ttl_after_short}"
+        );
+
+        cleanup_redis_local_auth_keys(&mut conn, &identity, &[&selector_long, &selector_short]);
+    }
+
+    #[cfg(feature = "redis-tests")]
+    #[test]
+    fn test_redis_password_reset_consume_rechecks_locked_state_atomically() {
+        let Some(mut conn) = redis_test_connection() else {
+            return;
+        };
+        let suffix = unique_redis_test_suffix("reset-locked-recheck");
+        let identity = redis_test_identity(&suffix);
+        let selector = format!("{suffix}-selector");
+        cleanup_redis_local_auth_keys(&mut conn, &identity, &[&selector]);
+
+        store_local_identity_redis_with_connection(&mut conn, &identity).unwrap();
+        let now = chrono::Utc::now().timestamp();
+        let token_hash = "reset-token-hash";
+        store_local_password_reset_token_redis(&LocalPasswordResetToken {
+            selector: selector.clone(),
+            local_user_id: identity.id.clone(),
+            token_hash: token_hash.to_string(),
+            created_at: now,
+            expires_at: now + 3600,
+        })
+        .unwrap();
+
+        let mut locked_identity = identity.clone();
+        locked_identity.state = LocalAccountState::Locked;
+        locked_identity.updated_at = now + 10;
+        store_local_identity_redis_with_connection(&mut conn, &locked_identity).unwrap();
+
+        let credential = redis_test_credential(&identity.id);
+        let consumed = invoke_redis_password_reset_consume_script(
+            &mut conn,
+            &redis_local_password_reset_key(&selector),
+            &redis_local_identity_key(&identity.id),
+            &redis_local_credential_key(&identity.id),
+            &redis_local_password_reset_user_set_key(&identity.id),
+            now + 20,
+            token_hash,
+            &identity.id,
+            &local_credential_to_json(&credential),
+        )
+        .unwrap();
+
+        assert_eq!(consumed, 0);
+        let stored_credential: Option<String> = redis::cmd("GET")
+            .arg(redis_local_credential_key(&identity.id))
+            .query(&mut conn)
+            .unwrap();
+        assert!(stored_credential.is_none());
+        let stored_token: Option<String> = redis::cmd("GET")
+            .arg(redis_local_password_reset_key(&selector))
+            .query(&mut conn)
+            .unwrap();
+        assert!(stored_token.is_some());
+        let stored_identity = get_local_identity_by_id_redis(&identity.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored_identity.state, LocalAccountState::Locked);
+
+        cleanup_redis_local_auth_keys(&mut conn, &identity, &[&selector]);
     }
 }

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -122,8 +122,11 @@ pub(in crate::stdlib::auth) fn normalize_local_identifier(
     let kind = identifier_kind.trim().to_ascii_lowercase();
     match kind.as_str() {
         "email" => normalize_email_identifier(identifier),
+        "phone" => normalize_phone_identifier(identifier),
+        "username" => normalize_username_identifier(identifier),
+        "custom" => normalize_custom_identifier(identifier),
         other => Err(format!(
-            "[auth] unsupported local identifier kind \"{}\". Supported kinds: email",
+            "[auth] unsupported local identifier kind \"{}\". Supported kinds: email, phone, username, custom",
             other
         )),
     }
@@ -141,6 +144,80 @@ fn normalize_email_identifier(identifier: &str) -> std::result::Result<String, S
         return Err("[auth] local email identifier domain is invalid".to_string());
     }
     Ok(normalized)
+}
+
+fn normalize_phone_identifier(identifier: &str) -> std::result::Result<String, String> {
+    let trimmed = identifier.trim();
+    if trimmed.is_empty() {
+        return Err("[auth] local phone identifier must not be empty".to_string());
+    }
+
+    let mut normalized = String::with_capacity(trimmed.len());
+    for (index, ch) in trimmed.chars().enumerate() {
+        if ch.is_ascii_digit() {
+            normalized.push(ch);
+        } else if ch == '+' && index == 0 {
+            normalized.push(ch);
+        } else if matches!(ch, ' ' | '\t' | '\n' | '\r' | '-' | '.' | '(' | ')') {
+            continue;
+        } else {
+            return Err("[auth] local phone identifier contains invalid characters".to_string());
+        }
+    }
+
+    let digit_count = normalized.chars().filter(|ch| ch.is_ascii_digit()).count();
+    if digit_count < 7 || digit_count > 15 {
+        return Err("[auth] local phone identifier must contain 7 to 15 digits".to_string());
+    }
+    if normalized == "+" || normalized.is_empty() {
+        return Err("[auth] local phone identifier must contain digits".to_string());
+    }
+    Ok(normalized)
+}
+
+fn normalize_username_identifier(identifier: &str) -> std::result::Result<String, String> {
+    let normalized = identifier.trim().to_ascii_lowercase();
+    let len = normalized.len();
+    if !(3..=64).contains(&len) {
+        return Err("[auth] local username identifier must be 3 to 64 characters".to_string());
+    }
+    if !normalized
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '-' | '.'))
+    {
+        return Err(
+            "[auth] local username identifier may contain only letters, digits, underscore, hyphen, and dot"
+                .to_string(),
+        );
+    }
+    let starts_and_ends_with_alnum = normalized
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+        && normalized
+            .chars()
+            .next_back()
+            .is_some_and(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit());
+    if !starts_and_ends_with_alnum {
+        return Err(
+            "[auth] local username identifier must start and end with a letter or digit"
+                .to_string(),
+        );
+    }
+    Ok(normalized)
+}
+
+fn normalize_custom_identifier(identifier: &str) -> std::result::Result<String, String> {
+    let normalized = identifier.trim();
+    if normalized.is_empty() {
+        return Err("[auth] local custom identifier must not be empty".to_string());
+    }
+    if normalized.chars().any(|ch| ch.is_control()) {
+        return Err(
+            "[auth] local custom identifier must not contain control characters".to_string(),
+        );
+    }
+    Ok(normalized.to_string())
 }
 
 #[derive(Debug, Default, Clone)]
@@ -382,7 +459,7 @@ fn local_identity_lookup_key(
     identifier_normalized: &str,
 ) -> std::result::Result<String, String> {
     let kind = identifier_kind.trim().to_ascii_lowercase();
-    let normalized = identifier_normalized.trim().to_ascii_lowercase();
+    let normalized = identifier_normalized.trim();
     if kind.is_empty() || normalized.is_empty() {
         return Err("[auth] local identity identifier kind/value must not be empty".to_string());
     }
@@ -454,12 +531,8 @@ pub(in crate::stdlib::auth) fn store_local_identity_record(
             .local_auth
             .store_identity(identity.clone()),
         AuthStorageBackend::Sqlite => store_local_identity_sqlite(identity),
-        AuthStorageBackend::Postgres => {
-            Err("[auth] local identity storage is not implemented for PostgreSQL yet".to_string())
-        }
-        AuthStorageBackend::Redis => {
-            Err("[auth] local identity storage is not implemented for Redis/Valkey yet".to_string())
-        }
+        AuthStorageBackend::Postgres => store_local_identity_postgres(identity),
+        AuthStorageBackend::Redis => store_local_identity_redis(identity),
     }
 }
 
@@ -495,14 +568,14 @@ fn store_local_identity_and_credential_record_inner(
         AuthStorageBackend::Sqlite => {
             store_local_identity_and_credential_sqlite(identity, credential, revoke_password_resets)
         }
-        AuthStorageBackend::Postgres => Err(
-            "[auth] local identity and credential storage is not implemented for PostgreSQL yet"
-                .to_string(),
+        AuthStorageBackend::Postgres => store_local_identity_and_credential_postgres(
+            identity,
+            credential,
+            revoke_password_resets,
         ),
-        AuthStorageBackend::Redis => Err(
-            "[auth] local identity and credential storage is not implemented for Redis/Valkey yet"
-                .to_string(),
-        ),
+        AuthStorageBackend::Redis => {
+            store_local_identity_and_credential_redis(identity, credential, revoke_password_resets)
+        }
     }
 }
 
@@ -516,12 +589,8 @@ pub(in crate::stdlib::auth) fn get_local_identity_by_id_record(
             .local_auth
             .get_identity_by_id(id),
         AuthStorageBackend::Sqlite => get_local_identity_by_id_sqlite(id),
-        AuthStorageBackend::Postgres => {
-            Err("[auth] local identity lookup is not implemented for PostgreSQL yet".to_string())
-        }
-        AuthStorageBackend::Redis => {
-            Err("[auth] local identity lookup is not implemented for Redis/Valkey yet".to_string())
-        }
+        AuthStorageBackend::Postgres => get_local_identity_by_id_postgres(id),
+        AuthStorageBackend::Redis => get_local_identity_by_id_redis(id),
     }
 }
 
@@ -539,10 +608,10 @@ pub(in crate::stdlib::auth) fn get_local_identity_by_identifier_record(
             get_local_identity_by_identifier_sqlite(identifier_kind, identifier_normalized)
         }
         AuthStorageBackend::Postgres => {
-            Err("[auth] local identity lookup is not implemented for PostgreSQL yet".to_string())
+            get_local_identity_by_identifier_postgres(identifier_kind, identifier_normalized)
         }
         AuthStorageBackend::Redis => {
-            Err("[auth] local identity lookup is not implemented for Redis/Valkey yet".to_string())
+            get_local_identity_by_identifier_redis(identifier_kind, identifier_normalized)
         }
     }
 }
@@ -566,12 +635,16 @@ where
             identifier_normalized,
             updater,
         ),
-        AuthStorageBackend::Postgres => {
-            Err("[auth] local identity update is not implemented for PostgreSQL yet".to_string())
-        }
-        AuthStorageBackend::Redis => {
-            Err("[auth] local identity update is not implemented for Redis/Valkey yet".to_string())
-        }
+        AuthStorageBackend::Postgres => update_local_identity_by_identifier_postgres(
+            identifier_kind,
+            identifier_normalized,
+            updater,
+        ),
+        AuthStorageBackend::Redis => update_local_identity_by_identifier_redis(
+            identifier_kind,
+            identifier_normalized,
+            updater,
+        ),
     }
 }
 
@@ -585,12 +658,8 @@ pub(in crate::stdlib::auth) fn store_local_credential_secret_record(
             .local_auth
             .store_credential_secret(credential.clone()),
         AuthStorageBackend::Sqlite => store_local_credential_secret_sqlite(credential),
-        AuthStorageBackend::Postgres => {
-            Err("[auth] local credential storage is not implemented for PostgreSQL yet".to_string())
-        }
-        AuthStorageBackend::Redis => Err(
-            "[auth] local credential storage is not implemented for Redis/Valkey yet".to_string(),
-        ),
+        AuthStorageBackend::Postgres => store_local_credential_secret_postgres(credential),
+        AuthStorageBackend::Redis => store_local_credential_secret_redis(credential),
     }
 }
 
@@ -604,12 +673,8 @@ pub(in crate::stdlib::auth) fn get_local_credential_secret_record(
             .local_auth
             .get_credential_secret(local_user_id),
         AuthStorageBackend::Sqlite => get_local_credential_secret_sqlite(local_user_id),
-        AuthStorageBackend::Postgres => {
-            Err("[auth] local credential lookup is not implemented for PostgreSQL yet".to_string())
-        }
-        AuthStorageBackend::Redis => Err(
-            "[auth] local credential lookup is not implemented for Redis/Valkey yet".to_string(),
-        ),
+        AuthStorageBackend::Postgres => get_local_credential_secret_postgres(local_user_id),
+        AuthStorageBackend::Redis => get_local_credential_secret_redis(local_user_id),
     }
 }
 
@@ -623,13 +688,8 @@ pub(in crate::stdlib::auth) fn store_local_password_reset_token_record(
             .local_auth
             .store_password_reset_token(token.clone()),
         AuthStorageBackend::Sqlite => store_local_password_reset_token_sqlite(token),
-        AuthStorageBackend::Postgres => Err(
-            "[auth] password reset token storage is not implemented for PostgreSQL yet".to_string(),
-        ),
-        AuthStorageBackend::Redis => Err(
-            "[auth] password reset token storage is not implemented for Redis/Valkey yet"
-                .to_string(),
-        ),
+        AuthStorageBackend::Postgres => store_local_password_reset_token_postgres(token),
+        AuthStorageBackend::Redis => store_local_password_reset_token_redis(token),
     }
 }
 
@@ -662,11 +722,19 @@ where
             )
         }
         AuthStorageBackend::Postgres => {
-            Err("[auth] password reset consume is not implemented for PostgreSQL yet".to_string())
+            consume_local_password_reset_token_and_store_credential_postgres(
+                selector,
+                token_hash,
+                now,
+                credential_builder,
+            )
         }
-        AuthStorageBackend::Redis => {
-            Err("[auth] password reset consume is not implemented for Redis/Valkey yet".to_string())
-        }
+        AuthStorageBackend::Redis => consume_local_password_reset_token_and_store_credential_redis(
+            selector,
+            token_hash,
+            now,
+            credential_builder,
+        ),
     }
 }
 
@@ -814,7 +882,7 @@ fn get_local_identity_by_identifier_sqlite(
     let conn_guard = SQLITE_CONN.lock().unwrap();
     let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
     let kind = identifier_kind.trim().to_ascii_lowercase();
-    let normalized = identifier_normalized.trim().to_ascii_lowercase();
+    let normalized = identifier_normalized.trim().to_string();
     conn.query_row(
         "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
          FROM auth_local_identities
@@ -837,7 +905,7 @@ where
     let mut conn_guard = SQLITE_CONN.lock().unwrap();
     let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
     let kind = identifier_kind.trim().to_ascii_lowercase();
-    let normalized = identifier_normalized.trim().to_ascii_lowercase();
+    let normalized = identifier_normalized.trim().to_string();
     let tx = conn.transaction().map_err(|e| {
         format!(
             "[auth] failed to begin local identity update transaction: {}",
@@ -1131,6 +1199,977 @@ where
     Ok(Some((identity, credential.clone())))
 }
 
+fn postgres_url() -> std::result::Result<String, String> {
+    POSTGRES_URL
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| "PostgreSQL not initialized".to_string())
+}
+
+fn redis_connection() -> std::result::Result<redis::Connection, String> {
+    let url = REDIS_URL
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| "Redis not initialized".to_string())?;
+    let client =
+        redis::Client::open(url.as_str()).map_err(|e| format!("Redis client error: {}", e))?;
+    client
+        .get_connection()
+        .map_err(|e| format!("Redis connection error: {}", e))
+}
+
+fn local_identity_from_postgres_row(
+    row: &postgres::Row,
+) -> std::result::Result<LocalIdentity, String> {
+    let state: String = row.get(6);
+    Ok(LocalIdentity {
+        id: row.get(0),
+        identifier_kind: row.get(1),
+        identifier: row.get(2),
+        identifier_normalized: row.get(3),
+        created_at: row.get(4),
+        updated_at: row.get(5),
+        state: LocalAccountState::from_str(&state)?,
+        metadata_json: row.get(7),
+    })
+}
+
+fn store_local_identity_postgres(identity: &LocalIdentity) -> std::result::Result<(), String> {
+    let identity = normalize_local_identity_for_storage(identity.clone())?;
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    client.execute(
+        "INSERT INTO auth_local_identities
+         (id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (id) DO UPDATE SET
+            identifier_kind = EXCLUDED.identifier_kind,
+            identifier = EXCLUDED.identifier,
+            identifier_normalized = EXCLUDED.identifier_normalized,
+            updated_at = EXCLUDED.updated_at,
+            state = EXCLUDED.state,
+            metadata_json = EXCLUDED.metadata_json",
+        &[
+            &identity.id,
+            &identity.identifier_kind,
+            &identity.identifier,
+            &identity.identifier_normalized,
+            &identity.created_at,
+            &identity.updated_at,
+            &identity.state.as_str(),
+            &identity.metadata_json,
+        ],
+    ).map_err(|e| format!("[auth] failed to store local identity: {}", e))?;
+    Ok(())
+}
+
+fn store_local_identity_and_credential_postgres(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+    revoke_password_resets: bool,
+) -> std::result::Result<(), String> {
+    let identity = normalize_local_identity_for_storage(identity.clone())?;
+    validate_local_credential_secret_for_storage(credential)?;
+    validate_local_identity_credential_pair(&identity, credential)?;
+
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let mut tx = client
+        .transaction()
+        .map_err(|e| format!("[auth] failed to begin local bootstrap transaction: {}", e))?;
+
+    tx.execute(
+        "INSERT INTO auth_local_identities
+         (id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (id) DO UPDATE SET
+            identifier_kind = EXCLUDED.identifier_kind,
+            identifier = EXCLUDED.identifier,
+            identifier_normalized = EXCLUDED.identifier_normalized,
+            updated_at = EXCLUDED.updated_at,
+            state = EXCLUDED.state,
+            metadata_json = EXCLUDED.metadata_json",
+        &[
+            &identity.id,
+            &identity.identifier_kind,
+            &identity.identifier,
+            &identity.identifier_normalized,
+            &identity.created_at,
+            &identity.updated_at,
+            &identity.state.as_str(),
+            &identity.metadata_json,
+        ],
+    ).map_err(|e| format!("[auth] failed to store local identity: {}", e))?;
+
+    tx.execute(
+        "INSERT INTO auth_local_credentials
+         (local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (local_user_id) DO UPDATE SET
+            password_hash = EXCLUDED.password_hash,
+            password_hash_algorithm = EXCLUDED.password_hash_algorithm,
+            password_hash_params_json = EXCLUDED.password_hash_params_json,
+            password_changed_at = EXCLUDED.password_changed_at,
+            must_change_password = EXCLUDED.must_change_password",
+        &[
+            &credential.local_user_id,
+            &credential.password_hash,
+            &credential.password_hash_algorithm,
+            &credential.password_hash_params_json,
+            &credential.password_changed_at,
+            &credential.must_change_password,
+        ],
+    ).map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
+
+    if revoke_password_resets {
+        tx.execute(
+            "DELETE FROM auth_local_password_reset_tokens WHERE local_user_id = $1",
+            &[&identity.id],
+        )
+        .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
+    }
+
+    tx.commit()
+        .map_err(|e| format!("[auth] failed to commit local bootstrap transaction: {}", e))
+}
+
+fn get_local_identity_by_id_postgres(
+    id: &str,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let rows = client
+        .query(
+            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+             FROM auth_local_identities WHERE id = $1",
+            &[&id],
+        )
+        .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))?;
+    rows.first()
+        .map(local_identity_from_postgres_row)
+        .transpose()
+}
+
+fn get_local_identity_by_identifier_postgres(
+    identifier_kind: &str,
+    identifier_normalized: &str,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let normalized = identifier_normalized.trim().to_string();
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let rows = client
+        .query(
+            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+             FROM auth_local_identities WHERE identifier_kind = $1 AND identifier_normalized = $2",
+            &[&kind, &normalized],
+        )
+        .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))?;
+    rows.first()
+        .map(local_identity_from_postgres_row)
+        .transpose()
+}
+
+fn update_local_identity_by_identifier_postgres<F>(
+    identifier_kind: &str,
+    identifier_normalized: &str,
+    updater: F,
+) -> std::result::Result<Option<LocalIdentity>, String>
+where
+    F: FnOnce(&mut LocalIdentity) -> std::result::Result<(), String>,
+{
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let normalized = identifier_normalized.trim().to_string();
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let mut tx = client.transaction().map_err(|e| {
+        format!(
+            "[auth] failed to begin local identity update transaction: {}",
+            e
+        )
+    })?;
+    let rows = tx
+        .query(
+            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+             FROM auth_local_identities WHERE identifier_kind = $1 AND identifier_normalized = $2 FOR UPDATE",
+            &[&kind, &normalized],
+        )
+        .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))?;
+    let Some(row) = rows.first() else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit local identity update transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+    let mut identity = local_identity_from_postgres_row(row)?;
+    updater(&mut identity)?;
+    let identity = normalize_local_identity_for_storage(identity)?;
+    tx.execute(
+        "UPDATE auth_local_identities
+         SET identifier_kind = $2, identifier = $3, identifier_normalized = $4,
+             updated_at = $5, state = $6, metadata_json = $7
+         WHERE id = $1",
+        &[
+            &identity.id,
+            &identity.identifier_kind,
+            &identity.identifier,
+            &identity.identifier_normalized,
+            &identity.updated_at,
+            &identity.state.as_str(),
+            &identity.metadata_json,
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to update local identity: {}", e))?;
+    tx.commit().map_err(|e| {
+        format!(
+            "[auth] failed to commit local identity update transaction: {}",
+            e
+        )
+    })?;
+    Ok(Some(identity))
+}
+
+fn store_local_credential_secret_postgres(
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    validate_local_credential_secret_for_storage(credential)?;
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    client.execute(
+        "INSERT INTO auth_local_credentials
+         (local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (local_user_id) DO UPDATE SET
+            password_hash = EXCLUDED.password_hash,
+            password_hash_algorithm = EXCLUDED.password_hash_algorithm,
+            password_hash_params_json = EXCLUDED.password_hash_params_json,
+            password_changed_at = EXCLUDED.password_changed_at,
+            must_change_password = EXCLUDED.must_change_password",
+        &[
+            &credential.local_user_id,
+            &credential.password_hash,
+            &credential.password_hash_algorithm,
+            &credential.password_hash_params_json,
+            &credential.password_changed_at,
+            &credential.must_change_password,
+        ],
+    ).map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
+    Ok(())
+}
+
+fn get_local_credential_secret_postgres(
+    local_user_id: &str,
+) -> std::result::Result<Option<LocalCredentialSecret>, String> {
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let rows = client
+        .query(
+            "SELECT local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password
+             FROM auth_local_credentials WHERE local_user_id = $1",
+            &[&local_user_id],
+        )
+        .map_err(|e| format!("[auth] failed to lookup local credential: {}", e))?;
+    Ok(rows.first().map(|row| LocalCredentialSecret {
+        local_user_id: row.get(0),
+        password_hash: row.get(1),
+        password_hash_algorithm: row.get(2),
+        password_hash_params_json: row.get(3),
+        password_changed_at: row.get(4),
+        must_change_password: row.get(5),
+    }))
+}
+
+fn store_local_password_reset_token_postgres(
+    token: &LocalPasswordResetToken,
+) -> std::result::Result<(), String> {
+    validate_local_password_reset_token_for_storage(token)?;
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    client
+        .execute(
+            "INSERT INTO auth_local_password_reset_tokens
+         (selector, local_user_id, token_hash, created_at, expires_at)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (selector) DO UPDATE SET
+            local_user_id = EXCLUDED.local_user_id,
+            token_hash = EXCLUDED.token_hash,
+            created_at = EXCLUDED.created_at,
+            expires_at = EXCLUDED.expires_at",
+            &[
+                &token.selector,
+                &token.local_user_id,
+                &token.token_hash,
+                &token.created_at,
+                &token.expires_at,
+            ],
+        )
+        .map_err(|e| format!("[auth] failed to store password reset token: {}", e))?;
+    Ok(())
+}
+
+fn consume_local_password_reset_token_and_store_credential_postgres<F>(
+    selector: &str,
+    token_hash: &str,
+    now: i64,
+    credential_builder: F,
+) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String>
+where
+    F: FnOnce(&str) -> std::result::Result<LocalCredentialSecret, String>,
+{
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let mut tx = client.transaction().map_err(|e| {
+        format!(
+            "[auth] failed to begin password reset consume transaction: {}",
+            e
+        )
+    })?;
+
+    let rows = tx
+        .query(
+            "SELECT selector, local_user_id, token_hash, created_at, expires_at
+             FROM auth_local_password_reset_tokens WHERE selector = $1 FOR UPDATE",
+            &[&selector],
+        )
+        .map_err(|e| format!("[auth] failed to lookup password reset token: {}", e))?;
+    let Some(row) = rows.first() else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+    let reset_token = LocalPasswordResetToken {
+        selector: row.get(0),
+        local_user_id: row.get(1),
+        token_hash: row.get(2),
+        created_at: row.get(3),
+        expires_at: row.get(4),
+    };
+    if reset_token.expires_at <= now {
+        tx.execute(
+            "DELETE FROM auth_local_password_reset_tokens WHERE selector = $1",
+            &[&selector],
+        )
+        .map_err(|e| {
+            format!(
+                "[auth] failed to delete expired password reset token: {}",
+                e
+            )
+        })?;
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    if !constant_time_compare(&reset_token.token_hash, token_hash) {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    let credential = credential_builder(&reset_token.local_user_id)?;
+    validate_local_credential_secret_for_storage(&credential)?;
+    let rows = tx
+        .query(
+            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+             FROM auth_local_identities WHERE id = $1 FOR UPDATE",
+            &[&reset_token.local_user_id],
+        )
+        .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))?;
+    let Some(row) = rows.first() else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+    let identity = local_identity_from_postgres_row(row)?;
+    if matches!(
+        identity.state,
+        LocalAccountState::Disabled | LocalAccountState::Locked
+    ) {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    let identity = normalize_local_identity_for_storage(LocalIdentity {
+        updated_at: now,
+        state: LocalAccountState::Active,
+        ..identity
+    })?;
+    tx.execute(
+        "UPDATE auth_local_identities SET updated_at = $2, state = $3 WHERE id = $1",
+        &[&identity.id, &identity.updated_at, &identity.state.as_str()],
+    )
+    .map_err(|e| format!("[auth] failed to update local identity: {}", e))?;
+    tx.execute(
+        "INSERT INTO auth_local_credentials
+         (local_user_id, password_hash, password_hash_algorithm, password_hash_params_json, password_changed_at, must_change_password)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (local_user_id) DO UPDATE SET
+            password_hash = EXCLUDED.password_hash,
+            password_hash_algorithm = EXCLUDED.password_hash_algorithm,
+            password_hash_params_json = EXCLUDED.password_hash_params_json,
+            password_changed_at = EXCLUDED.password_changed_at,
+            must_change_password = EXCLUDED.must_change_password",
+        &[
+            &credential.local_user_id,
+            &credential.password_hash,
+            &credential.password_hash_algorithm,
+            &credential.password_hash_params_json,
+            &credential.password_changed_at,
+            &credential.must_change_password,
+        ],
+    ).map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
+    tx.execute(
+        "DELETE FROM auth_local_password_reset_tokens WHERE local_user_id = $1",
+        &[&reset_token.local_user_id],
+    )
+    .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
+    tx.commit().map_err(|e| {
+        format!(
+            "[auth] failed to commit password reset consume transaction: {}",
+            e
+        )
+    })?;
+    Ok(Some((identity, credential)))
+}
+
+fn redis_local_identity_key(id: &str) -> String {
+    format!("ntnt:local_identity:{}", id)
+}
+
+fn redis_local_identity_lookup_key(identifier_kind: &str, identifier_normalized: &str) -> String {
+    format!(
+        "ntnt:local_identity_lookup:{}:{}",
+        identifier_kind.trim().to_ascii_lowercase(),
+        identifier_normalized.trim()
+    )
+}
+
+fn redis_local_credential_key(local_user_id: &str) -> String {
+    format!("ntnt:local_credential:{}", local_user_id)
+}
+
+fn redis_local_password_reset_key(selector: &str) -> String {
+    format!("ntnt:local_password_reset:{}", selector)
+}
+
+fn redis_local_password_reset_user_set_key(local_user_id: &str) -> String {
+    format!("ntnt:local_password_resets_for_user:{}", local_user_id)
+}
+
+fn local_identity_to_json(identity: &LocalIdentity) -> String {
+    serde_json::json!({
+        "id": identity.id,
+        "identifier_kind": identity.identifier_kind,
+        "identifier": identity.identifier,
+        "identifier_normalized": identity.identifier_normalized,
+        "created_at": identity.created_at,
+        "updated_at": identity.updated_at,
+        "state": identity.state.as_str(),
+        "metadata_json": identity.metadata_json,
+    })
+    .to_string()
+}
+
+fn local_identity_from_json(json_str: &str) -> std::result::Result<LocalIdentity, String> {
+    let json: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|e| format!("[auth] failed to parse local identity JSON: {}", e))?;
+    let state = json["state"]
+        .as_str()
+        .ok_or_else(|| "[auth] local identity JSON missing state".to_string())?;
+    Ok(LocalIdentity {
+        id: json["id"]
+            .as_str()
+            .ok_or_else(|| "[auth] local identity JSON missing id".to_string())?
+            .to_string(),
+        identifier_kind: json["identifier_kind"]
+            .as_str()
+            .ok_or_else(|| "[auth] local identity JSON missing identifier_kind".to_string())?
+            .to_string(),
+        identifier: json["identifier"]
+            .as_str()
+            .ok_or_else(|| "[auth] local identity JSON missing identifier".to_string())?
+            .to_string(),
+        identifier_normalized: json["identifier_normalized"]
+            .as_str()
+            .ok_or_else(|| "[auth] local identity JSON missing identifier_normalized".to_string())?
+            .to_string(),
+        created_at: json["created_at"]
+            .as_i64()
+            .ok_or_else(|| "[auth] local identity JSON missing created_at".to_string())?,
+        updated_at: json["updated_at"]
+            .as_i64()
+            .ok_or_else(|| "[auth] local identity JSON missing updated_at".to_string())?,
+        state: LocalAccountState::from_str(state)?,
+        metadata_json: json["metadata_json"]
+            .as_str()
+            .ok_or_else(|| "[auth] local identity JSON missing metadata_json".to_string())?
+            .to_string(),
+    })
+}
+
+fn local_credential_to_json(credential: &LocalCredentialSecret) -> String {
+    serde_json::json!({
+        "local_user_id": credential.local_user_id,
+        "password_hash": credential.password_hash,
+        "password_hash_algorithm": credential.password_hash_algorithm,
+        "password_hash_params_json": credential.password_hash_params_json,
+        "password_changed_at": credential.password_changed_at,
+        "must_change_password": credential.must_change_password,
+    })
+    .to_string()
+}
+
+fn local_credential_from_json(
+    json_str: &str,
+) -> std::result::Result<LocalCredentialSecret, String> {
+    let json: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|e| format!("[auth] failed to parse local credential JSON: {}", e))?;
+    Ok(LocalCredentialSecret {
+        local_user_id: json["local_user_id"]
+            .as_str()
+            .ok_or_else(|| "[auth] local credential JSON missing local_user_id".to_string())?
+            .to_string(),
+        password_hash: json["password_hash"]
+            .as_str()
+            .ok_or_else(|| "[auth] local credential JSON missing password_hash".to_string())?
+            .to_string(),
+        password_hash_algorithm: json["password_hash_algorithm"]
+            .as_str()
+            .ok_or_else(|| {
+                "[auth] local credential JSON missing password_hash_algorithm".to_string()
+            })?
+            .to_string(),
+        password_hash_params_json: json["password_hash_params_json"]
+            .as_str()
+            .ok_or_else(|| {
+                "[auth] local credential JSON missing password_hash_params_json".to_string()
+            })?
+            .to_string(),
+        password_changed_at: json["password_changed_at"].as_i64().ok_or_else(|| {
+            "[auth] local credential JSON missing password_changed_at".to_string()
+        })?,
+        must_change_password: json["must_change_password"].as_bool().unwrap_or(false),
+    })
+}
+
+fn local_password_reset_token_to_json(token: &LocalPasswordResetToken) -> String {
+    serde_json::json!({
+        "selector": token.selector,
+        "local_user_id": token.local_user_id,
+        "token_hash": token.token_hash,
+        "created_at": token.created_at,
+        "expires_at": token.expires_at,
+    })
+    .to_string()
+}
+
+fn local_password_reset_token_from_json(
+    json_str: &str,
+) -> std::result::Result<LocalPasswordResetToken, String> {
+    let json: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|e| format!("[auth] failed to parse password reset JSON: {}", e))?;
+    Ok(LocalPasswordResetToken {
+        selector: json["selector"]
+            .as_str()
+            .ok_or_else(|| "[auth] password reset JSON missing selector".to_string())?
+            .to_string(),
+        local_user_id: json["local_user_id"]
+            .as_str()
+            .ok_or_else(|| "[auth] password reset JSON missing local_user_id".to_string())?
+            .to_string(),
+        token_hash: json["token_hash"]
+            .as_str()
+            .ok_or_else(|| "[auth] password reset JSON missing token_hash".to_string())?
+            .to_string(),
+        created_at: json["created_at"]
+            .as_i64()
+            .ok_or_else(|| "[auth] password reset JSON missing created_at".to_string())?,
+        expires_at: json["expires_at"]
+            .as_i64()
+            .ok_or_else(|| "[auth] password reset JSON missing expires_at".to_string())?,
+    })
+}
+
+fn store_local_identity_redis(identity: &LocalIdentity) -> std::result::Result<(), String> {
+    let identity = normalize_local_identity_for_storage(identity.clone())?;
+    let mut conn = redis_connection()?;
+    store_local_identity_redis_with_connection(&mut conn, &identity)
+}
+
+fn store_local_identity_redis_with_connection(
+    conn: &mut redis::Connection,
+    identity: &LocalIdentity,
+) -> std::result::Result<(), String> {
+    let lookup_key =
+        redis_local_identity_lookup_key(&identity.identifier_kind, &identity.identifier_normalized);
+    let identity_key = redis_local_identity_key(&identity.id);
+    let stored: i64 = redis::Script::new(
+        r#"
+        local existing_id = redis.call('GET', KEYS[2])
+        if existing_id and existing_id ~= ARGV[1] then
+            return -1
+        end
+
+        local previous_identity = redis.call('GET', KEYS[1])
+        if previous_identity then
+            local previous = cjson.decode(previous_identity)
+            local previous_lookup_key = 'ntnt:local_identity_lookup:' .. previous.identifier_kind .. ':' .. previous.identifier_normalized
+            if previous_lookup_key ~= KEYS[2] then
+                redis.call('DEL', previous_lookup_key)
+            end
+        end
+
+        redis.call('SET', KEYS[1], ARGV[2])
+        redis.call('SET', KEYS[2], ARGV[1])
+        return 1
+        "#,
+    )
+    .key(&identity_key)
+    .key(&lookup_key)
+    .arg(&identity.id)
+    .arg(local_identity_to_json(identity))
+    .invoke(conn)
+    .map_err(|e| format!("Redis local identity store error: {}", e))?;
+
+    if stored == -1 {
+        return Err(format!(
+            "[auth] local identity identifier already exists for {}",
+            identity.identifier_kind
+        ));
+    }
+    Ok(())
+}
+
+fn store_local_identity_and_credential_redis(
+    identity: &LocalIdentity,
+    credential: &LocalCredentialSecret,
+    revoke_password_resets: bool,
+) -> std::result::Result<(), String> {
+    let identity = normalize_local_identity_for_storage(identity.clone())?;
+    validate_local_credential_secret_for_storage(credential)?;
+    validate_local_identity_credential_pair(&identity, credential)?;
+    let mut conn = redis_connection()?;
+    let identity_key = redis_local_identity_key(&identity.id);
+    let lookup_key =
+        redis_local_identity_lookup_key(&identity.identifier_kind, &identity.identifier_normalized);
+    let credential_key = redis_local_credential_key(&credential.local_user_id);
+    let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
+    let stored: i64 = redis::Script::new(
+        r#"
+        local existing_id = redis.call('GET', KEYS[2])
+        if existing_id and existing_id ~= ARGV[1] then
+            return -1
+        end
+
+        local previous_identity = redis.call('GET', KEYS[1])
+        if previous_identity then
+            local previous = cjson.decode(previous_identity)
+            local previous_lookup_key = 'ntnt:local_identity_lookup:' .. previous.identifier_kind .. ':' .. previous.identifier_normalized
+            if previous_lookup_key ~= KEYS[2] then
+                redis.call('DEL', previous_lookup_key)
+            end
+        end
+
+        redis.call('SET', KEYS[1], ARGV[2])
+        redis.call('SET', KEYS[2], ARGV[1])
+        redis.call('SET', KEYS[3], ARGV[3])
+
+        if ARGV[4] == '1' then
+            local reset_keys = redis.call('SMEMBERS', KEYS[4])
+            for _, key in ipairs(reset_keys) do
+                redis.call('DEL', key)
+            end
+            redis.call('DEL', KEYS[4])
+        end
+
+        return 1
+        "#,
+    )
+    .key(&identity_key)
+    .key(&lookup_key)
+    .key(&credential_key)
+    .key(&reset_set_key)
+    .arg(&identity.id)
+    .arg(local_identity_to_json(&identity))
+    .arg(local_credential_to_json(credential))
+    .arg(if revoke_password_resets { "1" } else { "0" })
+    .invoke(&mut conn)
+    .map_err(|e| format!("Redis local identity+credential store error: {}", e))?;
+
+    if stored == -1 {
+        return Err(format!(
+            "[auth] local identity identifier already exists for {}",
+            identity.identifier_kind
+        ));
+    }
+    Ok(())
+}
+
+fn get_local_identity_by_id_redis(id: &str) -> std::result::Result<Option<LocalIdentity>, String> {
+    let mut conn = redis_connection()?;
+    let json: Option<String> = redis::cmd("GET")
+        .arg(redis_local_identity_key(id))
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+    json.map(|json| local_identity_from_json(&json)).transpose()
+}
+
+fn get_local_identity_by_identifier_redis(
+    identifier_kind: &str,
+    identifier_normalized: &str,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    let mut conn = redis_connection()?;
+    let lookup_key = redis_local_identity_lookup_key(identifier_kind, identifier_normalized);
+    let id: Option<String> = redis::cmd("GET")
+        .arg(lookup_key)
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+    match id {
+        Some(id) => get_local_identity_by_id_redis(&id),
+        None => Ok(None),
+    }
+}
+
+fn update_local_identity_by_identifier_redis<F>(
+    identifier_kind: &str,
+    identifier_normalized: &str,
+    updater: F,
+) -> std::result::Result<Option<LocalIdentity>, String>
+where
+    F: FnOnce(&mut LocalIdentity) -> std::result::Result<(), String>,
+{
+    let mut conn = redis_connection()?;
+    let lookup_key = redis_local_identity_lookup_key(identifier_kind, identifier_normalized);
+    let id: Option<String> = redis::cmd("GET")
+        .arg(lookup_key)
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+    let Some(id) = id else {
+        return Ok(None);
+    };
+    let identity_json: Option<String> = redis::cmd("GET")
+        .arg(redis_local_identity_key(&id))
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+    let Some(identity_json) = identity_json else {
+        return Ok(None);
+    };
+    let mut identity = local_identity_from_json(&identity_json)?;
+    updater(&mut identity)?;
+    let identity = normalize_local_identity_for_storage(identity)?;
+    store_local_identity_redis_with_connection(&mut conn, &identity)?;
+    Ok(Some(identity))
+}
+
+fn store_local_credential_secret_redis(
+    credential: &LocalCredentialSecret,
+) -> std::result::Result<(), String> {
+    validate_local_credential_secret_for_storage(credential)?;
+    if get_local_identity_by_id_redis(&credential.local_user_id)?.is_none() {
+        return Err(
+            "[auth] local credential must reference an existing local identity".to_string(),
+        );
+    }
+    let mut conn = redis_connection()?;
+    redis::cmd("SET")
+        .arg(redis_local_credential_key(&credential.local_user_id))
+        .arg(local_credential_to_json(credential))
+        .query::<()>(&mut conn)
+        .map_err(|e| format!("Redis local credential store error: {}", e))
+}
+
+fn get_local_credential_secret_redis(
+    local_user_id: &str,
+) -> std::result::Result<Option<LocalCredentialSecret>, String> {
+    let mut conn = redis_connection()?;
+    let json: Option<String> = redis::cmd("GET")
+        .arg(redis_local_credential_key(local_user_id))
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+    json.map(|json| local_credential_from_json(&json))
+        .transpose()
+}
+
+fn store_local_password_reset_token_redis(
+    token: &LocalPasswordResetToken,
+) -> std::result::Result<(), String> {
+    validate_local_password_reset_token_for_storage(token)?;
+    if get_local_identity_by_id_redis(&token.local_user_id)?.is_none() {
+        return Err(
+            "[auth] password reset token must reference an existing local identity".to_string(),
+        );
+    }
+    let mut conn = redis_connection()?;
+    let now = chrono::Utc::now().timestamp();
+    let ttl = token.expires_at.saturating_sub(now);
+    if ttl <= 0 {
+        return Err("[auth] password reset token expires before it can be stored".to_string());
+    }
+    let token_key = redis_local_password_reset_key(&token.selector);
+    let user_set_key = redis_local_password_reset_user_set_key(&token.local_user_id);
+    redis::pipe()
+        .atomic()
+        .cmd("SETEX")
+        .arg(&token_key)
+        .arg(ttl)
+        .arg(local_password_reset_token_to_json(token))
+        .ignore()
+        .cmd("SADD")
+        .arg(&user_set_key)
+        .arg(&token_key)
+        .ignore()
+        .query::<()>(&mut conn)
+        .map_err(|e| format!("Redis password reset token store error: {}", e))
+}
+
+fn consume_local_password_reset_token_and_store_credential_redis<F>(
+    selector: &str,
+    token_hash: &str,
+    now: i64,
+    credential_builder: F,
+) -> std::result::Result<Option<(LocalIdentity, LocalCredentialSecret)>, String>
+where
+    F: FnOnce(&str) -> std::result::Result<LocalCredentialSecret, String>,
+{
+    let mut conn = redis_connection()?;
+    let token_key = redis_local_password_reset_key(selector);
+    let token_json: Option<String> = redis::cmd("GET")
+        .arg(&token_key)
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+    let Some(token_json) = token_json else {
+        return Ok(None);
+    };
+    let reset_token = local_password_reset_token_from_json(&token_json)?;
+    if reset_token.expires_at <= now {
+        redis::pipe()
+            .atomic()
+            .cmd("DEL")
+            .arg(&token_key)
+            .ignore()
+            .cmd("SREM")
+            .arg(redis_local_password_reset_user_set_key(
+                &reset_token.local_user_id,
+            ))
+            .arg(&token_key)
+            .ignore()
+            .query::<()>(&mut conn)
+            .map_err(|e| format!("Redis expired password reset cleanup error: {}", e))?;
+        return Ok(None);
+    }
+    if !constant_time_compare(&reset_token.token_hash, token_hash) {
+        return Ok(None);
+    }
+    let identity_json: Option<String> = redis::cmd("GET")
+        .arg(redis_local_identity_key(&reset_token.local_user_id))
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+    let Some(identity_json) = identity_json else {
+        return Ok(None);
+    };
+    let identity = local_identity_from_json(&identity_json)?;
+    if matches!(
+        identity.state,
+        LocalAccountState::Disabled | LocalAccountState::Locked
+    ) {
+        return Ok(None);
+    }
+    let credential = credential_builder(&reset_token.local_user_id)?;
+    validate_local_credential_secret_for_storage(&credential)?;
+    let identity = normalize_local_identity_for_storage(LocalIdentity {
+        updated_at: now,
+        state: LocalAccountState::Active,
+        ..identity
+    })?;
+
+    let identity_key = redis_local_identity_key(&identity.id);
+    let lookup_key =
+        redis_local_identity_lookup_key(&identity.identifier_kind, &identity.identifier_normalized);
+    let credential_key = redis_local_credential_key(&credential.local_user_id);
+    let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
+    let consumed: i64 = redis::Script::new(
+        r#"
+        local token_json = redis.call('GET', KEYS[1])
+        if not token_json then
+            return 0
+        end
+
+        local token = cjson.decode(token_json)
+        if tonumber(token.expires_at) <= tonumber(ARGV[1]) then
+            redis.call('DEL', KEYS[1])
+            redis.call('SREM', KEYS[4], KEYS[1])
+            return 0
+        end
+
+        if token.token_hash ~= ARGV[2] or token.local_user_id ~= ARGV[3] then
+            return 0
+        end
+
+        local existing_id = redis.call('GET', KEYS[5])
+        if existing_id and existing_id ~= ARGV[3] then
+            return -1
+        end
+
+        redis.call('SET', KEYS[2], ARGV[4])
+        redis.call('SET', KEYS[5], ARGV[3])
+        redis.call('SET', KEYS[3], ARGV[5])
+
+        local reset_keys = redis.call('SMEMBERS', KEYS[4])
+        for _, key in ipairs(reset_keys) do
+            redis.call('DEL', key)
+        end
+        redis.call('DEL', KEYS[4])
+        return 1
+        "#,
+    )
+    .key(&token_key)
+    .key(&identity_key)
+    .key(&credential_key)
+    .key(&reset_set_key)
+    .key(&lookup_key)
+    .arg(now)
+    .arg(token_hash)
+    .arg(&identity.id)
+    .arg(local_identity_to_json(&identity))
+    .arg(local_credential_to_json(&credential))
+    .invoke(&mut conn)
+    .map_err(|e| format!("Redis password reset consume error: {}", e))?;
+
+    if consumed == -1 {
+        return Err(format!(
+            "[auth] local identity identifier already exists for {}",
+            identity.identifier_kind
+        ));
+    }
+    if consumed != 1 {
+        return Ok(None);
+    }
+    Ok(Some((identity, credential)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1142,6 +2181,25 @@ mod tests {
             "alice@example.com"
         );
         assert!(normalize_local_identifier("email", "not-an-email").is_err());
+    }
+
+    #[test]
+    fn test_normalize_local_identifier_phone_username_and_custom() {
+        assert_eq!(
+            normalize_local_identifier("phone", " +1 (970) 444-8177 ").unwrap(),
+            "+19704448177"
+        );
+        assert!(normalize_local_identifier("phone", "555").is_err());
+        assert_eq!(
+            normalize_local_identifier("username", "  Alice.Admin-1  ").unwrap(),
+            "alice.admin-1"
+        );
+        assert!(normalize_local_identifier("username", "-alice").is_err());
+        assert_eq!(
+            normalize_local_identifier("custom", " External:ABC-123 ").unwrap(),
+            "External:ABC-123"
+        );
+        assert!(normalize_local_identifier("custom", "\n").is_err());
     }
 
     #[test]

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4041,7 +4041,11 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                 "consume_password_reset",
                 [
                     "token" => Type::String,
-                    "new_password" => Type::String
+                    "new_password" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
                 ],
                 Type::Generic {
                     name: "Result".to_string(),
@@ -4052,7 +4056,8 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                         },
                         Type::String,
                     ],
-                }
+                },
+                required(2)
             );
             sig!(
                 "verify_local_password",
@@ -4562,7 +4567,7 @@ mod tests {
             r#"
             import { issue_password_reset, consume_password_reset } from "std/auth"
             let issued = issue_password_reset("admin@example.com", map { "identifier_kind": "email", "ttl_seconds": 600 })
-            let consumed = consume_password_reset("selector.verifier", "new-password")
+            let consumed = consume_password_reset("selector.verifier", "new-password", map { "revoke_sessions": true })
             "#,
         );
         assert!(errs.is_empty(), "unexpected diagnostics: {errs:?}");


### PR DESCRIPTION
## Summary

- adds explicit `consume_password_reset(..., { revoke_sessions })` behavior, defaulting to keeping existing sessions
- documents UI checkbox plumbing for password-reset session revocation and `logout_all(req, keep_current)` for user-driven device logout
- adds local auth identity, credential, and password-reset persistence for PostgreSQL and Redis/Valkey
- supports `email`, `phone`, `username`, and `custom` local auth identifier kinds
- adds a local auth quickstart and updates DD-043/DD-059 to reflect the current 0.4.9 auth posture
- tightens Redis local-auth atomicity, including one-time reset-token consume under concurrency

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo build --profile dev-release`
- [x] `./target/dev-release/ntnt docs --generate`
- [x] `cargo test auth -- --test-threads=1`
- [x] `cargo test`
- [x] ephemeral Docker PostgreSQL + Redis/Valkey auth storage contract tests
- [x] ephemeral Docker Redis password-reset concurrent consume test

## Notes

This keeps password-reset session revocation explicit: apps must pass `revoke_sessions: true` from UI policy. Default behavior remains non-revocation.