### PR TITLE
feat(auth): add challenge-bound csrf helpers

### DIFF
--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1890,8 +1890,11 @@ The setup URI is secret-bearing because authenticator apps need it to enroll. Re
 
 For login, keep password-verified users in a staged auth challenge until TOTP verification succeeds. Do not call `sign_in_session(...)` for a TOTP-required account until the second factor is complete. Pair TOTP routes with the app's normal rate limiting/backoff; `verify_local_totp(...)` verifies the code but does not own account lockout policy.
 
+Staged auth challenges are not authenticated sessions, so session CSRF helpers (`csrf_field`, `verify_csrf`) are intentionally not enough for pre-session forms. `begin_auth_challenge(...)` creates a challenge-bound CSRF nonce automatically. Render it with `auth_challenge_csrf_field(req, kind)` and verify submissions with `verify_auth_challenge_csrf(req, form["_csrf"], kind)` before mutating credentials, MFA state, or sessions.
+
 ```ntnt
 import {
+    auth_challenge_csrf_field,
     begin_auth_challenge,
     begin_totp_enrollment,
     complete_auth_challenge,
@@ -1900,6 +1903,7 @@ import {
     current_user,
     sign_in_session,
     totp_status,
+    verify_auth_challenge_csrf,
     verify_local_password,
     verify_local_totp
 } from "std/auth"
@@ -1937,10 +1941,23 @@ fn login(req) {
     })
 }
 
+fn totp_login_page(req) {
+    return html("""
+<form method="post" action="/login/totp">
+  {{{auth_challenge_csrf_field(req, "mfa_pending")}}}
+  <input name="code" inputmode="numeric" autocomplete="one-time-code">
+  <button type="submit">Verify</button>
+</form>
+""")
+}
+
 fn finish_totp_login(req) {
     let challenge = current_auth_challenge(req) otherwise return redirect("/login")
     if challenge["kind"] != "mfa_pending" { return redirect("/login") }
     let form = parse_form(req)
+    if !verify_auth_challenge_csrf(req, form["_csrf"] ?? "", "mfa_pending") {
+        return html("CSRF token missing or invalid", 403)
+    }
     let email = challenge["data"]["email"] ?? ""
     verify_local_totp(email, form["code"] ?? "")?
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1822,6 +1822,8 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | Function | Description |
 |----------|-------------|
 | [`auth_callback`](#authcallback) | Handle OAuth callback - exchanges code for tokens, creates session. |
+| [`auth_challenge_csrf_field`](#authchallengecsrffield) | Get an HTML hidden input field for the current staged auth challenge CSRF token. |
+| [`auth_challenge_csrf_token`](#authchallengecsrftoken) | Get the CSRF token bound to the current staged auth challenge. |
 | [`auth_health`](#authhealth) | Return auth diagnostics for the built-in `/auth/health` route. |
 | [`auth_logout`](#authlogout) | Handle logout - clears the session and redirects. |
 | [`auth_me`](#authme) | Return current user as JSON for SPAs. |
@@ -1873,6 +1875,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`update_local_user_metadata`](#updatelocalusermetadata) | Merge or replace app-owned local identity metadata and return a safe payload. |
 | [`user_sessions`](#usersessions) | Get all active sessions for the current user. |
 | [`validate_csrf`](#validatecsrf) | Validate CSRF token on state-changing requests (POST, PUT, DELETE, PATCH). |
+| [`verify_auth_challenge_csrf`](#verifyauthchallengecsrf) | Verify a submitted CSRF token against the current staged auth challenge. |
 | [`verify_csrf`](#verifycsrf) | Verify a CSRF token against the session's token. |
 | [`verify_local_password`](#verifylocalpassword) | Verify a local credential record and return a safe auth user payload. |
 | [`verify_local_totp`](#verifylocaltotp) | Verify a local user's confirmed TOTP code without exposing the stored secret. |
@@ -1903,6 +1906,64 @@ get("/auth/{provider}/callback", auth_callback)  // Wire up callback route
 **See also:** `enable_auth`, `auth_start`
 
 *Since v0.3.11*
+
+---
+
+#### `auth_challenge_csrf_field`
+
+```ntnt
+auth_challenge_csrf_field(req: Request, kind?: String) -> String
+```
+
+Get an HTML hidden input field for the current staged auth challenge CSRF token.
+
+`begin_auth_challenge()` creates a server-side challenge CSRF nonce automatically. Render this helper in pre-session staged forms, then verify the submitted value with `verify_auth_challenge_csrf(req, form["_csrf"], kind)` before mutating credentials, MFA state, or sessions.
+
+**Parameters:**
+
+- `req` — The HTTP request object
+- `kind` — Optional challenge kind to require before rendering a field
+
+**Returns:** HTML string like `<input type="hidden" name="_csrf" value="..."/>`, or an empty string when no matching challenge is active
+
+**Examples:**
+
+```ntnt
+auth_challenge_csrf_field(req, "local.password_change")  // Render hidden CSRF input for staged password change
+```
+
+**See also:** `verify_auth_challenge_csrf`, `auth_challenge_csrf_token`, `csrf_field`
+
+*Since v0.4.9*
+
+---
+
+#### `auth_challenge_csrf_token`
+
+```ntnt
+auth_challenge_csrf_token(req: Request, kind?: String) -> Option<String>
+```
+
+Get the CSRF token bound to the current staged auth challenge.
+
+Use this only for pre-session staged forms such as first-login password rotation or password -> TOTP verification. Signed-in forms should use `csrf_field(req)` and `verify_csrf(req, token)` instead.
+
+**Parameters:**
+
+- `req` — The HTTP request object
+- `kind` — Optional challenge kind to require before returning a token
+
+**Returns:** Option containing the challenge CSRF token, or None when no matching challenge is active
+
+**Examples:**
+
+```ntnt
+auth_challenge_csrf_token(req, "local.totp")  // Read staged challenge CSRF token
+```
+
+**See also:** `auth_challenge_csrf_field`, `verify_auth_challenge_csrf`, `begin_auth_challenge`
+
+*Since v0.4.9*
 
 ---
 
@@ -3422,6 +3483,36 @@ validate_csrf(req)  // Check CSRF token on POST
 **See also:** `get_user`, `get_session`
 
 *Since v0.4.0*
+
+---
+
+#### `verify_auth_challenge_csrf`
+
+```ntnt
+verify_auth_challenge_csrf(req: Request, token: String, kind?: String) -> Bool
+```
+
+Verify a submitted CSRF token against the current staged auth challenge.
+
+This is for pre-session challenge forms. It validates against the active auth-challenge cookie rather than the authenticated-session cookie used by `verify_csrf()`.
+
+**Parameters:**
+
+- `req` — The HTTP request object
+- `token` — The submitted `_csrf` form value
+- `kind` — Optional challenge kind to require before accepting the token
+
+**Returns:** true when the token matches the active staged challenge, false otherwise
+
+**Examples:**
+
+```ntnt
+verify_auth_challenge_csrf(req, form["_csrf"], "local.totp")  // Validate staged challenge form
+```
+
+**See also:** `auth_challenge_csrf_field`, `auth_challenge_csrf_token`, `verify_csrf`
+
+*Since v0.4.9*
 
 ---
 

--- a/examples/auth_demo/server.tnt
+++ b/examples/auth_demo/server.tnt
@@ -15,6 +15,7 @@ import {
     auth_callback,
     auth_logout,
     auth_start,
+    auth_challenge_csrf_field,
     begin_auth_challenge,
     begin_totp_enrollment,
     bootstrap_local_user,
@@ -35,12 +36,12 @@ import {
     totp_status,
     update_local_user_metadata,
     user_sessions,
+    verify_auth_challenge_csrf,
     verify_csrf,
     verify_local_password,
     verify_local_totp
 } from "std/auth"
 import { get_key } from "std/collections"
-import { uuid } from "std/crypto"
 import { load_env, get_env } from "std/env"
 import { html_escape, trim, lower } from "std/string"
 
@@ -213,7 +214,7 @@ fn local_login(req) {
             "subject_id": user["subject_id"],
             "kind": "local.password_change",
             "ttl": 900,
-            "data": map { "user": user, "email": email, "csrf": uuid() }
+            "data": map { "user": user, "email": email }
         })
     }
 
@@ -223,7 +224,7 @@ fn local_login(req) {
             "subject_id": user["subject_id"],
             "kind": "local.totp",
             "ttl": 300,
-            "data": map { "user": user, "email": email, "csrf": uuid() }
+            "data": map { "user": user, "email": email }
         })
     }
 
@@ -252,7 +253,7 @@ fn change_password_page(req) {
 {{{notice_html(req)}}}
 <section class="card">
   <form method="post" action="/local/change-password">
-    <input type="hidden" name="_csrf" value="{{data["csrf"]}}">
+    {{{auth_challenge_csrf_field(req, "local.password_change")}}}
     <label>Email</label><input name="email" value="{{data["email"]}}" readonly>
     <label>Current setup password</label><input name="current_password" type="password" autocomplete="current-password">
     <label>New password</label><input name="new_password" type="password" autocomplete="new-password">
@@ -272,7 +273,7 @@ fn change_password(req) {
     if form_email != email {
         return redirect("/local/change-password?error=Invalid password change challenge")
     }
-    if (form["_csrf"] ?? "") != (value["data"]["csrf"] ?? "") {
+    if !verify_auth_challenge_csrf(req, form["_csrf"] ?? "", "local.password_change") {
         return html("CSRF token missing or invalid", 403)
     }
     let user = set_local_password(email, form["current_password"] ?? "", form["new_password"] ?? "")
@@ -293,7 +294,7 @@ fn local_totp_page(req) {
 {{{notice_html(req)}}}
 <section class="card">
   <form method="post" action="/local/totp">
-    <input type="hidden" name="_csrf" value="{{data["csrf"]}}">
+    {{{auth_challenge_csrf_field(req, "local.totp")}}}
     <label>Code for {{email}}</label><input name="code" inputmode="numeric" autocomplete="one-time-code">
     <button type="submit">Complete login</button>
   </form>
@@ -307,7 +308,7 @@ fn local_totp(req) {
     let value = unwrap(challenge)
     let email = value["data"]["email"]
     let form = parse_form(req)
-    if (form["_csrf"] ?? "") != (value["data"]["csrf"] ?? "") {
+    if !verify_auth_challenge_csrf(req, form["_csrf"] ?? "", "local.totp") {
         return html("CSRF token missing or invalid", 403)
     }
     let verified = verify_local_totp(email, trim(form["code"] ?? ""))

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -134,6 +134,8 @@ use utils::{
 // During this cleanup, prefer explicit semantics over clever abstraction, keep fallback/error
 // behavior intentional, and avoid mixing new auth features into refactor-only slices.
 
+const AUTH_CHALLENGE_CSRF_DATA_KEY: &str = "auth.challenge_csrf";
+
 // ============================================================================
 // SECURITY HELPERS
 // ============================================================================
@@ -682,6 +684,53 @@ fn validate_http_request_arg(function_name: &str, req: &Value) -> Result<()> {
             function_name,
             other.type_name()
         ))),
+    }
+}
+
+fn optional_kind_arg(function_name: &str, args: &[Value], index: usize) -> Result<Option<String>> {
+    match args.get(index) {
+        Some(Value::String(kind)) => {
+            Ok(Some(validate_auth_challenge_kind(kind).map_err(|err| {
+                IntentError::type_error(err.replace("begin_auth_challenge", function_name))
+            })?))
+        }
+        Some(other) => Err(IntentError::type_error(format!(
+            "[auth] {}() kind must be a string, got {}",
+            function_name,
+            other.type_name()
+        ))),
+        None => Ok(None),
+    }
+}
+
+fn active_auth_challenge_for_request(
+    function_name: &str,
+    req: &Value,
+    expected_kind: Option<&str>,
+) -> Result<Option<AuthChallenge>> {
+    validate_http_request_arg(function_name, req)?;
+
+    let Some(challenge_id) = get_auth_challenge_id_from_request(req) else {
+        return Ok(None);
+    };
+    let Some(challenge) =
+        get_auth_challenge_by_id(&challenge_id).map_err(IntentError::runtime_error)?
+    else {
+        return Ok(None);
+    };
+    if let Some(kind) = expected_kind {
+        if challenge.kind != kind {
+            return Ok(None);
+        }
+    }
+    Ok(Some(challenge))
+}
+
+fn auth_challenge_csrf_token(challenge: &AuthChallenge) -> Option<String> {
+    let data = json_string_to_value_map(&challenge.data_json);
+    match data.get(AUTH_CHALLENGE_CSRF_DATA_KEY) {
+        Some(Value::String(token)) if !token.is_empty() => Some(token.clone()),
+        _ => None,
     }
 }
 
@@ -1878,6 +1927,152 @@ pub fn init() -> HashMap<String, Value> {
                 }
 
                 Ok(make_none())
+            },
+        },
+    );
+
+    // @ntnt auth_challenge_csrf_token
+    // @module std/auth
+    // @signature auth_challenge_csrf_token(req: Request, kind?: String) -> Option<String>
+    // Get the CSRF token bound to the current staged auth challenge.
+    //
+    // Use this only for pre-session staged forms such as first-login password
+    // rotation or password -> TOTP verification. Signed-in forms should use
+    // `csrf_field(req)` and `verify_csrf(req, token)` instead.
+    // @param req The HTTP request object
+    // @param kind Optional challenge kind to require before returning a token
+    // @returns Option containing the challenge CSRF token, or None when no matching challenge is active
+    // @see_also auth_challenge_csrf_field, verify_auth_challenge_csrf, begin_auth_challenge
+    // @since v0.4.9
+    // @tags #auth, #security, #csrf
+    // @example auth_challenge_csrf_token(req, "local.totp") ~ "Read staged challenge CSRF token"
+    module.insert(
+        "auth_challenge_csrf_token".to_string(),
+        Value::NativeFunction {
+            name: "auth_challenge_csrf_token".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] auth_challenge_csrf_token() requires request and optional kind"
+                            .to_string(),
+                    ));
+                }
+                let kind = optional_kind_arg("auth_challenge_csrf_token", args, 1)?;
+                let Some(challenge) = active_auth_challenge_for_request(
+                    "auth_challenge_csrf_token",
+                    &args[0],
+                    kind.as_deref(),
+                )?
+                else {
+                    return Ok(make_none());
+                };
+                match auth_challenge_csrf_token(&challenge) {
+                    Some(token) => Ok(make_some(Value::String(token))),
+                    None => Ok(make_none()),
+                }
+            },
+        },
+    );
+
+    // @ntnt auth_challenge_csrf_field
+    // @module std/auth
+    // @signature auth_challenge_csrf_field(req: Request, kind?: String) -> String
+    // Get an HTML hidden input field for the current staged auth challenge CSRF token.
+    //
+    // `begin_auth_challenge()` creates a server-side challenge CSRF nonce automatically.
+    // Render this helper in pre-session staged forms, then verify the submitted value
+    // with `verify_auth_challenge_csrf(req, form["_csrf"], kind)` before mutating
+    // credentials, MFA state, or sessions.
+    // @param req The HTTP request object
+    // @param kind Optional challenge kind to require before rendering a field
+    // @returns HTML string like `<input type="hidden" name="_csrf" value="..."/>`, or an empty string when no matching challenge is active
+    // @see_also verify_auth_challenge_csrf, auth_challenge_csrf_token, csrf_field
+    // @since v0.4.9
+    // @tags #auth, #security, #csrf
+    // @example auth_challenge_csrf_field(req, "local.password_change") ~ "Render hidden CSRF input for staged password change"
+    module.insert(
+        "auth_challenge_csrf_field".to_string(),
+        Value::NativeFunction {
+            name: "auth_challenge_csrf_field".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] auth_challenge_csrf_field() requires request and optional kind"
+                            .to_string(),
+                    ));
+                }
+                let kind = optional_kind_arg("auth_challenge_csrf_field", args, 1)?;
+                let Some(challenge) = active_auth_challenge_for_request(
+                    "auth_challenge_csrf_field",
+                    &args[0],
+                    kind.as_deref(),
+                )?
+                else {
+                    return Ok(Value::String(String::new()));
+                };
+                let Some(token) = auth_challenge_csrf_token(&challenge) else {
+                    return Ok(Value::String(String::new()));
+                };
+                Ok(Value::String(format!(
+                    r#"<input type="hidden" name="_csrf" value="{}"/>"#,
+                    token
+                )))
+            },
+        },
+    );
+
+    // @ntnt verify_auth_challenge_csrf
+    // @module std/auth
+    // @signature verify_auth_challenge_csrf(req: Request, token: String, kind?: String) -> Bool
+    // Verify a submitted CSRF token against the current staged auth challenge.
+    //
+    // This is for pre-session challenge forms. It validates against the active
+    // auth-challenge cookie rather than the authenticated-session cookie used by
+    // `verify_csrf()`.
+    // @param req The HTTP request object
+    // @param token The submitted `_csrf` form value
+    // @param kind Optional challenge kind to require before accepting the token
+    // @returns true when the token matches the active staged challenge, false otherwise
+    // @see_also auth_challenge_csrf_field, auth_challenge_csrf_token, verify_csrf
+    // @since v0.4.9
+    // @tags #auth, #security, #csrf
+    // @example verify_auth_challenge_csrf(req, form["_csrf"], "local.totp") ~ "Validate staged challenge form"
+    module.insert(
+        "verify_auth_challenge_csrf".to_string(),
+        Value::NativeFunction {
+            name: "verify_auth_challenge_csrf".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(IntentError::type_error(
+                        "[auth] verify_auth_challenge_csrf() requires request, token, and optional kind"
+                            .to_string(),
+                    ));
+                }
+                let submitted_token = string_arg("verify_auth_challenge_csrf", args, 1, "token")?;
+                let kind = optional_kind_arg("verify_auth_challenge_csrf", args, 2)?;
+                let Some(challenge) = active_auth_challenge_for_request(
+                    "verify_auth_challenge_csrf",
+                    &args[0],
+                    kind.as_deref(),
+                )? else {
+                    return Ok(Value::Bool(false));
+                };
+                let Some(expected_token) = auth_challenge_csrf_token(&challenge) else {
+                    return Ok(Value::Bool(false));
+                };
+                Ok(Value::Bool(constant_time_compare(
+                    &expected_token,
+                    submitted_token,
+                )))
             },
         },
     );
@@ -6142,6 +6337,88 @@ mod tests {
         assert!(
             matches!(current_session(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "None")
         );
+    }
+
+    #[test]
+    fn test_auth_challenge_csrf_helpers_validate_active_challenge_token() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let begin_auth_challenge = module_fn(&module, "begin_auth_challenge");
+        let csrf_token = module_fn(&module, "auth_challenge_csrf_token");
+        let csrf_field = module_fn(&module, "auth_challenge_csrf_field");
+        let verify_csrf = module_fn(&module, "verify_auth_challenge_csrf");
+
+        let started = begin_auth_challenge(&[
+            redirect_response("/local/totp", None),
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("user-123".to_string()),
+                ),
+                ("kind".to_string(), Value::String("local.totp".to_string())),
+            ])),
+        ])
+        .unwrap();
+        let cookie = cookie_header_from_response(&started);
+        let req = request_with_cookie(&cookie);
+
+        let token_value =
+            csrf_token(&[req.clone(), Value::String("local.totp".to_string())]).unwrap();
+        let token = match token_value {
+            Value::EnumValue {
+                variant,
+                mut values,
+                ..
+            } => {
+                assert_eq!(variant, "Some");
+                match values.remove(0) {
+                    Value::String(token) => token,
+                    other => panic!("expected challenge csrf token string, got {:?}", other),
+                }
+            }
+            other => panic!("expected Some(token), got {:?}", other),
+        };
+        assert!(!token.is_empty());
+
+        let field = csrf_field(&[req.clone(), Value::String("local.totp".to_string())]).unwrap();
+        match field {
+            Value::String(field) => {
+                assert!(field.contains(r#"name="_csrf""#));
+                assert!(field.contains(&token));
+            }
+            other => panic!("expected challenge csrf field string, got {:?}", other),
+        }
+
+        assert!(matches!(
+            verify_csrf(&[
+                req.clone(),
+                Value::String(token.clone()),
+                Value::String("local.totp".to_string()),
+            ])
+            .unwrap(),
+            Value::Bool(true)
+        ));
+        assert!(matches!(
+            verify_csrf(&[
+                req.clone(),
+                Value::String("wrong".to_string()),
+                Value::String("local.totp".to_string()),
+            ])
+            .unwrap(),
+            Value::Bool(false)
+        ));
+        assert!(matches!(
+            verify_csrf(&[
+                req,
+                Value::String(token),
+                Value::String("local.password_change".to_string()),
+            ])
+            .unwrap(),
+            Value::Bool(false)
+        ));
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -260,6 +260,9 @@ pub struct AuthChallenge {
     pub subject_id: String,
     pub provider: String,
     pub kind: String,
+    /// Server-side nonce for pre-session staged auth forms. This must not be
+    /// exposed through the app-owned `data` map returned by current_auth_challenge().
+    pub csrf_token: String,
     pub data_json: String,
     pub created_at: i64,
     pub expires_at: i64,
@@ -727,6 +730,13 @@ fn active_auth_challenge_for_request(
 }
 
 fn auth_challenge_csrf_token(challenge: &AuthChallenge) -> Option<String> {
+    if !challenge.csrf_token.is_empty() {
+        return Some(challenge.csrf_token.clone());
+    }
+
+    // Compatibility for challenges created by the pre-review implementation.
+    // New challenges store this nonce in the dedicated csrf_token field so app-owned
+    // continuation data cannot leak or be overwritten.
     let data = json_string_to_value_map(&challenge.data_json);
     match data.get(AUTH_CHALLENGE_CSRF_DATA_KEY) {
         Some(Value::String(token)) if !token.is_empty() => Some(token.clone()),
@@ -6111,6 +6121,7 @@ mod tests {
             subject_id: format!("user-{}", label),
             provider: "local".to_string(),
             kind: "mfa_pending".to_string(),
+            csrf_token: "test-csrf".to_string(),
             data_json: "{}".to_string(),
             created_at: now,
             expires_at: now + 60,
@@ -6327,6 +6338,10 @@ mod tests {
                         assert!(
                             matches!(data.get("next"), Some(Value::String(next)) if next == "/admin")
                         );
+                        assert!(
+                            !data.contains_key(AUTH_CHALLENGE_CSRF_DATA_KEY),
+                            "current_auth_challenge() must not expose the private challenge csrf nonce"
+                        );
                     }
                     other => panic!("expected challenge data map, got {:?}", other),
                 }
@@ -6337,6 +6352,125 @@ mod tests {
         assert!(
             matches!(current_session(&[req]).unwrap(), Value::EnumValue { ref variant, .. } if variant == "None")
         );
+    }
+
+    #[test]
+    fn test_current_auth_challenge_hides_legacy_data_embedded_csrf_token() {
+        let now = chrono::Utc::now().timestamp();
+        let challenge = AuthChallenge {
+            id: "challenge-legacy-csrf".to_string(),
+            subject_id: "user-123".to_string(),
+            provider: "local".to_string(),
+            kind: "mfa_pending".to_string(),
+            csrf_token: String::new(),
+            data_json: value_map_to_json_string(&HashMap::from([
+                (
+                    AUTH_CHALLENGE_CSRF_DATA_KEY.to_string(),
+                    Value::String("legacy-secret".to_string()),
+                ),
+                ("next".to_string(), Value::String("/admin".to_string())),
+            ])),
+            created_at: now,
+            expires_at: now + 60,
+        };
+
+        let Value::Map(challenge_map) = auth_challenge_to_value(&challenge) else {
+            panic!("expected challenge map");
+        };
+        let Some(Value::Map(data)) = challenge_map.get("data") else {
+            panic!("expected data map");
+        };
+        assert!(
+            !data.contains_key(AUTH_CHALLENGE_CSRF_DATA_KEY),
+            "legacy data-embedded csrf tokens must stay private"
+        );
+        assert!(matches!(data.get("next"), Some(Value::String(next)) if next == "/admin"));
+    }
+
+    #[test]
+    fn test_begin_auth_challenge_preserves_app_data_named_like_internal_csrf_key() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let begin_auth_challenge = module_fn(&module, "begin_auth_challenge");
+        let current_auth_challenge = module_fn(&module, "current_auth_challenge");
+        let csrf_token = module_fn(&module, "auth_challenge_csrf_token");
+        let verify_csrf = module_fn(&module, "verify_auth_challenge_csrf");
+
+        let app_value = "app-owned-value".to_string();
+        let started = begin_auth_challenge(&[
+            redirect_response("/local/totp", None),
+            Value::Map(HashMap::from([
+                (
+                    "subject_id".to_string(),
+                    Value::String("user-123".to_string()),
+                ),
+                ("kind".to_string(), Value::String("local.totp".to_string())),
+                (
+                    "data".to_string(),
+                    Value::Map(HashMap::from([(
+                        AUTH_CHALLENGE_CSRF_DATA_KEY.to_string(),
+                        Value::String(app_value.clone()),
+                    )])),
+                ),
+            ])),
+        ])
+        .unwrap();
+        let req = request_with_cookie(&cookie_header_from_response(&started));
+
+        let challenge = current_auth_challenge(&[req.clone()]).unwrap();
+        let Value::EnumValue {
+            variant, values, ..
+        } = challenge
+        else {
+            panic!("expected Some(challenge)");
+        };
+        assert_eq!(variant, "Some");
+        let Some(Value::Map(challenge_map)) = values.first() else {
+            panic!("expected challenge map, got {:?}", values.first());
+        };
+        let Some(Value::Map(data)) = challenge_map.get("data") else {
+            panic!("expected challenge data map");
+        };
+        assert!(
+            matches!(data.get(AUTH_CHALLENGE_CSRF_DATA_KEY), Some(Value::String(value)) if value == &app_value)
+        );
+
+        let token_value =
+            csrf_token(&[req.clone(), Value::String("local.totp".to_string())]).unwrap();
+        let Value::EnumValue {
+            variant,
+            mut values,
+            ..
+        } = token_value
+        else {
+            panic!("expected Some(token)");
+        };
+        assert_eq!(variant, "Some");
+        let Value::String(generated_token) = values.remove(0) else {
+            panic!("expected generated challenge csrf token");
+        };
+        assert_ne!(generated_token, app_value);
+        assert!(matches!(
+            verify_csrf(&[
+                req.clone(),
+                Value::String(generated_token),
+                Value::String("local.totp".to_string()),
+            ])
+            .unwrap(),
+            Value::Bool(true)
+        ));
+        assert!(matches!(
+            verify_csrf(&[
+                req,
+                Value::String(app_value),
+                Value::String("local.totp".to_string()),
+            ])
+            .unwrap(),
+            Value::Bool(false)
+        ));
     }
 
     #[test]
@@ -9248,6 +9382,7 @@ mod tests {
             subject_id: "user-sqlite".to_string(),
             provider: "local".to_string(),
             kind: "mfa_pending".to_string(),
+            csrf_token: "test-csrf".to_string(),
             data_json: "{}".to_string(),
             created_at: now,
             expires_at: now + 60,
@@ -9273,6 +9408,7 @@ mod tests {
             subject_id: "user-sqlite".to_string(),
             provider: "local".to_string(),
             kind: "password_reset".to_string(),
+            csrf_token: "test-csrf".to_string(),
             data_json: "{}".to_string(),
             created_at: now - 120,
             expires_at: now - 60,
@@ -9298,6 +9434,7 @@ mod tests {
             subject_id: "user-123".to_string(),
             provider: "local".to_string(),
             kind: "mfa_pending".to_string(),
+            csrf_token: "test-csrf".to_string(),
             data_json: value_map_to_json_string(&HashMap::from([(
                 "next".to_string(),
                 Value::String("/admin".to_string()),
@@ -9327,6 +9464,7 @@ mod tests {
             subject_id: "user-456".to_string(),
             provider: "local".to_string(),
             kind: "password_reset".to_string(),
+            csrf_token: "test-csrf".to_string(),
             data_json: "{}".to_string(),
             created_at: now - 120,
             expires_at: now - 60,
@@ -9407,6 +9545,7 @@ mod tests {
             subject_id: "user-123".to_string(),
             provider: "local".to_string(),
             kind: "mfa_pending".to_string(),
+            csrf_token: "test-csrf".to_string(),
             data_json: "{}".to_string(),
             created_at: now - 120,
             expires_at: now - 60,
@@ -9435,6 +9574,7 @@ mod tests {
                 subject_id: "user-123".to_string(),
                 provider: "local".to_string(),
                 kind: "mfa_pending".to_string(),
+                csrf_token: "test-csrf".to_string(),
                 data_json: "{}".to_string(),
                 created_at: now - 120,
                 expires_at: now - 60,
@@ -9461,6 +9601,7 @@ mod tests {
             subject_id: "user-123".to_string(),
             provider: "local".to_string(),
             kind: "mfa_pending".to_string(),
+            csrf_token: "test-csrf".to_string(),
             data_json: "{}".to_string(),
             created_at: now,
             expires_at: now + 60,

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -297,6 +297,7 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
             subject_id TEXT NOT NULL,
             provider TEXT NOT NULL,
             kind TEXT NOT NULL,
+            csrf_token TEXT NOT NULL DEFAULT '',
             data_json TEXT NOT NULL,
             created_at INTEGER NOT NULL,
             expires_at INTEGER NOT NULL
@@ -304,6 +305,11 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
         [],
     )
     .map_err(|e| format!("Failed to create auth_challenges table: {}", e))?;
+
+    ignore_duplicate_column_sqlite(conn.execute(
+        "ALTER TABLE auth_challenges ADD COLUMN csrf_token TEXT NOT NULL DEFAULT ''",
+        [],
+    ))?;
 
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_auth_challenges_expires ON auth_challenges(expires_at)",
@@ -483,6 +489,7 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
             subject_id TEXT NOT NULL,
             provider TEXT NOT NULL,
             kind TEXT NOT NULL,
+            csrf_token TEXT NOT NULL DEFAULT '',
             data_json TEXT NOT NULL,
             created_at BIGINT NOT NULL,
             expires_at BIGINT NOT NULL
@@ -490,6 +497,11 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
             &[],
         )
         .map_err(|e| format!("Failed to create auth_challenges table: {}", e))?;
+
+    run_postgres_migration(
+        &mut client,
+        "ALTER TABLE auth_challenges ADD COLUMN IF NOT EXISTS csrf_token TEXT NOT NULL DEFAULT ''",
+    )?;
 
     client
         .execute(

--- a/src/stdlib/auth/request_helpers.rs
+++ b/src/stdlib/auth/request_helpers.rs
@@ -240,10 +240,14 @@ pub fn auth_challenge_to_value(challenge: &AuthChallenge) -> Value {
     map.insert("kind".to_string(), Value::String(challenge.kind.clone()));
     map.insert("created_at".to_string(), Value::Int(challenge.created_at));
     map.insert("expires_at".to_string(), Value::Int(challenge.expires_at));
-    map.insert(
-        "data".to_string(),
-        Value::Map(json_string_to_value_map(&challenge.data_json)),
-    );
+    let mut data = json_string_to_value_map(&challenge.data_json);
+    if matches!(
+        data.get(AUTH_CHALLENGE_CSRF_DATA_KEY),
+        Some(Value::String(token)) if challenge.csrf_token.is_empty() || token == &challenge.csrf_token
+    ) {
+        data.remove(AUTH_CHALLENGE_CSRF_DATA_KEY);
+    }
+    map.insert("data".to_string(), Value::Map(data));
 
     Value::Map(map)
 }

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -885,7 +885,7 @@ pub(super) fn create_auth_challenge(
         None => AUTH_CHALLENGE_TTL,
     };
 
-    let data_map = match challenge_spec.get("data") {
+    let mut data_map = match challenge_spec.get("data") {
         Some(Value::Map(map)) => map.clone(),
         Some(other) => {
             return Err(format!(
@@ -895,6 +895,10 @@ pub(super) fn create_auth_challenge(
         }
         None => HashMap::new(),
     };
+    data_map.insert(
+        AUTH_CHALLENGE_CSRF_DATA_KEY.to_string(),
+        Value::String(uuid::Uuid::new_v4().to_string()),
+    );
 
     let now = chrono::Utc::now().timestamp();
     Ok(AuthChallenge {

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -885,7 +885,7 @@ pub(super) fn create_auth_challenge(
         None => AUTH_CHALLENGE_TTL,
     };
 
-    let mut data_map = match challenge_spec.get("data") {
+    let data_map = match challenge_spec.get("data") {
         Some(Value::Map(map)) => map.clone(),
         Some(other) => {
             return Err(format!(
@@ -895,10 +895,6 @@ pub(super) fn create_auth_challenge(
         }
         None => HashMap::new(),
     };
-    data_map.insert(
-        AUTH_CHALLENGE_CSRF_DATA_KEY.to_string(),
-        Value::String(uuid::Uuid::new_v4().to_string()),
-    );
 
     let now = chrono::Utc::now().timestamp();
     Ok(AuthChallenge {
@@ -906,6 +902,7 @@ pub(super) fn create_auth_challenge(
         subject_id,
         provider,
         kind,
+        csrf_token: uuid::Uuid::new_v4().to_string(),
         data_json: value_map_to_json_string(&data_map),
         created_at: now,
         expires_at: now + ttl,
@@ -1045,13 +1042,14 @@ pub(super) fn store_auth_challenge_sqlite(
 
     conn.execute(
         "INSERT OR REPLACE INTO auth_challenges
-         (id, subject_id, provider, kind, data_json, created_at, expires_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+         (id, subject_id, provider, kind, csrf_token, data_json, created_at, expires_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         rusqlite::params![
             challenge.id,
             challenge.subject_id,
             challenge.provider,
             challenge.kind,
+            challenge.csrf_token,
             challenge.data_json,
             challenge.created_at,
             challenge.expires_at,
@@ -1069,15 +1067,16 @@ fn store_auth_challenge_postgres(challenge: &AuthChallenge) -> std::result::Resu
     client
         .execute(
             "INSERT INTO auth_challenges
-             (id, subject_id, provider, kind, data_json, created_at, expires_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             (id, subject_id, provider, kind, csrf_token, data_json, created_at, expires_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
              ON CONFLICT (id) DO UPDATE SET
-                subject_id = $2, provider = $3, kind = $4, data_json = $5, created_at = $6, expires_at = $7",
+                subject_id = $2, provider = $3, kind = $4, csrf_token = $5, data_json = $6, created_at = $7, expires_at = $8",
             &[
                 &challenge.id,
                 &challenge.subject_id,
                 &challenge.provider,
                 &challenge.kind,
+                &challenge.csrf_token,
                 &challenge.data_json,
                 &challenge.created_at,
                 &challenge.expires_at,
@@ -1104,6 +1103,19 @@ pub(super) fn auth_challenge_from_json_str(
             .ok_or_else(|| format!("Auth challenge JSON missing string field: {}", field))
     };
 
+    let csrf_token = json["csrf_token"]
+        .as_str()
+        .map(|s| s.to_string())
+        .or_else(|| {
+            json["data_json"].as_str().and_then(|data_json| {
+                match json_string_to_value_map(data_json).get(AUTH_CHALLENGE_CSRF_DATA_KEY) {
+                    Some(Value::String(token)) if !token.is_empty() => Some(token.clone()),
+                    _ => None,
+                }
+            })
+        })
+        .unwrap_or_default();
+
     let get_i64 = |field: &str| -> std::result::Result<i64, String> {
         json[field]
             .as_i64()
@@ -1115,6 +1127,7 @@ pub(super) fn auth_challenge_from_json_str(
         subject_id: get_string("subject_id")?,
         provider: get_string("provider")?,
         kind: get_string("kind")?,
+        csrf_token,
         data_json: get_string("data_json")?,
         created_at: get_i64("created_at")?,
         expires_at: get_i64("expires_at")?,
@@ -1136,6 +1149,7 @@ fn store_auth_challenge_redis(challenge: &AuthChallenge) -> std::result::Result<
         "subject_id": challenge.subject_id,
         "provider": challenge.provider,
         "kind": challenge.kind,
+        "csrf_token": challenge.csrf_token,
         "data_json": challenge.data_json,
         "created_at": challenge.created_at,
         "expires_at": challenge.expires_at,
@@ -1193,7 +1207,7 @@ fn get_auth_challenge_sqlite(id: &str) -> std::result::Result<Option<AuthChallen
     let now = chrono::Utc::now().timestamp();
 
     let result = conn.query_row(
-        "SELECT id, subject_id, provider, kind, data_json, created_at, expires_at
+        "SELECT id, subject_id, provider, kind, csrf_token, data_json, created_at, expires_at
          FROM auth_challenges WHERE id = ?1 AND expires_at > ?2",
         rusqlite::params![id, now],
         |row| {
@@ -1202,9 +1216,10 @@ fn get_auth_challenge_sqlite(id: &str) -> std::result::Result<Option<AuthChallen
                 subject_id: row.get(1)?,
                 provider: row.get(2)?,
                 kind: row.get(3)?,
-                data_json: row.get(4)?,
-                created_at: row.get(5)?,
-                expires_at: row.get(6)?,
+                csrf_token: row.get(4)?,
+                data_json: row.get(5)?,
+                created_at: row.get(6)?,
+                expires_at: row.get(7)?,
             })
         },
     );
@@ -1224,7 +1239,7 @@ fn get_auth_challenge_postgres(id: &str) -> std::result::Result<Option<AuthChall
     let mut client = postgres::Client::connect(url, postgres::NoTls).map_err(|e| e.to_string())?;
     let rows = client
         .query(
-            "SELECT id, subject_id, provider, kind, data_json, created_at, expires_at
+            "SELECT id, subject_id, provider, kind, csrf_token, data_json, created_at, expires_at
              FROM auth_challenges WHERE id = $1 AND expires_at > $2",
             &[&id, &now],
         )
@@ -1236,9 +1251,10 @@ fn get_auth_challenge_postgres(id: &str) -> std::result::Result<Option<AuthChall
             subject_id: row.get(1),
             provider: row.get(2),
             kind: row.get(3),
-            data_json: row.get(4),
-            created_at: row.get(5),
-            expires_at: row.get(6),
+            csrf_token: row.get(4),
+            data_json: row.get(5),
+            created_at: row.get(6),
+            expires_at: row.get(7),
         }))
     } else {
         Ok(None)
@@ -1343,7 +1359,7 @@ fn consume_auth_challenge_sqlite(id: &str) -> std::result::Result<Option<AuthCha
     let result = conn.query_row(
         "DELETE FROM auth_challenges
          WHERE id = ?1 AND expires_at > ?2
-         RETURNING id, subject_id, provider, kind, data_json, created_at, expires_at",
+         RETURNING id, subject_id, provider, kind, csrf_token, data_json, created_at, expires_at",
         rusqlite::params![id, now],
         |row| {
             Ok(AuthChallenge {
@@ -1351,9 +1367,10 @@ fn consume_auth_challenge_sqlite(id: &str) -> std::result::Result<Option<AuthCha
                 subject_id: row.get(1)?,
                 provider: row.get(2)?,
                 kind: row.get(3)?,
-                data_json: row.get(4)?,
-                created_at: row.get(5)?,
-                expires_at: row.get(6)?,
+                csrf_token: row.get(4)?,
+                data_json: row.get(5)?,
+                created_at: row.get(6)?,
+                expires_at: row.get(7)?,
             })
         },
     );
@@ -1375,7 +1392,7 @@ fn consume_auth_challenge_postgres(id: &str) -> std::result::Result<Option<AuthC
         .query(
             "DELETE FROM auth_challenges
              WHERE id = $1 AND expires_at > $2
-             RETURNING id, subject_id, provider, kind, data_json, created_at, expires_at",
+             RETURNING id, subject_id, provider, kind, csrf_token, data_json, created_at, expires_at",
             &[&id, &now],
         )
         .map_err(|e| e.to_string())?;
@@ -1386,9 +1403,10 @@ fn consume_auth_challenge_postgres(id: &str) -> std::result::Result<Option<AuthC
             subject_id: row.get(1),
             provider: row.get(2),
             kind: row.get(3),
-            data_json: row.get(4),
-            created_at: row.get(5),
-            expires_at: row.get(6),
+            csrf_token: row.get(4),
+            data_json: row.get(5),
+            created_at: row.get(6),
+            expires_at: row.get(7),
         }))
     } else {
         Ok(None)

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4081,6 +4081,46 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                 },
                 required(2)
             );
+            sig!(
+                "auth_challenge_csrf_token",
+                [
+                    "req" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "kind" => Type::String
+                ],
+                Type::Generic {
+                    name: "Option".to_string(),
+                    args: vec![Type::String],
+                },
+                required(1)
+            );
+            sig!(
+                "auth_challenge_csrf_field",
+                [
+                    "req" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "kind" => Type::String
+                ],
+                Type::String,
+                required(1)
+            );
+            sig!(
+                "verify_auth_challenge_csrf",
+                [
+                    "req" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    "token" => Type::String,
+                    "kind" => Type::String
+                ],
+                Type::Bool,
+                required(2)
+            );
         }
         "std/crypto" => {
             sig!("sha256", ["data" => Type::String], Type::String);
@@ -4601,6 +4641,33 @@ mod tests {
             let verified = verify_local_totp("admin@example.com", "123456", map { "identifier_kind": "email" })
             let status = totp_status("admin@example.com", map { "identifier_kind": "email" })
             let reset = reset_totp("admin@example.com", map { "identifier_kind": "email" })
+            "#,
+        );
+        assert!(errs.is_empty(), "unexpected diagnostics: {errs:?}");
+    }
+
+    #[test]
+    fn test_std_auth_challenge_csrf_signatures_check_args() {
+        let errs = check_errors(
+            r#"
+            import { auth_challenge_csrf_field, auth_challenge_csrf_token, verify_auth_challenge_csrf } from "std/auth"
+            auth_challenge_csrf_token("not request")
+            auth_challenge_csrf_field(map { "method": "GET", "path": "/" }, 42)
+            verify_auth_challenge_csrf(map { "method": "POST", "path": "/" }, 123)
+            "#,
+        );
+        assert_eq!(errs.len(), 3, "expected three errors, got: {:?}", errs);
+    }
+
+    #[test]
+    fn test_std_auth_challenge_csrf_signatures_allow_kind() {
+        let errs = check_errors(
+            r#"
+            import { auth_challenge_csrf_field, auth_challenge_csrf_token, verify_auth_challenge_csrf } from "std/auth"
+            let req = map { "method": "POST", "path": "/local/totp", "headers": map {} }
+            let token = auth_challenge_csrf_token(req, "local.totp")
+            let field = auth_challenge_csrf_field(req, "local.totp")
+            let ok = verify_auth_challenge_csrf(req, "token", "local.totp")
             "#,
         );
         assert!(errs.is_empty(), "unexpected diagnostics: {errs:?}");


### PR DESCRIPTION
## Summary
- add challenge-bound CSRF tokens to every `begin_auth_challenge(...)` record
- expose `auth_challenge_csrf_token`, `auth_challenge_csrf_field`, and `verify_auth_challenge_csrf` for pre-session staged auth forms
- typecheck and document the new helpers
- update the canonical auth demo to use challenge CSRF instead of app-managed nonce plumbing

## Why
Greptile caught that first-login password rotation and password→TOTP staged forms could accidentally omit CSRF because normal session CSRF is unavailable before the user is fully signed in. This makes the safe path first-class in `std/auth`: staged challenges carry their own server-side nonce and apps verify against the active challenge cookie/kind before mutating credentials, MFA state, or sessions.

## Verification
- `cargo fmt -- --check`
- `cargo test`
- `cargo build --profile dev-release`
- `./target/dev-release/ntnt docs --generate`
- `./target/dev-release/ntnt validate examples/` — passes; existing `examples/collections_demo.tnt` type warnings remain
- `./target/dev-release/ntnt lint examples/auth_demo/server.tnt` — no errors/warnings, existing contract suggestions only
- `git diff --check`

## Notes
- This PR intentionally stays narrow: it hardens staged auth form composition without adding a high-level local-auth framework wrapper.
- Signed-in forms should keep using `csrf_field(req)` / `verify_csrf(req, token)`; staged pre-session forms should use the new challenge CSRF helpers.
