### PR TITLE
docs: sync 0.4.9 release readiness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,7 +52,8 @@ src/
     ├── http_server.rs       # std/http/server — Response builders
     ├── http_server_async.rs # Async HTTP server (Axum + Tokio)
     ├── http_bridge.rs       # Bridge between async server and sync interpreter
-    ├── auth.rs              # std/auth — OAuth 2.0, OIDC, PKCE, TOTP, JWT (7,211 lines)
+    ├── auth.rs              # std/auth public registration/docs/tests (~11.5k lines)
+    ├── auth/                # std/auth internals: local auth, sessions, storage, OAuth, guards
     ├── template.rs          # External template loading (Mustache-style)
     ├── postgres.rs          # std/db/postgres — PostgreSQL (deadpool connection pool)
     ├── sqlite.rs            # std/db/sqlite — SQLite (bundled via rusqlite)
@@ -304,11 +305,12 @@ IAL is a term rewriting system that translates natural language assertions into 
 
 ## Auth System (`std/auth`)
 
-Full OAuth 2.0 and OIDC implementation (~7,200 lines):
+`std/auth` is the shared authentication subsystem for OAuth/OIDC and local app auth. The public module registers the API surface; focused internal modules own OAuth, sessions, cookies, guards, request helpers, local identity/credential lifecycle, storage backends, and route handlers.
 
 - **Flows:** Authorization Code, Authorization Code + PKCE, Client Credentials, Refresh Token
 - **Providers:** Google, GitHub, or any custom OIDC provider (auto-discovery from issuer URL)
-- **Features:** ID token validation, nonce replay protection, JWT encode/decode, TOTP (2FA), bcrypt/argon2 password hashing, AES-GCM encryption, constant-time comparison
+- **Features:** ID token validation, nonce replay protection, JWT encode/decode, CSRF, request-aware sessions, staged auth challenges, local credentials, password reset, TOTP, route/API protection, and app-owned claims/group handoff
+- **Boundary:** Generic crypto helpers such as `hash_password`, `verify_password`, UUIDs, HMAC, and AES-GCM live in `std/crypto`; `std/auth` owns auth lifecycle primitives that compose through shared session/challenge storage.
 
 ```ntnt
 import { oauth, enable_auth, get_user } from "std/auth"
@@ -369,7 +371,7 @@ CI validates that generated docs are up-to-date (build fails on drift).
 | `std/log` | Structured logging with levels (debug/info/warn/error), JSON context |
 | `std/http` | HTTP client (fetch with 1-arg and 2-arg forms, download) |
 | `std/http/server` | Response builders (json, html, redirect, set_cookie) |
-| `std/auth` | OAuth 2.0, OIDC, PKCE, JWT, TOTP, password hashing |
+| `std/auth` | OAuth/OIDC, JWT, CSRF, sessions, local credentials, password reset, TOTP, staged challenges, route/API protection |
 | `std/db/postgres` | PostgreSQL with connection pooling (deadpool), transactions |
 | `std/db/sqlite` | SQLite (bundled, zero external deps) with transactions |
 | `std/kv` | Unified key-value store (SQLite and Redis/Valkey backends) |

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ NTNT was built for human-AI collaboration. Requirements aren't separate from the
 | **Design by Contract** | `requires` and `ensures` built into function syntax. Agents read them as specs. Humans read them as docs. In HTTP routes, contract violations return 400/500 automatically. |
 | **Agent-Native Tooling** | `ntnt inspect` outputs JSON describing every function, route, and contract. `ntnt validate` returns machine-readable errors. An agent can understand an entire codebase in one call. |
 | **Gradual Type System** | Two independent axes: `NTNT_LINT_MODE` (static) and `NTNT_TYPE_MODE` (runtime). Start untyped, add annotations where they help, enable full type checking when you want it. |
-| **Built-In Auth & OAuth** | Full OAuth 2.0, OIDC discovery, JWT, CSRF, session management, bcrypt, TOTP — all in `std/auth`. Add Google or GitHub login in a few lines, not a few dependencies. |
+| **Built-In Auth** | OAuth/OIDC, JWT, CSRF, session management, local credentials, password reset, TOTP, staged auth challenges, and route/API protection — all in `std/auth`. Add Google/GitHub login or local email/password auth without dependency sprawl. |
 | **Background Jobs** | Language-native job DSL with priority queues, cron, unique jobs, and dead letter handling. Memory, PostgreSQL, and Redis backends. |
 | **Secure by Design** | No package manager means no supply chain attacks. Auto-escaping, SSRF protection, and security headers ship with the language. |
 | **Batteries Included** | HTTP servers, PostgreSQL, SQLite, Redis, JSON, CSV, file I/O, crypto, concurrency — all in the standard library. |
@@ -274,7 +274,7 @@ Everything's built in. No package manager needed.
 | **Web** | `std/http/server`, `std/http` | HTTP server with routing, middleware, static files; HTTP client |
 | **Data** | `std/json`, `std/csv`, `std/db/postgres`, `std/db/sqlite` | Parse/stringify; PostgreSQL and SQLite with transactions |
 | **Key-Value** | `std/kv` | Unified KV store (Redis, Valkey, DragonflyDB, SQLite, in-memory) |
-| **Auth** | `std/auth` | OAuth 2.0, OIDC, JWT, CSRF, session management, bcrypt, Argon2, TOTP |
+| **Auth** | `std/auth` | OAuth/OIDC, JWT, CSRF, sessions, local credentials, password reset, TOTP, staged challenges, route/API protection |
 | **Jobs** | `std/jobs` | Background job DSL with priority queues, cron, unique jobs, retry, dead letters. Memory, PostgreSQL, and Redis backends |
 | **Concurrency** | `std/concurrent` | Spawn, typed channels (Tx/Rx), select, parallel, race, schedule, after |
 | **Collections** | `std/collections` | push, pop, sort, reverse, keys, values, entries, map, filter, reduce, find, any, all |

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -1,9 +1,9 @@
 # DD-043: World-Class Auth — Making `std/auth` the Best stdlib Auth Ever
 
-**Status:** In Progress — 0.4.9 release polish
+**Status:** Release candidate — final v0.4.9 validation
 **Author:** Larri
-**Date:** 2026-03-20 (slashed and sharpened 2026-04-28; WebAuthn/passkeys phase added 2026-04-29; 0.4.9 auth polish updated 2026-05-29)
-**Branch:** `main` through v0.4.9; current polish branch: `feat/auth-049-local-backends-polish`; WebAuthn/passkeys are post-v0.4.9
+**Date:** 2026-03-20 (slashed and sharpened 2026-04-28; WebAuthn/passkeys phase added 2026-04-29; 0.4.9 auth polish updated 2026-05-29; release-readiness sync 2026-05-31)
+**Branch:** `main` for v0.4.9; WebAuthn/passkeys are post-v0.4.9
 
 ---
 
@@ -145,14 +145,14 @@ Goal: ship reset password securely enough to use, without owning email delivery 
 
 ### Template Integration Proof
 
-This may be a separate template-repo PR, but it is the real acceptance test.
+Completed in `larimonious/larri-site-template` PR #1 (`feat(auth): move template admin to std/auth primitives`), merged before the final v0.4.9 release-readiness pass.
 
-- [ ] `template.heylarri.com` uses built-in local identity, credential, session, challenge, TOTP, and reset primitives
-- [ ] Template stores app-specific auth extension data in namespaced metadata or session data
-- [ ] Template uses `group_ids` / claims to build app RBAC without stdlib owning app policy
-- [ ] Template protects both pages and API endpoints through `require_auth(...)` / group helpers
-- [ ] Template deletes parallel auth tables/state machines
-- [ ] The before/after diff is materially simpler
+- [x] `template.heylarri.com` uses built-in local identity, credential, session, challenge, TOTP, and reset primitives
+- [x] Template stores app-specific auth extension data in namespaced metadata or session data
+- [x] Template uses `group_ids` / claims to build app RBAC without stdlib owning app policy
+- [x] Template protects both pages and API endpoints through `require_auth(...)` / group helpers
+- [x] Template deletes parallel auth tables/state machines
+- [x] The before/after diff is materially simpler
 - [x] `docs/AI_AGENT_GUIDE.md` includes a local auth quickstart showing login, reset, explicit reset-session revocation checkbox plumbing, and standalone `logout_all(...)` UI composition
 
 ---
@@ -342,4 +342,4 @@ After the first WebAuthn/passkey phase proves the primitive shape:
 
 ---
 
-*Sharpened 2026-04-28. One DD, one roadmap. DD-062 retired. Final sprint keeps the secure essentials first-class — reset, TOTP, API/page protection, local backend parity, and authorization handoff — while pushing product/RBAC/platform bloat to Future Refinements. WebAuthn/passkeys added 2026-04-29 as a post-v0.4.9 phase after template proof.*
+*Sharpened 2026-04-28. One DD, one roadmap. DD-062 retired. Final sprint keeps the secure essentials first-class — reset, TOTP, API/page protection, local backend parity, and authorization handoff — while pushing product/RBAC/platform bloat to Future Refinements. WebAuthn/passkeys added 2026-04-29 as a post-v0.4.9 phase. Template proof completed 2026-05-31; remaining release work is validation, issue triage, tagging, and publishing.*


### PR DESCRIPTION
## Summary

- Mark DD-043 as v0.4.9 release-candidate state and check off the merged template integration proof.
- Update README auth positioning from OAuth-centric wording to the current 0.4.9 auth surface.
- Refresh ARCHITECTURE.md auth/module wording so it reflects the split auth internals and std/auth vs std/crypto boundary.

## Release validation run

Core checks:
- `cargo fmt -- --check` ✅
- `cargo build --profile dev-release` ✅
- `RUST_MIN_STACK=8388608 cargo test -- --test-threads=1` ✅ — 1077 lib tests plus integration suites passed
- `cargo build --release --locked` ✅
- `./target/release/ntnt docs --validate` ✅ — validation completed; non-blocking coverage notes remain for examples/params

Auth backend checks:
- PostgreSQL auth storage contract ✅ — `cargo test --locked --lib test_auth_storage_contract_postgres_round_trip_all_record_types -- --test-threads=1 --nocapture`
- Redis auth storage contract ✅ — `cargo test --locked --lib test_auth_storage_contract_redis_round_trip_all_record_types -- --test-threads=1 --nocapture`

Docs/examples:
- `./target/dev-release/ntnt docs --generate` ✅ — no generated-doc drift
- `./target/dev-release/ntnt lint examples/` ✅ exit 0; existing warnings/suggestions only
- `examples/auth_demo/server.tnt` smoke ✅ — home renders, `HEAD /` returns 200, unauthenticated `/api/me` returns 401

Issue triage:
- Closed #75 as completed after HEAD fallback tests and live smoke verification.
- Commented/kept #84 open as post-0.4.9 diagnostics/DX follow-up, not a release blocker.
- Commented/kept #85 open as post-0.4.9 follow-up; minimal hot-reload route-discovery repro passes on current `main`.

## Notes

No runtime/code changes in this PR. This is release-readiness documentation + validation/triage closure.