### PR TITLE
Fix open runtime and stdlib issues

### DIFF
--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -406,7 +406,7 @@ len("hello")            // compute a value from input
 split(text, ",")        // create a new array from a string
 trim(input)             // create a new string
 push(arr, item)         // create a new array with item added
-int(form.age)           // convert a value to a new type
+int(form.age) ?? 0      // convert a value to a new type, handling parse failure
 
 // WRONG - method-style calls on stdlib functions
 "hello".len()           // Use len("hello")
@@ -1329,7 +1329,8 @@ for user in users {
     print("Name: #{user[\"name\"]}")
 }
 
-execute(db, "INSERT INTO users (name, age) VALUES ($1, $2)", [name, int(age_str)])
+let age = int(age_str) otherwise { return Err("age must be an integer") }
+execute(db, "INSERT INTO users (name, age) VALUES ($1, $2)", [name, age])
 
 close(db)  // Releases the connection pool
 ```
@@ -1337,8 +1338,8 @@ close(db)  // Releases the connection pool
 **Type conversion for database:**
 ```ntnt
 let form = parse_form(req)
-let age = int(form["age"])     // Convert string to int!
-let price = float(form["price"])
+let age = int(form["age"]) otherwise { return status(400, "age must be an integer") }
+let price = float(form["price"]) ?? 0.0
 
 // WRONG - String to integer column causes "db error"
 execute(db, "INSERT INTO users (age) VALUES ($1)", [form["age"]])
@@ -1514,8 +1515,8 @@ import { now } from "std/time"
 let stat_result = file_stat("public/css/styles.css")
 let CACHE_BUST = if is_ok(stat_result) {
     let m = unwrap(stat_result)["modified"]
-    if m > 0 { m } else { int(now()) }
-} else { int(now()) }
+    if m > 0 { m } else { int(now()) ?? 0 }
+} else { int(now()) ?? 0 }
 
 fn render_page(options) {
     // ... build nav, footer, etc.
@@ -2998,8 +2999,8 @@ with_header(resp, "X-Custom", "value")                  // Add header
 |----------|-------------|
 | `print(x)` | Output to stdout |
 | `str(x)` | Convert to string |
-| `int(x)` | Convert to integer |
-| `float(x)` | Convert to float |
+| `int(x)` | Convert to integer → `Result<Int, String>` |
+| `float(x)` | Convert to float → `Result<Float, String>` |
 | `type(x)` | Get type name as string |
 | `typeof(x)` | Get type name (alias for `type`) |
 
@@ -3140,7 +3141,7 @@ NTNT error messages include error codes (E001-E012), source snippets, line numbe
 | `ensures clause failed` | Postcondition not met | Fix function to return correct values |
 | `key not found` | Missing map key | Use `has_key()` to check, or `get_key()` for Option |
 | `index out of bounds` | Array index invalid | Check `len()` before accessing |
-| `db error` | Type mismatch in query | Convert types: `int(form["age"])` for integers |
+| `db error` | Type mismatch in query | Convert and handle parse failures: `let age = int(form["age"]) otherwise { return status(400, "invalid age") }` |
 
 ### Contract Violations in HTTP Routes
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -49,10 +49,10 @@ These functions are available everywhere without importing.
 | [`enable_cors(options?: Map)`](#enablecors) | Enable CORS (Cross-Origin Resource Sharing) for the HTTP server. |
 | [`enable_csp(options?: Map \| Bool)`](#enablecsp) | Enable Content-Security-Policy headers for the HTTP server. |
 | [`flat_map(arr: Array, fn: Function)`](#flatmap) | Apply a function to each element and flatten the results into a single array. |
-| [`float(x: Int \| Float \| String)`](#float) | Converts a value to float. |
+| [`float(x: Int \| Float \| String)`](#float) | Converts a value to float without throwing on parse failure. |
 | [`floor(x: Int \| Float)`](#floor) | Rounds down to the nearest integer. |
 | [`get(pattern: String, handler: Function)`](#get) | Registers a GET route handler. |
-| [`int(x: Int \| Float \| String \| Bool)`](#int) | Converts a value to integer. |
+| [`int(x: Int \| Float \| String \| Bool)`](#int) | Converts a value to integer without throwing on parse failure. |
 | [`is_array(val: Any)`](#isarray) | Returns true if the value is an Array. |
 | [`is_bool(val: Any)`](#isbool) | Returns true if the value is a Bool. |
 | [`is_err(res: Result<Any, Any>)`](#iserr) | Checks if a Result is Err. |
@@ -462,32 +462,28 @@ flat_map([1, 2, 3], fn(x) { [x, x * 10] })  // => [1, 10, 2, 20, 3, 30]  // Expa
 #### `float`
 
 ```ntnt
-float(x: Int | Float | String) -> Float
+float(x: Int | Float | String) -> Result<Float, String>
 ```
 
-Converts a value to float.
+Converts a value to float without throwing on parse failure.
 
-Accepts Int (widens), Float (identity), and String (parses decimal).
+Accepts Int (widens), Float (identity), and String (parses decimal). Returns Ok(Float) on success and Err(String) when the value cannot be converted.
 
 **Parameters:**
 
 - `x` — The value to convert
 
-**Returns:** The float value
+**Returns:** Result containing the float value, or Err with a parse/conversion message
 
 **Examples:**
 
 ```ntnt
-float(42)  // => 42.0  // Integer widened to float
-float("3.14")  // => 3.14  // String parsed to float
+float(42)  // => Ok(42.0)  // Integer widened to float
+float("3.14")  // => Ok(3.14)  // String parsed to float
+float("none")  // => Err("Cannot parse as float: none")  // Invalid strings are handleable
 ```
 
-**Errors:**
-
-- **TypeError**: Cannot parse as float — *Fix: Ensure the string contains a valid number*
-- **TypeError**: Cannot convert to float — *Fix: Pass an Int, Float, or String*
-
-**See also:** `int`, `str`
+**See also:** `int`, `str`, `unwrap`
 
 *Since v0.1.0*
 
@@ -556,32 +552,28 @@ get("/health", fn(req) { return json(map { "ok": true }) })  // => Unit  // Regi
 #### `int`
 
 ```ntnt
-int(x: Int | Float | String | Bool) -> Int
+int(x: Int | Float | String | Bool) -> Result<Int, String>
 ```
 
-Converts a value to integer.
+Converts a value to integer without throwing on parse failure.
 
-Accepts Int (identity), Float (truncates toward zero), String (parses decimal), and Bool (true=1, false=0).
+Accepts Int (identity), Float (truncates toward zero), String (parses decimal), and Bool (true=1, false=0). Returns Ok(Int) on success and Err(String) when the value cannot be converted. Use `int(value) ?? default` for a fallback or `unwrap(int(value))` to preserve the old throwing behavior explicitly.
 
 **Parameters:**
 
 - `x` — The value to convert
 
-**Returns:** The integer value
+**Returns:** Result containing the integer value, or Err with a parse/conversion message
 
 **Examples:**
 
 ```ntnt
-int(3.7)  // => 3  // Float truncated to int
-int("42")  // => 42  // String parsed to int
+int(3.7)  // => Ok(3)  // Float truncated to int
+int("42")  // => Ok(42)  // String parsed to int
+int("none")  // => Err("Cannot parse as int: none")  // Invalid strings are handleable
 ```
 
-**Errors:**
-
-- **TypeError**: Cannot parse as int — *Fix: Ensure the string contains a valid integer*
-- **TypeError**: Cannot convert to int — *Fix: Pass an Int, Float, String, or Bool*
-
-**See also:** `float`, `str`
+**See also:** `float`, `str`, `unwrap`
 
 *Since v0.1.0*
 
@@ -8082,6 +8074,8 @@ import { open, get, get_int } from "std/kv"
 
 | Function | Description |
 |----------|-------------|
+| [`decr`](#decr) | Atomically decrement an integer value by 1. |
+| [`decr_by`](#decrby) | Atomically decrement an integer value by amount. |
 | [`del`](#del) | Delete a key from the KV store. |
 | [`expire`](#expire) | Set a TTL (time-to-live) on an existing key. |
 | [`flush`](#flush) | Delete all keys from the KV store. |
@@ -8091,12 +8085,72 @@ import { open, get, get_int } from "std/kv"
 | [`get_json`](#getjson) | Get a value by key and parse it as JSON. |
 | [`get_str`](#getstr) | Get a value by key and convert it to a string. |
 | [`has`](#has) | Check if a key exists in the KV store. |
-| [`incr`](#incr) | Atomically increment an integer value by amount. |
+| [`incr`](#incr) | Atomically increment an integer value by 1. |
+| [`incr_by`](#incrby) | Atomically increment an integer value by amount. |
 | [`list`](#list) | List keys in the KV store, optionally filtered by prefix. |
 | [`open`](#open) | Open a KV store connection. |
 | [`set`](#set) | Set a key-value pair in the KV store. |
 | [`set_nx`](#setnx) | Set a key only if it doesn't already exist (atomic NX operation). |
 | [`ttl`](#ttl) | Get the remaining TTL (time-to-live) for a key in seconds. |
+
+#### `decr`
+
+```ntnt
+decr(kv: KVStore, key: String) -> Result<Int, String>
+```
+
+Atomically decrement an integer value by 1.
+
+**Parameters:**
+
+- `kv` — The KV store handle from open()
+- `key` — The key to decrement
+
+**Returns:** Result containing the new integer value, or Err if the key holds a non-integer
+
+**Examples:**
+
+```ntnt
+decr(kv, "stock")  // => Ok(-1)  // Decrement a missing counter from zero
+```
+
+**Errors:**
+
+- **TypeError**: kv_incr() requires an integer value — *Fix: Ensure the key was set with an integer value or hasn't been written yet*
+
+**See also:** `incr`, `incr_by`, `decr_by`
+
+---
+
+#### `decr_by`
+
+```ntnt
+decr_by(kv: KVStore, key: String, amount: Int) -> Result<Int, String>
+```
+
+Atomically decrement an integer value by amount.
+
+**Parameters:**
+
+- `kv` — The KV store handle from open()
+- `key` — The key to decrement
+- `amount` — Integer to subtract
+
+**Returns:** Result containing the new integer value, or Err if the key holds a non-integer
+
+**Examples:**
+
+```ntnt
+decr_by(kv, "stock", 3)  // => Ok(-3)  // Subtract 3 from a counter
+```
+
+**Errors:**
+
+- **TypeError**: kv_incr() requires an integer value — *Fix: Ensure the key was set with an integer value or hasn't been written yet*
+
+**See also:** `incr`, `decr`, `incr_by`
+
+---
 
 #### `del`
 
@@ -8340,34 +8394,61 @@ has(cache, "user:123")  // Check if key exists
 #### `incr`
 
 ```ntnt
-incr(kv: KVStore, key: String, amount: Int) -> Result<Int, String>
+incr(kv: KVStore, key: String) -> Result<Int, String>
 ```
 
-Atomically increment an integer value by amount.
+Atomically increment an integer value by 1.
 
-If the key doesn't exist, it is created with value = amount (effectively starting from 0). Preserves any existing TTL on the key — does not reset it. Returns the new value after incrementing.
+If the key doesn't exist, it is created with value = 1 (effectively starting from 0). Preserves any existing TTL on the key — does not reset it. Returns the new value after incrementing.
 
 **Parameters:**
 
 - `kv` — The KV store handle from open()
 - `key` — The key to increment
-- `amount` — Integer to add (use negative values to decrement)
 
 **Returns:** Result containing the new integer value, or Err if the key holds a non-integer
 
 **Examples:**
 
 ```ntnt
-incr(kv, "page_views", 1)  // => Ok(1)  // Increment a counter from zero
-incr(kv, "score", 10)  // Add 10 to a score counter
-incr(kv, "countdown", -1)  // Decrement a counter
+incr(kv, "page_views")  // => Ok(1)  // Increment a counter from zero
 ```
 
 **Errors:**
 
 - **TypeError**: kv_incr() requires an integer value — *Fix: Ensure the key was set with an integer value or hasn't been written yet*
 
-**See also:** `expire`, `set`
+**See also:** `decr`, `incr_by`, `decr_by`, `expire`, `set`
+
+---
+
+#### `incr_by`
+
+```ntnt
+incr_by(kv: KVStore, key: String, amount: Int) -> Result<Int, String>
+```
+
+Atomically increment an integer value by amount.
+
+**Parameters:**
+
+- `kv` — The KV store handle from open()
+- `key` — The key to increment
+- `amount` — Integer to add
+
+**Returns:** Result containing the new integer value, or Err if the key holds a non-integer
+
+**Examples:**
+
+```ntnt
+incr_by(kv, "score", 10)  // => Ok(10)  // Add 10 to a score counter
+```
+
+**Errors:**
+
+- **TypeError**: kv_incr() requires an integer value — *Fix: Ensure the key was set with an integer value or hasn't been written yet*
+
+**See also:** `incr`, `decr`, `decr_by`
 
 ---
 

--- a/examples/auth_demo/server.tnt
+++ b/examples/auth_demo/server.tnt
@@ -514,7 +514,7 @@ get("/auth/{provider}", auth_start)
 get("/auth/{provider}/callback", auth_callback)
 post("/auth/logout", auth_logout)
 
-let port = int(get_env("PORT") ?? "8080")
+let port = int(get_env("PORT") ?? "8080") ?? 8080
 print("NTNT auth demo running on http://localhost:#{port}")
 print("Local demo user: #{demo_email}")
 listen(port)

--- a/examples/http_server.tnt
+++ b/examples/http_server.tnt
@@ -121,8 +121,8 @@ fn calc_divide(req) {
     }
 
     let params = req.query_params
-    let a = int(params["a"])
-    let b = int(params["b"])
+    let a = int(params["a"]) otherwise { return status(400, "Invalid parameter: a must be an integer") }
+    let b = int(params["b"]) otherwise { return status(400, "Invalid parameter: b must be an integer") }
     let result = safe_divide(a, b)
 
     return json(map {

--- a/examples/ial_demo/server.tnt
+++ b/examples/ial_demo/server.tnt
@@ -117,10 +117,10 @@ fn status(code, response) {
 
 // @implements: feature.task_details
 fn get_task_handler(req) {
-    let id = int(req.params["id"])
+    let id = int(req.params["id"]) otherwise { return status(400, json(map { "error": "Invalid task id" })) }
 
     for task in tasks {
-        if int(task["id"]) == id {
+        if (int(task["id"]) ?? -1) == id {
             return json(task)
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -106,7 +106,7 @@ pub enum IntentError {
     },
 
     #[error("Division by zero")]
-    DivisionByZero,
+    DivisionByZero { line: usize },
 
     #[error("Index out of bounds: index {index}, length {length}")]
     IndexOutOfBounds { index: i64, length: usize },
@@ -164,6 +164,7 @@ impl IntentError {
             IntentError::UndefinedVariable { line: l, .. } => *l = line,
             IntentError::UndefinedFunction { line: l, .. } => *l = line,
             IntentError::ArityMismatch { line: l, .. } => *l = line,
+            IntentError::DivisionByZero { line: l } => *l = line,
             _ => {}
         }
         self
@@ -213,7 +214,7 @@ impl IntentError {
             IntentError::UndefinedVariable { .. } => "E006",
             IntentError::UndefinedFunction { .. } => "E007",
             IntentError::ArityMismatch { .. } => "E008",
-            IntentError::DivisionByZero => "E009",
+            IntentError::DivisionByZero { .. } => "E009",
             IntentError::IndexOutOfBounds { .. } => "E010",
             IntentError::InvalidOperation(_) => "E011",
             IntentError::RequiresApproval(_) => "E012",
@@ -230,6 +231,7 @@ impl IntentError {
             IntentError::UndefinedVariable { line, .. } if *line > 0 => Some(*line),
             IntentError::UndefinedFunction { line, .. } if *line > 0 => Some(*line),
             IntentError::ArityMismatch { line, .. } if *line > 0 => Some(*line),
+            IntentError::DivisionByZero { line } if *line > 0 => Some(*line),
             _ => None,
         }
     }
@@ -437,7 +439,7 @@ mod tests {
                 got: 0,
                 line: 0,
             },
-            IntentError::DivisionByZero,
+            IntentError::DivisionByZero { line: 0 },
             IntentError::IndexOutOfBounds {
                 index: 0,
                 length: 0,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -9007,12 +9007,15 @@ impl Interpreter {
                                         .get_route_source(route_index)
                                         .and_then(|s| s.file_path.clone())
                                         .unwrap_or_default();
-                                    let loc = e
-                                        .line()
-                                        .map(|line| {
-                                            format!(":{} (approximate statement start)", line)
-                                        })
-                                        .unwrap_or_default();
+                                    let loc = if handler_file.is_empty() {
+                                        String::new()
+                                    } else {
+                                        e.line()
+                                            .map(|line| {
+                                                format!(":{} (approximate statement start)", line)
+                                            })
+                                            .unwrap_or_default()
+                                    };
                                     let error_context =
                                         self.format_route_error_context(&e, &handler_file);
                                     eprintln!(

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2333,20 +2333,22 @@ impl Interpreter {
         );
 
         // @ntnt int
-        // @signature int(x: Int | Float | String | Bool) -> Int
-        // Converts a value to integer.
+        // @signature int(x: Int | Float | String | Bool) -> Result<Int, String>
+        // Converts a value to integer without throwing on parse failure.
         //
         // Accepts Int (identity), Float (truncates toward zero),
-        // String (parses decimal), and Bool (true=1, false=0).
+        // String (parses decimal), and Bool (true=1, false=0). Returns Ok(Int)
+        // on success and Err(String) when the value cannot be converted.
+        // Use `int(value) ?? default` for a fallback or `unwrap(int(value))` to
+        // preserve the old throwing behavior explicitly.
         // @param x The value to convert
-        // @returns The integer value
+        // @returns Result containing the integer value, or Err with a parse/conversion message
         // @tags #pure, #deterministic
-        // @see_also float, str
+        // @see_also float, str, unwrap
         // @since v0.1.0
-        // @example int(3.7) => 3 ~ "Float truncated to int"
-        // @example int("42") => 42 ~ "String parsed to int"
-        // @error TypeError ~ "Cannot parse as int" fix: "Ensure the string contains a valid integer"
-        // @error TypeError ~ "Cannot convert to int" fix: "Pass an Int, Float, String, or Bool"
+        // @example int(3.7) => Ok(3) ~ "Float truncated to int"
+        // @example int("42") => Ok(42) ~ "String parsed to int"
+        // @example int("none") => Err("Cannot parse as int: none") ~ "Invalid strings are handleable"
         self.environment.borrow_mut().define(
             "int".to_string(),
             Value::NativeFunction {
@@ -2354,33 +2356,42 @@ impl Interpreter {
                 arity: 1,
                 max_arity: 1,
                 requires: None,
-                func: |args| match &args[0] {
-                    Value::Int(n) => Ok(Value::Int(*n)),
-                    Value::Float(f) => Ok(Value::Int(*f as i64)),
-                    Value::String(s) => s
-                        .parse::<i64>()
-                        .map(Value::Int)
-                        .map_err(|_| IntentError::type_error("Cannot parse as int".to_string())),
-                    Value::Bool(b) => Ok(Value::Int(if *b { 1 } else { 0 })),
-                    _ => Err(IntentError::type_error("Cannot convert to int".to_string())),
+                func: |args| {
+                    let result = match &args[0] {
+                        Value::Int(n) => Ok(Value::Int(*n)),
+                        Value::Float(f) => Ok(Value::Int(*f as i64)),
+                        Value::String(s) => s.parse::<i64>().map(Value::Int).map_err(|_| {
+                            if s.is_empty() {
+                                "Cannot parse as int: empty string".to_string()
+                            } else {
+                                format!("Cannot parse as int: {}", s)
+                            }
+                        }),
+                        Value::Bool(b) => Ok(Value::Int(if *b { 1 } else { 0 })),
+                        other => Err(format!("Cannot convert {} to int", other.type_name())),
+                    };
+                    Ok(match result {
+                        Ok(value) => Value::ok(value),
+                        Err(message) => Value::err(Value::String(message)),
+                    })
                 },
             },
         );
 
         // @ntnt float
-        // @signature float(x: Int | Float | String) -> Float
-        // Converts a value to float.
+        // @signature float(x: Int | Float | String) -> Result<Float, String>
+        // Converts a value to float without throwing on parse failure.
         //
         // Accepts Int (widens), Float (identity), and String (parses decimal).
+        // Returns Ok(Float) on success and Err(String) when the value cannot be converted.
         // @param x The value to convert
-        // @returns The float value
+        // @returns Result containing the float value, or Err with a parse/conversion message
         // @tags #pure, #deterministic
-        // @see_also int, str
+        // @see_also int, str, unwrap
         // @since v0.1.0
-        // @example float(42) => 42.0 ~ "Integer widened to float"
-        // @example float("3.14") => 3.14 ~ "String parsed to float"
-        // @error TypeError ~ "Cannot parse as float" fix: "Ensure the string contains a valid number"
-        // @error TypeError ~ "Cannot convert to float" fix: "Pass an Int, Float, or String"
+        // @example float(42) => Ok(42.0) ~ "Integer widened to float"
+        // @example float("3.14") => Ok(3.14) ~ "String parsed to float"
+        // @example float("none") => Err("Cannot parse as float: none") ~ "Invalid strings are handleable"
         self.environment.borrow_mut().define(
             "float".to_string(),
             Value::NativeFunction {
@@ -2388,16 +2399,23 @@ impl Interpreter {
                 arity: 1,
                 max_arity: 1,
                 requires: None,
-                func: |args| match &args[0] {
-                    Value::Int(n) => Ok(Value::Float(*n as f64)),
-                    Value::Float(f) => Ok(Value::Float(*f)),
-                    Value::String(s) => s
-                        .parse::<f64>()
-                        .map(Value::Float)
-                        .map_err(|_| IntentError::type_error("Cannot parse as float".to_string())),
-                    _ => Err(IntentError::type_error(
-                        "Cannot convert to float".to_string(),
-                    )),
+                func: |args| {
+                    let result = match &args[0] {
+                        Value::Int(n) => Ok(Value::Float(*n as f64)),
+                        Value::Float(f) => Ok(Value::Float(*f)),
+                        Value::String(s) => s.parse::<f64>().map(Value::Float).map_err(|_| {
+                            if s.is_empty() {
+                                "Cannot parse as float: empty string".to_string()
+                            } else {
+                                format!("Cannot parse as float: {}", s)
+                            }
+                        }),
+                        other => Err(format!("Cannot convert {} to float", other.type_name())),
+                    };
+                    Ok(match result {
+                        Ok(value) => Value::ok(value),
+                        Err(message) => Value::err(Value::String(message)),
+                    })
                 },
             },
         );
@@ -5758,14 +5776,14 @@ impl Interpreter {
                         return Ok(Value::Bool(rhs.is_truthy()));
                     }
                     BinaryOp::NullCoalesce => {
-                        // Return unwrapped left if it's Some, otherwise evaluate and return right
+                        // Return unwrapped left if it's Some/Ok, otherwise evaluate and return right.
+                        // This makes `int(raw) ?? 0` work now that parsing returns Result.
                         match &lhs {
                             Value::EnumValue {
                                 enum_name,
                                 variant,
                                 values,
                             } if enum_name == "Option" && variant == "Some" => {
-                                // Unwrap the Some value
                                 return Ok(values.first().cloned().unwrap_or(Value::Unit));
                             }
                             Value::EnumValue {
@@ -5773,7 +5791,19 @@ impl Interpreter {
                             } if enum_name == "Option" && variant == "None" => {
                                 return self.eval_expression(right);
                             }
-                            // For non-Option values, return as-is (like JavaScript's ??)
+                            Value::EnumValue {
+                                enum_name,
+                                variant,
+                                values,
+                            } if enum_name == "Result" && variant == "Ok" => {
+                                return Ok(values.first().cloned().unwrap_or(Value::Unit));
+                            }
+                            Value::EnumValue {
+                                enum_name, variant, ..
+                            } if enum_name == "Result" && variant == "Err" => {
+                                return self.eval_expression(right);
+                            }
+                            // For non-Option/Result values, return as-is (like JavaScript's ??)
                             _ => return Ok(lhs),
                         }
                     }
@@ -6360,7 +6390,13 @@ impl Interpreter {
                                 }
                                 let handler = self.eval_expression(&arguments[1])?;
                                 let method = name.to_uppercase();
-                                self.server_state.add_route(&method, pattern_str, handler);
+                                self.server_state.add_route_with_source(
+                                    &method,
+                                    pattern_str,
+                                    handler,
+                                    self.current_file.clone(),
+                                    self.imported_files.clone(),
+                                );
                                 return Ok(Value::Unit);
                             }
                             // Otherwise fall through to normal function call (HTTP client)
@@ -8971,22 +9007,17 @@ impl Interpreter {
                                         .get_route_source(route_index)
                                         .and_then(|s| s.file_path.clone())
                                         .unwrap_or_default();
-                                    let loc = if self.current_line > 0 {
-                                        format!("line {}", self.current_line)
-                                    } else {
-                                        String::new()
-                                    };
+                                    let loc = e
+                                        .line()
+                                        .map(|line| {
+                                            format!(":{} (approximate statement start)", line)
+                                        })
+                                        .unwrap_or_default();
+                                    let error_context =
+                                        self.format_route_error_context(&e, &handler_file);
                                     eprintln!(
                                         "[ERROR] {} {} | handler: {}{} | {}",
-                                        method,
-                                        path,
-                                        handler_file,
-                                        if loc.is_empty() {
-                                            String::new()
-                                        } else {
-                                            format!(":{}", loc)
-                                        },
-                                        e
+                                        method, path, handler_file, loc, e
                                     );
                                     // Try on_error handler if registered
                                     if let Some(error_handler) =
@@ -9006,7 +9037,7 @@ impl Interpreter {
                                                 let method_path = format!("{} {}", method, path);
                                                 http_server::create_error_response_with_context(
                                                     500,
-                                                    &e.to_string(),
+                                                    &error_context,
                                                     &method_path,
                                                     &handler_file,
                                                 )
@@ -9033,7 +9064,7 @@ impl Interpreter {
                                             } else {
                                                 http_server::create_error_response_with_context(
                                                     500,
-                                                    &e.to_string(),
+                                                    &error_context,
                                                     &method_path,
                                                     &handler_file,
                                                 )
@@ -9041,7 +9072,7 @@ impl Interpreter {
                                         } else {
                                             http_server::create_error_response_with_context(
                                                 500,
-                                                &e.to_string(),
+                                                &error_context,
                                                 &method_path,
                                                 &handler_file,
                                             )
@@ -9338,6 +9369,45 @@ impl Interpreter {
         Ok(Value::Unit)
     }
 
+    /// Format route runtime errors with source context for dev error pages.
+    /// Runtime errors currently carry statement-start lines, not expression spans, so the
+    /// location is explicitly labeled approximate instead of pretending to be exact.
+    fn format_route_error_context(&self, error: &IntentError, handler_file: &str) -> String {
+        let mut message = error.to_string();
+        if handler_file.is_empty() {
+            return message;
+        }
+
+        if let Some(line) = error.line() {
+            message.push_str(&format!(
+                "\n\nLocation: {}:{} (approximate statement start)",
+                handler_file, line
+            ));
+
+            if let Ok(source) = std::fs::read_to_string(handler_file) {
+                let lines: Vec<&str> = source.lines().collect();
+                let idx = line.saturating_sub(1);
+                message.push_str("\n\nSource excerpt:");
+                if idx > 0 {
+                    if let Some(prev) = lines.get(idx - 1) {
+                        message.push_str(&format!("\n {:>4} | {}", line - 1, prev));
+                    }
+                }
+                if let Some(current) = lines.get(idx) {
+                    message.push_str(&format!("\n {:>4} | {}", line, current));
+                    message.push_str("\n      | ^ approximate failing statement");
+                }
+                if let Some(next) = lines.get(idx + 1) {
+                    message.push_str(&format!("\n {:>4} | {}", line + 1, next));
+                }
+            }
+        } else {
+            message.push_str(&format!("\n\nLocation: {} (line unknown)", handler_file));
+        }
+
+        message
+    }
+
     /// Process a single HTTP request: find route, run middleware, call handler, apply CORS
     fn process_request(
         &mut self,
@@ -9475,11 +9545,11 @@ impl Interpreter {
                             .get_route_source(route_index)
                             .and_then(|s| s.file_path.clone())
                             .unwrap_or_default();
-                        let loc = if self.current_line > 0 {
-                            format!(":{}", self.current_line)
-                        } else {
-                            String::new()
-                        };
+                        let loc = e
+                            .line()
+                            .map(|line| format!(":{} (approximate statement start)", line))
+                            .unwrap_or_default();
+                        let error_context = self.format_route_error_context(&e, &handler_file);
                         eprintln!(
                             "[ERROR] {} {} | handler: {}{} | {}",
                             method, path, handler_file, loc, e
@@ -9495,7 +9565,7 @@ impl Interpreter {
                                     eprintln!("[ERROR] on_error handler failed: {}", handler_err);
                                     crate::stdlib::http_server::create_error_response_with_context(
                                         500,
-                                        &e.to_string(),
+                                        &error_context,
                                         &format!("{} {}", method, path),
                                         &handler_file,
                                     )
@@ -9504,7 +9574,7 @@ impl Interpreter {
                         } else {
                             crate::stdlib::http_server::create_error_response_with_context(
                                 500,
-                                &e.to_string(),
+                                &error_context,
                                 &format!("{} {}", method, path),
                                 &handler_file,
                             )
@@ -9983,7 +10053,9 @@ impl Interpreter {
             (BinaryOp::Add, Value::Int(a), Value::Int(b)) => Ok(Value::Int(a + b)),
             (BinaryOp::Sub, Value::Int(a), Value::Int(b)) => Ok(Value::Int(a - b)),
             (BinaryOp::Mul, Value::Int(a), Value::Int(b)) => Ok(Value::Int(a * b)),
-            (BinaryOp::Div, Value::Int(_), Value::Int(0)) => Err(IntentError::DivisionByZero),
+            (BinaryOp::Div, Value::Int(_), Value::Int(0)) => {
+                Err(IntentError::DivisionByZero { line: 0 })
+            }
             (BinaryOp::Div, Value::Int(a), Value::Int(b)) => Ok(Value::Int(a / b)),
             (BinaryOp::Mod, Value::Int(a), Value::Int(b)) => Ok(Value::Int(a % b)),
             (BinaryOp::Pow, Value::Int(a), Value::Int(b)) => Ok(Value::Int(a.pow(b as u32))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -734,6 +734,7 @@ fn format_error(error: &anyhow::Error, file_path: Option<&PathBuf>) {
                 let lines: Vec<&str> = source.lines().collect();
                 let line_idx = line.saturating_sub(1); // 0-indexed
 
+                eprintln!("  {} Source context", "-->".blue().bold());
                 eprintln!("   {}", "|".blue().bold());
 
                 // Show 1 line before for context
@@ -758,12 +759,21 @@ fn format_error(error: &anyhow::Error, file_path: Option<&PathBuf>) {
                         error_line
                     );
 
-                    // Column pointer
+                    // Column pointer. Runtime/type errors currently carry statement-start
+                    // lines unless the parser supplied a true column, so label those
+                    // locations honestly instead of implying expression precision.
                     if let Some(col) = col_info {
                         if col > 0 {
                             let padding = " ".repeat(col.saturating_sub(1));
                             eprintln!("     {} {}{}", "|".blue().bold(), padding, "^".red().bold());
                         }
+                    } else {
+                        eprintln!(
+                            "     {} {}",
+                            "|".blue().bold(),
+                            "^ approximate failing statement (expression span unavailable)"
+                                .yellow()
+                        );
                     }
                 }
 

--- a/src/stdlib/http_server_async.rs
+++ b/src/stdlib/http_server_async.rs
@@ -675,16 +675,65 @@ async fn handle_request(State(state): State<AppState>, req: Request<Body>) -> im
                 }
             }
 
-            // No route or static file - return 404
-            error_response(
-                404,
-                "Not Found",
-                &method.to_string(),
-                &path,
-                "",
-                state.is_production,
-                csp_ref,
-            )
+            if state.is_production {
+                return error_response(
+                    404,
+                    "Not Found",
+                    &method.to_string(),
+                    &path,
+                    "",
+                    state.is_production,
+                    csp_ref,
+                );
+            }
+
+            // In development, the interpreter owns hot-reload checks. A request for a newly
+            // added file-based route may miss this async route index until the interpreter
+            // gets a chance to rescan routes/. Forward the would-be 404 once so hot-reload
+            // can run before deciding the route is really missing.
+            let mut response = match axum_to_bridge_request(req, HashMap::new()).await {
+                Ok(bridge_req) => match state.interpreter.call(bridge_req).await {
+                    Ok(response) => bridge_to_axum_response(response, csp_ref),
+                    Err(e) => {
+                        let error_msg = format!("{}", e);
+                        eprintln!(
+                            "[ERROR] {} {} | fallback route refresh | {}",
+                            method, path, error_msg
+                        );
+                        error_response(
+                            500,
+                            &error_msg,
+                            &method.to_string(),
+                            &path,
+                            "",
+                            state.is_production,
+                            csp_ref,
+                        )
+                    }
+                },
+                Err(e) => {
+                    let error_msg = format!("{}", e);
+                    eprintln!(
+                        "[ERROR] {} {} | fallback request parse | {}",
+                        method, path, error_msg
+                    );
+                    error_response(
+                        400,
+                        &error_msg,
+                        &method.to_string(),
+                        &path,
+                        "",
+                        state.is_production,
+                        csp_ref,
+                    )
+                }
+            };
+
+            if method == axum::http::Method::HEAD {
+                *response.body_mut() = Body::empty();
+            }
+
+            response
         }
     }
 }

--- a/src/stdlib/kv.rs
+++ b/src/stdlib/kv.rs
@@ -463,7 +463,16 @@ impl SQLiteKV {
                         )));
                     }
                 };
-                let new_val = current + amount;
+                let new_val = match current.checked_add(amount) {
+                    Some(n) => n,
+                    None => {
+                        let _ = self.conn.execute_batch("ROLLBACK");
+                        return Err(IntentError::runtime_error(format!(
+                            "kv_incr() value is out of range for key '{}'",
+                            key
+                        )));
+                    }
+                };
                 let upd = self.conn.execute(
                     "UPDATE _kv SET value = ? WHERE key = ?",
                     params![new_val.to_string(), key],
@@ -930,7 +939,21 @@ impl RedisKV {
             .key(key)
             .arg(amount)
             .invoke(&mut self.conn)
-            .map_err(|e| IntentError::runtime_error(format!("Redis incr error: {}", e)))?;
+            .map_err(|e| {
+                let message = e.to_string();
+                if matches!(
+                    e.kind(),
+                    redis::ErrorKind::ResponseError | redis::ErrorKind::ExtensionError | redis::ErrorKind::TypeError
+                ) && message.contains("value is not an integer or out of range")
+                {
+                    IntentError::runtime_error(format!(
+                        "kv_incr() requires an integer value, but key '{}' is not an integer or is out of range",
+                        key
+                    ))
+                } else {
+                    IntentError::runtime_error(format!("Redis incr error: {}", e))
+                }
+            })?;
         Ok(new_val)
     }
 }
@@ -1043,10 +1066,33 @@ fn native_counter_delta(handle: &Value, key: &str, amount: i64) -> Result<Value>
         }
     };
 
-    Ok(match new_val {
-        Ok(new_val) => Value::ok(Value::Int(new_val)),
-        Err(e) => Value::err(Value::String(e.to_string())),
-    })
+    match new_val {
+        Ok(new_val) => Ok(Value::ok(Value::Int(new_val))),
+        Err(e) => {
+            if let Some(message) = counter_domain_error_message(&e) {
+                Ok(Value::err(Value::String(message)))
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+fn counter_domain_error_message(error: &IntentError) -> Option<String> {
+    let message = match error {
+        IntentError::RuntimeError { message, .. } | IntentError::TypeError { message, .. } => {
+            message
+        }
+        _ => return None,
+    };
+
+    if message.contains("kv_incr() requires an integer value")
+        || message.contains("kv_incr() value is out of range")
+    {
+        Some(message.clone())
+    } else {
+        None
+    }
 }
 
 fn parse_counter_key(args: &[Value], function_name: &str) -> Result<String> {
@@ -2154,7 +2200,12 @@ pub fn create_kv_module() -> HashMap<String, Value> {
             func: |args| {
                 let key = parse_counter_key(args, "decr_by")?;
                 let amount = parse_counter_amount(args, 2, "decr_by")?;
-                native_counter_delta(&args[0], &key, -amount)
+                let Some(delta) = amount.checked_neg() else {
+                    return Ok(Value::err(Value::String(
+                        "decr_by() amount is out of range".to_string(),
+                    )));
+                };
+                native_counter_delta(&args[0], &key, delta)
             },
         },
     );
@@ -2444,6 +2495,15 @@ mod tests {
                 variant, values, ..
             } if variant == "Ok" => values.into_iter().next().unwrap_or(Value::Unit),
             other => panic!("Expected Ok result, got {:?}", other),
+        }
+    }
+
+    fn unwrap_err(value: Value) -> Value {
+        match value {
+            Value::EnumValue {
+                variant, values, ..
+            } if variant == "Err" => values.into_iter().next().unwrap_or(Value::Unit),
+            other => panic!("Expected Err result, got {:?}", other),
         }
     }
 
@@ -2921,6 +2981,41 @@ mod tests {
             matches!(&ttl_inner, Value::EnumValue { variant, .. } if variant == "Some"),
             "TTL should be preserved after incr: {:?}",
             ttl_inner
+        );
+    }
+
+    #[test]
+    fn test_kv_module_counter_helpers_recoverable_domain_errors() {
+        let module = create_kv_module();
+        let open = get_fn(&module, "open");
+        let set = get_fn(&module, "set");
+        let incr = get_fn(&module, "incr");
+        let decr_by = get_fn(&module, "decr_by");
+
+        let kv = unwrap_ok(open(&[Value::String(":memory:".to_string())]).unwrap());
+
+        set(&[
+            kv.clone(),
+            Value::String("not_counter".to_string()),
+            Value::String("hello".to_string()),
+        ])
+        .unwrap();
+
+        let r = incr(&[kv.clone(), Value::String("not_counter".to_string())]).unwrap();
+        assert!(
+            matches!(unwrap_err(r), Value::String(message) if message.contains("integer")),
+            "non-integer counter values should be recoverable Err(String)"
+        );
+
+        let r = decr_by(&[
+            kv.clone(),
+            Value::String("counter".to_string()),
+            Value::Int(i64::MIN),
+        ])
+        .unwrap();
+        assert!(
+            matches!(unwrap_err(r), Value::String(message) if message.contains("out of range")),
+            "i64::MIN decr_by should not panic or wrap"
         );
     }
 }

--- a/src/stdlib/kv.rs
+++ b/src/stdlib/kv.rs
@@ -1023,6 +1023,52 @@ fn get_redis_kv(handle: &Value) -> Result<Arc<Mutex<RedisKV>>> {
     }
 }
 
+/// Apply an atomic counter delta for native std/kv counter helpers.
+fn native_counter_delta(handle: &Value, key: &str, amount: i64) -> Result<Value> {
+    let backend = get_backend_type(handle)?;
+    let new_val = match backend {
+        KVBackend::SQLite => {
+            let kv_arc = get_sqlite_kv(handle)?;
+            let kv = kv_arc
+                .lock()
+                .map_err(|e| IntentError::runtime_error(format!("KV lock error: {}", e)))?;
+            kv.incr(key, amount)
+        }
+        KVBackend::Redis => {
+            let kv_arc = get_redis_kv(handle)?;
+            let mut kv = kv_arc
+                .lock()
+                .map_err(|e| IntentError::runtime_error(format!("KV lock error: {}", e)))?;
+            kv.incr(key, amount)
+        }
+    };
+
+    Ok(match new_val {
+        Ok(new_val) => Value::ok(Value::Int(new_val)),
+        Err(e) => Value::err(Value::String(e.to_string())),
+    })
+}
+
+fn parse_counter_key(args: &[Value], function_name: &str) -> Result<String> {
+    match &args[1] {
+        Value::String(s) => Ok(s.clone()),
+        _ => Err(IntentError::type_error(format!(
+            "{}() requires a string key",
+            function_name
+        ))),
+    }
+}
+
+fn parse_counter_amount(args: &[Value], index: usize, function_name: &str) -> Result<i64> {
+    match &args[index] {
+        Value::Int(i) => Ok(*i),
+        _ => Err(IntentError::type_error(format!(
+            "{}() requires an integer amount",
+            function_name
+        ))),
+    }
+}
+
 // ============================================================================
 // Module Export
 // ============================================================================
@@ -2011,72 +2057,104 @@ pub fn create_kv_module() -> HashMap<String, Value> {
 
     // @ntnt incr
     // @module std/kv
-    // @signature incr(kv: KVStore, key: String, amount: Int) -> Result<Int, String>
-    // Atomically increment an integer value by amount.
+    // @signature incr(kv: KVStore, key: String) -> Result<Int, String>
+    // Atomically increment an integer value by 1.
     //
-    // If the key doesn't exist, it is created with value = amount (effectively starting from 0).
+    // If the key doesn't exist, it is created with value = 1 (effectively starting from 0).
     // Preserves any existing TTL on the key — does not reset it.
     // Returns the new value after incrementing.
     // @param kv The KV store handle from open()
     // @param key The key to increment
-    // @param amount Integer to add (use negative values to decrement)
     // @returns Result containing the new integer value, or Err if the key holds a non-integer
     // @error TypeError ~ "kv_incr() requires an integer value" fix: "Ensure the key was set with an integer value or hasn't been written yet"
-    // @see_also expire, set
-    // @example incr(kv, "page_views", 1) => Ok(1) ~ "Increment a counter from zero"
-    // @example incr(kv, "score", 10) ~ "Add 10 to a score counter"
-    // @example incr(kv, "countdown", -1) ~ "Decrement a counter"
+    // @see_also decr, incr_by, decr_by, expire, set
+    // @example incr(kv, "page_views") => Ok(1) ~ "Increment a counter from zero"
     module.insert(
         "incr".to_string(),
         Value::NativeFunction {
             name: "incr".to_string(),
+            arity: 2,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                let key = parse_counter_key(args, "incr")?;
+                native_counter_delta(&args[0], &key, 1)
+            },
+        },
+    );
+
+    // @ntnt decr
+    // @module std/kv
+    // @signature decr(kv: KVStore, key: String) -> Result<Int, String>
+    // Atomically decrement an integer value by 1.
+    // @param kv The KV store handle from open()
+    // @param key The key to decrement
+    // @returns Result containing the new integer value, or Err if the key holds a non-integer
+    // @error TypeError ~ "kv_incr() requires an integer value" fix: "Ensure the key was set with an integer value or hasn't been written yet"
+    // @see_also incr, incr_by, decr_by
+    // @example decr(kv, "stock") => Ok(-1) ~ "Decrement a missing counter from zero"
+    module.insert(
+        "decr".to_string(),
+        Value::NativeFunction {
+            name: "decr".to_string(),
+            arity: 2,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                let key = parse_counter_key(args, "decr")?;
+                native_counter_delta(&args[0], &key, -1)
+            },
+        },
+    );
+
+    // @ntnt incr_by
+    // @module std/kv
+    // @signature incr_by(kv: KVStore, key: String, amount: Int) -> Result<Int, String>
+    // Atomically increment an integer value by amount.
+    // @param kv The KV store handle from open()
+    // @param key The key to increment
+    // @param amount Integer to add
+    // @returns Result containing the new integer value, or Err if the key holds a non-integer
+    // @error TypeError ~ "kv_incr() requires an integer value" fix: "Ensure the key was set with an integer value or hasn't been written yet"
+    // @see_also incr, decr, decr_by
+    // @example incr_by(kv, "score", 10) => Ok(10) ~ "Add 10 to a score counter"
+    module.insert(
+        "incr_by".to_string(),
+        Value::NativeFunction {
+            name: "incr_by".to_string(),
             arity: 3,
             max_arity: 3,
             requires: None,
             func: |args| {
-                if args.len() != 3 {
-                    return Err(IntentError::type_error(
-                        "incr() requires 3 arguments (kv, key, amount)".to_string(),
-                    ));
-                }
+                let key = parse_counter_key(args, "incr_by")?;
+                let amount = parse_counter_amount(args, 2, "incr_by")?;
+                native_counter_delta(&args[0], &key, amount)
+            },
+        },
+    );
 
-                let key = match &args[1] {
-                    Value::String(s) => s.clone(),
-                    _ => {
-                        return Err(IntentError::type_error(
-                            "incr() requires a string key".to_string(),
-                        ))
-                    }
-                };
-
-                let amount = match &args[2] {
-                    Value::Int(i) => *i,
-                    _ => {
-                        return Err(IntentError::type_error(
-                            "incr() requires an integer amount".to_string(),
-                        ))
-                    }
-                };
-
-                let backend = get_backend_type(&args[0])?;
-                let new_val = match backend {
-                    KVBackend::SQLite => {
-                        let kv_arc = get_sqlite_kv(&args[0])?;
-                        let kv = kv_arc.lock().map_err(|e| {
-                            IntentError::runtime_error(format!("KV lock error: {}", e))
-                        })?;
-                        kv.incr(&key, amount)?
-                    }
-                    KVBackend::Redis => {
-                        let kv_arc = get_redis_kv(&args[0])?;
-                        let mut kv = kv_arc.lock().map_err(|e| {
-                            IntentError::runtime_error(format!("KV lock error: {}", e))
-                        })?;
-                        kv.incr(&key, amount)?
-                    }
-                };
-
-                Ok(Value::ok(Value::Int(new_val)))
+    // @ntnt decr_by
+    // @module std/kv
+    // @signature decr_by(kv: KVStore, key: String, amount: Int) -> Result<Int, String>
+    // Atomically decrement an integer value by amount.
+    // @param kv The KV store handle from open()
+    // @param key The key to decrement
+    // @param amount Integer to subtract
+    // @returns Result containing the new integer value, or Err if the key holds a non-integer
+    // @error TypeError ~ "kv_incr() requires an integer value" fix: "Ensure the key was set with an integer value or hasn't been written yet"
+    // @see_also incr, decr, incr_by
+    // @example decr_by(kv, "stock", 3) => Ok(-3) ~ "Subtract 3 from a counter"
+    module.insert(
+        "decr_by".to_string(),
+        Value::NativeFunction {
+            name: "decr_by".to_string(),
+            arity: 3,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                let key = parse_counter_key(args, "decr_by")?;
+                let amount = parse_counter_amount(args, 2, "decr_by")?;
+                native_counter_delta(&args[0], &key, -amount)
             },
         },
     );
@@ -2803,29 +2881,37 @@ mod tests {
     }
 
     #[test]
-    fn test_kv_module_incr() {
+    fn test_kv_module_counter_helpers() {
         let module = create_kv_module();
         let open = get_fn(&module, "open");
         let incr = get_fn(&module, "incr");
+        let decr = get_fn(&module, "decr");
+        let incr_by = get_fn(&module, "incr_by");
+        let decr_by = get_fn(&module, "decr_by");
         let expire = get_fn(&module, "expire");
 
         let kv = unwrap_ok(open(&[Value::String(":memory:".to_string())]).unwrap());
 
-        // First incr on missing key returns 1
-        let r = incr(&[kv.clone(), Value::String("c".to_string()), Value::Int(1)]).unwrap();
+        // incr/decr default to +/-1
+        let r = incr(&[kv.clone(), Value::String("c".to_string())]).unwrap();
         assert!(matches!(unwrap_ok(r), Value::Int(1)));
 
-        // Second incr returns 2
-        let r = incr(&[kv.clone(), Value::String("c".to_string()), Value::Int(1)]).unwrap();
+        let r = incr(&[kv.clone(), Value::String("c".to_string())]).unwrap();
         assert!(matches!(unwrap_ok(r), Value::Int(2)));
 
-        // incr by 5
-        let r = incr(&[kv.clone(), Value::String("c".to_string()), Value::Int(5)]).unwrap();
+        let r = decr(&[kv.clone(), Value::String("c".to_string())]).unwrap();
+        assert!(matches!(unwrap_ok(r), Value::Int(1)));
+
+        // Explicit by helpers handle larger deltas.
+        let r = incr_by(&[kv.clone(), Value::String("c".to_string()), Value::Int(10)]).unwrap();
+        assert!(matches!(unwrap_ok(r), Value::Int(11)));
+
+        let r = decr_by(&[kv.clone(), Value::String("c".to_string()), Value::Int(4)]).unwrap();
         assert!(matches!(unwrap_ok(r), Value::Int(7)));
 
         // expire on the key, then incr again should preserve TTL
         expire(&[kv.clone(), Value::String("c".to_string()), Value::Int(3600)]).unwrap();
-        incr(&[kv.clone(), Value::String("c".to_string()), Value::Int(1)]).unwrap();
+        incr(&[kv.clone(), Value::String("c".to_string())]).unwrap();
         // TTL is still set (not None)
         let ttl_fn = get_fn(&module, "ttl");
         let ttl_result = ttl_fn(&[kv.clone(), Value::String("c".to_string())]).unwrap();

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -355,21 +355,21 @@ fn comparison_type_hint(left_type: &Type, right_type: &Type, left_expr: &Express
             || !left_type.is_compatible(right_type))
     {
         return format!(
-            "Map values may have mixed types. Use int() or str() to convert before comparing"
+            "Map values may have mixed types. Use int(value) ?? default, str(value), or another explicit conversion before comparing"
         );
     }
 
     match (left_type, right_type) {
         (Type::Int, Type::String) | (Type::String, Type::Int) => {
-            "Convert types: use int(s) to convert String to Int, or str(n) to convert Int to String"
+            "Convert types: use int(s) ?? default to handle parse errors, or str(n) to convert Int to String"
                 .to_string()
         }
         (Type::Float, Type::String) | (Type::String, Type::Float) => {
-            "Convert types: use float(s) to convert String to Float, or str(n) to convert Float to String"
+            "Convert types: use float(s) ?? default to handle parse errors, or str(n) to convert Float to String"
                 .to_string()
         }
         (Type::Int, Type::Float) | (Type::Float, Type::Int) => {
-            "Convert types: use float(n) or int(f) to match types".to_string()
+            "Convert types: use float(n) or int(f) ?? default to match types".to_string()
         }
         _ => format!(
             "Cannot compare {} with {}. Convert to the same type first",
@@ -2367,9 +2367,12 @@ impl TypeContext {
 
             // Null coalescing
             BinaryOp::NullCoalesce => {
-                // a ?? b: if a is Optional(T), result is T, else Any
+                // a ?? b: unwrap Option<T>/Result<T, E> on success, otherwise use b
                 match left {
-                    Type::Optional(inner) => (**inner).clone(),
+                    Type::Optional(inner) => self.union_type(inner, right),
+                    Type::Generic { name, args } if name == "Result" && !args.is_empty() => {
+                        self.union_type(&args[0], right)
+                    }
                     _ => right.clone(),
                 }
             }
@@ -3342,8 +3345,8 @@ impl TypeContext {
 
         // Conversion
         sig!("str", ["value" => Type::Any], Type::String);
-        sig!("int", ["value" => Type::Any], Type::Int);
-        sig!("float", ["value" => Type::Any], Type::Float);
+        sig!("int", ["value" => Type::Any], Type::Generic { name: "Result".to_string(), args: vec![Type::Int, Type::String] });
+        sig!("float", ["value" => Type::Any], Type::Generic { name: "Result".to_string(), args: vec![Type::Float, Type::String] });
         sig!("bool", ["value" => Type::Any], Type::Bool);
         sig!("type", ["value" => Type::Any], Type::String);
         sig!("typeof", ["value" => Type::Any], Type::String);
@@ -3618,10 +3621,14 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("get_float", ["kv" => Type::Any, "key" => Type::String, "default" => Type::Float], Type::Float, required(2));
             sig!("get_json", ["kv" => Type::Any, "key" => Type::String, "default" => Type::Any], Type::Any, required(2));
             sig!("get_str", ["kv" => Type::Any, "key" => Type::String, "default" => Type::String], Type::String, required(2));
-            sig!("incr", ["kv" => Type::Any, "key" => Type::String, "amount" => Type::Int], Type::Generic {
+            let kv_int_result = Type::Generic {
                 name: "Result".to_string(),
                 args: vec![Type::Int, Type::String],
-            });
+            };
+            sig!("incr", ["kv" => Type::Any, "key" => Type::String], kv_int_result.clone());
+            sig!("decr", ["kv" => Type::Any, "key" => Type::String], kv_int_result.clone());
+            sig!("incr_by", ["kv" => Type::Any, "key" => Type::String, "amount" => Type::Int], kv_int_result.clone());
+            sig!("decr_by", ["kv" => Type::Any, "key" => Type::String, "amount" => Type::Int], kv_int_result);
         }
         "std/fs" => {
             sig!("read_file", ["path" => Type::String], Type::String);

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -634,7 +634,12 @@ impl TypeContext {
         }
     }
 
-    fn infer_null_coalesce_type(&self, left: &Expression, left_ty: &Type, right_ty: &Type) -> Type {
+    fn infer_null_coalesce_type(
+        &mut self,
+        left: &Expression,
+        right: &Expression,
+        left_ty: &Type,
+    ) -> Type {
         let known_variant = match left {
             Expression::EnumVariant { variant, .. } => Some(variant.as_str()),
             Expression::Call { function, .. } => match function.as_ref() {
@@ -661,12 +666,13 @@ impl TypeContext {
                     }
                     return Type::Any;
                 }
-                "None" | "Err" => return right_ty.clone(),
+                "None" | "Err" => return self.infer_expression(right),
                 _ => {}
             }
         }
 
-        self.infer_binary_op(&BinaryOp::NullCoalesce, left_ty, right_ty)
+        let right_ty = self.infer_expression(right);
+        self.infer_binary_op(&BinaryOp::NullCoalesce, left_ty, &right_ty)
     }
 
     fn return_otherwise_uses_value_fallback_union(&self, expr_ty: &Type) -> bool {
@@ -1715,11 +1721,12 @@ impl TypeContext {
                 right,
             } => {
                 let left_type = self.infer_expression(left);
-                let right_type = self.infer_expression(right);
 
                 if matches!(operator, BinaryOp::NullCoalesce) {
-                    return self.infer_null_coalesce_type(left, &left_type, &right_type);
+                    return self.infer_null_coalesce_type(left, right, &left_type);
                 }
+
+                let right_type = self.infer_expression(right);
 
                 // Validate comparison operand compatibility
                 if matches!(

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -640,13 +640,29 @@ impl TypeContext {
         right: &Expression,
         left_ty: &Type,
     ) -> Type {
+        let left_is_result = matches!(left_ty, Type::Generic { name, .. } if name == "Result");
         let known_variant = match left {
-            Expression::EnumVariant { variant, .. } => Some(variant.as_str()),
+            Expression::EnumVariant {
+                enum_name, variant, ..
+            } if enum_name == "Option" || enum_name == "Result" => Some(variant.as_str()),
             Expression::Call { function, .. } => match function.as_ref() {
-                Expression::Identifier(name) => Some(name.as_str()),
+                Expression::Identifier(name)
+                    if name == "Some" && matches!(left_ty, Type::Optional(_)) =>
+                {
+                    Some(name.as_str())
+                }
+                Expression::Identifier(name)
+                    if matches!(name.as_str(), "Ok" | "Err") && left_is_result =>
+                {
+                    Some(name.as_str())
+                }
                 _ => None,
             },
-            Expression::Identifier(name) if name == "None" => Some("None"),
+            Expression::Identifier(name)
+                if name == "None" && matches!(left_ty, Type::Optional(_)) =>
+            {
+                Some("None")
+            }
             _ => None,
         };
 
@@ -669,6 +685,10 @@ impl TypeContext {
                 "None" | "Err" => return self.infer_expression(right),
                 _ => {}
             }
+        }
+
+        if !matches!(left_ty, Type::Optional(_) | Type::Any) && !left_is_result {
+            return left_ty.clone();
         }
 
         let right_ty = self.infer_expression(right);
@@ -2128,7 +2148,7 @@ impl TypeContext {
 
                 // Special handling for Option/Result constructors
                 match (enum_name.as_str(), variant.as_str()) {
-                    ("Option", "Some") | (_, "Some") => {
+                    ("Option", "Some") => {
                         if let Some(first) = arguments.first() {
                             let inner = self.infer_expression(first);
                             if let Type::Optional(_) = &inner {
@@ -2151,8 +2171,8 @@ impl TypeContext {
                             Type::Optional(Box::new(Type::Any))
                         }
                     }
-                    ("Option", "None") | (_, "None") => Type::Optional(Box::new(Type::Any)),
-                    ("Result", "Ok") | (_, "Ok") => {
+                    ("Option", "None") => Type::Optional(Box::new(Type::Any)),
+                    ("Result", "Ok") => {
                         if let Some(first) = arguments.first() {
                             let inner = self.infer_expression(first);
                             Type::Generic {
@@ -2166,7 +2186,7 @@ impl TypeContext {
                             }
                         }
                     }
-                    ("Result", "Err") | (_, "Err") => {
+                    ("Result", "Err") => {
                         if let Some(first) = arguments.first() {
                             let inner = self.infer_expression(first);
                             Type::Generic {
@@ -2419,7 +2439,7 @@ impl TypeContext {
                     Type::Generic { name, args } if name == "Result" && !args.is_empty() => {
                         self.union_type(&args[0], right)
                     }
-                    _ => right.clone(),
+                    _ => left.clone(),
                 }
             }
         }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -634,6 +634,41 @@ impl TypeContext {
         }
     }
 
+    fn infer_null_coalesce_type(&self, left: &Expression, left_ty: &Type, right_ty: &Type) -> Type {
+        let known_variant = match left {
+            Expression::EnumVariant { variant, .. } => Some(variant.as_str()),
+            Expression::Call { function, .. } => match function.as_ref() {
+                Expression::Identifier(name) => Some(name.as_str()),
+                _ => None,
+            },
+            Expression::Identifier(name) if name == "None" => Some("None"),
+            _ => None,
+        };
+
+        if let Some(variant) = known_variant {
+            match variant {
+                "Some" => {
+                    if let Type::Optional(inner) = left_ty {
+                        return (**inner).clone();
+                    }
+                    return Type::Any;
+                }
+                "Ok" => {
+                    if let Type::Generic { name, args } = left_ty {
+                        if name == "Result" && !args.is_empty() {
+                            return args[0].clone();
+                        }
+                    }
+                    return Type::Any;
+                }
+                "None" | "Err" => return right_ty.clone(),
+                _ => {}
+            }
+        }
+
+        self.infer_binary_op(&BinaryOp::NullCoalesce, left_ty, right_ty)
+    }
+
     fn return_otherwise_uses_value_fallback_union(&self, expr_ty: &Type) -> bool {
         matches!(expr_ty, Type::Optional(_))
             || matches!(expr_ty, Type::Generic { name, args } if name == "Result" && !args.is_empty())
@@ -1681,6 +1716,10 @@ impl TypeContext {
             } => {
                 let left_type = self.infer_expression(left);
                 let right_type = self.infer_expression(right);
+
+                if matches!(operator, BinaryOp::NullCoalesce) {
+                    return self.infer_null_coalesce_type(left, &left_type, &right_type);
+                }
 
                 // Validate comparison operand compatibility
                 if matches!(

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -1186,6 +1186,101 @@ print(val)
     assert!(stdout.contains("42"), "Should unwrap Some(42)");
 }
 
+#[test]
+fn test_null_coalesce_operator_unwraps_result() {
+    let code = r#"
+let good = Ok(42) ?? 0
+let bad = Err("nope") ?? 7
+print(good)
+print(bad)
+"#;
+    let (stdout, _, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0, "?? operator should work with Result");
+    assert!(stdout.contains("42"), "Should unwrap Ok value");
+    assert!(stdout.contains("7"), "Should use fallback for Err");
+}
+
+#[test]
+fn test_numeric_conversions_return_results() {
+    let code = r#"
+let good = int("42") ?? 0
+let bad = int("none") ?? 7
+let fgood = float("3.5") ?? 0.0
+let fbad = float("nope") ?? 2.5
+match int("42") {
+    Ok(v) => print("int-ok:" + str(v)),
+    Err(_) => print("int-unexpected")
+}
+match int("none") {
+    Ok(_) => print("int-unexpected"),
+    Err(e) => print("int-err:" + e)
+}
+match float("3.5") {
+    Ok(v) => print("float-ok:" + str(v)),
+    Err(_) => print("float-unexpected")
+}
+match float("nope") {
+    Ok(_) => print("float-unexpected"),
+    Err(e) => print("float-err:" + e)
+}
+print(good)
+print(bad)
+print(fgood)
+print(fbad)
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(
+        exit_code, 0,
+        "int()/float() parse failures should be handleable\nstdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+    assert!(stdout.contains("42"), "int should unwrap valid parse");
+    assert!(
+        stdout.contains("7"),
+        "int should fall back on invalid parse"
+    );
+    assert!(stdout.contains("3.5"), "float should unwrap valid parse");
+    assert!(
+        stdout.contains("2.5"),
+        "float should fall back on invalid parse"
+    );
+    assert!(
+        stdout.contains("int-ok:42"),
+        "int should return Ok for valid parse"
+    );
+    assert!(
+        stdout.contains("int-err:Cannot parse as int: none"),
+        "int should return Err for invalid parse"
+    );
+    assert!(
+        stdout.contains("float-ok:3.5"),
+        "float should return Ok for valid parse"
+    );
+    assert!(
+        stdout.contains("float-err:Cannot parse as float: nope"),
+        "float should return Err for invalid parse"
+    );
+}
+
+#[test]
+fn test_runtime_errors_show_approximate_source_context() {
+    let code = r#"
+let x = 1 / 0
+"#;
+    let (_stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_ne!(exit_code, 0, "division by zero should fail");
+    assert!(
+        stderr.contains("Source context"),
+        "runtime error should include source context: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("approximate failing statement"),
+        "runtime error without expression column should label the pointer approximate: {}",
+        stderr
+    );
+}
+
 // ============================================================================
 // String Functions: replace_chars, remove_chars, keep_chars
 // ============================================================================
@@ -4602,6 +4697,27 @@ get_int(123, "k")
         stderr.contains("KV store handle") || stderr.contains("Expected a KV store handle"),
         "error should mention KV handle, got: {}",
         stderr
+    );
+}
+
+#[test]
+fn test_kv_counter_helpers_return_err_result_on_non_integer_value() {
+    let code = r#"
+import { open, set, incr } from "std/kv"
+let kv = unwrap(open(":memory:"))
+unwrap(set(kv, "counter", "not-an-int"))
+let recovered = incr(kv, "counter") ?? 99
+print(recovered)
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(
+        exit_code, 0,
+        "incr() domain failures should be recoverable Result::Err\nstdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+    assert!(
+        stdout.contains("99"),
+        "?? should recover from non-integer counter errors"
     );
 }
 

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -988,6 +988,33 @@ let c: Int = Some(3) ?? len()
     );
 }
 
+#[test]
+fn test_user_enum_variants_named_like_option_result_do_not_coalesce_as_builtins() {
+    let code = r#"
+enum MyEnum {
+    Ok(Int),
+    Err(String),
+    Some(Int),
+    None
+}
+
+let a: MyEnum = MyEnum::Ok(1) ?? len()
+let b: MyEnum = MyEnum::Some(2) ?? len()
+let c: MyEnum = MyEnum::Err("bad") ?? len()
+let d: MyEnum = MyEnum::None ?? len()
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let errors = json["summary"]["errors"].as_i64().unwrap_or(0);
+    assert_eq!(
+        errors, 0,
+        "user enum variants named Some/None/Ok/Err should stay user enum values under ??. Output: {}",
+        stdout
+    );
+}
+
 // ============================================================================
 // Generic type parameter unification tests (DD-009 Phase 7.4)
 // ============================================================================

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -935,15 +935,37 @@ fn check(x: Int, y: String) -> Bool {
         "Should have a comparison type warning"
     );
 
-    // The hint should mention int() or str() conversion
+    // The hint should mention handleable int() conversion or str() conversion
     let has_conversion_hint = comparison_warnings.iter().any(|w| {
         let hint = w["hint"].as_str().unwrap_or("");
-        hint.contains("int(") || hint.contains("str(")
+        hint.contains("int(") && (hint.contains("??") || hint.contains("str("))
     });
     assert!(
         has_conversion_hint,
-        "Comparison hint should suggest int()/str() conversion. Warnings: {:?}",
+        "Comparison hint should suggest handleable int()/str() conversion. Warnings: {:?}",
         comparison_warnings
+    );
+}
+
+#[test]
+fn test_result_null_coalesce_fallback_type_is_checked() {
+    let code = r#"
+let x: Int = int("bad") ?? "not an int"
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let files = json["files"].as_array().unwrap();
+    assert!(!files.is_empty(), "lint should report file results");
+    let issues = files[0]["issues"].as_array().unwrap();
+    assert!(
+        issues.iter().any(|issue| {
+            let msg = issue["message"].as_str().unwrap_or("");
+            msg.contains("Type mismatch") && msg.contains("String") && msg.contains("Int")
+        }),
+        "Result ?? fallback with a String fallback should not typecheck as Int. Issues: {:?}",
+        issues
     );
 }
 

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -974,6 +974,7 @@ fn test_known_success_null_coalesce_does_not_union_unreachable_fallback() {
     let code = r#"
 let a: Int = Some(1) ?? "not an int"
 let b: Int = Ok(2) ?? "also not an int"
+let c: Int = Some(3) ?? len()
 "#;
 
     let (stdout, _stderr, _code) = lint_code(code);

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -969,6 +969,24 @@ let x: Int = int("bad") ?? "not an int"
     );
 }
 
+#[test]
+fn test_known_success_null_coalesce_does_not_union_unreachable_fallback() {
+    let code = r#"
+let a: Int = Some(1) ?? "not an int"
+let b: Int = Ok(2) ?? "also not an int"
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let errors = json["summary"]["errors"].as_i64().unwrap_or(0);
+    assert_eq!(
+        errors, 0,
+        "known Some/Ok coalesce should infer the success value type only. Output: {}",
+        stdout
+    );
+}
+
 // ============================================================================
 // Generic type parameter unification tests (DD-009 Phase 7.4)
 // ============================================================================


### PR DESCRIPTION
## Summary
- Fix dev hot-reload route discovery for newly added file-based routes before returning 404.
- Improve runtime error source attribution for CLI and HTTP dev errors, including approximate source markers when expression spans are unavailable.
- Change `int()` and `float()` to return `Result<_, String>` and make `??` unwrap `Result::Ok` / fall back on `Result::Err`.
- Complete std/kv counter helpers with `incr`, `decr`, `incr_by`, and `decr_by`.

## Review follow-ups
- Addressed Greptile findings on `??` inference: known-success `Some(...)` / `Ok(...)` no longer unions or even typechecks unreachable fallback expressions, while variable `Option`/`Result` coalescing still accounts for fallback type.
- Addressed counter edge cases: `decr_by(..., i64::MIN)` returns `Err(String)` instead of overflowing, SQLite counter math uses checked addition, and only recoverable counter-domain failures become `Result::Err`.
- Storage/lock/backend KV failures now still throw instead of being masked by `??` fallbacks.

## Verification
- `cargo fmt`
- `cargo build --profile dev-release`
- `cargo test`
- `./target/dev-release/ntnt docs --generate`
- `./target/dev-release/ntnt docs --validate`
- `./target/dev-release/ntnt validate examples/`
- `git diff --check`
- Manual hot-reload smoke: adding a route file while the dev server is running makes the direct request to the new route return `200` on the first attempt.
- Manual HTTP dev error-context smoke: inline route division-by-zero shows a dev error page with source excerpt and approximate marker.

## PR health
- CI: green
- Greptile: pass
- Review threads: 0 unresolved

Closes #50
Closes #51
Closes #84
Closes #85
