### PR TITLE
Add std/net IPAM helpers and explicit reachability probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "ntnt"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntnt"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 authors = ["NTNT Language Team"]
 description = "NTNT (Intent) - A programming language designed for AI-driven development"

--- a/design-docs/README.md
+++ b/design-docs/README.md
@@ -13,6 +13,11 @@ This folder contains planning and design documents for NTNT features.
 | [ial_unit_testing.md](ial_unit_testing.md) | ✅ Complete | Unit testing framework design |
 | [high_concurrency_http_server.md](high_concurrency_http_server.md) | ✅ Complete | Async Axum server (v0.4.0) |
 | [dd-040-fetch-stdlib-friction.md](dd-040-fetch-stdlib-friction.md) | 🔶 Partial | 4/6 issues resolved in v0.4.4; 2 remain |
+| [dd-043-auth-excellence.md](dd-043-auth-excellence.md) | ✅ Shipped in v0.4.9 | `std/auth` local auth, reset, TOTP, session, API/page protection baseline; WebAuthn remains future planning |
+| [dd-046-std-net.md](dd-046-std-net.md) | 📋 Refined Plan | Safe `std/net` primitives: IPAM-grade IPv4/IPv6 CIDR math, first-shot ping, TCP probes, DNS, bounded scans, TLS inspection |
+| [dd-059-auth-crypto-boundary.md](dd-059-auth-crypto-boundary.md) | ✅ Complete | `std/auth` / `std/crypto` helper boundary in the v0.4.9 auth baseline |
+| [dd-060-ai-native-developer-experience.md](dd-060-ai-native-developer-experience.md) | 📋 Draft | AI-native developer experience roadmap |
+| [dd-061-interpreter-performance-roadmap.md](dd-061-interpreter-performance-roadmap.md) | 🔶 In Review | Interpreter-native performance roadmap |
 | [language_comparison.md](language_comparison.md) | ✅ Complete | NTNT vs other languages |
 | [INTENT_DRIVEN_DEVELOPMENT.md](INTENT_DRIVEN_DEVELOPMENT.md) | ✅ Complete | IDD philosophy and workflow |
 | [INTENT_ASSERTION_LANGUAGE.md](INTENT_ASSERTION_LANGUAGE.md) | ✅ Complete | IAL spec v1.0.0 |

--- a/design-docs/README.md
+++ b/design-docs/README.md
@@ -14,7 +14,8 @@ This folder contains planning and design documents for NTNT features.
 | [high_concurrency_http_server.md](high_concurrency_http_server.md) | ✅ Complete | Async Axum server (v0.4.0) |
 | [dd-040-fetch-stdlib-friction.md](dd-040-fetch-stdlib-friction.md) | 🔶 Partial | 4/6 issues resolved in v0.4.4; 2 remain |
 | [dd-043-auth-excellence.md](dd-043-auth-excellence.md) | ✅ Shipped in v0.4.9 | `std/auth` local auth, reset, TOTP, session, API/page protection baseline; WebAuthn remains future planning |
-| [dd-046-std-net.md](dd-046-std-net.md) | 📋 Refined Plan | Safe `std/net` primitives: IPAM-grade IPv4/IPv6 CIDR math, first-shot ping, TCP probes, DNS, bounded scans, TLS inspection |
+| [dd-046-std-net.md](dd-046-std-net.md) | 🔶 In Review | Safe `std/net` primitives: IPAM-grade IPv4/IPv6 CIDR math, first-shot ping, TCP probes, DNS, bounded scans, TLS inspection |
+| [dd-047-std-netmon.md](dd-047-std-netmon.md) | 📋 Draft | `std/netmon` private-library candidate for SNMP/device telemetry, interface counters, topology hints, composite checks, and alert-state helpers |
 | [dd-059-auth-crypto-boundary.md](dd-059-auth-crypto-boundary.md) | ✅ Complete | `std/auth` / `std/crypto` helper boundary in the v0.4.9 auth baseline |
 | [dd-060-ai-native-developer-experience.md](dd-060-ai-native-developer-experience.md) | 📋 Draft | AI-native developer experience roadmap |
 | [dd-061-interpreter-performance-roadmap.md](dd-061-interpreter-performance-roadmap.md) | 🔶 In Review | Interpreter-native performance roadmap |

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -1,6 +1,6 @@
 # DD-046: `std/net` — Safe Network Primitives for ntnt
 
-**Status:** Refined implementation plan
+**Status:** PR 1 implemented and under review; PRs 2-5 planned
 **Author:** Larri
 **Created:** 2026-03-22
 **Updated:** 2026-06-02
@@ -734,7 +734,21 @@ SNMP is a real network-monitoring need, but it is its own protocol family. Defer
 
 ## Implementation Plan
 
+### Status Dashboard
+
+As of 2026-06-02:
+
+- [x] **PR 1 — `std/net` shell + IPAM helpers + `ping`**: implemented in [PR #113](https://github.com/ntntlang/ntnt/pull/113). Status: open, mergeable, CI green, no unresolved review threads at head `944a397`.
+- [ ] **PR 2 — Dedicated TCP probe refinement**: next planned slice. Reuses the Phase 1 TCP fallback helper as public `tcp_connect`.
+- [ ] **PR 3 — DNS A/AAAA/PTR**: planned after TCP probe.
+- [ ] **PR 4 — Bounded port scan**: planned after DNS.
+- [ ] **PR 5 — TLS info**: planned after port scan/dependency decision.
+
+PR 1 shipped the core module registration, runtime functions, typechecker signatures, generated docs, deterministic examples, and tests for Phase 1. Review hardening added policy fixes for private, link-local, multicast, documentation, mapped-address, and broadcast-style targets.
+
 ### PR 1 — `std/net` shell + IPAM helpers + `ping`
+
+Status: **implemented in PR #113; awaiting merge/review completion.**
 
 Scope:
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -1,9 +1,9 @@
 # DD-046: `std/net` — Safe Network Primitives for ntnt
 
-**Status:** PR 1 implemented and under review; PRs 2-5 planned
+**Status:** PR 1 implemented and under review; includes IPAM helpers, ICMP-honest `ping()`, explicit `tcp_connect()`, and high-level `reachable()`; DNS/scan/TLS slices planned
 **Author:** Larri
 **Created:** 2026-03-22
-**Updated:** 2026-06-02
+**Updated:** 2026-06-03
 **Target baseline:** v0.4.10 (`std/net` track)
 
 ---
@@ -93,7 +93,7 @@ As of the v0.4.9 baseline:
 
 5. **No shellouts.** The implementation should not invoke `ping`, `dig`, `nmap`, `openssl`, `whois`, or `ssh`. If a capability requires a large/privileged dependency, defer it rather than pretending it is simple.
 
-6. **No permission hell, no silent protocol switch.** Default APIs should not require root, `CAP_NET_RAW`, Docker `cap_add`, or sysctl tuning. If ICMP is unavailable in the current runtime, `ping()` should return a clear `Err(String)` rather than quietly trying TCP ports. TCP reachability is still available only as an explicit developer choice (`method: "tcp"` plus explicit `tcp_ports`).
+6. **No permission hell, no silent protocol switch.** Default APIs should not require root, `CAP_NET_RAW`, Docker `cap_add`, or sysctl tuning. If ICMP is unavailable in the current runtime, `ping()` should return a clear `Err(String)` rather than quietly trying TCP ports. TCP reachability is available as an explicit developer choice through `tcp_connect()`, or through `reachable()` when the app intentionally wants high-level fallback semantics with caller-provided `tcp_ports`.
 
 7. **CI-safe by default.** Tests should not require public internet, raw socket capabilities, root, or Docker privileges. External-network and raw-socket tests are opt-in.
 
@@ -208,7 +208,7 @@ Use these rules consistently:
 - `Ok(map { ... "connected": false ... })` for ordinary TCP refused/timeout results.
 - `Ok([])` for DNS names that have no records of the requested type when the resolver returns a clean no-answer response.
 - `Err(String)` for invalid host/port/options, resolver/system errors, policy denial, or permission/capability failure.
-- `ping(..., map { "method": "icmp" })` and the default `method: "auto"` may return `Err` when ICMP is unavailable or denied. They must not silently fall back to TCP. Apps that intentionally want TCP reachability must request `method: "tcp"` and provide `tcp_ports` explicitly.
+- `ping(..., map { "method": "icmp" })` and default `ping()` may return `Err` when ICMP is unavailable or denied. They must not silently fall back to TCP. Apps that intentionally want TCP reachability should use `tcp_connect()`; apps that intentionally want high-level fallback semantics should use `reachable()` with explicit `tcp_ports`.
 - `Ok(map { "valid": false, "validation_error": ... })` for TLS certificates that connect but fail validation.
 - `Err(String)` for TLS handshake/connect failures where no certificate information can be obtained.
 
@@ -452,24 +452,23 @@ let result = ping("example.com")
 // })
 ```
 
-If ICMP is unavailable in the runtime, default `method: "auto"` fails clearly instead of falling back to TCP:
+If ICMP is unavailable in the runtime, `ping()` fails clearly instead of falling back to TCP:
 
 ```ntnt
 ping("example.com")
-// Err("ICMP ping unavailable: std/net does not fall back to TCP automatically. Use method: 'tcp' with explicit tcp_ports only when the app intentionally wants TCP reachability instead of ICMP ping.")
+// Err("ICMP ping unavailable: std/net does not fall back to TCP automatically. Use tcp_connect() for explicit TCP port checks or reachable(..., map { 'tcp_ports': [...] }) for explicit reachability fallback.")
 ```
 
-Apps that intentionally want TCP reachability can ask for it explicitly and run multiple bounded attempts in one call:
+Apps that intentionally want TCP reachability should use `tcp_connect()` for a single explicit port or `reachable()` for high-level ICMP-then-TCP fallback semantics:
 
 ```ntnt
-ping("example.com", map {
-  "method": "tcp",
-  "tcp_ports": [443],
+tcp_connect("example.com", 443, map {
   "count": 5
 })
 // Ok(map {
 //   "host": "example.com",
-//   "reachable": true,
+//   "port": 443,
+//   "connected": true,
 //   "method": "tcp",
 //   "sent": 5,
 //   "received": 5,
@@ -480,41 +479,54 @@ ping("example.com", map {
 //   "max_ms": 25.2,
 //   "attempts": [...]
 // })
+
+reachable("example.com", map {
+  "tcp_ports": [443],
+  "count": 5
+})
+// Ok(map {
+//   "host": "example.com",
+//   "reachable": true,
+//   "method": "tcp",
+//   "fallback_from": "icmp",
+//   "ports_tried": [443],
+//   "attempts": [...]
+// })
 ```
 
 Options:
 
-- `method`: `"auto"` (default), `"icmp"`, or explicit `"tcp"`
 - `count`: default 1, clamped to `1..=10`
 - `timeout_ms`: default 2000, clamped to shared timeout bounds
 - `interval_ms`: default 0, clamped to `0..=5000`
-- `tcp_ports`: required for `method: "tcp"`, max 10 explicit ports; no default/random ports
+- `tcp_ports`: required for `reachable()` while Phase 1 has no ICMP implementation, max 10 explicit ports; no default/random ports
 - `allow_private`: default false, requires process-level `NTNT_NET_ALLOW_PRIVATE=1`
 
 Semantics:
 
-- `method: "auto"` uses ICMP when available. If ICMP is unavailable/unsupported, return `Err("ICMP ping unavailable: ...")` with actionable guidance.
-- `method: "icmp"` means the caller explicitly asked for ICMP. If the OS lacks permission/capability, return the same clear `Err` instead of degrading to another protocol.
-- `method: "tcp"` is an explicit app-level reachability choice. It performs TCP connect probes only, requires explicit ports, and returns `reachable: true` if any configured port connects.
-- `reachable: false` is an ordinary probe result, not an `Err`, once the selected method is actually available and permitted.
+- `ping()` means ICMP ping. If ICMP is unavailable/unsupported, return `Err("ICMP ping unavailable: ...")` with actionable guidance.
+- `ping(..., map { "method": "tcp" })` is rejected; TCP checks belong to `tcp_connect()` or `reachable()`.
+- `tcp_connect(host, port, opts?)` performs TCP connect probes only and returns `connected: true` if the configured port connects.
+- `reachable(host, opts?)` is the explicit high-level fallback API. In Phase 1 it requires caller-provided `tcp_ports`, performs TCP connect probes, and records `method: "tcp"` plus `fallback_from: "icmp"` instead of pretending TCP is ping.
+- `reachable: false` / `connected: false` is an ordinary probe result, not an `Err`, once the selected method is actually available and permitted.
 - Include `resolved_addrs` only if doing so does not leak denied/private resolved targets in policy errors.
 
 Implementation approach:
 
-- Build the API around a small internal `ReachabilityMethod::{Auto, Icmp, Tcp}` parser.
-- Do not implement automatic TCP fallback inside `ping()`; protocol fallback belongs in app code or an explicit future helper.
-- Keep the lower-level TCP connect helper for explicit `method: "tcp"` in Phase 1 and the public `tcp_connect` function in Phase 2.
+- Keep `ping()` ICMP-only and protocol-honest.
+- Share the lower-level TCP probe substrate between `tcp_connect()` and `reachable()`.
+- Do not implement automatic TCP fallback inside `ping()`; protocol fallback belongs in `reachable()` or app code.
 - Add ICMP support only through a crate/path that supports unprivileged operation where the OS allows it. Linux may use datagram ICMP sockets when `/proc/sys/net/ipv4/ping_group_range` permits the process group; raw sockets still require `CAP_NET_RAW` and must be optional.
 - Do not shell out to system `ping`.
 - Do not require Docker `cap_add` for app code that deliberately chooses TCP reachability; ICMP-specific deployment docs belong to the ICMP path.
 
 Tests:
 
-- `method` parser accepts `auto`, `icmp`, `tcp` and rejects unknown values
 - option clamps for `count`, `interval_ms`, `timeout_ms`, and `tcp_ports`
-- default `method: "auto"` returns a clear ICMP-unavailable `Err` rather than TCP fallback when ICMP is unsupported
-- `method: "tcp"` requires explicit `tcp_ports`
-- explicit TCP method can run multiple bounded attempts and returns per-attempt plus aggregate summary fields
+- default `ping()` returns a clear ICMP-unavailable `Err` rather than TCP fallback when ICMP is unsupported
+- `ping(..., map { "method": "tcp" })` rejects with guidance to use `tcp_connect()` or `reachable()`
+- `tcp_connect()` can run multiple bounded attempts and returns per-attempt plus aggregate summary fields
+- `reachable()` requires explicit `tcp_ports`, uses TCP fallback honestly, and records `fallback_from: "icmp"`
 - forced `method: "icmp"` maps missing capability to clear `Err` in an opt-in/unit-testable path
 - policy-denied private/loopback target unless explicitly allowed by config/test override
 
@@ -765,7 +777,7 @@ As of 2026-06-02:
 
 PR 1 shipped the core module registration, runtime functions, typechecker signatures, generated docs, deterministic examples, and tests for Phase 1. Review hardening added policy fixes for private, link-local, multicast, documentation, mapped-address, and broadcast-style targets.
 
-### PR 1 — `std/net` shell + IPAM helpers + `ping`
+### PR 1 — `std/net` shell + IPAM helpers + protocol-honest reachability
 
 Status: **implemented in PR #113; awaiting merge/review completion.**
 
@@ -776,10 +788,12 @@ Scope:
 - [x] `src/typechecker.rs`
 - [x] unit tests for helpers and IPv4/IPv6 IPAM behavior
 - [x] `ip_parse`, `subnet_contains`, `subnet_overlaps`, `subnet_split`, `subnet_supernet`, `subnet_summarize`, `ip_range_to_cidrs`
-- [x] `ping(host, opts?)` with strict no-implicit-TCP-fallback semantics and explicit multi-attempt TCP mode
-- [x] shared target safety checks used by `ping` and future TCP functions
+- [x] `ping(host, opts?)` with strict no-implicit-TCP-fallback semantics
+- [x] `tcp_connect(host, port, opts?)` for explicit TCP port probes
+- [x] `reachable(host, opts?)` for explicit high-level ICMP-then-TCP fallback semantics using caller-provided `tcp_ports`
+- [x] shared target safety checks used by `tcp_connect`, `reachable`, and future network functions
 - [x] generated docs for all Phase 1 functions
-- [x] safe example showing `ping("example.com")`, explicit TCP reachability, and an internal-monitoring env-var example
+- [x] AI guide coverage for `ping`, `tcp_connect`, `reachable`, and private-target opt-in
 - [x] IPAM examples for IPv4 subnet splitting and IPv6 parsing/summarization
 
 Acceptance:
@@ -788,28 +802,15 @@ Acceptance:
 - [x] IPv6 parsing, containment, overlap, splitting, supernet, summarization, and range conversion are supported and tested.
 - [x] Large IPv6 counts/results do not overflow or generate unbounded arrays.
 - [x] `ping("example.com")` has documented protocol-honest failure when ICMP support is unavailable.
-- [x] Missing ICMP capability does not silently fall back to TCP; explicit TCP reachability requires `method: "tcp"` and `tcp_ports`.
+- [x] Missing ICMP capability does not silently fall back to TCP; explicit TCP reachability uses `tcp_connect()` or `reachable(..., map { "tcp_ports": [...] })`.
+- [x] local open/closed TCP port tests pass
+- [x] private/loopback policy behavior is explicit and tested
+- [x] `Err` vs `Ok(map { "connected": false })` semantics are documented and tested
 - [x] no public internet dependency
 - [x] no new dependency unless clearly justified; any ICMP dependency must preserve no-implicit-TCP-fallback semantics
-- [x] `cargo build --profile dev-release`, `cargo test net`, docs generation pass
+- [x] `cargo build --profile dev-release`, `cargo test`, docs generation, example validation pass
 
-### PR 2 — Dedicated TCP probe refinement
-
-Scope:
-
-- [ ] `tcp_connect`
-- [ ] reuse/refactor the Phase 1 explicit TCP reachability helper into the public `tcp_connect` API
-- [ ] local-listener tests
-- [ ] typechecker signature tests
-- [ ] AI agent guide section for `std/net` safety and jobs/concurrency guidance
-
-Acceptance:
-
-- [ ] local open/closed port tests pass
-- [ ] private/loopback policy behavior is explicit and tested
-- [ ] `Err` vs `Ok({ connected: false })` semantics are documented and tested
-
-### PR 3 — DNS A/AAAA/PTR
+### PR 2 — DNS A/AAAA/PTR
 
 Scope:
 
@@ -824,7 +825,7 @@ Acceptance:
 - [ ] no public DNS dependency by default
 - [ ] initial records limited to A/AAAA/PTR unless implementation remains small and clean
 
-### PR 4 — Bounded port scan
+### PR 3 — Bounded port scan
 
 Scope:
 
@@ -838,7 +839,7 @@ Acceptance:
 - [ ] deterministic order
 - [ ] no unbounded scanning
 
-### PR 5 — TLS info
+### PR 4 — TLS info
 
 Scope:
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -935,7 +935,7 @@ For network-specific PRs:
 
 6. Should `ping()` mean strict ICMP or pragmatic reachability?
 
-   Decision: strict/protocol-honest by default. `method: "auto"` should use ICMP when available and return a clear `Err` when unavailable. It must not fall back to TCP automatically. Developers can explicitly choose `method: "tcp"` with explicit `tcp_ports` when their app wants TCP reachability instead of ICMP ping.
+   Decision: strict/protocol-honest by default. `method: "auto"` should use ICMP when available and return a clear `Err` when unavailable. It must not fall back to TCP automatically. Developers should use `tcp_connect(host, port, opts?)` for explicit TCP port checks, or `reachable(host, map { "tcp_ports": [...] })` when they want a high-level reachability helper with explicit TCP fallback.
 
 7. Should internal targets be easy to enable for monitoring?
 
@@ -954,3 +954,19 @@ The refined `std/net` path is smaller and much safer:
 5. TLS inspection after dependency choice
 
 That gets ntnt real network-monitoring capability without making the first user trip over `CAP_NET_RAW`, and without smuggling in traceroute, SSH, SNMP, scanners, public-network CI flakes, and SSRF footguns in one heroic PR. Heroic PRs are where bugs go to get tenure.
+
+---
+
+## PR #113 Cleanup Note
+
+The PR cleanup deliberately split “can I ICMP ping this host?” from “can I reach the service I care about?” instead of hiding TCP connection attempts behind a function named `ping()`.
+
+What changed:
+
+1. `ping(host, opts?)` stays protocol-honest: ICMP only, with a clear error when ICMP is unavailable.
+2. TCP probing is explicit via `tcp_connect(host, port, opts?)`, so the caller must name the port and own the semantics.
+3. High-level reachability uses `reachable(host, opts?)`, with explicit `tcp_ports`, so fallback behavior is useful but not surprising.
+4. The safety model stays layered: per-call `allow_private: true` plus process-level `NTNT_NET_ALLOW_PRIVATE=1` for private/internal targets; special-purpose targets remain denied.
+5. The typechecker, generated stdlib reference, agent guide, examples, and tests were updated to document and enforce the split.
+
+Net result: PR #113 keeps the operational utility Josh wanted, but avoids calling TCP service checks “ping.” Tiny naming hill, worth defending.

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -93,7 +93,7 @@ As of the v0.4.9 baseline:
 
 5. **No shellouts.** The implementation should not invoke `ping`, `dig`, `nmap`, `openssl`, `whois`, or `ssh`. If a capability requires a large/privileged dependency, defer it rather than pretending it is simple.
 
-6. **No permission hell.** Default APIs should not require root, `CAP_NET_RAW`, Docker `cap_add`, or sysctl tuning. If ICMP is available through unprivileged OS support, use it. If it is not, `ping(..., method: "auto")` must fall back to an unprivileged TCP reachability probe and report which method was used.
+6. **No permission hell, no silent protocol switch.** Default APIs should not require root, `CAP_NET_RAW`, Docker `cap_add`, or sysctl tuning. If ICMP is unavailable in the current runtime, `ping()` should return a clear `Err(String)` rather than quietly trying TCP ports. TCP reachability is still available only as an explicit developer choice (`method: "tcp"` plus explicit `tcp_ports`).
 
 7. **CI-safe by default.** Tests should not require public internet, raw socket capabilities, root, or Docker privileges. External-network and raw-socket tests are opt-in.
 
@@ -208,7 +208,7 @@ Use these rules consistently:
 - `Ok(map { ... "connected": false ... })` for ordinary TCP refused/timeout results.
 - `Ok([])` for DNS names that have no records of the requested type when the resolver returns a clean no-answer response.
 - `Err(String)` for invalid host/port/options, resolver/system errors, policy denial, or permission/capability failure.
-- `ping(..., map { "method": "icmp" })` may return `Err` when the OS denies ICMP capability. `ping(..., map { "method": "auto" })` should not: it should fall back to TCP reachability and include `method: "tcp"`, `fallback_from: "icmp"`, and `permission_limited: true`.
+- `ping(..., map { "method": "icmp" })` and the default `method: "auto"` may return `Err` when ICMP is unavailable or denied. They must not silently fall back to TCP. Apps that intentionally want TCP reachability must request `method: "tcp"` and provide `tcp_ports` explicitly.
 - `Ok(map { "valid": false, "validation_error": ... })` for TLS certificates that connect but fail validation.
 - `Err(String)` for TLS handshake/connect failures where no certificate information can be obtained.
 
@@ -255,7 +255,7 @@ cargo test net -- --test-threads=1
 
 ## Phase 1 — IPAM-Grade IP/CIDR Utilities + First-Shot Ping
 
-Ship first because this gives developers an immediately useful `std/net` module without making them solve Docker capabilities before breakfast. IP/CIDR helpers should be good enough for real IPAM/routing calculators, not just demo parsing. `ping()` ships with an unprivileged default path so the first example works on ordinary machines and containers.
+Ship first because this gives developers an immediately useful `std/net` module. IP/CIDR helpers should be good enough for real IPAM/routing calculators, not just demo parsing. `ping()` intentionally stays protocol-honest: it does not pretend a TCP connect to arbitrary ports is an ICMP ping. If ICMP support is unavailable in Phase 1, callers get a clear `Err`; explicit TCP reachability remains an app/developer decision.
 
 Phase 1 IPAM goals:
 
@@ -430,7 +430,7 @@ Tests:
 
 ### `ping(host, opts?) -> Result<Map, String>`
 
-`ping()` is a host reachability probe. Its default behavior prioritizes "works on the first shot" over purity about ICMP.
+`ping()` is a host reachability probe. Its default behavior is protocol-honest: ICMP ping should either produce ICMP results or fail clearly; it must not silently switch to TCP ports.
 
 Default method:
 
@@ -452,53 +452,69 @@ let result = ping("example.com")
 // })
 ```
 
-If ICMP is unavailable, default `method: "auto"` falls back to TCP reachability:
+If ICMP is unavailable in the runtime, default `method: "auto"` fails clearly instead of falling back to TCP:
 
 ```ntnt
 ping("example.com")
+// Err("ICMP ping unavailable: std/net does not fall back to TCP automatically. Use method: 'tcp' with explicit tcp_ports only when the app intentionally wants TCP reachability instead of ICMP ping.")
+```
+
+Apps that intentionally want TCP reachability can ask for it explicitly and run multiple bounded attempts in one call:
+
+```ntnt
+ping("example.com", map {
+  "method": "tcp",
+  "tcp_ports": [443],
+  "count": 5
+})
 // Ok(map {
 //   "host": "example.com",
 //   "reachable": true,
 //   "method": "tcp",
-//   "fallback_from": "icmp",
-//   "permission_limited": true,
-//   "ports_tried": [443, 80],
-//   "connected_port": 443,
-//   "latency_ms": 22.8
+//   "sent": 5,
+//   "received": 5,
+//   "failed": 0,
+//   "loss_percent": 0,
+//   "min_ms": 18.6,
+//   "avg_ms": 21.4,
+//   "max_ms": 25.2,
+//   "attempts": [...]
 // })
 ```
 
 Options:
 
-- `method`: `"auto"` (default), `"icmp"`, or `"tcp"`
-- `count`: default 4, clamped to `1..=10`
+- `method`: `"auto"` (default), `"icmp"`, or explicit `"tcp"`
+- `count`: default 1, clamped to `1..=10`
 - `timeout_ms`: default 2000, clamped to shared timeout bounds
-- `interval_ms`: default 250, clamped to shared interval bounds
-- `tcp_ports`: default `[443, 80]`, max 10 explicit ports
+- `interval_ms`: default 0, clamped to `0..=5000`
+- `tcp_ports`: required for `method: "tcp"`, max 10 explicit ports; no default/random ports
 - `allow_private`: default false, requires process-level `NTNT_NET_ALLOW_PRIVATE=1`
 
 Semantics:
 
-- `method: "auto"` should never fail solely because ICMP permissions are missing. It should use ICMP when available and TCP fallback otherwise.
-- `method: "icmp"` means the caller explicitly asked for ICMP. If the OS lacks permission/capability, return `Err("ICMP ping unavailable: ...")` with actionable guidance.
-- `method: "tcp"` performs TCP connect probes only and returns `reachable: true` if any configured port connects.
-- `reachable: false` is an ordinary probe result, not an `Err`.
+- `method: "auto"` uses ICMP when available. If ICMP is unavailable/unsupported, return `Err("ICMP ping unavailable: ...")` with actionable guidance.
+- `method: "icmp"` means the caller explicitly asked for ICMP. If the OS lacks permission/capability, return the same clear `Err` instead of degrading to another protocol.
+- `method: "tcp"` is an explicit app-level reachability choice. It performs TCP connect probes only, requires explicit ports, and returns `reachable: true` if any configured port connects.
+- `reachable: false` is an ordinary probe result, not an `Err`, once the selected method is actually available and permitted.
 - Include `resolved_addrs` only if doing so does not leak denied/private resolved targets in policy errors.
 
 Implementation approach:
 
 - Build the API around a small internal `ReachabilityMethod::{Auto, Icmp, Tcp}` parser.
-- Implement TCP fallback first using the same lower-level connect helper planned for `tcp_connect`.
+- Do not implement automatic TCP fallback inside `ping()`; protocol fallback belongs in app code or an explicit future helper.
+- Keep the lower-level TCP connect helper for explicit `method: "tcp"` in Phase 1 and the public `tcp_connect` function in Phase 2.
 - Add ICMP support only through a crate/path that supports unprivileged operation where the OS allows it. Linux may use datagram ICMP sockets when `/proc/sys/net/ipv4/ping_group_range` permits the process group; raw sockets still require `CAP_NET_RAW` and must be optional.
 - Do not shell out to system `ping`.
-- Do not require Docker `cap_add` for the default example. Docker capability docs are for `method: "icmp"`, not the default `auto` path.
+- Do not require Docker `cap_add` for app code that deliberately chooses TCP reachability; ICMP-specific deployment docs belong to the ICMP path.
 
 Tests:
 
 - `method` parser accepts `auto`, `icmp`, `tcp` and rejects unknown values
 - option clamps for `count`, `interval_ms`, `timeout_ms`, and `tcp_ports`
-- local TCP listener fallback returns `reachable: true` without ICMP capability
-- closed local TCP fallback returns `reachable: false`
+- default `method: "auto"` returns a clear ICMP-unavailable `Err` rather than TCP fallback when ICMP is unsupported
+- `method: "tcp"` requires explicit `tcp_ports`
+- explicit TCP method can run multiple bounded attempts and returns per-attempt plus aggregate summary fields
 - forced `method: "icmp"` maps missing capability to clear `Err` in an opt-in/unit-testable path
 - policy-denied private/loopback target unless explicitly allowed by config/test override
 
@@ -717,7 +733,7 @@ Traceroute and other raw packet path-discovery tools require a separate capabili
 - graceful `Err` when unavailable
 - no default CI dependency on raw sockets
 
-`ping()` is **not** deferred. It belongs in Phase 1, but its default `auto` method must avoid permission hell by falling back to TCP reachability when ICMP is unavailable.
+`ping()` is **not** deferred. It belongs in Phase 1, but its default `auto` method must avoid lying: when ICMP is unavailable, return a clear `Err` rather than falling back to TCP reachability. TCP reachability remains explicit app/developer intent.
 
 ### WHOIS
 
@@ -742,7 +758,7 @@ SNMP is a real network-monitoring need, but it is its own protocol family. It sh
 As of 2026-06-02:
 
 - [x] **PR 1 — `std/net` shell + IPAM helpers + `ping`**: implemented in [PR #113](https://github.com/ntntlang/ntnt/pull/113). Status: open, mergeable, CI green, no unresolved review threads.
-- [ ] **PR 2 — Dedicated TCP probe refinement**: next planned slice. Reuses the Phase 1 TCP fallback helper as public `tcp_connect`.
+- [ ] **PR 2 — Dedicated TCP probe refinement**: next planned slice. Reuses the Phase 1 explicit TCP reachability helper as public `tcp_connect`.
 - [ ] **PR 3 — DNS A/AAAA/PTR**: planned after TCP probe.
 - [ ] **PR 4 — Bounded port scan**: planned after DNS.
 - [ ] **PR 5 — TLS info**: planned after port scan/dependency decision.
@@ -760,10 +776,10 @@ Scope:
 - [x] `src/typechecker.rs`
 - [x] unit tests for helpers and IPv4/IPv6 IPAM behavior
 - [x] `ip_parse`, `subnet_contains`, `subnet_overlaps`, `subnet_split`, `subnet_supernet`, `subnet_summarize`, `ip_range_to_cidrs`
-- [x] `ping(host, opts?)` with `method: "auto"` default and TCP fallback
+- [x] `ping(host, opts?)` with strict no-implicit-TCP-fallback semantics and explicit multi-attempt TCP mode
 - [x] shared target safety checks used by `ping` and future TCP functions
 - [x] generated docs for all Phase 1 functions
-- [x] safe example showing `ping("example.com")` and an internal-monitoring env-var example
+- [x] safe example showing `ping("example.com")`, explicit TCP reachability, and an internal-monitoring env-var example
 - [x] IPAM examples for IPv4 subnet splitting and IPv6 parsing/summarization
 
 Acceptance:
@@ -771,10 +787,10 @@ Acceptance:
 - [x] Phase 1 imports work at runtime and lint/typecheck time.
 - [x] IPv6 parsing, containment, overlap, splitting, supernet, summarization, and range conversion are supported and tested.
 - [x] Large IPv6 counts/results do not overflow or generate unbounded arrays.
-- [x] `ping("example.com")` has a documented no-root/no-capability path through TCP fallback.
-- [x] Missing ICMP capability does not break default `ping()` usage.
+- [x] `ping("example.com")` has documented protocol-honest failure when ICMP support is unavailable.
+- [x] Missing ICMP capability does not silently fall back to TCP; explicit TCP reachability requires `method: "tcp"` and `tcp_ports`.
 - [x] no public internet dependency
-- [x] no new dependency unless clearly justified; any ICMP dependency must keep the TCP fallback path clean
+- [x] no new dependency unless clearly justified; any ICMP dependency must preserve no-implicit-TCP-fallback semantics
 - [x] `cargo build --profile dev-release`, `cargo test net`, docs generation pass
 
 ### PR 2 — Dedicated TCP probe refinement
@@ -782,7 +798,7 @@ Acceptance:
 Scope:
 
 - [ ] `tcp_connect`
-- [ ] reuse/refactor the Phase 1 TCP fallback helper into the public `tcp_connect` API
+- [ ] reuse/refactor the Phase 1 explicit TCP reachability helper into the public `tcp_connect` API
 - [ ] local-listener tests
 - [ ] typechecker signature tests
 - [ ] AI agent guide section for `std/net` safety and jobs/concurrency guidance
@@ -918,7 +934,7 @@ For network-specific PRs:
 
 6. Should `ping()` mean strict ICMP or pragmatic reachability?
 
-   Recommendation: pragmatic by default. `method: "auto"` should use ICMP when available and TCP fallback when not. Strict ICMP is still available via `method: "icmp"`, but that path may require OS capability and should fail with clear guidance instead of silently degrading.
+   Decision: strict/protocol-honest by default. `method: "auto"` should use ICMP when available and return a clear `Err` when unavailable. It must not fall back to TCP automatically. Developers can explicitly choose `method: "tcp"` with explicit `tcp_ports` when their app wants TCP reachability instead of ICMP ping.
 
 7. Should internal targets be easy to enable for monitoring?
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -4,7 +4,7 @@
 **Author:** Larri
 **Created:** 2026-03-22
 **Updated:** 2026-06-02
-**Target baseline:** post-v0.4.9
+**Target baseline:** v0.4.10 (`std/net` track)
 
 ---
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -156,6 +156,7 @@ That option should only work when the process-level config also allows private t
 - Loopback/private/link-local target: denied by default in all server/runtime modes.
 - Loopback/private/link-local target with `allow_private: true` but no process-level opt-in: `Err("Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1")`.
 - Loopback/private/link-local target with process-level opt-in and `allow_private: true`: allowed.
+- Cloud metadata, multicast, broadcast, unspecified, and documentation targets: never allowed, even with private-network opt-in.
 - User-controlled target strings in public web apps: still the app's responsibility to validate input, but stdlib policy blocks the worst SSRF targets by default.
 
 This keeps the first-shot developer experience clean for the common public-host case while making internal monitoring a visible deployment choice, not a hidden code-path surprise.
@@ -306,7 +307,7 @@ Recommended fields:
 - `netmask`: IPv4 dotted-quad for IPv4 networks
 - `wildcard_mask`: IPv4 dotted-quad for IPv4 networks
 - `reverse_zone`: reverse DNS zone for CIDR prefixes that align cleanly on nibble/octet boundaries; otherwise `None`
-- classification booleans: `is_private`, `is_loopback`, `is_link_local`, `is_multicast`, `is_unspecified`, `is_documentation`, `is_unique_local`
+- classification booleans: `is_private`, `is_loopback`, `is_link_local`, `is_multicast`, `is_unspecified`, `is_documentation`, `is_broadcast`, `is_unique_local`
 
 ### `subnet_contains(cidr, ip_or_cidr) -> Result<Bool, String>`
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -1,505 +1,922 @@
-# DD-046: `std/net` — Network Operations Standard Library
+# DD-046: `std/net` — Safe Network Primitives for ntnt
 
-**Status:** Draft
+**Status:** Refined implementation plan
 **Author:** Larri
 **Created:** 2026-03-22
+**Updated:** 2026-06-02
+**Target baseline:** post-v0.4.9
 
 ---
 
 ## Summary
 
-Add a `std/net` module to ntnt providing network diagnostic, monitoring, and connectivity functions. These are the building blocks for network monitoring systems, health checks, infrastructure automation, and connectivity testing — implemented in pure Rust with no external binary dependencies.
+Add a focused `std/net` module for safe, bounded network primitives: IP/CIDR utilities, first-shot host reachability checks, TCP connectivity probes, DNS lookup, limited port scanning, and TLS certificate inspection.
+
+This is **not** a grab-bag for every network-adjacent operation. The first version should make common monitoring and diagnostics possible without shelling out, while preserving ntnt's safety posture for apps that run on the public web.
+
+Initial scope:
+
+- `ip_parse(ip_or_cidr)`
+- `subnet_contains(cidr, ip)`
+- `subnet_overlaps(a, b)`
+- `subnet_split(cidr, new_prefix, opts?)`
+- `subnet_supernet(cidr, new_prefix?)`
+- `subnet_summarize(cidrs)`
+- `ip_range_to_cidrs(start_ip, end_ip)`
+- `ping(host, opts?)`
+- `tcp_connect(host, port, opts?)`
+- `dns_lookup(name, record_type?, opts?)`
+- `dns_reverse(ip, opts?)`
+- `port_scan(host, ports, opts?)` with strict bounds
+- `tls_info(host, opts?)`
+
+Explicitly deferred:
+
+- `traceroute` and other raw packet path-discovery tools
+- SSH remote command execution
+- SNMP polling/walking
+- WHOIS
+- packet collectors, ARP scans, BGP, bandwidth tests, and other specialized monitoring tools
+
+The original DD had the right instinct — network operations are a great ntnt use case — but the scope was too broad and not sharp enough about SSRF/security, blocking behavior, testability, and dependency reality. Tiny router-shaped confetti cannon. We are putting the pin back in.
 
 ---
 
 ## Motivation
 
-ntnt already handles HTTP (`std/http`), databases (`std/db`), and key-value stores (`std/kv`). But network operations below the HTTP layer — ping, DNS resolution, TCP connectivity, TLS inspection, port scanning — require dropping to shell commands or external tools. A developer building a network monitoring dashboard, uptime checker, or infrastructure tool has no stdlib support.
+ntnt already covers high-level HTTP (`std/http`), web serving (`std/http/server`), databases, KV, jobs, auth, and concurrency. But below HTTP, developers still have to drop to external binaries or custom Rust/Python for basic diagnostics:
 
-Josh's background is network engineering (MSP/ISP). The target audience for this module is exactly his domain: people building tools to monitor routers, switches, servers, and services. `std/net` gives ntnt a native advantage for this use case.
+- Is this host:port reachable?
+- Is this host reachable at all, without making the user understand Linux capabilities first?
+- Which address records does this name resolve to?
+- Is this CIDR containing that IP or child subnet?
+- Which subnets overlap before I allocate one twice and ruin Tuesday?
+- How do I split a `/24` into `/28`s, summarize routes, or convert an IP range into CIDRs?
+- Which of these explicitly listed ports are open?
+- Is this TLS certificate close to expiry?
 
-### Use Cases
+Those primitives matter for:
 
-- **Uptime monitoring:** Ping hosts, check TCP ports, verify HTTP endpoints
-- **Network diagnostics:** DNS lookups, traceroute, TLS certificate inspection
-- **Infrastructure dashboards:** Port scans, host discovery, latency graphing
-- **Alerting systems:** "Ping X every 60s, alert if loss > 10%"
-- **Security auditing:** TLS cert expiry, open port detection, DNS record verification
-- **Automation:** SSH command execution, SNMP polling, WHOIS lookups
+- uptime monitoring
+- internal service health checks
+- infrastructure dashboards
+- DNS/certificate audits
+- agent-built diagnostics tooling
+- small MSP/ISP/network-engineering tools
+
+The important product idea: `std/net` should make ntnt good at **bounded, auditable network checks** that work on the first try, not turn every ntnt app into a raw socket toolkit.
+
+---
+
+## Current State
+
+As of the v0.4.9 baseline:
+
+- There is no `src/stdlib/net.rs`.
+- `src/stdlib/mod.rs` has no `std/net` registry entry.
+- `src/typechecker.rs` has no `std/net` module signatures.
+- `docs/STDLIB_REFERENCE.md` and `docs/AI_AGENT_GUIDE.md` do not document `std/net`.
+- `std/http::fetch()` already has SSRF/private-IP policy logic. `std/net` must not silently bypass that posture.
+- `Cargo.toml` uses `reqwest` with its current native TLS dependency path. `rustls` / `webpki` should not be assumed available unless explicitly added.
 
 ---
 
 ## Design Principles
 
-1. **Pure Rust** — no shelling out to `ping`, `dig`, `nmap`, etc. All functions use Rust crates or raw socket APIs. This means ntnt binaries work on any platform without installing system tools.
+1. **Safe by default.** Network primitives can become SSRF and scanning tools. Public-web apps must not accidentally probe metadata services, localhost, or private networks from user-controlled input.
 
-2. **Consistent with existing stdlib** — returns `Result<T, String>` like other modules. Maps for structured data. Options where appropriate.
+2. **Diagnostics use `Ok` for expected probe outcomes.** A closed port, refused connection, DNS NXDOMAIN, or TLS validation failure is often the thing being measured. Reserve `Err(String)` for invalid input, unsupported options, missing permissions, policy-denied targets, or system/config failures.
 
-3. **Progressive disclosure** — simple functions for common cases (`ping("8.8.8.8")`), options maps for advanced config (`ping("8.8.8.8", map { "count": 10, "timeout": 5000 })`).
+3. **Strict bounds.** Every operation has timeout clamps and input limits. `port_scan` must have max ports, max concurrency, deterministic ordering, and cancellation/yield checks.
 
-4. **Non-blocking where possible** — long-running operations (port scans, traceroutes) should work with ntnt's async bridge if called from the HTTP server path.
+4. **Synchronous first, honest about it.** Current stdlib native functions are synchronous. Do not claim async/non-blocking behavior unless the implementation actually has an async execution model. Long-running checks belong in `std/jobs` or `std/concurrent`, not inline in latency-sensitive route handlers.
+
+5. **No shellouts.** The implementation should not invoke `ping`, `dig`, `nmap`, `openssl`, `whois`, or `ssh`. If a capability requires a large/privileged dependency, defer it rather than pretending it is simple.
+
+6. **No permission hell.** Default APIs should not require root, `CAP_NET_RAW`, Docker `cap_add`, or sysctl tuning. If ICMP is available through unprivileged OS support, use it. If it is not, `ping(..., method: "auto")` must fall back to an unprivileged TCP reachability probe and report which method was used.
+
+7. **CI-safe by default.** Tests should not require public internet, raw socket capabilities, root, or Docker privileges. External-network and raw-socket tests are opt-in.
+
+8. **Cross-layer contract from day one.** Every public function needs runtime registration, `// @ntnt` docs, typechecker signatures, generated docs, examples where safe, and tests.
 
 ---
 
-## Module: `std/net`
+## Network Safety Policy
 
-### Phase 1: Core Connectivity (ship first)
+`std/net` must reuse or generalize the existing outbound safety posture used by `std/http`.
 
-These are the most-needed functions and have the simplest Rust implementations.
+### Default policy
 
-#### `tcp_connect(host, port, opts?) -> Result<Map, String>`
+For production/web-server use, deny targets that resolve to or are directly specified as:
 
-Test TCP connectivity to a host:port with optional timeout.
+- loopback (`127.0.0.0/8`, `::1`)
+- link-local (`169.254.0.0/16`, `fe80::/10`)
+- RFC1918 private IPv4 ranges
+- unique-local IPv6 ranges
+- cloud metadata endpoints such as `169.254.169.254`
+- multicast, unspecified, and documentation ranges where appropriate
+
+This is conservative. The use case for `std/net` includes internal monitoring, but the default must not hand an SSRF primitive to every web app.
+
+### One-command opt-in for internal monitoring
+
+Internal/private network checks should require explicit configuration, but the happy path for monitoring apps must be a single process-level setting, not a scavenger hunt through OS capabilities and per-call flags.
+
+Preferred approach:
+
+- Reuse `NTNT_ALLOW_PRIVATE_IPS` if we decide it should govern all outbound network access.
+- Or introduce `NTNT_NET_ALLOW_PRIVATE=1` if `std/net` needs a separate monitoring-specific opt-in.
+- Document the blessed monitoring setup as:
+
+  ```bash
+  NTNT_NET_ALLOW_PRIVATE=1 ntnt run monitor.tnt
+  ```
+
+- For Docker examples, set the env var only. Do **not** require `cap_add: [NET_RAW]` for the default `ping()` path.
+
+The implementation plan should decide this in PR 0, not scatter policy choices per function.
+
+Recommended decision: introduce `NTNT_NET_ALLOW_PRIVATE=1` for `std/net`, while allowing a future shared outbound policy helper to read both names. `std/http` and `std/net` have related SSRF risks, but `std/net` is much more likely to be intentionally used for internal monitoring. A dedicated env var makes that intent auditable.
+
+### Per-call options
+
+If per-call override exists, it must be explicit and auditable:
 
 ```ntnt
-import { tcp_connect } from "std/net"
-
-let result = tcp_connect("db.internal", 5432)
-// => Ok({ connected: true, latency_ms: 2.3, local_addr: "10.0.1.5:48230", remote_addr: "10.0.1.10:5432" })
-
-let result = tcp_connect("offline.host", 80, map { "timeout": 2000 })
-// => Err("Connection timed out after 2000ms")
+tcp_connect("10.0.0.5", 5432, map { "allow_private": true })
 ```
 
-**Rust:** `std::net::TcpStream::connect_timeout()`. Measure `Instant::now()` to `Instant::elapsed()` for latency. Zero dependencies.
+That option should only work when the process-level config also allows private targets. A user-controlled map must not be enough to bypass server policy.
 
-**Implementation:**
-- [ ] Basic connect with timeout (default 5000ms)
-- [ ] Return latency_ms, local_addr, remote_addr
-- [ ] `opts.timeout` override (milliseconds)
-- [ ] Error messages include host:port for diagnostics
+### Default safety matrix
+
+`std/net` should be easy for public targets and deliberate for private ones:
+
+- Public IP/hostname target: allowed by default.
+- Loopback/private/link-local target: denied by default in all server/runtime modes.
+- Loopback/private/link-local target with `allow_private: true` but no process-level opt-in: `Err("Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1")`.
+- Loopback/private/link-local target with process-level opt-in and `allow_private: true`: allowed.
+- User-controlled target strings in public web apps: still the app's responsibility to validate input, but stdlib policy blocks the worst SSRF targets by default.
+
+This keeps the first-shot developer experience clean for the common public-host case while making internal monitoring a visible deployment choice, not a hidden code-path surprise.
+
+### DNS rebinding and multi-address behavior
+
+Functions that accept hostnames must apply policy after resolution to **every resolved address** they might connect to. If all addresses are denied, return `Err("Network target denied by policy: ...")`.
+
+For `tcp_connect`, choose and document one of these:
+
+- try addresses in resolver order until one connects or all fail
+- prefer IPv6/IPv4 with a simple ordering
+- implement Happy Eyeballs later
+
+Initial recommendation: try resolved addresses in order with per-address timeout budget, returning the first success and a structured failure when all fail.
 
 ---
 
-#### `dns_lookup(domain, record_type?) -> Result<Array<Map>, String>`
+## API Contracts
 
-Resolve DNS records for a domain.
+### Common option conventions
+
+Use millisecond suffixes to avoid ambiguity:
+
+- `timeout_ms`
+- `interval_ms`
+- `connect_timeout_ms`
+
+Clamp rather than trust unbounded inputs:
+
+- minimum timeout: 50ms
+- default timeout: 2000ms for TCP/scan, 5000ms for DNS/TLS
+- maximum timeout: 30000ms unless a future API justifies more
+- `ping.count`: default 4, hard maximum 10
+- `ping.interval_ms`: default 250ms, hard minimum 100ms, hard maximum 5000ms
+- `subnet_split.max_results`: default 4096, hard maximum 65536 unless streaming/iterator support exists
+- `subnet_summarize.max_inputs`: default/hard maximum 4096 for first implementation
+- `ip_range_to_cidrs.max_results`: default 4096, hard maximum 65536
+- `port_scan.max_ports`: 1024 by default/hard maximum for first implementation
+- `port_scan.concurrency`: default 20, hard maximum 100
+
+Exact numbers can be tuned during implementation, but the DD must require clamps.
+
+### Result semantics
+
+Use these rules consistently:
+
+- `Ok(map { ... "reachable": true/false ... })` for ordinary ping/reachability outcomes.
+- `Ok(map { ... "connected": false ... })` for ordinary TCP refused/timeout results.
+- `Ok([])` for DNS names that have no records of the requested type when the resolver returns a clean no-answer response.
+- `Err(String)` for invalid host/port/options, resolver/system errors, policy denial, or permission/capability failure.
+- `ping(..., map { "method": "icmp" })` may return `Err` when the OS denies ICMP capability. `ping(..., map { "method": "auto" })` should not: it should fall back to TCP reachability and include `method: "tcp"`, `fallback_from: "icmp"`, and `permission_limited: true`.
+- `Ok(map { "valid": false, "validation_error": ... })` for TLS certificates that connect but fail validation.
+- `Err(String)` for TLS handshake/connect failures where no certificate information can be obtained.
+
+This gives monitoring apps useful data without making normal probe failures feel like language/runtime failures.
+
+---
+
+## Phase 0 — Scaffolding, Policy, and Shared Helpers
+
+Goal: create the module and safety foundation before exposing broad network behavior.
+
+Files:
+
+- Create: `src/stdlib/net.rs`
+- Modify: `src/stdlib/mod.rs`
+- Modify: `src/typechecker.rs`
+- Later generated: `docs/STDLIB_REFERENCE.md`
+- Later manual docs: `docs/AI_AGENT_GUIDE.md`, `examples/README.md`
+
+Work:
+
+- Add `std/net` runtime module registration.
+- Add `std/net` typechecker module signatures as functions land.
+- Add shared helpers for:
+  - options-map parsing
+  - integer-to-port validation (`1..=65535`)
+  - timeout/concurrency clamps
+  - IP/host normalization
+  - target safety classification
+  - resolved-address policy checks
+- Add `// @ntnt` docs from the first public function onward.
+- Add deterministic unit tests for parsing/clamping/policy classification.
+
+Verification:
+
+```bash
+cargo fmt
+cargo build --profile dev-release
+cargo test net -- --test-threads=1
+./target/dev-release/ntnt docs --generate
+```
+
+---
+
+## Phase 1 — IPAM-Grade IP/CIDR Utilities + First-Shot Ping
+
+Ship first because this gives developers an immediately useful `std/net` module without making them solve Docker capabilities before breakfast. IP/CIDR helpers should be good enough for real IPAM/routing calculators, not just demo parsing. `ping()` ships with an unprivileged default path so the first example works on ordinary machines and containers.
+
+Phase 1 IPAM goals:
+
+- IPv4 and IPv6 support from the start.
+- Deterministic, pure functions that do not touch the network.
+- No silent integer overflow. Large IPv6 counts are strings.
+- No unbounded array generation. Splits/ranges require result caps.
+- Function names should distinguish parsing/classification from subnet math. Do not make `ip_parse()` the one function that knows everything and eventually needs a therapist.
+
+### `ip_parse(ip_or_cidr) -> Result<Map, String>`
+
+Parse either an address or CIDR and return canonical fields plus classification. This includes IPv6.
+
+Examples:
 
 ```ntnt
-import { dns_lookup, dns_reverse } from "std/net"
+import { ip_parse } from "std/net"
 
-let records = dns_lookup("google.com")
-// => Ok([{ type: "A", value: "142.250.80.46", ttl: 300 }])
-
-let records = dns_lookup("google.com", "MX")
-// => Ok([{ type: "MX", value: "smtp.google.com", priority: 10, ttl: 3600 }])
-
-let records = dns_lookup("example.com", "TXT")
-// => Ok([{ type: "TXT", value: "v=spf1 include:_spf.google.com ~all", ttl: 300 }])
-
-// Supported record types: A, AAAA, MX, CNAME, TXT, NS, SOA, PTR, SRV
+let info = ip_parse("192.168.1.0/24")
+// Ok(map {
+//   "ip": "192.168.1.0",
+//   "prefix": 24,
+//   "network": "192.168.1.0",
+//   "broadcast": "192.168.1.255",
+//   "first_host": "192.168.1.1",
+//   "last_host": "192.168.1.254",
+//   "host_count": 254,
+//   "version": 4,
+//   "is_private": true
+// })
 ```
 
-**Rust:** `hickory-resolver` (formerly trust-dns). Well-maintained, pure Rust, async-capable.
+IPv6 note: IPv6 host counts can exceed `i64`. Return `host_count` as a string for large IPv6 networks or omit host-count fields for IPv6 ranges where they are not useful. Do not silently overflow.
 
-**Implementation:**
-- [ ] Default to A records when no type specified
-- [ ] Support: A, AAAA, MX, CNAME, TXT, NS, SOA, PTR, SRV
-- [ ] Return array of maps with type, value, ttl (and priority for MX/SRV)
-- [ ] Custom nameserver support: `dns_lookup("example.com", "A", map { "server": "8.8.8.8" })`
+Recommended fields:
 
----
+- `input`: original input string
+- `kind`: `"address"` or `"network"`
+- `version`: `4` or `6`
+- `ip`: canonical/compressed address string
+- `expanded`: expanded IPv6 form when useful; omit or equal `ip` for IPv4
+- `prefix`: present for CIDR input, absent or `None` for bare IP input
+- `network`: present for CIDR input
+- `first`: first address in the range
+- `last`: last address in the range
+- `total_addresses`: string for all CIDRs to avoid overflow surprises
+- `usable_hosts`: string or `None`; IPv4 `/31` and `/32` semantics must be explicit
+- `broadcast`: IPv4 only, `None` for IPv6
+- `netmask`: IPv4 dotted-quad for IPv4 networks
+- `wildcard_mask`: IPv4 dotted-quad for IPv4 networks
+- `reverse_zone`: reverse DNS zone for CIDR prefixes that align cleanly on nibble/octet boundaries; otherwise `None`
+- classification booleans: `is_private`, `is_loopback`, `is_link_local`, `is_multicast`, `is_unspecified`, `is_documentation`, `is_unique_local`
 
-#### `dns_reverse(ip) -> Result<String, String>`
-
-Reverse DNS lookup (PTR record).
+### `subnet_contains(cidr, ip_or_cidr) -> Result<Bool, String>`
 
 ```ntnt
-let hostname = dns_reverse("8.8.8.8")
-// => Ok("dns.google")
+import { subnet_contains } from "std/net"
+
+subnet_contains("10.0.0.0/8", "10.50.100.200")
+// Ok(true)
+
+subnet_contains("10.0.0.0/8", "10.50.0.0/16")
+// Ok(true)
 ```
 
-**Rust:** Same `hickory-resolver`, PTR query.
+If the second argument is a CIDR, return true only when the entire child subnet fits inside the parent.
 
-- [ ] IPv4 and IPv6 support
-- [ ] Return first PTR result as string
+### `subnet_overlaps(a, b) -> Result<Bool, String>`
 
----
+```ntnt
+import { subnet_overlaps } from "std/net"
 
-#### `ping(host, opts?) -> Result<Map, String>`
+subnet_overlaps("10.0.0.0/24", "10.0.0.128/25")
+// Ok(true)
+```
 
-ICMP ping with statistics.
+Return `Err` for mixed address families instead of pretending IPv4 and IPv6 are comparable.
+
+### `subnet_split(cidr, new_prefix, opts?) -> Result<Array<String>, String>`
+
+```ntnt
+import { subnet_split } from "std/net"
+
+subnet_split("192.168.1.0/24", 28)
+// Ok(["192.168.1.0/28", "192.168.1.16/28", ...])
+```
+
+Rules:
+
+- `new_prefix` must be longer than the input prefix.
+- IPv4 and IPv6 both supported.
+- Enforce `max_results` to prevent generating enormous IPv6 arrays.
+- Return subnets in numeric order.
+
+### `subnet_supernet(cidr, new_prefix?) -> Result<String, String>`
+
+```ntnt
+import { subnet_supernet } from "std/net"
+
+subnet_supernet("192.168.1.0/24")
+// Ok("192.168.0.0/23")
+
+subnet_supernet("192.168.1.0/24", 16)
+// Ok("192.168.0.0/16")
+```
+
+Default `new_prefix` should be one bit shorter. Explicit `new_prefix` must be shorter than the current prefix.
+
+### `subnet_summarize(cidrs) -> Result<Array<String>, String>`
+
+Summarize adjacent/overlapping CIDRs into the shortest equivalent route list.
+
+```ntnt
+import { subnet_summarize } from "std/net"
+
+subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"])
+// Ok(["10.0.0.0/24"])
+```
+
+Rules:
+
+- IPv4 and IPv6 supported.
+- Mixed families return `Err`.
+- Inputs are normalized before summarizing.
+- Output is sorted by address then prefix.
+
+### `ip_range_to_cidrs(start_ip, end_ip) -> Result<Array<String>, String>`
+
+Convert an inclusive IP range into the minimal CIDR cover.
+
+```ntnt
+import { ip_range_to_cidrs } from "std/net"
+
+ip_range_to_cidrs("192.168.1.20", "192.168.1.45")
+// Ok(["192.168.1.20/30", "192.168.1.24/29", ...])
+```
+
+Rules:
+
+- Same address family required.
+- `start_ip <= end_ip` required.
+- Enforce result caps.
+
+Candidate follow-up helpers for a later IPAM phase:
+
+- `ip_add(ip, offset)` / `ip_sub(ip, offset)` for safe address arithmetic
+- `cidr_exclude(parent, child)` for carve-outs/reservations
+- `subnet_nth(cidr, new_prefix, index)` for allocating a subnet without materializing every sibling
+- `subnet_index(parent, child)` for locating a child subnet inside a larger block
+- `prefix_to_netmask(prefix)` and `netmask_to_prefix(mask)` if users want Cisco-style calculators
+- `longest_prefix_match(ip, routes)` for route-table tooling
+
+Implementation choice:
+
+- Prefer `ipnet` or equivalent for boring-correct IPv4/IPv6 CIDR math unless manual implementation is clearly smaller and well-tested.
+- Avoid crates that only partially support IPv6 or make host iteration too easy to misuse.
+- Internally represent addresses as `u128` plus version/prefix for arithmetic; convert at the boundary.
+
+Tests:
+
+- IPv4 address only
+- IPv4 CIDR `/24`, `/32`, `/0`
+- IPv6 address and CIDR
+- invalid IP, invalid prefix, mismatched IP families
+- private/loopback/link-local classification
+- IPv6 compression/expansion/canonicalization
+- IPv6 `/64`, `/127`, `/128`, and large-count behavior
+- subnet contains IP and subnet
+- overlap true/false cases
+- split/supernet/summarize/range-to-CIDR deterministic ordering
+- result caps for explosive splits/ranges
+
+### `ping(host, opts?) -> Result<Map, String>`
+
+`ping()` is a host reachability probe. Its default behavior prioritizes "works on the first shot" over purity about ICMP.
+
+Default method:
 
 ```ntnt
 import { ping } from "std/net"
 
-let result = ping("8.8.8.8")
-// => Ok({ host: "8.8.8.8", alive: true, min: 12.3, avg: 15.1, max: 22.7, loss: 0.0, count: 4 })
-
-let result = ping("192.168.1.1", map { "count": 10, "timeout": 3000, "interval": 200 })
-// => Ok({ host: "192.168.1.1", alive: true, min: 0.5, avg: 1.2, max: 3.1, loss: 0.0, count: 10 })
-
-let result = ping("dead.host.example")
-// => Ok({ host: "dead.host.example", alive: false, loss: 100.0, count: 4 })
+let result = ping("example.com")
+// Ok(map {
+//   "host": "example.com",
+//   "reachable": true,
+//   "method": "icmp",
+//   "sent": 4,
+//   "received": 4,
+//   "loss_percent": 0,
+//   "min_ms": 12.4,
+//   "avg_ms": 14.1,
+//   "max_ms": 18.7,
+//   "permission_limited": false
+// })
 ```
 
-**Rust:** `surge-ping` crate. Pure Rust ICMP. **Requires `CAP_NET_RAW` capability or root.**
-
-**Docker note:** Add `cap_add: [NET_RAW]` to docker-compose, or run the container with `--cap-add=NET_RAW`. Without it, ping returns a permissions error.
-
-**Implementation:**
-- [ ] Default: 4 pings, 1000ms timeout, 1000ms interval
-- [ ] `opts.count`, `opts.timeout`, `opts.interval` overrides
-- [ ] Return min/avg/max/loss statistics
-- [ ] Resolve hostname to IP before pinging
-- [ ] Clear error message when CAP_NET_RAW is missing
-- [ ] IPv4 and IPv6 support
-
----
-
-#### `tls_info(host, port?) -> Result<Map, String>`
-
-Inspect TLS certificate and connection details.
+If ICMP is unavailable, default `method: "auto"` falls back to TCP reachability:
 
 ```ntnt
-import { tls_info } from "std/net"
-
-let cert = tls_info("example.com")
-// => Ok({
-//   subject: "*.example.com",
-//   issuer: "DigiCert Inc",
-//   not_before: "2025-01-15T00:00:00Z",
-//   not_after: "2026-12-01T23:59:59Z",
-//   days_left: 254,
-//   serial: "0A:1B:2C:...",
-//   san: ["*.example.com", "example.com"],
-//   protocol: "TLSv1.3",
-//   cipher: "TLS_AES_256_GCM_SHA384",
-//   valid: true
+ping("example.com")
+// Ok(map {
+//   "host": "example.com",
+//   "reachable": true,
+//   "method": "tcp",
+//   "fallback_from": "icmp",
+//   "permission_limited": true,
+//   "ports_tried": [443, 80],
+//   "connected_port": 443,
+//   "latency_ms": 22.8
 // })
-
-let cert = tls_info("internal.server", 8443)
-// Check non-standard ports
 ```
 
-**Rust:** `rustls` + `webpki` (already in dependency tree via `reqwest`). Connect, extract cert chain, parse X.509.
+Options:
 
-**Implementation:**
-- [ ] Default port 443
-- [ ] Extract subject, issuer, validity dates, SAN list
-- [ ] Calculate `days_left` from current time
-- [ ] Extract protocol version and cipher suite
-- [ ] `valid` field: cert chain validates against system roots
-- [ ] Support custom port
-- [ ] Timeout support (default 5000ms)
+- `method`: `"auto"` (default), `"icmp"`, or `"tcp"`
+- `count`: default 4, clamped to `1..=10`
+- `timeout_ms`: default 2000, clamped to shared timeout bounds
+- `interval_ms`: default 250, clamped to shared interval bounds
+- `tcp_ports`: default `[443, 80]`, max 10 explicit ports
+- `allow_private`: default false, requires process-level `NTNT_NET_ALLOW_PRIVATE=1`
+
+Semantics:
+
+- `method: "auto"` should never fail solely because ICMP permissions are missing. It should use ICMP when available and TCP fallback otherwise.
+- `method: "icmp"` means the caller explicitly asked for ICMP. If the OS lacks permission/capability, return `Err("ICMP ping unavailable: ...")` with actionable guidance.
+- `method: "tcp"` performs TCP connect probes only and returns `reachable: true` if any configured port connects.
+- `reachable: false` is an ordinary probe result, not an `Err`.
+- Include `resolved_addrs` only if doing so does not leak denied/private resolved targets in policy errors.
+
+Implementation approach:
+
+- Build the API around a small internal `ReachabilityMethod::{Auto, Icmp, Tcp}` parser.
+- Implement TCP fallback first using the same lower-level connect helper planned for `tcp_connect`.
+- Add ICMP support only through a crate/path that supports unprivileged operation where the OS allows it. Linux may use datagram ICMP sockets when `/proc/sys/net/ipv4/ping_group_range` permits the process group; raw sockets still require `CAP_NET_RAW` and must be optional.
+- Do not shell out to system `ping`.
+- Do not require Docker `cap_add` for the default example. Docker capability docs are for `method: "icmp"`, not the default `auto` path.
+
+Tests:
+
+- `method` parser accepts `auto`, `icmp`, `tcp` and rejects unknown values
+- option clamps for `count`, `interval_ms`, `timeout_ms`, and `tcp_ports`
+- local TCP listener fallback returns `reachable: true` without ICMP capability
+- closed local TCP fallback returns `reachable: false`
+- forced `method: "icmp"` maps missing capability to clear `Err` in an opt-in/unit-testable path
+- policy-denied private/loopback target unless explicitly allowed by config/test override
 
 ---
 
-#### `port_scan(host, ports, opts?) -> Result<Array<Map>, String>`
+## Phase 2 — TCP Connectivity Probe
 
-Scan TCP ports on a host.
+### `tcp_connect(host, port, opts?) -> Result<Map, String>`
+
+```ntnt
+import { tcp_connect } from "std/net"
+
+let result = tcp_connect("db.internal", 5432, map {
+    "timeout_ms": 1000,
+    "allow_private": true
+})
+
+// Ok(map {
+//   "host": "db.internal",
+//   "port": 5432,
+//   "connected": true,
+//   "latency_ms": 2.3,
+//   "remote_addr": "10.0.1.10:5432",
+//   "local_addr": "10.0.1.5:48230"
+// })
+```
+
+Failure example:
+
+```ntnt
+tcp_connect("example.com", 81, map { "timeout_ms": 500 })
+// Ok(map {
+//   "host": "example.com",
+//   "port": 81,
+//   "connected": false,
+//   "reason": "timeout"
+// })
+```
+
+Implementation notes:
+
+- Use `std::net::ToSocketAddrs` and `TcpStream::connect_timeout` initially.
+- Apply safety policy to every resolved address before connecting.
+- Measure latency with `Instant`.
+- Set read/write timeouts on the connected stream before inspecting local/remote addr, then drop it.
+- Include host:port in diagnostic errors.
+- Avoid unbounded DNS/connect time; clamp options.
+
+Tests:
+
+- local `TcpListener` open port returns `connected: true`
+- closed local port returns `connected: false`
+- invalid port and invalid opts return `Err`
+- policy-denied private/loopback target unless explicitly allowed by config/test override
+- typechecker rejects non-string host and non-int port
+
+---
+
+## Phase 3 — DNS Lookup
+
+### `dns_lookup(name, record_type?, opts?) -> Result<Array<Map>, String>`
+
+Supported initial record types:
+
+- `A`
+- `AAAA`
+- `PTR`
+
+Candidate follow-up record types once the shape is proven:
+
+- `MX`
+- `TXT`
+- `NS`
+- `CNAME`
+- `SOA`
+- `SRV`
+
+```ntnt
+import { dns_lookup } from "std/net"
+
+dns_lookup("example.com", "A")
+// Ok([map { "type": "A", "value": "93.184.216.34", "ttl": 300 }])
+```
+
+### `dns_reverse(ip, opts?) -> Result<Array<String>, String>`
+
+Return an array, not a single string. PTR can have multiple names, and `[]` is a clearer no-answer shape than choosing one.
+
+```ntnt
+import { dns_reverse } from "std/net"
+
+dns_reverse("8.8.8.8")
+// Ok(["dns.google."])
+```
+
+Implementation notes:
+
+- Use `hickory-resolver` only when ready to add the dependency intentionally.
+- Do not rely on public DNS in CI.
+- Build a resolver abstraction or local/mock DNS test fixture before adding many record types.
+- Custom nameserver support is deferred until safety implications are explicit. A `server` option can bypass enterprise DNS policy and should not be a casual Phase 1 feature.
+
+Tests:
+
+- record-type parser
+- no-answer behavior
+- invalid type returns `Err`
+- local/mock resolver results for A/AAAA/PTR
+- optional external DNS smoke test gated behind env var, not default CI
+
+---
+
+## Phase 4 — Bounded Port Scan
+
+### `port_scan(host, ports, opts?) -> Result<Array<Map>, String>`
 
 ```ntnt
 import { port_scan } from "std/net"
 
-let results = port_scan("192.168.1.1", [22, 80, 443, 3306, 5432, 8080])
-// => Ok([
-//   { port: 22, open: true, latency_ms: 1.2 },
-//   { port: 80, open: true, latency_ms: 0.8 },
-//   { port: 443, open: true, latency_ms: 0.9 },
-//   { port: 3306, open: false },
-//   { port: 5432, open: false },
-//   { port: 8080, open: true, latency_ms: 1.1 }
-// ])
-
-// Common port ranges
-let results = port_scan("server.example", 1..1024, map { "timeout": 1000, "concurrency": 50 })
-```
-
-**Rust:** `std::net::TcpStream::connect_timeout()` with thread pool. No special permissions needed.
-
-**Implementation:**
-- [ ] Accept array of ports or range
-- [ ] Default timeout 2000ms per port
-- [ ] `opts.timeout`, `opts.concurrency` (default 20 parallel connections)
-- [ ] Return array of maps with port, open, latency_ms
-- [ ] Sort results by port number
-
----
-
-#### `whois(domain) -> Result<String, String>`
-
-WHOIS lookup.
-
-```ntnt
-import { whois } from "std/net"
-
-let info = whois("example.com")
-// => Ok("Domain Name: EXAMPLE.COM\nRegistrar: ...")
-```
-
-**Rust:** TCP connection to port 43 of the appropriate WHOIS server. Parse referral chain for TLDs.
-
-**Implementation:**
-- [ ] Determine WHOIS server from TLD (hardcoded map for common TLDs + IANA referral)
-- [ ] Follow referrals (e.g., .com → verisign → registrar)
-- [ ] Return raw WHOIS text
-- [ ] Timeout support (default 10000ms)
-
----
-
-#### `ip_parse(ip_or_cidr) -> Result<Map, String>`
-
-Parse and inspect IP addresses and CIDR notation.
-
-```ntnt
-import { ip_parse, subnet_contains } from "std/net"
-
-let info = ip_parse("192.168.1.0/24")
-// => Ok({ ip: "192.168.1.0", prefix: 24, network: "192.168.1.0", broadcast: "192.168.1.255",
-//         first_host: "192.168.1.1", last_host: "192.168.1.254", host_count: 254, version: 4 })
-
-let contains = subnet_contains("10.0.0.0/8", "10.50.100.200")
-// => Ok(true)
-```
-
-**Rust:** `ipnetwork` crate or `std::net::IpAddr` with manual CIDR math.
-
-**Implementation:**
-- [ ] Parse IPv4 and IPv6 addresses and CIDR notation
-- [ ] Calculate network, broadcast, first/last host, host count
-- [ ] `subnet_contains(cidr, ip)` for membership testing
-- [ ] Validate addresses (return Err for invalid input)
-
----
-
-### Phase 2: Diagnostics (after Phase 1 ships)
-
-#### `traceroute(host, opts?) -> Result<Array<Map>, String>`
-
-Trace network path to a host.
-
-```ntnt
-import { traceroute } from "std/net"
-
-let hops = traceroute("8.8.8.8")
-// => Ok([
-//   { hop: 1, ip: "192.168.1.1", hostname: "router.local", latency_ms: 1.2 },
-//   { hop: 2, ip: "10.0.0.1", hostname: "isp-gw.example.net", latency_ms: 5.3 },
-//   { hop: 3, ip: "*", hostname: "*", latency_ms: null },
-//   ...
-//   { hop: 9, ip: "8.8.8.8", hostname: "dns.google", latency_ms: 15.1 }
-// ])
-```
-
-**Rust:** `surge-ping` with incrementing TTL (ICMP approach) or TCP SYN with TTL (TCP approach). **Requires CAP_NET_RAW.**
-
-**Implementation:**
-- [ ] Default: max 30 hops, 3 probes per hop, 5000ms timeout
-- [ ] `opts.max_hops`, `opts.timeout`, `opts.probes`
-- [ ] Reverse DNS on each hop IP
-- [ ] `*` for non-responding hops
-- [ ] TCP traceroute mode (port 80/443) as alternative to ICMP
-
----
-
-#### `ssh_exec(host, opts) -> Result<Map, String>`
-
-Execute a command on a remote host via SSH.
-
-```ntnt
-import { ssh_exec } from "std/net"
-
-let result = ssh_exec("router.internal", map {
-    "user": "admin",
-    "key": get_env("SSH_PRIVATE_KEY_PATH"),
-    "cmd": "show ip route"
+let results = port_scan("192.168.1.1", [22, 80, 443], map {
+    "timeout_ms": 500,
+    "concurrency": 20,
+    "allow_private": true
 })
-// => Ok({ stdout: "...", stderr: "", exit_code: 0, latency_ms: 45.2 })
 ```
 
-**Rust:** `russh` (pure Rust SSH2) or `ssh2` (libssh2 bindings). `russh` is preferable — no C dependency.
-
-**Implementation:**
-- [ ] Key-based auth (path to private key)
-- [ ] Password auth (optional)
-- [ ] Command execution with stdout/stderr capture
-- [ ] Timeout support
-- [ ] Known hosts verification (optional, default permissive for monitoring use case)
-- [ ] Connection reuse/pooling for repeated commands (future enhancement)
-
----
-
-#### `snmp_get(host, community, oid) -> Result<Map, String>`
-
-SNMP GET/WALK for network device monitoring.
+Result shape:
 
 ```ntnt
-import { snmp_get, snmp_walk } from "std/net"
-
-let result = snmp_get("switch.internal", "public", "1.3.6.1.2.1.1.1.0")
-// => Ok({ oid: "1.3.6.1.2.1.1.1.0", type: "OctetString", value: "Cisco IOS..." })
-
-let interfaces = snmp_walk("switch.internal", "public", "1.3.6.1.2.1.2.2.1")
-// => Ok([{ oid: "...1", type: "Integer", value: 1 }, ...])
+Ok([
+    map { "port": 22, "open": true, "latency_ms": 1.2 },
+    map { "port": 80, "open": false, "reason": "refused" },
+    map { "port": 443, "open": true, "latency_ms": 0.9 }
+])
 ```
 
-**Rust:** UDP packets with ASN.1 encoding. Can use `snmp-parser` for parsing or implement the simple SNMP v2c protocol directly (it's straightforward — UDP packet with BER-encoded PDU).
+Implementation notes:
 
-**Implementation:**
-- [ ] SNMP v2c GET and WALK
-- [ ] Community string auth
-- [ ] Timeout and retry support
-- [ ] Parse common value types (Integer, OctetString, Counter32, Gauge32, TimeTicks, IPAddress)
-- [ ] SNMP v3 (future — more complex, USM auth)
+- Build on the same lower-level connect helper used by `tcp_connect`.
+- Accept arrays of ints first. Range syntax can be added only if runtime and typechecker behavior are confirmed together.
+- Enforce max ports and max concurrency.
+- Return results sorted by port.
+- Check cancellation/yield points between batches.
+- Treat this as the highest abuse-risk initial API; policy checks are mandatory.
 
----
+Tests:
 
-### Phase 3: Advanced (future/private module candidates)
-
-These are more specialized and might live in a private `netmon` module rather than `std/net`:
-
-| Function | Description | Complexity |
-|---|---|---|
-| `sflow_collector(port)` | Receive and parse sFlow packets | Medium — UDP listener + sFlow v5 parsing |
-| `netflow_collector(port)` | Receive NetFlow/IPFIX | Medium — similar to sFlow |
-| `bandwidth_test(host, opts)` | iperf-style throughput measurement | Medium — TCP stream + timing |
-| `arp_scan(interface)` | ARP discovery on local subnet | Needs CAP_NET_RAW |
-| `wake_on_lan(mac, broadcast?)` | Send WOL magic packet | Simple — UDP broadcast |
-| `interface_list()` | List network interfaces with stats | Platform-specific |
-| `route_table()` | Read system routing table | Linux: netlink, macOS: sysctl |
-| `bgp_peer(host, asn)` | BGP session monitoring | Complex — full BGP FSM |
+- local open/closed ports
+- deterministic sorted order
+- rejects duplicate/invalid/out-of-range ports
+- rejects too many ports
+- clamps concurrency
+- policy-denied targets
 
 ---
 
-## Dependencies
+## Phase 5 — TLS Certificate Inspection
 
-New Cargo.toml dependencies for Phase 1:
+### `tls_info(host, opts?) -> Result<Map, String>`
 
-```toml
-# std/net — network operations
-hickory-resolver = "0.24"          # DNS resolution (pure Rust, formerly trust-dns)
-surge-ping = "0.8"                  # ICMP ping (pure Rust, needs CAP_NET_RAW)
-ipnetwork = "0.20"                  # IP/CIDR parsing and math
-```
-
-For Phase 2:
-```toml
-russh = "0.45"                      # SSH2 (pure Rust, no C deps)
-```
-
-`tokio` is already a dependency (for axum). `hickory-resolver` integrates with tokio for async DNS. `surge-ping` also uses tokio.
-
-**No new C dependencies.** Everything is pure Rust.
-
----
-
-## File Structure
-
-```
-src/stdlib/
-├── net.rs              # Phase 1: tcp_connect, dns_lookup, dns_reverse, ping,
-│                       #           tls_info, port_scan, whois, ip_parse, subnet_contains
-├── net_ssh.rs          # Phase 2: ssh_exec (separate file due to size/complexity)
-├── net_snmp.rs         # Phase 2: snmp_get, snmp_walk
-└── mod.rs              # Module registry (add "net" entry)
-```
-
----
-
-## Implementation Order
-
-| PR | Functions | Effort | Dependencies |
-|----|-----------|--------|-------------|
-| 1 | `tcp_connect`, `ip_parse`, `subnet_contains` | Small (2-3h) | None (std::net only) |
-| 2 | `dns_lookup`, `dns_reverse` | Small (2-3h) | `hickory-resolver` |
-| 3 | `tls_info` | Medium (3-4h) | `rustls` (already in tree) |
-| 4 | `ping` | Medium (3-4h) | `surge-ping` |
-| 5 | `port_scan` | Small (2-3h) | None (std::net + thread pool) |
-| 6 | `whois` | Small (1-2h) | None (raw TCP) |
-| 7 | `traceroute` | Medium (4-5h) | `surge-ping` |
-| 8 | `ssh_exec` | Medium (4-5h) | `russh` |
-| 9 | `snmp_get`, `snmp_walk` | Medium (4-5h) | Direct UDP + ASN.1 |
-
-**Phase 1 total:** ~15-20 hours across 6 PRs.
-
----
-
-## Docker / Permissions
-
-For functions requiring raw sockets (ping, traceroute):
-
-```yaml
-services:
-  app:
-    cap_add:
-      - NET_RAW    # Required for ICMP ping and traceroute
-```
-
-Or at runtime: `docker run --cap-add=NET_RAW ...`
-
-Functions that DON'T need special permissions: tcp_connect, dns_lookup, tls_info, port_scan, whois, ip_parse, ssh_exec, snmp_get.
-
----
-
-## Testing Strategy
-
-- **Unit tests:** Parse/format functions (ip_parse, subnet_contains), WHOIS server lookup
-- **Integration tests:** tcp_connect to localhost, dns_lookup for known domains, tls_info for public sites
-- **Mock tests:** Ping/traceroute with mock ICMP (or skip if CAP_NET_RAW unavailable)
-- **CI note:** GitHub Actions runners don't have CAP_NET_RAW. Ping/traceroute tests should detect this and skip gracefully.
-
----
-
-## Example: Network Monitor in ntnt
+Use an options map instead of a positional optional port to keep room for SNI and validation options:
 
 ```ntnt
-import { ping, dns_lookup, tcp_connect, tls_info, port_scan } from "std/net"
-import { configure_queue, enqueue_in } from "std/jobs"
-import { json } from "std/http/server"
-import { now } from "std/time"
+import { tls_info } from "std/net"
 
-configure_queue(map { "store": "redis://redis:6379" })
-
-let targets = [
-    map { "name": "Web Server", "host": "web.example.com", "checks": ["ping", "http", "tls"] },
-    map { "name": "Database", "host": "db.internal", "port": 5432, "checks": ["ping", "tcp"] },
-    map { "name": "DNS", "host": "8.8.8.8", "checks": ["ping", "dns"] }
-]
-
-job HealthCheck on monitoring (retry: 2, timeout: 30) {
-    perform(target) {
-        let results = map {}
-
-        if contains(target["checks"], "ping") {
-            results["ping"] = ping(target["host"])
-        }
-        if contains(target["checks"], "tcp") {
-            results["tcp"] = tcp_connect(target["host"], target["port"] ?? 80)
-        }
-        if contains(target["checks"], "tls") {
-            let cert = tls_info(target["host"])
-            results["tls"] = cert
-            if unwrap(cert)["days_left"] < 30 {
-                // Alert: cert expiring soon
-                enqueue("AlertCertExpiry", map { "host": target["host"], "days": unwrap(cert)["days_left"] })
-            }
-        }
-        if contains(target["checks"], "dns") {
-            results["dns"] = dns_lookup(target["host"], "A")
-        }
-
-        // Store results for dashboard
-        kv_set(kv, "health:#{target["name"]}:#{now()}", results)
-
-        // Re-enqueue for next check
-        enqueue_in("HealthCheck", 60, target)
-    }
-}
-
-// Kick off monitoring
-for target in targets {
-    enqueue("HealthCheck", target)
-}
-
-// Dashboard endpoint
-get("/api/health", fn(req) {
-    // ... query recent health check results from KV ...
-    return json(results)
+let cert = tls_info("example.com", map {
+    "port": 443,
+    "timeout_ms": 5000,
+    "server_name": "example.com"
 })
-
-work_async(map { "concurrency": 4 })
-listen(8080)
 ```
 
-This is a complete network monitoring system in ~50 lines of ntnt.
+Result shape:
+
+```ntnt
+Ok(map {
+    "host": "example.com",
+    "port": 443,
+    "subject": "example.com",
+    "issuer": "DigiCert Inc",
+    "not_before": "2025-01-15T00:00:00Z",
+    "not_after": "2026-12-01T23:59:59Z",
+    "days_left": 254,
+    "serial": "0A:1B:2C:...",
+    "san": ["example.com", "www.example.com"],
+    "valid": true,
+    "validation_error": None,
+    "protocol": "TLSv1.3"
+})
+```
+
+Implementation decision required before coding:
+
+- Either use `native-tls` / platform cert store and an X.509 parser, or explicitly add `rustls`, roots, and `x509-parser`.
+- Do not claim `rustls` is already available via `reqwest`; current dependency state does not justify that.
+
+Tests:
+
+- local TLS server with deterministic self-signed cert
+- returns certificate fields even when validation fails
+- expiry date parsing/days-left math with fixed test clock helper if needed
+- invalid host/port/options
+- policy-denied target
+
+---
+
+## Deferred / Out of Scope for Initial `std/net`
+
+### `traceroute` and raw packet tooling
+
+Traceroute and other raw packet path-discovery tools require a separate capability story:
+
+- runtime capability detection or `net_capabilities()` helper
+- clear Docker docs (`cap_add: [NET_RAW]`) for APIs that truly require raw sockets
+- CI opt-in via something like `NTNT_RUN_RAW_NET_TESTS=1`
+- graceful `Err` when unavailable
+- no default CI dependency on raw sockets
+
+`ping()` is **not** deferred. It belongs in Phase 1, but its default `auto` method must avoid permission hell by falling back to TCP reachability when ICMP is unavailable.
+
+### WHOIS
+
+WHOIS is domain registry plumbing, not core connectivity. It also involves referral chains, inconsistent formats, rate limits, and public-network CI flakiness. Defer until someone needs it enough to design it separately.
+
+### SSH execution
+
+Remote command execution is too privileged for `std/net`. If added, it should likely be `std/ssh` or an app/plugin-level module with explicit host-key verification and credential handling. Default-permissive known-host behavior is not acceptable for a stdlib primitive.
+
+### SNMP
+
+SNMP is a real network-monitoring need, but it is its own protocol family. Defer to `std/snmp` or a private/experimental monitoring module. Do not make the first `std/net` PR carry BER/ASN.1 and SNMP semantics.
+
+---
+
+## Implementation Plan
+
+### PR 1 — `std/net` shell + IPAM helpers + `ping`
+
+Scope:
+
+- `src/stdlib/net.rs`
+- `src/stdlib/mod.rs`
+- `src/typechecker.rs`
+- unit tests for helpers and IPv4/IPv6 IPAM behavior
+- `ip_parse`, `subnet_contains`, `subnet_overlaps`, `subnet_split`, `subnet_supernet`, `subnet_summarize`, `ip_range_to_cidrs`
+- `ping(host, opts?)` with `method: "auto"` default and TCP fallback
+- shared target safety checks used by `ping` and future TCP functions
+- generated docs for all Phase 1 functions
+- safe example showing `ping("example.com")` and an internal-monitoring env-var example
+- IPAM examples for IPv4 subnet splitting and IPv6 parsing/summarization
+
+Acceptance:
+
+- Phase 1 imports work at runtime and lint/typecheck time.
+- IPv6 parsing, containment, overlap, splitting, supernet, summarization, and range conversion are supported and tested.
+- Large IPv6 counts/results do not overflow or generate unbounded arrays.
+- `ping("example.com")` has a documented no-root/no-capability path through TCP fallback.
+- Missing ICMP capability does not break default `ping()` usage.
+- no public internet dependency
+- no new dependency unless clearly justified; any ICMP dependency must keep the TCP fallback path clean
+- `cargo build --profile dev-release`, `cargo test net`, docs generation pass
+
+### PR 2 — Dedicated TCP probe refinement
+
+Scope:
+
+- `tcp_connect`
+- reuse/refactor the Phase 1 TCP fallback helper into the public `tcp_connect` API
+- local-listener tests
+- typechecker signature tests
+- AI agent guide section for `std/net` safety and jobs/concurrency guidance
+
+Acceptance:
+
+- local open/closed port tests pass
+- private/loopback policy behavior is explicit and tested
+- `Err` vs `Ok({ connected: false })` semantics are documented and tested
+
+### PR 3 — DNS A/AAAA/PTR
+
+Scope:
+
+- `dns_lookup`
+- `dns_reverse`
+- `hickory-resolver` or equivalent dependency decision
+- resolver abstraction or mock/local fixture
+
+Acceptance:
+
+- deterministic CI tests
+- no public DNS dependency by default
+- initial records limited to A/AAAA/PTR unless implementation remains small and clean
+
+### PR 4 — Bounded port scan
+
+Scope:
+
+- `port_scan` over explicit port arrays
+- bounds and cancellation checks
+- local open/closed test fixture
+
+Acceptance:
+
+- rejects too many ports/concurrency/invalid ports
+- deterministic order
+- no unbounded scanning
+
+### PR 5 — TLS info
+
+Scope:
+
+- dependency choice
+- `tls_info`
+- local TLS test server
+- generated docs and examples
+
+Acceptance:
+
+- returns certificate details for valid and validation-failing certs
+- no dependency claim mismatch
+- no public internet dependency by default
+
+---
+
+## Cross-Layer Touchpoints
+
+Every public function must update all layers:
+
+1. Runtime module:
+   - `src/stdlib/net.rs`
+   - `Value::NativeFunction` arity/max_arity matching actual args
+   - returns `Value::ok(...)` / `Value::err(...)` for documented `Result`
+
+2. Module registry:
+   - `src/stdlib/mod.rs`
+   - `pub mod net;`
+   - `modules.insert("std/net", net::init())`
+
+3. Typechecker:
+   - `src/typechecker.rs`
+   - `get_module_signatures("std/net")`
+   - focused tests for wrong arg types and optional args
+
+4. Docs:
+   - `// @ntnt` blocks in source
+   - `./target/dev-release/ntnt docs --generate`
+   - `docs/AI_AGENT_GUIDE.md` for practical usage and safety posture
+
+5. Examples:
+   - deterministic examples only for default validation
+   - public-network examples clearly marked as manual/optional if included
+
+---
+
+## Verification Checklist
+
+For each implementation PR:
+
+```bash
+cargo fmt
+cargo build --profile dev-release
+cargo test --lib
+cargo test --test type_checker_tests
+./target/dev-release/ntnt docs --generate
+./target/dev-release/ntnt validate examples/
+./target/dev-release/ntnt lint examples/*.tnt
+```
+
+For network-specific PRs:
+
+- tests use local listeners or mocks by default
+- public internet tests are opt-in only
+- raw socket tests are opt-in only
+- timeout clamps are tested
+- policy-denied targets are tested
+- docs drift is checked with `git diff docs/`
+
+---
+
+## Open Decisions Before Coding
+
+1. Should private/internal targets be governed by existing `NTNT_ALLOW_PRIVATE_IPS`, or should `std/net` introduce `NTNT_NET_ALLOW_PRIVATE`?
+
+   Recommendation: introduce `NTNT_NET_ALLOW_PRIVATE=1` for `std/net`, while implementing the check through a shared outbound-policy helper that can also honor `NTNT_ALLOW_PRIVATE_IPS` if we later want one global knob. Dedicated monitoring intent beats making `std/http` and `std/net` quietly share a footgun drawer.
+
+2. Should `tcp_connect` return `Ok({ connected: false })` for all ordinary connect failures?
+
+   Recommendation: yes. It is a diagnostic probe. Invalid input and policy denial remain `Err`.
+
+3. Should `dns_reverse` return one string or all PTR hostnames?
+
+   Recommendation: return `Result<Array<String>, String>`.
+
+4. Should `port_scan` accept range values in the first PR?
+
+   Recommendation: no. Start with explicit arrays; add ranges only after runtime/typechecker handling is confirmed.
+
+5. Should TLS inspection use `native-tls` or `rustls`?
+
+   Recommendation: decide in the TLS PR based on cert-chain extraction quality and dependency weight. Do not block IP/TCP/DNS on this.
+
+6. Should `ping()` mean strict ICMP or pragmatic reachability?
+
+   Recommendation: pragmatic by default. `method: "auto"` should use ICMP when available and TCP fallback when not. Strict ICMP is still available via `method: "icmp"`, but that path may require OS capability and should fail with clear guidance instead of silently degrading.
+
+7. Should internal targets be easy to enable for monitoring?
+
+   Recommendation: yes, but at process scope. Use `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private: true`. That makes a monitoring app easy to launch while preventing a random request body from flipping the SSRF guard off.
+
+---
+
+## Bottom Line
+
+The refined `std/net` path is smaller and much safer:
+
+1. deterministic IP helpers plus first-shot `ping()`
+2. dedicated TCP probe with explicit safety policy
+3. DNS with mockable tests
+4. bounded port scan
+5. TLS inspection after dependency choice
+
+That gets ntnt real network-monitoring capability without making the first user trip over `CAP_NET_RAW`, and without smuggling in traceroute, SSH, SNMP, scanners, public-network CI flakes, and SSRF footguns in one heroic PR. Heroic PRs are where bugs go to get tenure.

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -738,7 +738,7 @@ SNMP is a real network-monitoring need, but it is its own protocol family. Defer
 
 As of 2026-06-02:
 
-- [x] **PR 1 — `std/net` shell + IPAM helpers + `ping`**: implemented in [PR #113](https://github.com/ntntlang/ntnt/pull/113). Status: open, mergeable, CI green, no unresolved review threads at head `944a397`.
+- [x] **PR 1 — `std/net` shell + IPAM helpers + `ping`**: implemented in [PR #113](https://github.com/ntntlang/ntnt/pull/113). Status: open, mergeable, CI green, no unresolved review threads.
 - [ ] **PR 2 — Dedicated TCP probe refinement**: next planned slice. Reuses the Phase 1 TCP fallback helper as public `tcp_connect`.
 - [ ] **PR 3 — DNS A/AAAA/PTR**: planned after TCP probe.
 - [ ] **PR 4 — Bounded port scan**: planned after DNS.
@@ -752,87 +752,87 @@ Status: **implemented in PR #113; awaiting merge/review completion.**
 
 Scope:
 
-- `src/stdlib/net.rs`
-- `src/stdlib/mod.rs`
-- `src/typechecker.rs`
-- unit tests for helpers and IPv4/IPv6 IPAM behavior
-- `ip_parse`, `subnet_contains`, `subnet_overlaps`, `subnet_split`, `subnet_supernet`, `subnet_summarize`, `ip_range_to_cidrs`
-- `ping(host, opts?)` with `method: "auto"` default and TCP fallback
-- shared target safety checks used by `ping` and future TCP functions
-- generated docs for all Phase 1 functions
-- safe example showing `ping("example.com")` and an internal-monitoring env-var example
-- IPAM examples for IPv4 subnet splitting and IPv6 parsing/summarization
+- [x] `src/stdlib/net.rs`
+- [x] `src/stdlib/mod.rs`
+- [x] `src/typechecker.rs`
+- [x] unit tests for helpers and IPv4/IPv6 IPAM behavior
+- [x] `ip_parse`, `subnet_contains`, `subnet_overlaps`, `subnet_split`, `subnet_supernet`, `subnet_summarize`, `ip_range_to_cidrs`
+- [x] `ping(host, opts?)` with `method: "auto"` default and TCP fallback
+- [x] shared target safety checks used by `ping` and future TCP functions
+- [x] generated docs for all Phase 1 functions
+- [x] safe example showing `ping("example.com")` and an internal-monitoring env-var example
+- [x] IPAM examples for IPv4 subnet splitting and IPv6 parsing/summarization
 
 Acceptance:
 
-- Phase 1 imports work at runtime and lint/typecheck time.
-- IPv6 parsing, containment, overlap, splitting, supernet, summarization, and range conversion are supported and tested.
-- Large IPv6 counts/results do not overflow or generate unbounded arrays.
-- `ping("example.com")` has a documented no-root/no-capability path through TCP fallback.
-- Missing ICMP capability does not break default `ping()` usage.
-- no public internet dependency
-- no new dependency unless clearly justified; any ICMP dependency must keep the TCP fallback path clean
-- `cargo build --profile dev-release`, `cargo test net`, docs generation pass
+- [x] Phase 1 imports work at runtime and lint/typecheck time.
+- [x] IPv6 parsing, containment, overlap, splitting, supernet, summarization, and range conversion are supported and tested.
+- [x] Large IPv6 counts/results do not overflow or generate unbounded arrays.
+- [x] `ping("example.com")` has a documented no-root/no-capability path through TCP fallback.
+- [x] Missing ICMP capability does not break default `ping()` usage.
+- [x] no public internet dependency
+- [x] no new dependency unless clearly justified; any ICMP dependency must keep the TCP fallback path clean
+- [x] `cargo build --profile dev-release`, `cargo test net`, docs generation pass
 
 ### PR 2 — Dedicated TCP probe refinement
 
 Scope:
 
-- `tcp_connect`
-- reuse/refactor the Phase 1 TCP fallback helper into the public `tcp_connect` API
-- local-listener tests
-- typechecker signature tests
-- AI agent guide section for `std/net` safety and jobs/concurrency guidance
+- [ ] `tcp_connect`
+- [ ] reuse/refactor the Phase 1 TCP fallback helper into the public `tcp_connect` API
+- [ ] local-listener tests
+- [ ] typechecker signature tests
+- [ ] AI agent guide section for `std/net` safety and jobs/concurrency guidance
 
 Acceptance:
 
-- local open/closed port tests pass
-- private/loopback policy behavior is explicit and tested
-- `Err` vs `Ok({ connected: false })` semantics are documented and tested
+- [ ] local open/closed port tests pass
+- [ ] private/loopback policy behavior is explicit and tested
+- [ ] `Err` vs `Ok({ connected: false })` semantics are documented and tested
 
 ### PR 3 — DNS A/AAAA/PTR
 
 Scope:
 
-- `dns_lookup`
-- `dns_reverse`
-- `hickory-resolver` or equivalent dependency decision
-- resolver abstraction or mock/local fixture
+- [ ] `dns_lookup`
+- [ ] `dns_reverse`
+- [ ] `hickory-resolver` or equivalent dependency decision
+- [ ] resolver abstraction or mock/local fixture
 
 Acceptance:
 
-- deterministic CI tests
-- no public DNS dependency by default
-- initial records limited to A/AAAA/PTR unless implementation remains small and clean
+- [ ] deterministic CI tests
+- [ ] no public DNS dependency by default
+- [ ] initial records limited to A/AAAA/PTR unless implementation remains small and clean
 
 ### PR 4 — Bounded port scan
 
 Scope:
 
-- `port_scan` over explicit port arrays
-- bounds and cancellation checks
-- local open/closed test fixture
+- [ ] `port_scan` over explicit port arrays
+- [ ] bounds and cancellation checks
+- [ ] local open/closed test fixture
 
 Acceptance:
 
-- rejects too many ports/concurrency/invalid ports
-- deterministic order
-- no unbounded scanning
+- [ ] rejects too many ports/concurrency/invalid ports
+- [ ] deterministic order
+- [ ] no unbounded scanning
 
 ### PR 5 — TLS info
 
 Scope:
 
-- dependency choice
-- `tls_info`
-- local TLS test server
-- generated docs and examples
+- [ ] dependency choice
+- [ ] `tls_info`
+- [ ] local TLS test server
+- [ ] generated docs and examples
 
 Acceptance:
 
-- returns certificate details for valid and validation-failing certs
-- no dependency claim mismatch
-- no public internet dependency by default
+- [ ] returns certificate details for valid and validation-failing certs
+- [ ] no dependency claim mismatch
+- [ ] no public internet dependency by default
 
 ---
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -726,9 +726,11 @@ WHOIS is domain registry plumbing, not core connectivity. It also involves refer
 
 Remote command execution is too privileged for `std/net`. If added, it should likely be `std/ssh` or an app/plugin-level module with explicit host-key verification and credential handling. Default-permissive known-host behavior is not acceptable for a stdlib primitive.
 
-### SNMP
+### SNMP / network monitoring
 
-SNMP is a real network-monitoring need, but it is its own protocol family. Defer to `std/snmp` or a private/experimental monitoring module. Do not make the first `std/net` PR carry BER/ASN.1 and SNMP semantics.
+SNMP and higher-level monitoring concerns are covered by [DD-047: `std/netmon`](dd-047-std-netmon.md). Keep them out of the initial `std/net` module. `std/net` should provide safe primitives; `std/netmon` can build SNMP/device telemetry, interface counters, topology hints, composite checks, and alert-state helpers on top.
+
+SNMP is a real network-monitoring need, but it is its own protocol family. It should likely start as a private or separately distributed `std/netmon` library rather than default stdlib surface area. Do not make the first `std/net` PR carry BER/ASN.1 and SNMP semantics.
 
 ---
 

--- a/design-docs/dd-047-std-netmon.md
+++ b/design-docs/dd-047-std-netmon.md
@@ -1,0 +1,749 @@
+# DD-047: `std/netmon` — Network Monitoring Toolkit
+
+**Status:** Draft / private-library candidate
+**Author:** Larri
+**Created:** 2026-06-02
+**Related:** [DD-046: `std/net`](dd-046-std-net.md)
+**Target baseline:** after DD-046 Phase 2+ primitives stabilize
+
+---
+
+## Summary
+
+Design a `std/netmon` module for building real network monitoring systems in ntnt: SNMP device telemetry, interface counters, topology hints, check orchestration helpers, alert-state modeling, and opinionated monitoring data shapes.
+
+Unlike DD-046, this is **not necessarily part of the default standard library**. The current recommendation is to treat `std/netmon` as a private or separately distributed library first, then promote stable pieces only if they prove broadly useful and safe enough for the standard distribution.
+
+DD-046 gives ntnt safe network primitives. DD-047 is where those primitives become an MSP/ISP-grade monitoring toolkit instead of a polite loop that asks routers whether they are alive and then shrugs.
+
+---
+
+## Relationship to DD-046
+
+DD-046 owns the low-level, generally safe primitives:
+
+- IP/CIDR/IPAM helpers
+- `ping()` with first-shot fallback behavior
+- `tcp_connect()`
+- DNS lookup/reverse lookup
+- bounded port scanning
+- TLS certificate inspection
+
+DD-047 owns higher-level monitoring concerns:
+
+- SNMP polling/walking
+- interface telemetry and counter normalization
+- device inventory and profile helpers
+- topology hints from LLDP/CDP/SNMP tables
+- check definitions that combine DD-046 primitives
+- alert-state transitions, flap suppression, and maintenance windows
+- storage-friendly metric/event shapes
+
+`std/netmon` should consume `std/net`; it should not duplicate low-level connection, DNS, IPAM, or TLS logic.
+
+---
+
+## Product Positioning
+
+`std/netmon` has three possible packaging modes:
+
+1. **Private library first** — preferred initial path. Iterate fast, support real-world device weirdness, and avoid making unstable SNMP/device contracts part of ntnt's default stdlib promise.
+2. **Optional bundled library** — ships with ntnt but is explicitly optional/experimental, similar to a batteries-included contrib module.
+3. **Promoted standard module** — only after the API shape has survived real monitoring apps, device diversity, and operational abuse.
+
+Recommendation: start as a private library using the public module path `std/netmon` in examples/design so the eventual promotion path is clean, but do not commit to bundling it in the default standard library yet.
+
+---
+
+## Design Principles
+
+1. **Operationally useful before academically complete.** Start with the checks and telemetry a small MSP actually needs: device up/down, interface status, bandwidth/error counters, TLS/DNS/TCP checks, and alert state.
+
+2. **Private/internal by default.** Monitoring tools intentionally touch private networks. `std/netmon` should assume explicit deployment intent and should not weaken DD-046's public-web safety posture.
+
+3. **Bounded polling, no surprise scanners.** Inventory/discovery APIs must require explicit targets/subnets, strict caps, and clear opt-ins. A monitoring library should not accidentally become a LAN Roomba with a clipboard.
+
+4. **SNMP is protocol-specific enough to deserve its own layer.** Keep SNMP parsing, OID helpers, and device-profile logic out of `std/net`.
+
+5. **Normalize the boring parts.** Return consistent maps for counters, gauges, status, latency, loss, and timestamps so app code can store and display metrics without knowing every vendor's charming personal problems.
+
+6. **Make failure states first-class.** Timeouts, auth failures, noSuchName/noSuchObject, counter wraps, stale data, and partial polls are monitoring data, not just errors.
+
+7. **No secrets in design-level configs.** Community strings, SNMPv3 credentials, webhook tokens, and device credentials must come from env/secret stores, not checked-in examples.
+
+8. **Prefer jobs over request-path polling.** Heavy polling belongs in `std/jobs` / worker loops, not HTTP route handlers.
+
+---
+
+## Security and Deployment Model
+
+`std/netmon` is intentionally for internal monitoring. It still needs guardrails.
+
+Recommended process-level opt-in:
+
+```bash
+NTNT_NETMON_ENABLE=1 NTNT_NET_ALLOW_PRIVATE=1 ntnt run monitor.tnt
+```
+
+Suggested policy:
+
+- `std/netmon` refuses to poll unless `NTNT_NETMON_ENABLE=1` is set.
+- Private targets still require DD-046's private-network opt-in where DD-046 primitives are used.
+- Per-call target lists or subnets must be explicit and bounded.
+- Discovery/sweep helpers require stricter opt-ins than single-device checks.
+- Secrets must be passed as secret references or loaded from env, never embedded in examples.
+- Default examples use local/mock agents or documentation-only sample targets.
+
+Open question: whether `std/netmon` should also require an app-level config object like `netmon_configure(...)` before any polling. Recommendation: yes for private-library v1; explicit setup makes accidental usage harder.
+
+---
+
+## Proposed Module: `std/netmon`
+
+### Configuration
+
+#### `netmon_configure(opts) -> Result<Map, String>`
+
+Configure global monitoring behavior for the current process.
+
+```ntnt
+import { netmon_configure } from "std/netmon"
+
+netmon_configure(map {
+    "poll_timeout_ms": 2000,
+    "max_targets_per_run": 256,
+    "max_ports_per_target": 64,
+    "allow_discovery": false,
+    "snmp_defaults": map {
+        "version": "2c",
+        "timeout_ms": 1500,
+        "retries": 1
+    }
+})
+```
+
+Return effective config with clamps applied. Do not expose secrets in the returned map.
+
+### Device model helpers
+
+#### `device(target, opts?) -> Map`
+
+Build a normalized device descriptor used by other helpers.
+
+```ntnt
+let router = device("10.0.50.1", map {
+    "name": "core-router",
+    "role": "router",
+    "site": "home-lab",
+    "vendor": "mikrotik",
+    "snmp": map { "community_env": "CORE_ROUTER_SNMP_COMMUNITY" }
+})
+```
+
+Recommended fields:
+
+- `id`
+- `name`
+- `target`
+- `role`
+- `site`
+- `vendor`
+- `tags`
+- `snmp` credential reference metadata only, not raw secrets
+
+### SNMP primitives
+
+#### `snmp_get(target, oid, opts?) -> Result<Map, String>`
+
+Read one OID from a device.
+
+```ntnt
+import { snmp_get } from "std/netmon"
+
+let sys_name = snmp_get("10.0.50.1", "1.3.6.1.2.1.1.5.0", map {
+    "version": "2c",
+    "community_env": "ROUTER_SNMP_COMMUNITY"
+})
+```
+
+Result shape:
+
+```ntnt
+Ok(map {
+    "target": "10.0.50.1",
+    "oid": "1.3.6.1.2.1.1.5.0",
+    "name": "sysName.0",
+    "type": "OctetString",
+    "value": "core-router",
+    "latency_ms": 12.4,
+    "timestamp": "2026-06-02T12:00:00Z"
+})
+```
+
+#### `snmp_walk(target, oid, opts?) -> Result<Array<Map>, String>`
+
+Walk a subtree with strict row/result caps.
+
+Options:
+
+- `max_results`: default 2048, hard cap 20000 for private-library v1
+- `timeout_ms`: default 1500, clamp to shared netmon max
+- `retries`: default 1, hard cap 3
+- `version`: `"2c"` first; SNMPv3 later
+- `community_env`: environment variable containing community string
+
+#### `snmp_bulk_walk(target, oid, opts?) -> Result<Array<Map>, String>`
+
+Optional optimization after basic walk is stable. SNMP GETBULK can reduce polling overhead but should not be in PR 1 unless the implementation stays small and testable.
+
+#### `snmp_capabilities(target, opts?) -> Result<Map, String>`
+
+Probe SNMP availability and supported basics without doing a full inventory poll.
+
+```ntnt
+snmp_capabilities("10.0.50.1", map { "community_env": "ROUTER_SNMP_COMMUNITY" })
+// Ok(map { "reachable": true, "version": "2c", "sys_object_id": "...", "vendor_hint": "mikrotik" })
+```
+
+### Interface telemetry
+
+#### `interface_list(target, opts?) -> Result<Array<Map>, String>`
+
+Return normalized interface inventory from IF-MIB.
+
+Recommended fields:
+
+- `index`
+- `name`
+- `description`
+- `alias`
+- `type`
+- `mtu`
+- `speed_bps`
+- `admin_status`
+- `oper_status`
+- `mac`
+- `last_change`
+
+#### `interface_counters(target, opts?) -> Result<Array<Map>, String>`
+
+Return 64-bit counters where available, falling back to 32-bit with explicit metadata.
+
+Recommended fields:
+
+- `index`
+- `name`
+- `in_octets`
+- `out_octets`
+- `in_packets`
+- `out_packets`
+- `in_errors`
+- `out_errors`
+- `in_discards`
+- `out_discards`
+- `counter_bits`
+- `timestamp`
+
+#### `interface_rates(previous, current, opts?) -> Result<Array<Map>, String>`
+
+Convert counter snapshots into rates while handling wraps, resets, and impossible deltas.
+
+Recommended fields:
+
+- `index`
+- `interval_seconds`
+- `in_bps`
+- `out_bps`
+- `in_pps`
+- `out_pps`
+- `error_rate`
+- `discard_rate`
+- `utilization_in_percent`
+- `utilization_out_percent`
+- `counter_reset_detected`
+
+This helper is important enough to design early. Good monitoring lives on rates, not raw counters. Raw counters are just odometers with commitment issues.
+
+### Device inventory
+
+#### `device_identity(target, opts?) -> Result<Map, String>`
+
+Read basic identity:
+
+- `sys_name`
+- `sys_descr`
+- `sys_object_id`
+- `sys_contact`
+- `sys_location`
+- `uptime_seconds`
+- `vendor_hint`
+- `model_hint`
+- `os_hint`
+
+#### `device_inventory(target, opts?) -> Result<Map, String>`
+
+Higher-level inventory bundle:
+
+```ntnt
+Ok(map {
+    "identity": map { ... },
+    "interfaces": [...],
+    "neighbors": [...],
+    "routes_summary": map { ... },
+    "poll_status": "partial",
+    "warnings": ["LLDP table unavailable"]
+})
+```
+
+V1 should tolerate partial results. A device that refuses LLDP should not discard interface counters.
+
+### Topology hints
+
+#### `lldp_neighbors(target, opts?) -> Result<Array<Map>, String>`
+
+Read LLDP-MIB where available.
+
+#### `cdp_neighbors(target, opts?) -> Result<Array<Map>, String>`
+
+Optional Cisco CDP support. Candidate for vendor-profile phase, not initial core.
+
+#### `topology_edges(devices, opts?) -> Result<Array<Map>, String>`
+
+Normalize neighbor data into graph edges.
+
+Fields:
+
+- `local_device`
+- `local_interface`
+- `remote_device`
+- `remote_interface`
+- `protocol`
+- `confidence`
+- `raw`
+
+### Composite checks
+
+Composite checks combine `std/net` and `std/netmon` primitives into reusable monitoring definitions.
+
+#### `check_ping(target, opts?) -> Result<Map, String>`
+
+Wrapper over DD-046 `ping()` with monitoring result shape.
+
+#### `check_tcp(target, port, opts?) -> Result<Map, String>`
+
+Wrapper over DD-046 `tcp_connect()`.
+
+#### `check_dns(name, record_type?, opts?) -> Result<Map, String>`
+
+Wrapper over DD-046 DNS helpers with latency and expected-record matching.
+
+#### `check_tls(host, opts?) -> Result<Map, String>`
+
+Wrapper over DD-046 `tls_info()` with expiry thresholds.
+
+#### `check_snmp(target, opts?) -> Result<Map, String>`
+
+SNMP liveness/identity check.
+
+#### `run_checks(targets, checks, opts?) -> Result<Array<Map>, String>`
+
+Run bounded checks for multiple targets. This should be job-friendly and deterministic, not an unbounded fan-out.
+
+Result shape:
+
+```ntnt
+Ok([
+    map {
+        "target": "core-router",
+        "check": "snmp",
+        "status": "ok",
+        "latency_ms": 18.2,
+        "observed_at": "2026-06-02T12:00:00Z",
+        "data": map { ... }
+    }
+])
+```
+
+### Alert-state helpers
+
+`std/netmon` should not own delivery channels, but it can own state transitions.
+
+#### `evaluate_threshold(metric, rule, window?) -> Result<Map, String>`
+
+Examples:
+
+- interface utilization over 90% for 5 minutes
+- packet loss over 10% for 3 checks
+- TLS expiry below 14 days
+- device down for 2 consecutive polls
+
+#### `alert_transition(previous_state, current_result, opts?) -> Result<Map, String>`
+
+Return `open`, `resolved`, `unchanged`, `suppressed`, or `flapping`.
+
+Fields:
+
+- `state`
+- `severity`
+- `reason`
+- `dedupe_key`
+- `opened_at`
+- `resolved_at`
+- `last_observed_at`
+- `suppressed_until`
+
+#### `maintenance_window(target, schedule, now?) -> Result<Map, String>`
+
+Small helper for suppressing expected outages. Full calendar integration belongs elsewhere.
+
+---
+
+## Data Model Recommendations
+
+A reference monitoring app should store these durable shapes:
+
+### `devices`
+
+- `id`
+- `name`
+- `target`
+- `site`
+- `role`
+- `vendor`
+- `tags`
+- credential references, not raw secrets
+- enabled/disabled state
+
+### `checks`
+
+- `id`
+- `device_id`
+- `type`
+- `options`
+- `interval_seconds`
+- `timeout_ms`
+- enabled/disabled state
+
+### `metric_samples`
+
+- `device_id`
+- `interface_index` optional
+- `metric`
+- `value`
+- `unit`
+- `observed_at`
+- `source`
+
+### `check_results`
+
+- `check_id`
+- `status`
+- `latency_ms`
+- `observed_at`
+- `data`
+- `error`
+
+### `alerts`
+
+- `dedupe_key`
+- `state`
+- `severity`
+- `target`
+- `reason`
+- `opened_at`
+- `resolved_at`
+- `last_observed_at`
+
+Retention, rollups, dashboards, and notification delivery should live in the reference app, not necessarily inside `std/netmon`.
+
+---
+
+## Module Boundary: What Belongs Where
+
+### `std/net` / DD-046
+
+- IPAM math
+- TCP connect probe
+- ping/reachability
+- DNS lookup/reverse
+- bounded port scan
+- TLS inspection
+
+### `std/netmon` / DD-047
+
+- SNMP device telemetry
+- interface counters/rates
+- topology hints
+- device inventory normalization
+- composite monitoring checks
+- alert-state helpers
+- storage-friendly metric/check shapes
+
+### Reference app, not library
+
+- UI/dashboard
+- auth/users/teams
+- notification delivery integrations
+- long-term retention policies
+- chart rendering
+- topology graph layout
+- customer/site management
+- billing/multi-tenant concerns
+
+### Future raw/network toolbox, not initial `std/netmon`
+
+- traceroute/MTR
+- ARP scan
+- packet capture
+- bandwidth testing
+- route-table reads
+- BGP session tooling
+- NetFlow/sFlow collectors
+
+Some of these may become useful later, but they carry OS permissions, abuse risk, and platform-specific pain. Do not let them sneak into SNMP v1 wearing a fake mustache.
+
+---
+
+## Implementation Plan
+
+### Status Dashboard
+
+- [ ] **PR 0 — packaging decision and private-library skeleton**
+- [ ] **PR 1 — SNMP v2c basics**
+- [ ] **PR 2 — interface inventory and counters**
+- [ ] **PR 3 — counter-rate normalization**
+- [ ] **PR 4 — device identity and inventory bundle**
+- [ ] **PR 5 — topology hints from LLDP**
+- [ ] **PR 6 — composite checks over DD-046 primitives**
+- [ ] **PR 7 — alert-state helpers**
+- [ ] **PR 8 — reference monitoring app / examples**
+
+### PR 0 — Packaging Decision and Skeleton
+
+Scope:
+
+- [ ] Decide private library vs optional bundled module for first implementation.
+- [ ] Choose module layout and import path strategy for `std/netmon`.
+- [ ] Add a small private-library skeleton or experimental module gate.
+- [ ] Define credential-reference conventions (`community_env`, later secret refs).
+- [ ] Add deterministic mock SNMP fixture plan.
+- [ ] Add README/docs caveat that this is not default stdlib until promoted.
+
+Acceptance:
+
+- [ ] Consumers can import the private module in a documented way.
+- [ ] No raw secrets appear in examples, tests, or generated docs.
+- [ ] `NTNT_NETMON_ENABLE=1` requirement is documented or implemented.
+- [ ] DD-046 boundary is preserved.
+
+### PR 1 — SNMP v2c Basics
+
+Scope:
+
+- [ ] `snmp_get(target, oid, opts?)`
+- [ ] `snmp_walk(target, oid, opts?)`
+- [ ] Basic ASN.1/BER value decoding or dependency choice.
+- [ ] SNMP response/error normalization.
+- [ ] Timeout and retry clamps.
+- [ ] Mock SNMP agent test fixture.
+
+Acceptance:
+
+- [ ] GET returns normalized map for scalar OIDs.
+- [ ] WALK returns ordered rows with strict result cap.
+- [ ] noSuchObject/noSuchName/timeouts produce monitoring-useful results.
+- [ ] Tests do not require a real network device.
+- [ ] Community strings are loaded via env/secret references only.
+
+### PR 2 — Interface Inventory and Counters
+
+Scope:
+
+- [ ] `interface_list(target, opts?)`
+- [ ] `interface_counters(target, opts?)`
+- [ ] IF-MIB OID constants/helpers.
+- [ ] Prefer high-capacity 64-bit counters when present.
+- [ ] Explicit fallback metadata for 32-bit counters.
+
+Acceptance:
+
+- [ ] Interfaces have stable normalized fields.
+- [ ] Counters include timestamp and counter width.
+- [ ] Missing optional fields degrade gracefully.
+- [ ] Fixture covers up/down/admin-down interfaces.
+
+### PR 3 — Counter-Rate Normalization
+
+Scope:
+
+- [ ] `interface_rates(previous, current, opts?)`
+- [ ] Counter wrap/reset detection.
+- [ ] Utilization percentage from speed when available.
+- [ ] Invalid delta filtering.
+
+Acceptance:
+
+- [ ] 64-bit and 32-bit counters calculate sane rates.
+- [ ] Wraps/resets are detected and marked.
+- [ ] Negative/impossible deltas do not produce bogus traffic spikes.
+- [ ] Tests cover missing speed and zero interval.
+
+### PR 4 — Device Identity and Inventory Bundle
+
+Scope:
+
+- [ ] `device_identity(target, opts?)`
+- [ ] `device_inventory(target, opts?)`
+- [ ] sysDescr/sysObjectID/vendor-hint mapping.
+- [ ] Partial-result warnings.
+
+Acceptance:
+
+- [ ] Identity includes name, description, object ID, location/contact, uptime, vendor hint.
+- [ ] Inventory bundle returns partial data rather than failing the whole poll when optional tables are unavailable.
+- [ ] Vendor-hint mapping is data-driven and easy to extend.
+
+### PR 5 — Topology Hints from LLDP
+
+Scope:
+
+- [ ] `lldp_neighbors(target, opts?)`
+- [ ] `topology_edges(devices, opts?)`
+- [ ] Normalize neighbor identities and local/remote port names.
+- [ ] Optional CDP design stub, but do not implement unless tiny.
+
+Acceptance:
+
+- [ ] LLDP neighbor table becomes stable edge maps.
+- [ ] Missing LLDP support returns clear empty/unsupported result.
+- [ ] Edges include confidence/protocol/source fields.
+
+### PR 6 — Composite Checks Over DD-046 Primitives
+
+Scope:
+
+- [ ] `check_ping`
+- [ ] `check_tcp`
+- [ ] `check_dns`
+- [ ] `check_tls`
+- [ ] `check_snmp`
+- [ ] `run_checks`
+
+Acceptance:
+
+- [ ] Check result shape is consistent across check types.
+- [ ] `run_checks` enforces target/check/concurrency caps.
+- [ ] DD-046 helpers are reused, not reimplemented.
+- [ ] Results are storage-friendly and include observed timestamp.
+
+### PR 7 — Alert-State Helpers
+
+Scope:
+
+- [ ] `evaluate_threshold(metric, rule, window?)`
+- [ ] `alert_transition(previous_state, current_result, opts?)`
+- [ ] Maintenance-window helper.
+- [ ] Flap detection and dedupe-key conventions.
+
+Acceptance:
+
+- [ ] Down/up/open/resolved transitions are deterministic.
+- [ ] Dedupe keys are stable.
+- [ ] Maintenance windows suppress without losing raw check results.
+- [ ] Flapping state is explicit and test-covered.
+
+### PR 8 — Reference Monitoring App / Examples
+
+Scope:
+
+- [ ] Example ntnt app that polls devices through jobs.
+- [ ] Storage schema for devices/checks/results/alerts.
+- [ ] Small dashboard route examples.
+- [ ] Mock-device mode for examples and CI.
+
+Acceptance:
+
+- [ ] Example works without real devices by default.
+- [ ] Real-device usage is documented with env vars and private-network opt-ins.
+- [ ] Polling runs in workers/jobs, not request handlers.
+- [ ] Alerts are stateful and deduped.
+
+---
+
+## Dependencies / Implementation Choices
+
+SNMP implementation options:
+
+1. Use an existing Rust SNMP crate if it is maintained, dependency-light, supports v2c cleanly, and can be tested with fixtures.
+2. Implement minimal SNMP v2c GET/WALK encoding/decoding directly if dependency quality is poor.
+3. Defer SNMPv3 until v2c and data shapes are stable.
+
+Recommendation: evaluate crates during PR 0/1, but bias toward a small, auditable implementation path. SNMP v2c is not pretty, but it is finite. Unlike humans in meetings.
+
+Potential helper crates/features:
+
+- ASN.1/BER encoder/decoder if direct implementation wins
+- fixed test clock helper for rate and alert tests
+- mock UDP SNMP agent fixture for CI
+
+---
+
+## Testing Strategy
+
+Default CI must not require private network access or real devices.
+
+Required tests:
+
+- [ ] mock SNMP GET scalar success
+- [ ] mock SNMP WALK table success
+- [ ] timeout / retry behavior
+- [ ] malformed SNMP response handling
+- [ ] noSuchObject/noSuchName normalization
+- [ ] interface inventory normalization
+- [ ] 32-bit and 64-bit counter snapshots
+- [ ] counter wrap/reset detection
+- [ ] alert-state transitions
+- [ ] maintenance-window suppression
+- [ ] `run_checks` concurrency/cap enforcement
+
+Optional/manual tests:
+
+- [ ] real SNMP v2c device smoke test gated by `NTNT_RUN_NETMON_DEVICE_TESTS=1`
+- [ ] vendor profile smoke tests gated by explicit target/env vars
+- [ ] long-running polling soak test outside default CI
+
+---
+
+## Open Decisions
+
+1. **Packaging:** private library only, optional bundled module, or experimental stdlib module?
+
+   Recommendation: private library first, preserving `std/netmon` as the intended import path.
+
+2. **SNMP dependency:** external crate or direct minimal v2c implementation?
+
+   Recommendation: decide after crate spike. Prefer boring-maintained over clever-abandoned.
+
+3. **SNMPv3 timing:** include in initial module or defer?
+
+   Recommendation: defer. v2c still dominates small/internal monitoring; v3 adds auth/privacy/key-handling complexity that should not block normalized telemetry shapes.
+
+4. **OID/MIB strategy:** ship hardcoded IF-MIB/SYSTEM/LLDP constants or parse MIB files?
+
+   Recommendation: hardcoded curated constants first. MIB parsing is a swamp with paperwork.
+
+5. **Discovery scope:** should `std/netmon` include subnet discovery?
+
+   Recommendation: not initially. Require explicit device inventory first. Add bounded discovery later after policy and abuse controls are proven.
+
+6. **Alert delivery:** should the module send notifications?
+
+   Recommendation: no. It can calculate alert state; apps own email/webhook/Telegram/PagerDuty delivery.
+
+---
+
+## Bottom Line
+
+`std/netmon` should make ntnt credible for network monitoring by adding SNMP/device telemetry and monitoring-specific state helpers on top of DD-046's safe primitives.
+
+Start private. Keep the API honest. Normalize the data shapes. Avoid pretending a full NMS is a stdlib function. That way we get a useful monitoring toolkit without turning ntnt's default stdlib into a closet full of enterprise networking adapters wearing one trench coat.

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -988,7 +988,15 @@ These helpers return `Result<..., String>`; use `unwrap(...)` for quick scripts/
 
 `ip_parse()` supports IPv4 and IPv6. Large IPv6 address counts are returned as strings so `/64` and larger networks do not overflow integer values.
 
-`ping()` defaults to `method: "auto"`. Phase 1 uses an unprivileged TCP fallback path instead of requiring root, `CAP_NET_RAW`, or Docker `cap_add` just to run the first example. If you need strict ICMP behavior, pass `method: "icmp"`; unsupported ICMP capability returns `Err(String)` with guidance.
+`ping()` defaults to `method: "auto"` and does **not** silently fall back to TCP ports. In Phase 1, unsupported ICMP returns `Err(String)` with guidance. If an app intentionally wants TCP reachability instead of ICMP ping, pass `method: "tcp"` with explicit `tcp_ports` and optional `count` (1-10) to get per-attempt results plus `sent`, `received`, `failed`, and `loss_percent` summary fields.
+
+```ntnt
+let tcp_reachability = ping("example.com", map {
+    "method": "tcp",
+    "tcp_ports": [443],
+    "count": 5
+})
+```
 
 Private/internal targets are denied by default. Monitoring apps must opt in at process scope **and** call scope:
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -972,31 +972,35 @@ Both `fetch(map { "url": url, ... })` and `fetch(url, map { ... })` work. The tw
 
 ### Network/IPAM Helpers (`std/net`)
 
-`std/net` provides deterministic IPv4/IPv6 CIDR helpers plus a first-shot reachability probe:
+`std/net` provides deterministic IPv4/IPv6 CIDR helpers, protocol-honest ICMP ping, explicit TCP connect probes, and a high-level reachability helper:
 
 ```ntnt
-import { ip_parse, subnet_contains, subnet_split, subnet_summarize, ping } from "std/net"
+import { ip_parse, subnet_contains, subnet_split, subnet_summarize, tcp_connect, reachable } from "std/net"
 
 let info = unwrap(ip_parse("192.168.1.0/24"))
 let contains = unwrap(subnet_contains("10.0.0.0/8", "10.42.0.0/16"))
 let children = unwrap(subnet_split("192.168.1.0/24", 28))
 let summary = unwrap(subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"]))
-let reachability = unwrap(ping("example.com"))
+let tcp = unwrap(tcp_connect("example.com", 443))
+let reachability = unwrap(reachable("example.com", map { "tcp_ports": [443] }))
 ```
 
 These helpers return `Result<..., String>`; use `unwrap(...)` for quick scripts/examples, or `match`/`otherwise` when the app should handle invalid input or policy denial.
 
 `ip_parse()` supports IPv4 and IPv6. Large IPv6 address counts are returned as strings so `/64` and larger networks do not overflow integer values.
 
-`ping()` defaults to `method: "auto"` and does **not** silently fall back to TCP ports. In Phase 1, unsupported ICMP returns `Err(String)` with guidance. If an app intentionally wants TCP reachability instead of ICMP ping, pass `method: "tcp"` with explicit `tcp_ports` and optional `count` (1-10) to get per-attempt results plus `sent`, `received`, `failed`, and `loss_percent` summary fields.
+`ping()` is ICMP-only and does **not** silently fall back to TCP ports. In Phase 1, unsupported ICMP returns `Err(String)` with guidance. If an app intentionally wants a TCP port check, use `tcp_connect(host, port, opts?)`. If it wants a high-level “is this host reachable somehow?” check, use `reachable(host, opts?)` with explicit `tcp_ports` so the result can honestly report `method: "tcp"` and `fallback_from: "icmp"`.
 
 ```ntnt
-let tcp_reachability = ping("example.com", map {
-    "method": "tcp",
+let tcp = tcp_connect("example.com", 443, map { "count": 5 })
+
+let reachability = reachable("example.com", map {
     "tcp_ports": [443],
     "count": 5
 })
 ```
+
+`tcp_connect()` and `reachable()` support optional `count` (1-10), `timeout_ms`, and `interval_ms`, returning per-attempt results plus `sent`, `received`, `failed`, and `loss_percent` summary fields.
 
 Private/internal targets are denied by default. Monitoring apps must opt in at process scope **and** call scope:
 
@@ -1005,7 +1009,7 @@ NTNT_NET_ALLOW_PRIVATE=1 ntnt run monitor.tnt
 ```
 
 ```ntnt
-let result = ping("10.0.0.5", map { "allow_private": true })
+let result = tcp_connect("10.0.0.5", 443, map { "allow_private": true })
 ```
 
 Special-purpose and high-risk targets such as cloud metadata endpoints, multicast, broadcast, unspecified, and documentation ranges remain blocked even with private-network opt-in.

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -977,12 +977,14 @@ Both `fetch(map { "url": url, ... })` and `fetch(url, map { ... })` work. The tw
 ```ntnt
 import { ip_parse, subnet_contains, subnet_split, subnet_summarize, ping } from "std/net"
 
-let info = ip_parse("192.168.1.0/24")
-let contains = subnet_contains("10.0.0.0/8", "10.42.0.0/16")
-let children = subnet_split("192.168.1.0/24", 28)
-let summary = subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"])
-let reachability = ping("example.com")
+let info = unwrap(ip_parse("192.168.1.0/24"))
+let contains = unwrap(subnet_contains("10.0.0.0/8", "10.42.0.0/16"))
+let children = unwrap(subnet_split("192.168.1.0/24", 28))
+let summary = unwrap(subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"]))
+let reachability = unwrap(ping("example.com"))
 ```
+
+These helpers return `Result<..., String>`; use `unwrap(...)` for quick scripts/examples, or `match`/`otherwise` when the app should handle invalid input or policy denial.
 
 `ip_parse()` supports IPv4 and IPv6. Large IPv6 address counts are returned as strings so `/64` and larger networks do not overflow integer values.
 
@@ -997,6 +999,8 @@ NTNT_NET_ALLOW_PRIVATE=1 ntnt run monitor.tnt
 ```ntnt
 let result = ping("10.0.0.5", map { "allow_private": true })
 ```
+
+Special-purpose and high-risk targets such as cloud metadata endpoints, multicast, broadcast, unspecified, and documentation ranges remain blocked even with private-network opt-in.
 
 Do not pipe user-controlled hostnames directly into `std/net` probes in public web apps. The stdlib blocks the worst SSRF targets by default, but app-level validation is still required.
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -970,6 +970,38 @@ let resp = fetch("https://api.example.com/data", map {
 
 Both `fetch(map { "url": url, ... })` and `fetch(url, map { ... })` work. The two-argument form is typically more natural.
 
+### Network/IPAM Helpers (`std/net`)
+
+`std/net` provides deterministic IPv4/IPv6 CIDR helpers plus a first-shot reachability probe:
+
+```ntnt
+import { ip_parse, subnet_contains, subnet_split, subnet_summarize, ping } from "std/net"
+
+let info = ip_parse("192.168.1.0/24")
+let contains = subnet_contains("10.0.0.0/8", "10.42.0.0/16")
+let children = subnet_split("192.168.1.0/24", 28)
+let summary = subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"])
+let reachability = ping("example.com")
+```
+
+`ip_parse()` supports IPv4 and IPv6. Large IPv6 address counts are returned as strings so `/64` and larger networks do not overflow integer values.
+
+`ping()` defaults to `method: "auto"`. Phase 1 uses an unprivileged TCP fallback path instead of requiring root, `CAP_NET_RAW`, or Docker `cap_add` just to run the first example. If you need strict ICMP behavior, pass `method: "icmp"`; unsupported ICMP capability returns `Err(String)` with guidance.
+
+Private/internal targets are denied by default. Monitoring apps must opt in at process scope **and** call scope:
+
+```bash
+NTNT_NET_ALLOW_PRIVATE=1 ntnt run monitor.tnt
+```
+
+```ntnt
+let result = ping("10.0.0.5", map { "allow_private": true })
+```
+
+Do not pipe user-controlled hostnames directly into `std/net` probes in public web apps. The stdlib blocks the worst SSRF targets by default, but app-level validation is still required.
+
+### JSON Body Parsing
+
 Use `"json": map{...}` for JSON POST or `"form": map{...}` for form POST — auto-encodes and sets Content-Type.
 
 ### CORS (Cross-Origin Resource Sharing)
@@ -1610,7 +1642,7 @@ The most-used stdlib functions are auto-injected — no import needed:
 | `std/time` | `now`, `format` |
 | `std/crypto` | `uuid`, `sha256` |
 
-**NOT in prelude** (still need explicit import): `fetch` (std/http), `connect`/`query`/`execute` (database modules), `set_cookie`/`get_cookie`/`with_cookie` (std/http/server), `sort_by`/`first`/`last`/`push`/`pop` (std/collections), KV, jobs, fs, csv, concurrent.
+**NOT in prelude** (still need explicit import): `fetch` (std/http), `std/net` IPAM/probe helpers, `connect`/`query`/`execute` (database modules), `set_cookie`/`get_cookie`/`with_cookie` (std/http/server), `sort_by`/`first`/`last`/`push`/`pop` (std/collections), KV, jobs, fs, csv, concurrent.
 
 Explicit imports still work — prelude just makes them unnecessary for common functions.
 

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [ial.toml](ial.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.9
+> Last updated: v0.4.10
 
 IAL is a term rewriting engine that translates natural language assertions into executable tests
 

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [runtime.toml](runtime.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.9
+> Last updated: v0.4.10
 
 Runtime configuration, environment variables, and CLI commands for NTNT
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -9696,12 +9696,14 @@ import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
 |----------|-------------|
 | [`ip_parse`](#ipparse) | Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields. |
 | [`ip_range_to_cidrs`](#iprangetocidrs) | Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover. |
-| [`ping`](#ping) | Performs a bounded host reachability probe. Phase 1 does not silently fall back from ICMP ping to TCP ports; apps that intentionally want TCP reachability must request method: "tcp" and provide tcp_ports explicitly. Private targets require both process and call-level opt-in; special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges are never allowed. |
+| [`ping`](#ping) | Performs an ICMP ping when ICMP support is available. It is protocol-honest: ping() does not fall back to TCP ports. Apps that want TCP port checks should use tcp_connect(); apps that want explicit ICMP-then-TCP reachability should use reachable(). |
+| [`reachable`](#reachable) | Performs an explicit high-level reachability check. Phase 1 has no ICMP implementation, so TCP fallback requires caller-provided tcp_ports; the result records method and fallback_from instead of pretending TCP is ping. |
 | [`subnet_contains`](#subnetcontains) | Returns true when the parent CIDR contains the entire child address or subnet. |
 | [`subnet_overlaps`](#subnetoverlaps) | Returns true when two IPv4 or IPv6 CIDRs overlap. |
 | [`subnet_split`](#subnetsplit) | Splits a CIDR into child subnets with a longer prefix, enforcing result caps. |
 | [`subnet_summarize`](#subnetsummarize) | Summarizes adjacent or overlapping CIDRs into the shortest equivalent route list. |
 | [`subnet_supernet`](#subnetsupernet) | Returns the parent/supernet of a CIDR. Defaults to one bit shorter. |
+| [`tcp_connect`](#tcpconnect) | Performs a bounded TCP connect probe to one explicit port. Closed, refused, or timed-out ports return Ok(map { "connected": false, ... }); invalid input, policy denial, and resolver/system failures return Err(String). |
 
 #### `ip_parse`
 
@@ -9745,7 +9747,32 @@ Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover.
 ping(host: String, opts?: Map) -> Result<Map, String>
 ```
 
-Performs a bounded host reachability probe. Phase 1 does not silently fall back from ICMP ping to TCP ports; apps that intentionally want TCP reachability must request method: "tcp" and provide tcp_ports explicitly. Private targets require both process and call-level opt-in; special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges are never allowed.
+Performs an ICMP ping when ICMP support is available. It is protocol-honest: ping() does not fall back to TCP ports. Apps that want TCP port checks should use tcp_connect(); apps that want explicit ICMP-then-TCP reachability should use reachable().
+
+*Since v0.4.10*
+
+---
+
+#### `reachable`
+
+```ntnt
+reachable(host: String, opts?: Map) -> Result<Map, String>
+```
+
+Performs an explicit high-level reachability check. Phase 1 has no ICMP implementation, so TCP fallback requires caller-provided tcp_ports; the result records method and fallback_from instead of pretending TCP is ping.
+
+**Parameters:**
+
+- `host` — Hostname or IP address to resolve and probe
+- `opts` — Optional map with tcp_ports, timeout_ms, count, interval_ms, and allow_private
+
+**Returns:** Result containing reachability status, method used, fallback metadata, and attempt summary
+
+**Examples:**
+
+```ntnt
+reachable("example.com", map { "tcp_ports": [443], "count": 5 })  // Check host reachability with explicit TCP fallback
+```
 
 *Since v0.4.10*
 
@@ -9806,6 +9833,32 @@ subnet_supernet(cidr: String, new_prefix?: Int) -> Result<String, String>
 ```
 
 Returns the parent/supernet of a CIDR. Defaults to one bit shorter.
+
+*Since v0.4.10*
+
+---
+
+#### `tcp_connect`
+
+```ntnt
+tcp_connect(host: String, port: Int, opts?: Map) -> Result<Map, String>
+```
+
+Performs a bounded TCP connect probe to one explicit port. Closed, refused, or timed-out ports return Ok(map { "connected": false, ... }); invalid input, policy denial, and resolver/system failures return Err(String).
+
+**Parameters:**
+
+- `host` — Hostname or IP address to resolve and probe
+- `port` — TCP port from 1 to 65535
+- `opts` — Optional map with timeout_ms, count, interval_ms, and allow_private
+
+**Returns:** Result containing connection status, latency summary, and per-attempt results
+
+**Examples:**
+
+```ntnt
+tcp_connect("example.com", 443)  // Check whether TCP 443 accepts connections
+```
 
 *Since v0.4.10*
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from source code doc comments** - Do not edit directly.
 >
-> Last updated: v0.4.9
+> Last updated: v0.4.10
 
 ## Table of Contents
 
@@ -9723,7 +9723,7 @@ Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields.
 ip_parse("192.168.1.0/24")  // Parse an IPv4 subnet
 ```
 
-*Since v0.5.0*
+*Since v0.4.10*
 
 ---
 
@@ -9735,7 +9735,7 @@ ip_range_to_cidrs(start_ip: String, end_ip: String) -> Result<Array<String>, Str
 
 Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover.
 
-*Since v0.5.0*
+*Since v0.4.10*
 
 ---
 
@@ -9747,7 +9747,7 @@ ping(host: String, opts?: Map) -> Result<Map, String>
 
 Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable.
 
-*Since v0.5.0*
+*Since v0.4.10*
 
 ---
 
@@ -9759,7 +9759,7 @@ subnet_contains(cidr: String, ip_or_cidr: String) -> Result<Bool, String>
 
 Returns true when the parent CIDR contains the entire child address or subnet.
 
-*Since v0.5.0*
+*Since v0.4.10*
 
 ---
 
@@ -9771,7 +9771,7 @@ subnet_overlaps(a: String, b: String) -> Result<Bool, String>
 
 Returns true when two IPv4 or IPv6 CIDRs overlap.
 
-*Since v0.5.0*
+*Since v0.4.10*
 
 ---
 
@@ -9783,7 +9783,7 @@ subnet_split(cidr: String, new_prefix: Int, opts?: Map) -> Result<Array<String>,
 
 Splits a CIDR into child subnets with a longer prefix, enforcing result caps.
 
-*Since v0.5.0*
+*Since v0.4.10*
 
 ---
 
@@ -9795,7 +9795,7 @@ subnet_summarize(cidrs: Array<String>) -> Result<Array<String>, String>
 
 Summarizes adjacent or overlapping CIDRs into the shortest equivalent route list.
 
-*Since v0.5.0*
+*Since v0.4.10*
 
 ---
 
@@ -9807,7 +9807,7 @@ subnet_supernet(cidr: String, new_prefix?: Int) -> Result<String, String>
 
 Returns the parent/supernet of a CIDR. Defaults to one bit shorter.
 
-*Since v0.5.0*
+*Since v0.4.10*
 
 ---
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -22,6 +22,7 @@
 - [std/log](#stdlog)
 - [std/markdown](#stdmarkdown)
 - [std/math](#stdmath)
+- [std/net](#stdnet)
 - [std/path](#stdpath)
 - [std/postgres](#stdpostgres)
 - [std/sqlite](#stdsqlite)
@@ -9678,6 +9679,135 @@ tanh(1)  // => 0.7615941559557649  // Hyperbolic tangent of one
 **See also:** `sinh`, `cosh`, `tan`
 
 *Since v0.1.0*
+
+---
+
+## std/net
+
+Safe network primitives: IPAM-grade CIDR math and reachability probes
+
+```ntnt
+import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
+```
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| [`ip_parse`](#ipparse) | Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields. |
+| [`ip_range_to_cidrs`](#iprangetocidrs) | Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover. |
+| [`ping`](#ping) | Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable. |
+| [`subnet_contains`](#subnetcontains) | Returns true when the parent CIDR contains the entire child address or subnet. |
+| [`subnet_overlaps`](#subnetoverlaps) | Returns true when two IPv4 or IPv6 CIDRs overlap. |
+| [`subnet_split`](#subnetsplit) | Splits a CIDR into child subnets with a longer prefix, enforcing result caps. |
+| [`subnet_summarize`](#subnetsummarize) | Summarizes adjacent or overlapping CIDRs into the shortest equivalent route list. |
+| [`subnet_supernet`](#subnetsupernet) | Returns the parent/supernet of a CIDR. Defaults to one bit shorter. |
+
+#### `ip_parse`
+
+```ntnt
+ip_parse(ip_or_cidr: String) -> Result<Map, String>
+```
+
+Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields.
+
+**Parameters:**
+
+- `ip_or_cidr` — Address or CIDR string, e.g. "192.168.1.0/24" or "2001:db8::/64"
+
+**Returns:** Result containing a map of canonical fields and classification booleans
+
+**Examples:**
+
+```ntnt
+ip_parse("192.168.1.0/24")  // Parse an IPv4 subnet
+```
+
+*Since v0.5.0*
+
+---
+
+#### `ip_range_to_cidrs`
+
+```ntnt
+ip_range_to_cidrs(start_ip: String, end_ip: String) -> Result<Array<String>, String>
+```
+
+Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover.
+
+*Since v0.5.0*
+
+---
+
+#### `ping`
+
+```ntnt
+ping(host: String, opts?: Map) -> Result<Map, String>
+```
+
+Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable.
+
+*Since v0.5.0*
+
+---
+
+#### `subnet_contains`
+
+```ntnt
+subnet_contains(cidr: String, ip_or_cidr: String) -> Result<Bool, String>
+```
+
+Returns true when the parent CIDR contains the entire child address or subnet.
+
+*Since v0.5.0*
+
+---
+
+#### `subnet_overlaps`
+
+```ntnt
+subnet_overlaps(a: String, b: String) -> Result<Bool, String>
+```
+
+Returns true when two IPv4 or IPv6 CIDRs overlap.
+
+*Since v0.5.0*
+
+---
+
+#### `subnet_split`
+
+```ntnt
+subnet_split(cidr: String, new_prefix: Int, opts?: Map) -> Result<Array<String>, String>
+```
+
+Splits a CIDR into child subnets with a longer prefix, enforcing result caps.
+
+*Since v0.5.0*
+
+---
+
+#### `subnet_summarize`
+
+```ntnt
+subnet_summarize(cidrs: Array<String>) -> Result<Array<String>, String>
+```
+
+Summarizes adjacent or overlapping CIDRs into the shortest equivalent route list.
+
+*Since v0.5.0*
+
+---
+
+#### `subnet_supernet`
+
+```ntnt
+subnet_supernet(cidr: String, new_prefix?: Int) -> Result<String, String>
+```
+
+Returns the parent/supernet of a CIDR. Defaults to one bit shorter.
+
+*Since v0.5.0*
 
 ---
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -9696,7 +9696,7 @@ import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
 |----------|-------------|
 | [`ip_parse`](#ipparse) | Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields. |
 | [`ip_range_to_cidrs`](#iprangetocidrs) | Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover. |
-| [`ping`](#ping) | Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable. |
+| [`ping`](#ping) | Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable. Private targets require both process and call-level opt-in; special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges are never allowed. |
 | [`subnet_contains`](#subnetcontains) | Returns true when the parent CIDR contains the entire child address or subnet. |
 | [`subnet_overlaps`](#subnetoverlaps) | Returns true when two IPv4 or IPv6 CIDRs overlap. |
 | [`subnet_split`](#subnetsplit) | Splits a CIDR into child subnets with a longer prefix, enforcing result caps. |
@@ -9745,7 +9745,7 @@ Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover.
 ping(host: String, opts?: Map) -> Result<Map, String>
 ```
 
-Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable.
+Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable. Private targets require both process and call-level opt-in; special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges are never allowed.
 
 *Since v0.4.10*
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -9696,7 +9696,7 @@ import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
 |----------|-------------|
 | [`ip_parse`](#ipparse) | Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields. |
 | [`ip_range_to_cidrs`](#iprangetocidrs) | Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover. |
-| [`ping`](#ping) | Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable. Private targets require both process and call-level opt-in; special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges are never allowed. |
+| [`ping`](#ping) | Performs a bounded host reachability probe. Phase 1 does not silently fall back from ICMP ping to TCP ports; apps that intentionally want TCP reachability must request method: "tcp" and provide tcp_ports explicitly. Private targets require both process and call-level opt-in; special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges are never allowed. |
 | [`subnet_contains`](#subnetcontains) | Returns true when the parent CIDR contains the entire child address or subnet. |
 | [`subnet_overlaps`](#subnetoverlaps) | Returns true when two IPv4 or IPv6 CIDRs overlap. |
 | [`subnet_split`](#subnetsplit) | Splits a CIDR into child subnets with a longer prefix, enforcing result caps. |
@@ -9745,7 +9745,7 @@ Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover.
 ping(host: String, opts?: Map) -> Result<Map, String>
 ```
 
-Performs a first-shot host reachability probe. The default auto method uses unprivileged TCP fallback when ICMP is unavailable. Private targets require both process and call-level opt-in; special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges are never allowed.
+Performs a bounded host reachability probe. Phase 1 does not silently fall back from ICMP ping to TCP ports; apps that intentionally want TCP reachability must request method: "tcp" and provide tcp_ports explicitly. Private targets require both process and call-level opt-in; special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges are never allowed.
 
 *Since v0.4.10*
 

--- a/docs/SYNTAX_REFERENCE.md
+++ b/docs/SYNTAX_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [syntax.toml](syntax.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.9
+> Last updated: v0.4.10
 
 ## Table of Contents
 

--- a/examples/std_net_ipam.tnt
+++ b/examples/std_net_ipam.tnt
@@ -1,0 +1,51 @@
+// std/net Phase 1: IPAM-grade IPv4/IPv6 CIDR helpers
+
+import { join } from "std/string"
+import { ip_parse, subnet_contains, subnet_overlaps, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs } from "std/net"
+
+match ip_parse("192.168.1.0/24") {
+    Ok(info) => {
+        print("network: " + info["network"])
+        print("netmask: " + info["netmask"])
+        print("usable hosts: " + info["usable_hosts"])
+    },
+    Err(e) => print("parse error: " + e)
+}
+
+match ip_parse("2001:db8::/64") {
+    Ok(info) => {
+        print("ipv6 network: " + info["network"])
+        print("ipv6 addresses: " + info["total_addresses"])
+    },
+    Err(e) => print("ipv6 parse error: " + e)
+}
+
+match subnet_contains("10.0.0.0/8", "10.42.0.0/16") {
+    Ok(contains) => print("contains child subnet: " + str(contains)),
+    Err(e) => print("contains error: " + e)
+}
+
+match subnet_overlaps("10.0.0.0/24", "10.0.0.128/25") {
+    Ok(overlaps) => print("overlaps: " + str(overlaps)),
+    Err(e) => print("overlap error: " + e)
+}
+
+match subnet_split("192.168.1.0/24", 28) {
+    Ok(subnets) => print("/28s: " + join(subnets, ", ")),
+    Err(e) => print("split error: " + e)
+}
+
+match subnet_supernet("192.168.1.0/24") {
+    Ok(parent) => print("parent: " + parent),
+    Err(e) => print("supernet error: " + e)
+}
+
+match subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"]) {
+    Ok(routes) => print("summary: " + join(routes, ", ")),
+    Err(e) => print("summary error: " + e)
+}
+
+match ip_range_to_cidrs("192.168.1.20", "192.168.1.31") {
+    Ok(cidrs) => print("range cover: " + join(cidrs, ", ")),
+    Err(e) => print("range error: " + e)
+}

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -23,6 +23,7 @@ pub mod kv;
 pub mod log;
 pub mod markdown;
 pub mod math;
+pub mod net;
 pub mod path;
 pub mod postgres;
 pub mod sqlite;
@@ -51,6 +52,7 @@ pub fn init_all_modules() -> HashMap<String, StdlibModule> {
     modules.insert("std/time".to_string(), time::init());
     modules.insert("std/crypto".to_string(), crypto::init());
     modules.insert("std/url".to_string(), url::init());
+    modules.insert("std/net".to_string(), net::init());
     modules.insert("std/http".to_string(), http::init());
     modules.insert("std/http/server".to_string(), http_server::init());
     modules.insert("std/db/postgres".to_string(), postgres::init());

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -886,7 +886,8 @@ fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> 
         || classification.is_link_local
         || classification.is_unspecified
         || classification.is_multicast
-        || classification.is_documentation;
+        || classification.is_documentation
+        || matches!(ip, IpAddr::V4(ipv4) if ipv4.is_broadcast());
     if !denied_by_default {
         return Ok(());
     }
@@ -1156,9 +1157,11 @@ mod tests {
     fn target_policy_rejects_special_ranges_by_default() {
         let multicast = "224.0.0.1:80".parse::<SocketAddr>().unwrap();
         let documentation = "192.0.2.1:80".parse::<SocketAddr>().unwrap();
+        let broadcast = "255.255.255.255:80".parse::<SocketAddr>().unwrap();
 
         assert!(enforce_resolved_target_policy(&[(80, multicast)], false).is_err());
         assert!(enforce_resolved_target_policy(&[(80, documentation)], false).is_err());
+        assert!(enforce_resolved_target_policy(&[(80, broadcast)], false).is_err());
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -131,7 +131,7 @@ pub fn init() -> HashMap<String, Value> {
     // Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields.
     // @param ip_or_cidr Address or CIDR string, e.g. "192.168.1.0/24" or "2001:db8::/64"
     // @returns Result containing a map of canonical fields and classification booleans
-    // @since v0.5.0
+    // @since v0.4.10
     // @tags #pure, #deterministic, #network
     // @example ip_parse("192.168.1.0/24") ~ "Parse an IPv4 subnet"
     module.insert(
@@ -154,7 +154,7 @@ pub fn init() -> HashMap<String, Value> {
     // @module std/net
     // @signature subnet_contains(cidr: String, ip_or_cidr: String) -> Result<Bool, String>
     // Returns true when the parent CIDR contains the entire child address or subnet.
-    // @since v0.5.0
+    // @since v0.4.10
     // @tags #pure, #deterministic, #network
     module.insert(
         "subnet_contains".to_string(),
@@ -171,7 +171,7 @@ pub fn init() -> HashMap<String, Value> {
     // @module std/net
     // @signature subnet_overlaps(a: String, b: String) -> Result<Bool, String>
     // Returns true when two IPv4 or IPv6 CIDRs overlap.
-    // @since v0.5.0
+    // @since v0.4.10
     // @tags #pure, #deterministic, #network
     module.insert(
         "subnet_overlaps".to_string(),
@@ -188,7 +188,7 @@ pub fn init() -> HashMap<String, Value> {
     // @module std/net
     // @signature subnet_split(cidr: String, new_prefix: Int, opts?: Map) -> Result<Array<String>, String>
     // Splits a CIDR into child subnets with a longer prefix, enforcing result caps.
-    // @since v0.5.0
+    // @since v0.4.10
     // @tags #pure, #deterministic, #network
     module.insert(
         "subnet_split".to_string(),
@@ -205,7 +205,7 @@ pub fn init() -> HashMap<String, Value> {
     // @module std/net
     // @signature subnet_supernet(cidr: String, new_prefix?: Int) -> Result<String, String>
     // Returns the parent/supernet of a CIDR. Defaults to one bit shorter.
-    // @since v0.5.0
+    // @since v0.4.10
     // @tags #pure, #deterministic, #network
     module.insert(
         "subnet_supernet".to_string(),
@@ -222,7 +222,7 @@ pub fn init() -> HashMap<String, Value> {
     // @module std/net
     // @signature subnet_summarize(cidrs: Array<String>) -> Result<Array<String>, String>
     // Summarizes adjacent or overlapping CIDRs into the shortest equivalent route list.
-    // @since v0.5.0
+    // @since v0.4.10
     // @tags #pure, #deterministic, #network
     module.insert(
         "subnet_summarize".to_string(),
@@ -239,7 +239,7 @@ pub fn init() -> HashMap<String, Value> {
     // @module std/net
     // @signature ip_range_to_cidrs(start_ip: String, end_ip: String) -> Result<Array<String>, String>
     // Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover.
-    // @since v0.5.0
+    // @since v0.4.10
     // @tags #pure, #deterministic, #network
     module.insert(
         "ip_range_to_cidrs".to_string(),
@@ -257,7 +257,7 @@ pub fn init() -> HashMap<String, Value> {
     // @signature ping(host: String, opts?: Map) -> Result<Map, String>
     // Performs a first-shot host reachability probe. The default auto method uses
     // unprivileged TCP fallback when ICMP is unavailable.
-    // @since v0.5.0
+    // @since v0.4.10
     // @tags #network
     module.insert(
         "ping".to_string(),

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -5,6 +5,7 @@ use crate::interpreter::Value;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
+use std::thread;
 use std::time::{Duration, Instant};
 
 const DEFAULT_MAX_RESULTS: usize = 4096;
@@ -12,7 +13,10 @@ const HARD_MAX_RESULTS: usize = 65_536;
 const DEFAULT_TIMEOUT_MS: u64 = 2_000;
 const MIN_TIMEOUT_MS: u64 = 50;
 const MAX_TIMEOUT_MS: u64 = 30_000;
-const DEFAULT_TCP_PORTS: &[u16] = &[443, 80];
+const DEFAULT_PING_COUNT: usize = 1;
+const MAX_PING_COUNT: usize = 10;
+const DEFAULT_INTERVAL_MS: u64 = 0;
+const MAX_INTERVAL_MS: u64 = 5_000;
 const MAX_TCP_PORTS: usize = 10;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -255,11 +259,12 @@ pub fn init() -> HashMap<String, Value> {
     // @ntnt ping
     // @module std/net
     // @signature ping(host: String, opts?: Map) -> Result<Map, String>
-    // Performs a first-shot host reachability probe. The default auto method uses
-    // unprivileged TCP fallback when ICMP is unavailable. Private targets require
-    // both process and call-level opt-in; special-purpose targets such as cloud
-    // metadata, multicast, broadcast, unspecified, and documentation ranges are
-    // never allowed.
+    // Performs a bounded host reachability probe. Phase 1 does not silently fall
+    // back from ICMP ping to TCP ports; apps that intentionally want TCP
+    // reachability must request method: "tcp" and provide tcp_ports explicitly.
+    // Private targets require both process and call-level opt-in; special-purpose
+    // targets such as cloud metadata, multicast, broadcast, unspecified, and
+    // documentation ranges are never allowed.
     // @since v0.4.10
     // @tags #network
     module.insert(
@@ -548,52 +553,34 @@ fn ping_fn(args: &[Value]) -> Result<Value, IntentError> {
 
     Ok(result_from((|| {
         let method = ReachabilityMethod::parse(opts.and_then(|m| m.get("method")))?;
-        if method == ReachabilityMethod::Icmp {
-            return Err(
-                "ICMP ping unavailable: std/net Phase 1 defaults to unprivileged TCP fallback; use method: 'auto' or 'tcp' unless the runtime adds ICMP capability support"
-                    .to_string(),
-            );
-        }
-
         let allow_private = parse_bool_option(opts, "allow_private", false)?;
         let timeout_ms = parse_u64_option(opts, "timeout_ms", DEFAULT_TIMEOUT_MS)?
             .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
-        let tcp_ports = parse_tcp_ports(opts)?;
+        let count = parse_count_option(opts)?;
+        let interval_ms = parse_u64_option(opts, "interval_ms", DEFAULT_INTERVAL_MS)?
+            .clamp(DEFAULT_INTERVAL_MS, MAX_INTERVAL_MS);
 
-        let probe = tcp_reachability(
-            host,
-            &tcp_ports,
-            Duration::from_millis(timeout_ms),
-            allow_private,
-        )?;
-        let mut result = HashMap::new();
-        result.insert("host".to_string(), Value::String(host.to_string()));
-        result.insert("reachable".to_string(), Value::Bool(probe.reachable));
-        result.insert("method".to_string(), Value::String("tcp".to_string()));
-        if method == ReachabilityMethod::Auto {
-            result.insert(
-                "fallback_from".to_string(),
-                Value::String("icmp".to_string()),
-            );
-            result.insert("permission_limited".to_string(), Value::Bool(true));
-        } else {
-            result.insert("permission_limited".to_string(), Value::Bool(false));
+        match method {
+            ReachabilityMethod::Auto | ReachabilityMethod::Icmp => Err(icmp_unavailable_message()),
+            ReachabilityMethod::Tcp => {
+                let tcp_ports = parse_tcp_ports(opts)?;
+                let attempts = tcp_reachability_attempts_for_host(
+                    host,
+                    &tcp_ports,
+                    Duration::from_millis(timeout_ms),
+                    count,
+                    Duration::from_millis(interval_ms),
+                    allow_private,
+                )?;
+                Ok(Value::Map(tcp_ping_result_map(host, &tcp_ports, &attempts)))
+            }
         }
-        result.insert(
-            "ports_tried".to_string(),
-            Value::Array(tcp_ports.iter().map(|p| Value::Int(*p as i64)).collect()),
-        );
-        if let Some(port) = probe.connected_port {
-            result.insert("connected_port".to_string(), Value::Int(port as i64));
-        } else {
-            result.insert("connected_port".to_string(), Value::none());
-            result.insert("reason".to_string(), Value::String(probe.reason));
-        }
-        if let Some(latency_ms) = probe.latency_ms {
-            result.insert("latency_ms".to_string(), Value::Float(latency_ms));
-        }
-        Ok(Value::Map(result))
     })()))
+}
+
+fn icmp_unavailable_message() -> String {
+    "ICMP ping unavailable: std/net does not fall back to TCP automatically. Use method: 'tcp' with explicit tcp_ports only when the app intentionally wants TCP reachability instead of ICMP ping."
+        .to_string()
 }
 
 #[derive(Debug)]
@@ -604,47 +591,71 @@ struct TcpProbeResult {
     reason: String,
 }
 
-fn tcp_reachability(
+fn tcp_reachability_attempts_for_host(
     host: &str,
     ports: &[u16],
     timeout: Duration,
+    count: usize,
+    interval: Duration,
     allow_private: bool,
-) -> Result<TcpProbeResult, String> {
+) -> Result<Vec<TcpProbeResult>, String> {
     let targets = resolve_tcp_targets(host, ports)?;
+    enforce_resolved_target_policy(&targets, allow_private)?;
+    Ok(tcp_reachability_attempts(
+        &targets, timeout, count, interval,
+    ))
+}
+
+fn tcp_reachability_attempts(
+    targets: &[(u16, SocketAddr)],
+    timeout: Duration,
+    count: usize,
+    interval: Duration,
+) -> Vec<TcpProbeResult> {
+    let mut attempts = Vec::with_capacity(count);
+    for attempt_index in 0..count {
+        if attempt_index > 0 && !interval.is_zero() {
+            thread::sleep(interval);
+        }
+        attempts.push(tcp_reachability_once(targets, timeout));
+    }
+    attempts
+}
+
+fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> TcpProbeResult {
     if targets.is_empty() {
-        return Ok(TcpProbeResult {
+        return TcpProbeResult {
             reachable: false,
             connected_port: None,
             latency_ms: None,
             reason: "no resolved addresses".to_string(),
-        });
+        };
     }
-    enforce_resolved_target_policy(&targets, allow_private)?;
 
     let mut last_reason = "unreachable".to_string();
     for (port, addr) in targets {
         let start = Instant::now();
-        match TcpStream::connect_timeout(&addr, timeout) {
+        match TcpStream::connect_timeout(addr, timeout) {
             Ok(stream) => {
                 drop(stream);
-                return Ok(TcpProbeResult {
+                return TcpProbeResult {
                     reachable: true,
-                    connected_port: Some(port),
+                    connected_port: Some(*port),
                     latency_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
                     reason: "connected".to_string(),
-                });
+                };
             }
             Err(e) => {
                 last_reason = e.kind().to_string();
             }
         }
     }
-    Ok(TcpProbeResult {
+    TcpProbeResult {
         reachable: false,
         connected_port: None,
         latency_ms: None,
         reason: last_reason,
-    })
+    }
 }
 
 fn resolve_tcp_targets(host: &str, ports: &[u16]) -> Result<Vec<(u16, SocketAddr)>, String> {
@@ -667,6 +678,97 @@ fn enforce_resolved_target_policy(
         enforce_target_policy(addr.ip(), allow_private)?;
     }
     Ok(())
+}
+
+fn tcp_ping_result_map(
+    host: &str,
+    ports: &[u16],
+    attempts: &[TcpProbeResult],
+) -> HashMap<String, Value> {
+    let sent = attempts.len();
+    let received = attempts.iter().filter(|attempt| attempt.reachable).count();
+    let failed = sent.saturating_sub(received);
+    let latencies: Vec<f64> = attempts
+        .iter()
+        .filter_map(|attempt| attempt.latency_ms)
+        .collect();
+
+    let mut result = HashMap::new();
+    result.insert("host".to_string(), Value::String(host.to_string()));
+    result.insert("reachable".to_string(), Value::Bool(received > 0));
+    result.insert("method".to_string(), Value::String("tcp".to_string()));
+    result.insert("permission_limited".to_string(), Value::Bool(false));
+    result.insert("sent".to_string(), Value::Int(sent as i64));
+    result.insert("received".to_string(), Value::Int(received as i64));
+    result.insert("failed".to_string(), Value::Int(failed as i64));
+    result.insert(
+        "loss_percent".to_string(),
+        Value::Float(if sent == 0 {
+            0.0
+        } else {
+            (failed as f64 / sent as f64) * 100.0
+        }),
+    );
+    result.insert(
+        "ports_tried".to_string(),
+        Value::Array(ports.iter().map(|p| Value::Int(*p as i64)).collect()),
+    );
+    result.insert(
+        "attempts".to_string(),
+        Value::Array(attempts.iter().map(tcp_attempt_to_value).collect()),
+    );
+
+    if let Some(first_success) = attempts.iter().find(|attempt| attempt.reachable) {
+        result.insert(
+            "connected_port".to_string(),
+            first_success
+                .connected_port
+                .map(|port| Value::Int(port as i64))
+                .unwrap_or_else(Value::none),
+        );
+    } else {
+        result.insert("connected_port".to_string(), Value::none());
+        if let Some(last_failure) = attempts.last() {
+            result.insert(
+                "reason".to_string(),
+                Value::String(last_failure.reason.clone()),
+            );
+        }
+    }
+
+    if !latencies.is_empty() {
+        let min_ms = latencies.iter().copied().fold(f64::INFINITY, f64::min);
+        let max_ms = latencies.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let avg_ms = latencies.iter().sum::<f64>() / latencies.len() as f64;
+        result.insert("min_ms".to_string(), Value::Float(min_ms));
+        result.insert("avg_ms".to_string(), Value::Float(avg_ms));
+        result.insert("max_ms".to_string(), Value::Float(max_ms));
+        if sent == 1 {
+            result.insert("latency_ms".to_string(), Value::Float(avg_ms));
+        }
+    }
+
+    result
+}
+
+fn tcp_attempt_to_value(attempt: &TcpProbeResult) -> Value {
+    let mut map = HashMap::new();
+    map.insert("reachable".to_string(), Value::Bool(attempt.reachable));
+    map.insert("method".to_string(), Value::String("tcp".to_string()));
+    map.insert(
+        "connected_port".to_string(),
+        attempt
+            .connected_port
+            .map(|port| Value::Int(port as i64))
+            .unwrap_or_else(Value::none),
+    );
+    if let Some(latency_ms) = attempt.latency_ms {
+        map.insert("latency_ms".to_string(), Value::Float(latency_ms));
+    }
+    if !attempt.reachable {
+        map.insert("reason".to_string(), Value::String(attempt.reason.clone()));
+    }
+    Value::Map(map)
 }
 
 fn parse_ip(input: &str) -> Result<ParsedInput, String> {
@@ -992,9 +1094,24 @@ fn parse_u64_option(
     }
 }
 
+fn parse_count_option(opts: Option<&HashMap<String, Value>>) -> Result<usize, String> {
+    match opts.and_then(|m| m.get("count")) {
+        None => Ok(DEFAULT_PING_COUNT),
+        Some(Value::Int(value)) if *value > 0 => {
+            let count = usize::try_from(*value).map_err(|_| "option 'count' is too large")?;
+            Ok(min(count, MAX_PING_COUNT))
+        }
+        Some(Value::Int(_)) => Err("option 'count' must be positive".to_string()),
+        Some(other) => Err(format!(
+            "option 'count' must be Int, got {}",
+            other.type_name()
+        )),
+    }
+}
+
 fn parse_tcp_ports(opts: Option<&HashMap<String, Value>>) -> Result<Vec<u16>, String> {
     let Some(value) = opts.and_then(|m| m.get("tcp_ports")) else {
-        return Ok(DEFAULT_TCP_PORTS.to_vec());
+        return Err("option 'tcp_ports' is required when ping method is 'tcp'".to_string());
     };
     let Value::Array(values) = value else {
         return Err("option 'tcp_ports' must be Array<Int>".to_string());
@@ -1169,6 +1286,24 @@ fn floor_log2(value: u128) -> u32 {
 mod tests {
     use super::*;
 
+    fn assert_result_err_contains(value: Value, expected: &str) {
+        match value {
+            Value::EnumValue {
+                enum_name,
+                variant,
+                values,
+            } => {
+                assert_eq!(enum_name, "Result");
+                assert_eq!(variant, "Err");
+                assert!(
+                    matches!(values.as_slice(), [Value::String(message)] if message.contains(expected)),
+                    "expected Result::Err message to contain {expected:?}, got {values:?}"
+                );
+            }
+            other => panic!("expected Result::Err, got {other:?}"),
+        }
+    }
+
     #[test]
     fn target_policy_classifies_ipv4_mapped_ipv6_by_embedded_address() {
         let mapped_loopback = "[::ffff:127.0.0.1]:80".parse::<SocketAddr>().unwrap();
@@ -1223,5 +1358,72 @@ mod tests {
 
         let err = enforce_resolved_target_policy(&targets, false).unwrap_err();
         assert!(err.contains("Network target denied by policy"));
+    }
+
+    #[test]
+    fn ping_auto_reports_icmp_unavailable_without_tcp_fallback() {
+        let result = ping_fn(&[Value::String("example.com".to_string())]).unwrap();
+        assert_result_err_contains(result, "does not fall back to TCP automatically");
+    }
+
+    #[test]
+    fn ping_tcp_requires_explicit_ports() {
+        let result = ping_fn(&[
+            Value::String("example.com".to_string()),
+            Value::Map(HashMap::from([(
+                "method".to_string(),
+                Value::String("tcp".to_string()),
+            )])),
+        ])
+        .unwrap();
+
+        assert_result_err_contains(result, "tcp_ports");
+    }
+
+    #[test]
+    fn ping_count_is_positive_and_clamped() {
+        assert_eq!(parse_count_option(None).unwrap(), DEFAULT_PING_COUNT);
+        assert_eq!(
+            parse_count_option(Some(&HashMap::from([(
+                "count".to_string(),
+                Value::Int((MAX_PING_COUNT as i64) + 50),
+            )])))
+            .unwrap(),
+            MAX_PING_COUNT
+        );
+        assert!(parse_count_option(Some(&HashMap::from([
+            ("count".to_string(), Value::Int(0),)
+        ])))
+        .is_err());
+    }
+
+    #[test]
+    fn tcp_reachability_attempts_return_per_attempt_summary() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let count = 3;
+        let accept_thread = thread::spawn(move || {
+            for _ in 0..count {
+                let _ = listener.accept();
+            }
+        });
+
+        let attempts = tcp_reachability_attempts(
+            &[(addr.port(), addr)],
+            Duration::from_millis(500),
+            count,
+            Duration::ZERO,
+        );
+        accept_thread.join().unwrap();
+
+        assert_eq!(attempts.len(), count);
+        assert!(attempts.iter().all(|attempt| attempt.reachable));
+
+        let summary = tcp_ping_result_map("127.0.0.1", &[addr.port()], &attempts);
+        assert!(matches!(summary.get("sent"), Some(Value::Int(3))));
+        assert!(matches!(summary.get("received"), Some(Value::Int(3))));
+        assert!(matches!(summary.get("failed"), Some(Value::Int(0))));
+        assert!(matches!(summary.get("loss_percent"), Some(Value::Float(value)) if *value == 0.0));
+        assert!(matches!(summary.get("attempts"), Some(Value::Array(values)) if values.len() == 3));
     }
 }

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -98,22 +98,24 @@ struct ParsedInput {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReachabilityMethod {
+enum PingMethod {
     Auto,
     Icmp,
-    Tcp,
 }
 
-impl ReachabilityMethod {
-    fn parse(value: Option<&Value>) -> Result<Self, String> {
+impl PingMethod {
+    fn parse_for_ping(value: Option<&Value>) -> Result<Self, String> {
         match value {
-            None => Ok(ReachabilityMethod::Auto),
+            None => Ok(PingMethod::Auto),
             Some(Value::String(method)) => match method.as_str() {
-                "auto" => Ok(ReachabilityMethod::Auto),
-                "icmp" => Ok(ReachabilityMethod::Icmp),
-                "tcp" => Ok(ReachabilityMethod::Tcp),
+                "auto" => Ok(PingMethod::Auto),
+                "icmp" => Ok(PingMethod::Icmp),
+                "tcp" => Err(
+                    "ping() does not perform TCP probes; use tcp_connect() for a TCP port check or reachable() for explicit fallback reachability"
+                        .to_string(),
+                ),
                 other => Err(format!(
-                    "ping() method must be 'auto', 'icmp', or 'tcp', got '{}'",
+                    "ping() method must be 'auto' or 'icmp', got '{}'",
                     other
                 )),
             },
@@ -259,12 +261,10 @@ pub fn init() -> HashMap<String, Value> {
     // @ntnt ping
     // @module std/net
     // @signature ping(host: String, opts?: Map) -> Result<Map, String>
-    // Performs a bounded host reachability probe. Phase 1 does not silently fall
-    // back from ICMP ping to TCP ports; apps that intentionally want TCP
-    // reachability must request method: "tcp" and provide tcp_ports explicitly.
-    // Private targets require both process and call-level opt-in; special-purpose
-    // targets such as cloud metadata, multicast, broadcast, unspecified, and
-    // documentation ranges are never allowed.
+    // Performs an ICMP ping when ICMP support is available. It is protocol-honest:
+    // ping() does not fall back to TCP ports. Apps that want TCP port checks should
+    // use tcp_connect(); apps that want explicit ICMP-then-TCP reachability should
+    // use reachable().
     // @since v0.4.10
     // @tags #network
     module.insert(
@@ -275,6 +275,53 @@ pub fn init() -> HashMap<String, Value> {
             max_arity: 2,
             requires: None,
             func: ping_fn,
+        },
+    );
+
+    // @ntnt tcp_connect
+    // @module std/net
+    // @signature tcp_connect(host: String, port: Int, opts?: Map) -> Result<Map, String>
+    // Performs a bounded TCP connect probe to one explicit port. Closed, refused,
+    // or timed-out ports return Ok(map { "connected": false, ... }); invalid input,
+    // policy denial, and resolver/system failures return Err(String).
+    // @param host Hostname or IP address to resolve and probe
+    // @param port TCP port from 1 to 65535
+    // @param opts Optional map with timeout_ms, count, interval_ms, and allow_private
+    // @returns Result containing connection status, latency summary, and per-attempt results
+    // @since v0.4.10
+    // @tags #network
+    // @example tcp_connect("example.com", 443) ~ "Check whether TCP 443 accepts connections"
+    module.insert(
+        "tcp_connect".to_string(),
+        Value::NativeFunction {
+            name: "tcp_connect".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: tcp_connect_fn,
+        },
+    );
+
+    // @ntnt reachable
+    // @module std/net
+    // @signature reachable(host: String, opts?: Map) -> Result<Map, String>
+    // Performs an explicit high-level reachability check. Phase 1 has no ICMP
+    // implementation, so TCP fallback requires caller-provided tcp_ports; the result
+    // records method and fallback_from instead of pretending TCP is ping.
+    // @param host Hostname or IP address to resolve and probe
+    // @param opts Optional map with tcp_ports, timeout_ms, count, interval_ms, and allow_private
+    // @returns Result containing reachability status, method used, fallback metadata, and attempt summary
+    // @since v0.4.10
+    // @tags #network
+    // @example reachable("example.com", map { "tcp_ports": [443], "count": 5 }) ~ "Check host reachability with explicit TCP fallback"
+    module.insert(
+        "reachable".to_string(),
+        Value::NativeFunction {
+            name: "reachable".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: reachable_fn,
         },
     );
 
@@ -548,39 +595,91 @@ fn ip_range_to_cidrs_fn(args: &[Value]) -> Result<Value, IntentError> {
 }
 
 fn ping_fn(args: &[Value]) -> Result<Value, IntentError> {
-    let host = string_arg(args, 0, "ping")?;
+    let _host = string_arg(args, 0, "ping")?;
     let opts = opts_arg(args, 1, "ping")?;
 
-    Ok(result_from((|| {
-        let method = ReachabilityMethod::parse(opts.and_then(|m| m.get("method")))?;
-        let allow_private = parse_bool_option(opts, "allow_private", false)?;
-        let timeout_ms = parse_u64_option(opts, "timeout_ms", DEFAULT_TIMEOUT_MS)?
-            .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
-        let count = parse_count_option(opts)?;
-        let interval_ms = parse_u64_option(opts, "interval_ms", DEFAULT_INTERVAL_MS)?
-            .clamp(DEFAULT_INTERVAL_MS, MAX_INTERVAL_MS);
+    Ok(result_from::<Value>((|| {
+        let _method = PingMethod::parse_for_ping(opts.and_then(|m| m.get("method")))?;
+        Err(icmp_unavailable_message())
+    })()))
+}
 
-        match method {
-            ReachabilityMethod::Auto | ReachabilityMethod::Icmp => Err(icmp_unavailable_message()),
-            ReachabilityMethod::Tcp => {
-                let tcp_ports = parse_tcp_ports(opts)?;
-                let attempts = tcp_reachability_attempts_for_host(
-                    host,
-                    &tcp_ports,
-                    Duration::from_millis(timeout_ms),
-                    count,
-                    Duration::from_millis(interval_ms),
-                    allow_private,
-                )?;
-                Ok(Value::Map(tcp_ping_result_map(host, &tcp_ports, &attempts)))
-            }
-        }
+fn tcp_connect_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let host = string_arg(args, 0, "tcp_connect")?;
+    let raw_port = int_arg(args, 1, "tcp_connect")?;
+    let opts = opts_arg(args, 2, "tcp_connect")?;
+
+    Ok(result_from((|| {
+        let port = validate_tcp_port_arg(raw_port, "tcp_connect")?;
+        let options = parse_probe_options(opts)?;
+        let attempts = tcp_reachability_attempts_for_host(
+            host,
+            &[port],
+            options.timeout,
+            options.count,
+            options.interval,
+            options.allow_private,
+        )?;
+        Ok(Value::Map(tcp_connect_result_map(host, port, &attempts)))
+    })()))
+}
+
+fn reachable_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let host = string_arg(args, 0, "reachable")?;
+    let opts = opts_arg(args, 1, "reachable")?;
+
+    Ok(result_from((|| {
+        let options = parse_probe_options(opts)?;
+        let tcp_ports = parse_tcp_ports(opts, "reachable")?;
+        let attempts = tcp_reachability_attempts_for_host(
+            host,
+            &tcp_ports,
+            options.timeout,
+            options.count,
+            options.interval,
+            options.allow_private,
+        )?;
+        Ok(Value::Map(reachable_result_map(
+            host, &tcp_ports, &attempts,
+        )))
     })()))
 }
 
 fn icmp_unavailable_message() -> String {
-    "ICMP ping unavailable: std/net does not fall back to TCP automatically. Use method: 'tcp' with explicit tcp_ports only when the app intentionally wants TCP reachability instead of ICMP ping."
+    "ICMP ping unavailable: std/net does not fall back to TCP automatically. Use tcp_connect() for explicit TCP port checks or reachable(..., map { 'tcp_ports': [...] }) for explicit reachability fallback."
         .to_string()
+}
+
+struct ProbeOptions {
+    timeout: Duration,
+    count: usize,
+    interval: Duration,
+    allow_private: bool,
+}
+
+fn parse_probe_options(opts: Option<&HashMap<String, Value>>) -> Result<ProbeOptions, String> {
+    let allow_private = parse_bool_option(opts, "allow_private", false)?;
+    let timeout_ms = parse_u64_option(opts, "timeout_ms", DEFAULT_TIMEOUT_MS)?
+        .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
+    let count = parse_count_option(opts)?;
+    let interval_ms = parse_u64_option(opts, "interval_ms", DEFAULT_INTERVAL_MS)?
+        .clamp(DEFAULT_INTERVAL_MS, MAX_INTERVAL_MS);
+    Ok(ProbeOptions {
+        timeout: Duration::from_millis(timeout_ms),
+        count,
+        interval: Duration::from_millis(interval_ms),
+        allow_private,
+    })
+}
+
+fn validate_tcp_port_arg(port: i64, fn_name: &str) -> Result<u16, String> {
+    if !(1..=65_535).contains(&port) {
+        return Err(format!(
+            "{}() port must be between 1 and 65535, got {}",
+            fn_name, port
+        ));
+    }
+    Ok(port as u16)
 }
 
 #[derive(Debug)]
@@ -588,6 +687,8 @@ struct TcpProbeResult {
     reachable: bool,
     connected_port: Option<u16>,
     latency_ms: Option<f64>,
+    remote_addr: Option<String>,
+    local_addr: Option<String>,
     reason: String,
 }
 
@@ -628,6 +729,8 @@ fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> Tc
             reachable: false,
             connected_port: None,
             latency_ms: None,
+            remote_addr: None,
+            local_addr: None,
             reason: "no resolved addresses".to_string(),
         };
     }
@@ -637,11 +740,15 @@ fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> Tc
         let start = Instant::now();
         match TcpStream::connect_timeout(addr, timeout) {
             Ok(stream) => {
+                let remote_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
+                let local_addr = stream.local_addr().ok().map(|addr| addr.to_string());
                 drop(stream);
                 return TcpProbeResult {
                     reachable: true,
                     connected_port: Some(*port),
                     latency_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
+                    remote_addr,
+                    local_addr,
                     reason: "connected".to_string(),
                 };
             }
@@ -654,6 +761,8 @@ fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> Tc
         reachable: false,
         connected_port: None,
         latency_ms: None,
+        remote_addr: None,
+        local_addr: None,
         reason: last_reason,
     }
 }
@@ -680,7 +789,7 @@ fn enforce_resolved_target_policy(
     Ok(())
 }
 
-fn tcp_ping_result_map(
+fn tcp_reachability_result_map(
     host: &str,
     ports: &[u16],
     attempts: &[TcpProbeResult],
@@ -726,6 +835,20 @@ fn tcp_ping_result_map(
                 .map(|port| Value::Int(port as i64))
                 .unwrap_or_else(Value::none),
         );
+        result.insert(
+            "remote_addr".to_string(),
+            first_success
+                .remote_addr
+                .clone()
+                .map_or_else(Value::none, Value::String),
+        );
+        result.insert(
+            "local_addr".to_string(),
+            first_success
+                .local_addr
+                .clone()
+                .map_or_else(Value::none, Value::String),
+        );
     } else {
         result.insert("connected_port".to_string(), Value::none());
         if let Some(last_failure) = attempts.last() {
@@ -751,6 +874,32 @@ fn tcp_ping_result_map(
     result
 }
 
+fn tcp_connect_result_map(
+    host: &str,
+    port: u16,
+    attempts: &[TcpProbeResult],
+) -> HashMap<String, Value> {
+    let mut result = tcp_reachability_result_map(host, &[port], attempts);
+    let connected = attempts.iter().any(|attempt| attempt.reachable);
+    result.insert("port".to_string(), Value::Int(port as i64));
+    result.insert("connected".to_string(), Value::Bool(connected));
+    result
+}
+
+fn reachable_result_map(
+    host: &str,
+    ports: &[u16],
+    attempts: &[TcpProbeResult],
+) -> HashMap<String, Value> {
+    let mut result = tcp_reachability_result_map(host, ports, attempts);
+    result.insert(
+        "fallback_from".to_string(),
+        Value::String("icmp".to_string()),
+    );
+    result.insert("permission_limited".to_string(), Value::Bool(true));
+    result
+}
+
 fn tcp_attempt_to_value(attempt: &TcpProbeResult) -> Value {
     let mut map = HashMap::new();
     map.insert("reachable".to_string(), Value::Bool(attempt.reachable));
@@ -764,6 +913,15 @@ fn tcp_attempt_to_value(attempt: &TcpProbeResult) -> Value {
     );
     if let Some(latency_ms) = attempt.latency_ms {
         map.insert("latency_ms".to_string(), Value::Float(latency_ms));
+    }
+    if let Some(remote_addr) = &attempt.remote_addr {
+        map.insert(
+            "remote_addr".to_string(),
+            Value::String(remote_addr.clone()),
+        );
+    }
+    if let Some(local_addr) = &attempt.local_addr {
+        map.insert("local_addr".to_string(), Value::String(local_addr.clone()));
     }
     if !attempt.reachable {
         map.insert("reason".to_string(), Value::String(attempt.reason.clone()));
@@ -1109,31 +1267,40 @@ fn parse_count_option(opts: Option<&HashMap<String, Value>>) -> Result<usize, St
     }
 }
 
-fn parse_tcp_ports(opts: Option<&HashMap<String, Value>>) -> Result<Vec<u16>, String> {
+fn parse_tcp_ports(
+    opts: Option<&HashMap<String, Value>>,
+    fn_name: &str,
+) -> Result<Vec<u16>, String> {
     let Some(value) = opts.and_then(|m| m.get("tcp_ports")) else {
-        return Err("option 'tcp_ports' is required when ping method is 'tcp'".to_string());
+        return Err(format!(
+            "{}() option 'tcp_ports' is required for explicit TCP reachability fallback",
+            fn_name
+        ));
     };
     let Value::Array(values) = value else {
-        return Err("option 'tcp_ports' must be Array<Int>".to_string());
+        return Err(format!(
+            "{}() option 'tcp_ports' must be Array<Int>",
+            fn_name
+        ));
     };
     if values.is_empty() {
-        return Err("option 'tcp_ports' cannot be empty".to_string());
+        return Err(format!("{}() option 'tcp_ports' cannot be empty", fn_name));
     }
     if values.len() > MAX_TCP_PORTS {
         return Err(format!(
-            "option 'tcp_ports' supports at most {} ports",
-            MAX_TCP_PORTS
+            "{}() option 'tcp_ports' supports at most {} ports",
+            fn_name, MAX_TCP_PORTS
         ));
     }
     let mut ports = Vec::with_capacity(values.len());
     for value in values {
         let Value::Int(port) = value else {
-            return Err("option 'tcp_ports' must be Array<Int>".to_string());
+            return Err(format!(
+                "{}() option 'tcp_ports' must be Array<Int>",
+                fn_name
+            ));
         };
-        if *port < 1 || *port > 65_535 {
-            return Err(format!("invalid TCP port: {}", port));
-        }
-        let port = *port as u16;
+        let port = validate_tcp_port_arg(*port, fn_name)?;
         if !ports.contains(&port) {
             ports.push(port);
         }
@@ -1367,7 +1534,7 @@ mod tests {
     }
 
     #[test]
-    fn ping_tcp_requires_explicit_ports() {
+    fn ping_tcp_method_points_to_tcp_connect_or_reachable() {
         let result = ping_fn(&[
             Value::String("example.com".to_string()),
             Value::Map(HashMap::from([(
@@ -1377,7 +1544,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert_result_err_contains(result, "tcp_ports");
+        assert_result_err_contains(result, "use tcp_connect()");
     }
 
     #[test]
@@ -1419,7 +1586,7 @@ mod tests {
         assert_eq!(attempts.len(), count);
         assert!(attempts.iter().all(|attempt| attempt.reachable));
 
-        let summary = tcp_ping_result_map("127.0.0.1", &[addr.port()], &attempts);
+        let summary = tcp_reachability_result_map("127.0.0.1", &[addr.port()], &attempts);
         assert!(matches!(summary.get("sent"), Some(Value::Int(3))));
         assert!(matches!(summary.get("received"), Some(Value::Int(3))));
         assert!(matches!(summary.get("failed"), Some(Value::Int(0))));

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -607,32 +607,32 @@ fn tcp_reachability(
     timeout: Duration,
     allow_private: bool,
 ) -> Result<TcpProbeResult, String> {
+    let targets = resolve_tcp_targets(host, ports)?;
+    if targets.is_empty() {
+        return Ok(TcpProbeResult {
+            reachable: false,
+            connected_port: None,
+            latency_ms: None,
+            reason: "no resolved addresses".to_string(),
+        });
+    }
+    enforce_resolved_target_policy(&targets, allow_private)?;
+
     let mut last_reason = "unreachable".to_string();
-    for port in ports {
-        let addrs: Vec<SocketAddr> = (host, *port)
-            .to_socket_addrs()
-            .map_err(|e| format!("failed to resolve {}:{}: {}", host, port, e))?
-            .collect();
-        if addrs.is_empty() {
-            last_reason = "no resolved addresses".to_string();
-            continue;
-        }
-        for addr in addrs {
-            enforce_target_policy(addr.ip(), allow_private)?;
-            let start = Instant::now();
-            match TcpStream::connect_timeout(&addr, timeout) {
-                Ok(stream) => {
-                    drop(stream);
-                    return Ok(TcpProbeResult {
-                        reachable: true,
-                        connected_port: Some(*port),
-                        latency_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
-                        reason: "connected".to_string(),
-                    });
-                }
-                Err(e) => {
-                    last_reason = e.kind().to_string();
-                }
+    for (port, addr) in targets {
+        let start = Instant::now();
+        match TcpStream::connect_timeout(&addr, timeout) {
+            Ok(stream) => {
+                drop(stream);
+                return Ok(TcpProbeResult {
+                    reachable: true,
+                    connected_port: Some(port),
+                    latency_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
+                    reason: "connected".to_string(),
+                });
+            }
+            Err(e) => {
+                last_reason = e.kind().to_string();
             }
         }
     }
@@ -642,6 +642,28 @@ fn tcp_reachability(
         latency_ms: None,
         reason: last_reason,
     })
+}
+
+fn resolve_tcp_targets(host: &str, ports: &[u16]) -> Result<Vec<(u16, SocketAddr)>, String> {
+    let mut targets = Vec::new();
+    for port in ports {
+        let addrs: Vec<SocketAddr> = (host, *port)
+            .to_socket_addrs()
+            .map_err(|e| format!("failed to resolve {}:{}: {}", host, port, e))?
+            .collect();
+        targets.extend(addrs.into_iter().map(|addr| (*port, addr)));
+    }
+    Ok(targets)
+}
+
+fn enforce_resolved_target_policy(
+    targets: &[(u16, SocketAddr)],
+    allow_private: bool,
+) -> Result<(), String> {
+    for (_, addr) in targets {
+        enforce_target_policy(addr.ip(), allow_private)?;
+    }
+    Ok(())
 }
 
 fn parse_ip(input: &str) -> Result<ParsedInput, String> {
@@ -829,6 +851,9 @@ fn classify_ip(ip: IpAddr) -> IpClassification {
             is_unique_local: false,
         },
         IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                return classify_ip(IpAddr::V4(mapped));
+            }
             let first_segment = ip.segments()[0];
             let is_unique_local = (first_segment & 0xfe00) == 0xfc00;
             let is_link_local = (first_segment & 0xffc0) == 0xfe80;
@@ -859,7 +884,9 @@ fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> 
     let denied_by_default = classification.is_private
         || classification.is_loopback
         || classification.is_link_local
-        || classification.is_unspecified;
+        || classification.is_unspecified
+        || classification.is_multicast
+        || classification.is_documentation;
     if !denied_by_default {
         return Ok(());
     }
@@ -1110,4 +1137,37 @@ fn range_to_networks(
 fn floor_log2(value: u128) -> u32 {
     debug_assert!(value > 0);
     127 - value.leading_zeros()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_policy_classifies_ipv4_mapped_ipv6_by_embedded_address() {
+        let mapped_loopback = "[::ffff:127.0.0.1]:80".parse::<SocketAddr>().unwrap();
+        let mapped_metadata = "[::ffff:169.254.169.254]:80".parse::<SocketAddr>().unwrap();
+
+        assert!(enforce_resolved_target_policy(&[(80, mapped_loopback)], false).is_err());
+        assert!(enforce_resolved_target_policy(&[(80, mapped_metadata)], false).is_err());
+    }
+
+    #[test]
+    fn target_policy_rejects_special_ranges_by_default() {
+        let multicast = "224.0.0.1:80".parse::<SocketAddr>().unwrap();
+        let documentation = "192.0.2.1:80".parse::<SocketAddr>().unwrap();
+
+        assert!(enforce_resolved_target_policy(&[(80, multicast)], false).is_err());
+        assert!(enforce_resolved_target_policy(&[(80, documentation)], false).is_err());
+    }
+
+    #[test]
+    fn target_policy_checks_all_resolved_addresses_before_probe() {
+        let public = "93.184.216.34:443".parse::<SocketAddr>().unwrap();
+        let private = "127.0.0.1:443".parse::<SocketAddr>().unwrap();
+        let targets = [(443, public), (443, private)];
+
+        let err = enforce_resolved_target_policy(&targets, false).unwrap_err();
+        assert!(err.contains("Network target denied by policy"));
+    }
 }

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -256,7 +256,10 @@ pub fn init() -> HashMap<String, Value> {
     // @module std/net
     // @signature ping(host: String, opts?: Map) -> Result<Map, String>
     // Performs a first-shot host reachability probe. The default auto method uses
-    // unprivileged TCP fallback when ICMP is unavailable.
+    // unprivileged TCP fallback when ICMP is unavailable. Private targets require
+    // both process and call-level opt-in; special-purpose targets such as cloud
+    // metadata, multicast, broadcast, unspecified, and documentation ranges are
+    // never allowed.
     // @since v0.4.10
     // @tags #network
     module.insert(
@@ -837,6 +840,7 @@ struct IpClassification {
     is_unspecified: bool,
     is_documentation: bool,
     is_broadcast: bool,
+    is_metadata_endpoint: bool,
     is_unique_local: bool,
 }
 
@@ -850,6 +854,7 @@ fn classify_ip(ip: IpAddr) -> IpClassification {
             is_unspecified: ip.is_unspecified(),
             is_documentation: is_ipv4_documentation(ip),
             is_broadcast: ip.is_broadcast(),
+            is_metadata_endpoint: is_ipv4_metadata_endpoint(ip),
             is_unique_local: false,
         },
         IpAddr::V6(ip) => {
@@ -868,6 +873,7 @@ fn classify_ip(ip: IpAddr) -> IpClassification {
                 is_unspecified: ip.is_unspecified(),
                 is_documentation,
                 is_broadcast: false,
+                is_metadata_endpoint: is_ipv6_metadata_endpoint(ip),
                 is_unique_local,
             }
         }
@@ -882,16 +888,32 @@ fn is_ipv4_documentation(ip: Ipv4Addr) -> bool {
     )
 }
 
+fn is_ipv4_metadata_endpoint(ip: Ipv4Addr) -> bool {
+    ip.octets() == [169, 254, 169, 254]
+}
+
+fn is_ipv6_metadata_endpoint(ip: Ipv6Addr) -> bool {
+    ip.segments() == [0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254]
+}
+
 fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> {
     let classification = classify_ip(ip);
-    let denied_by_default = classification.is_private
-        || classification.is_loopback
-        || classification.is_link_local
+    let never_allowed = classification.is_metadata_endpoint
         || classification.is_unspecified
         || classification.is_multicast
         || classification.is_documentation
         || classification.is_broadcast;
-    if !denied_by_default {
+    if never_allowed {
+        return Err(
+            "Network target denied by policy: special-purpose targets are not allowed".to_string(),
+        );
+    }
+
+    let private_target = classification.is_private
+        || classification.is_loopback
+        || classification.is_link_local
+        || classification.is_unique_local;
+    if !private_target {
         return Ok(());
     }
     if !allow_private || !process_allows_private_targets() {
@@ -1167,6 +1189,26 @@ mod tests {
         assert!(enforce_resolved_target_policy(&[(80, documentation)], false).is_err());
         assert!(enforce_resolved_target_policy(&[(80, broadcast)], false).is_err());
         assert!(enforce_resolved_target_policy(&[(80, mapped_broadcast)], false).is_err());
+    }
+
+    #[test]
+    fn target_policy_never_allows_metadata_or_special_ranges() {
+        let metadata = "169.254.169.254:80".parse::<SocketAddr>().unwrap();
+        let mapped_metadata = "[::ffff:169.254.169.254]:80".parse::<SocketAddr>().unwrap();
+        let multicast = "224.0.0.1:80".parse::<SocketAddr>().unwrap();
+        let documentation = "192.0.2.1:80".parse::<SocketAddr>().unwrap();
+        let broadcast = "255.255.255.255:80".parse::<SocketAddr>().unwrap();
+
+        for target in [
+            metadata,
+            mapped_metadata,
+            multicast,
+            documentation,
+            broadcast,
+        ] {
+            let err = enforce_resolved_target_policy(&[(80, target)], true).unwrap_err();
+            assert!(err.contains("special-purpose targets are not allowed"));
+        }
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -1,0 +1,1113 @@
+//! std/net module - IPAM-grade IP/CIDR helpers and reachability probes.
+
+use crate::error::IntentError;
+use crate::interpreter::Value;
+use std::cmp::{max, min};
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::{Duration, Instant};
+
+const DEFAULT_MAX_RESULTS: usize = 4096;
+const HARD_MAX_RESULTS: usize = 65_536;
+const DEFAULT_TIMEOUT_MS: u64 = 2_000;
+const MIN_TIMEOUT_MS: u64 = 50;
+const MAX_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_TCP_PORTS: &[u16] = &[443, 80];
+const MAX_TCP_PORTS: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Family {
+    V4,
+    V6,
+}
+
+impl Family {
+    fn bits(self) -> u8 {
+        match self {
+            Family::V4 => 32,
+            Family::V6 => 128,
+        }
+    }
+
+    fn version(self) -> i64 {
+        match self {
+            Family::V4 => 4,
+            Family::V6 => 6,
+        }
+    }
+
+    fn max_value(self) -> u128 {
+        match self {
+            Family::V4 => (1u128 << 32) - 1,
+            Family::V6 => u128::MAX,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Network {
+    family: Family,
+    network: u128,
+    prefix: u8,
+}
+
+impl Network {
+    fn bits(&self) -> u8 {
+        self.family.bits()
+    }
+
+    fn mask(&self) -> u128 {
+        mask_for(self.family, self.prefix)
+    }
+
+    fn last(&self) -> u128 {
+        self.network | (!self.mask() & self.family.max_value())
+    }
+
+    fn total_addresses_string(&self) -> String {
+        pow2_decimal((self.bits() - self.prefix) as u32)
+    }
+
+    fn contains_network(&self, other: &Network) -> bool {
+        self.family == other.family && self.network <= other.network && self.last() >= other.last()
+    }
+
+    fn overlaps(&self, other: &Network) -> bool {
+        self.family == other.family && self.network <= other.last() && other.network <= self.last()
+    }
+
+    fn cidr_string(&self) -> String {
+        format!(
+            "{}/{}",
+            ip_to_string(self.family, self.network),
+            self.prefix
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParsedInput {
+    input: String,
+    original_ip: u128,
+    network: Network,
+    kind: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReachabilityMethod {
+    Auto,
+    Icmp,
+    Tcp,
+}
+
+impl ReachabilityMethod {
+    fn parse(value: Option<&Value>) -> Result<Self, String> {
+        match value {
+            None => Ok(ReachabilityMethod::Auto),
+            Some(Value::String(method)) => match method.as_str() {
+                "auto" => Ok(ReachabilityMethod::Auto),
+                "icmp" => Ok(ReachabilityMethod::Icmp),
+                "tcp" => Ok(ReachabilityMethod::Tcp),
+                other => Err(format!(
+                    "ping() method must be 'auto', 'icmp', or 'tcp', got '{}'",
+                    other
+                )),
+            },
+            Some(other) => Err(format!(
+                "ping() option 'method' must be String, got {}",
+                other.type_name()
+            )),
+        }
+    }
+}
+
+pub fn init() -> HashMap<String, Value> {
+    let mut module = HashMap::new();
+
+    // @ntnt ip_parse
+    // @module std/net
+    // @module_description Safe network primitives: IPAM-grade CIDR math and reachability probes
+    // @signature ip_parse(ip_or_cidr: String) -> Result<Map, String>
+    // Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields.
+    // @param ip_or_cidr Address or CIDR string, e.g. "192.168.1.0/24" or "2001:db8::/64"
+    // @returns Result containing a map of canonical fields and classification booleans
+    // @since v0.5.0
+    // @tags #pure, #deterministic, #network
+    // @example ip_parse("192.168.1.0/24") ~ "Parse an IPv4 subnet"
+    module.insert(
+        "ip_parse".to_string(),
+        Value::NativeFunction {
+            name: "ip_parse".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| match string_arg(args, 0, "ip_parse") {
+                Ok(input) => Ok(result_from(
+                    parse_ip(input).map(|parsed| parsed_to_map(&parsed)),
+                )),
+                Err(e) => Err(e),
+            },
+        },
+    );
+
+    // @ntnt subnet_contains
+    // @module std/net
+    // @signature subnet_contains(cidr: String, ip_or_cidr: String) -> Result<Bool, String>
+    // Returns true when the parent CIDR contains the entire child address or subnet.
+    // @since v0.5.0
+    // @tags #pure, #deterministic, #network
+    module.insert(
+        "subnet_contains".to_string(),
+        Value::NativeFunction {
+            name: "subnet_contains".to_string(),
+            arity: 2,
+            max_arity: 2,
+            requires: None,
+            func: |args| binary_network_bool(args, "subnet_contains", |a, b| a.contains_network(b)),
+        },
+    );
+
+    // @ntnt subnet_overlaps
+    // @module std/net
+    // @signature subnet_overlaps(a: String, b: String) -> Result<Bool, String>
+    // Returns true when two IPv4 or IPv6 CIDRs overlap.
+    // @since v0.5.0
+    // @tags #pure, #deterministic, #network
+    module.insert(
+        "subnet_overlaps".to_string(),
+        Value::NativeFunction {
+            name: "subnet_overlaps".to_string(),
+            arity: 2,
+            max_arity: 2,
+            requires: None,
+            func: |args| binary_network_bool(args, "subnet_overlaps", |a, b| a.overlaps(b)),
+        },
+    );
+
+    // @ntnt subnet_split
+    // @module std/net
+    // @signature subnet_split(cidr: String, new_prefix: Int, opts?: Map) -> Result<Array<String>, String>
+    // Splits a CIDR into child subnets with a longer prefix, enforcing result caps.
+    // @since v0.5.0
+    // @tags #pure, #deterministic, #network
+    module.insert(
+        "subnet_split".to_string(),
+        Value::NativeFunction {
+            name: "subnet_split".to_string(),
+            arity: 2,
+            max_arity: 3,
+            requires: None,
+            func: subnet_split_fn,
+        },
+    );
+
+    // @ntnt subnet_supernet
+    // @module std/net
+    // @signature subnet_supernet(cidr: String, new_prefix?: Int) -> Result<String, String>
+    // Returns the parent/supernet of a CIDR. Defaults to one bit shorter.
+    // @since v0.5.0
+    // @tags #pure, #deterministic, #network
+    module.insert(
+        "subnet_supernet".to_string(),
+        Value::NativeFunction {
+            name: "subnet_supernet".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: subnet_supernet_fn,
+        },
+    );
+
+    // @ntnt subnet_summarize
+    // @module std/net
+    // @signature subnet_summarize(cidrs: Array<String>) -> Result<Array<String>, String>
+    // Summarizes adjacent or overlapping CIDRs into the shortest equivalent route list.
+    // @since v0.5.0
+    // @tags #pure, #deterministic, #network
+    module.insert(
+        "subnet_summarize".to_string(),
+        Value::NativeFunction {
+            name: "subnet_summarize".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: subnet_summarize_fn,
+        },
+    );
+
+    // @ntnt ip_range_to_cidrs
+    // @module std/net
+    // @signature ip_range_to_cidrs(start_ip: String, end_ip: String) -> Result<Array<String>, String>
+    // Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover.
+    // @since v0.5.0
+    // @tags #pure, #deterministic, #network
+    module.insert(
+        "ip_range_to_cidrs".to_string(),
+        Value::NativeFunction {
+            name: "ip_range_to_cidrs".to_string(),
+            arity: 2,
+            max_arity: 2,
+            requires: None,
+            func: ip_range_to_cidrs_fn,
+        },
+    );
+
+    // @ntnt ping
+    // @module std/net
+    // @signature ping(host: String, opts?: Map) -> Result<Map, String>
+    // Performs a first-shot host reachability probe. The default auto method uses
+    // unprivileged TCP fallback when ICMP is unavailable.
+    // @since v0.5.0
+    // @tags #network
+    module.insert(
+        "ping".to_string(),
+        Value::NativeFunction {
+            name: "ping".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: ping_fn,
+        },
+    );
+
+    module
+}
+
+fn string_arg<'a>(args: &'a [Value], index: usize, fn_name: &str) -> Result<&'a str, IntentError> {
+    match &args[index] {
+        Value::String(s) => Ok(s),
+        other => Err(IntentError::type_error(format!(
+            "{}() argument {} must be String, got {}",
+            fn_name,
+            index + 1,
+            other.type_name()
+        ))),
+    }
+}
+
+fn int_arg(args: &[Value], index: usize, fn_name: &str) -> Result<i64, IntentError> {
+    match &args[index] {
+        Value::Int(i) => Ok(*i),
+        other => Err(IntentError::type_error(format!(
+            "{}() argument {} must be Int, got {}",
+            fn_name,
+            index + 1,
+            other.type_name()
+        ))),
+    }
+}
+
+fn opts_arg<'a>(
+    args: &'a [Value],
+    index: usize,
+    fn_name: &str,
+) -> Result<Option<&'a HashMap<String, Value>>, IntentError> {
+    if args.len() <= index {
+        return Ok(None);
+    }
+    match &args[index] {
+        Value::Map(m) => Ok(Some(m)),
+        other => Err(IntentError::type_error(format!(
+            "{}() options argument must be Map, got {}",
+            fn_name,
+            other.type_name()
+        ))),
+    }
+}
+
+fn result_from<T>(result: Result<T, String>) -> Value
+where
+    T: Into<Value>,
+{
+    match result {
+        Ok(value) => Value::ok(value.into()),
+        Err(err) => Value::err(Value::String(err)),
+    }
+}
+
+impl From<HashMap<String, Value>> for Value {
+    fn from(value: HashMap<String, Value>) -> Self {
+        Value::Map(value)
+    }
+}
+
+fn binary_network_bool(
+    args: &[Value],
+    fn_name: &str,
+    op: fn(&Network, &Network) -> bool,
+) -> Result<Value, IntentError> {
+    let a = match string_arg(args, 0, fn_name) {
+        Ok(s) => s,
+        Err(e) => return Err(e),
+    };
+    let b = match string_arg(args, 1, fn_name) {
+        Ok(s) => s,
+        Err(e) => return Err(e),
+    };
+
+    Ok(result_from((|| {
+        let left = parse_ip(a)?.network;
+        let right = parse_ip(b)?.network;
+        ensure_same_family(&left, &right)?;
+        Ok(Value::Bool(op(&left, &right)))
+    })()))
+}
+
+fn subnet_split_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let cidr = string_arg(args, 0, "subnet_split")?;
+    let new_prefix = int_arg(args, 1, "subnet_split")?;
+    let opts = opts_arg(args, 2, "subnet_split")?;
+
+    Ok(result_from((|| {
+        let network = parse_ip(cidr)?.network;
+        let bits = network.bits();
+        if new_prefix < 0 || new_prefix > bits as i64 {
+            return Err(format!(
+                "new_prefix must be between 0 and {} for IPv{}, got {}",
+                bits,
+                network.family.version(),
+                new_prefix
+            ));
+        }
+        let new_prefix = new_prefix as u8;
+        if new_prefix <= network.prefix {
+            return Err(format!(
+                "new_prefix must be longer than input prefix /{}, got /{}",
+                network.prefix, new_prefix
+            ));
+        }
+
+        let max_results = parse_max_results(opts, "subnet_split.max_results")?;
+        let count_exp = (new_prefix - network.prefix) as u32;
+        if count_exp >= usize::BITS || (1usize << count_exp) > max_results {
+            return Err(format!(
+                "too many subnets: split would produce more than {} results",
+                max_results
+            ));
+        }
+        let count = 1usize << count_exp;
+        let step = block_size(network.family, new_prefix);
+        let mut subnets = Vec::with_capacity(count);
+        for i in 0..count {
+            let addr = network.network + step * i as u128;
+            subnets.push(Value::String(
+                Network {
+                    family: network.family,
+                    network: addr,
+                    prefix: new_prefix,
+                }
+                .cidr_string(),
+            ));
+        }
+        Ok(Value::Array(subnets))
+    })()))
+}
+
+fn subnet_supernet_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let cidr = string_arg(args, 0, "subnet_supernet")?;
+    Ok(result_from((|| {
+        let network = parse_ip(cidr)?.network;
+        let new_prefix = if args.len() > 1 {
+            let explicit = int_arg(args, 1, "subnet_supernet").map_err(|e| e.to_string())?;
+            if explicit < 0 || explicit > network.bits() as i64 {
+                return Err(format!(
+                    "new_prefix must be between 0 and {}, got {}",
+                    network.bits(),
+                    explicit
+                ));
+            }
+            explicit as u8
+        } else if network.prefix == 0 {
+            return Err("cannot compute supernet for a /0 network".to_string());
+        } else {
+            network.prefix - 1
+        };
+
+        if new_prefix >= network.prefix {
+            return Err(format!(
+                "new_prefix must be shorter than input prefix /{}, got /{}",
+                network.prefix, new_prefix
+            ));
+        }
+        let mask = mask_for(network.family, new_prefix);
+        Ok(Value::String(
+            Network {
+                family: network.family,
+                network: network.network & mask,
+                prefix: new_prefix,
+            }
+            .cidr_string(),
+        ))
+    })()))
+}
+
+fn subnet_summarize_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let values = match &args[0] {
+        Value::Array(values) => values,
+        other => {
+            return Err(IntentError::type_error(format!(
+                "subnet_summarize() argument 1 must be Array<String>, got {}",
+                other.type_name()
+            )))
+        }
+    };
+
+    Ok(result_from((|| {
+        if values.len() > DEFAULT_MAX_RESULTS {
+            return Err(format!(
+                "too many CIDRs: maximum is {}",
+                DEFAULT_MAX_RESULTS
+            ));
+        }
+
+        let mut ranges: Vec<(Family, u128, u128)> = Vec::with_capacity(values.len());
+        for value in values {
+            let cidr = match value {
+                Value::String(s) => s,
+                other => {
+                    return Err(format!(
+                        "subnet_summarize() expects Array<String>, got {} item",
+                        other.type_name()
+                    ))
+                }
+            };
+            let network = parse_ip(cidr)?.network;
+            ranges.push((network.family, network.network, network.last()));
+        }
+
+        if ranges.is_empty() {
+            return Ok(Value::Array(vec![]));
+        }
+
+        let family = ranges[0].0;
+        if ranges
+            .iter()
+            .any(|(item_family, _, _)| *item_family != family)
+        {
+            return Err("mixed IPv4/IPv6 families are not comparable".to_string());
+        }
+
+        ranges.sort_by_key(|(_, start, end)| (*start, *end));
+        let mut merged: Vec<(u128, u128)> = Vec::new();
+        for (_, start, end) in ranges {
+            if let Some((_, last_end)) = merged.last_mut() {
+                if start <= last_end.saturating_add(1) {
+                    *last_end = max(*last_end, end);
+                    continue;
+                }
+            }
+            merged.push((start, end));
+        }
+
+        let mut output = Vec::new();
+        for (start, end) in merged {
+            for network in range_to_networks(family, start, end, HARD_MAX_RESULTS)? {
+                output.push(Value::String(network.cidr_string()));
+            }
+        }
+        Ok(Value::Array(output))
+    })()))
+}
+
+fn ip_range_to_cidrs_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let start = string_arg(args, 0, "ip_range_to_cidrs")?;
+    let end = string_arg(args, 1, "ip_range_to_cidrs")?;
+
+    Ok(result_from((|| {
+        let start = parse_ip(start)?;
+        let end = parse_ip(end)?;
+        if start.network.prefix != start.network.bits() || end.network.prefix != end.network.bits()
+        {
+            return Err("ip_range_to_cidrs() expects bare IP addresses, not CIDRs".to_string());
+        }
+        ensure_same_family(&start.network, &end.network)?;
+        if start.original_ip > end.original_ip {
+            return Err("start_ip must be less than or equal to end_ip".to_string());
+        }
+        let networks = range_to_networks(
+            start.network.family,
+            start.original_ip,
+            end.original_ip,
+            DEFAULT_MAX_RESULTS,
+        )?;
+        Ok(Value::Array(
+            networks
+                .into_iter()
+                .map(|network| Value::String(network.cidr_string()))
+                .collect(),
+        ))
+    })()))
+}
+
+fn ping_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let host = string_arg(args, 0, "ping")?;
+    let opts = opts_arg(args, 1, "ping")?;
+
+    Ok(result_from((|| {
+        let method = ReachabilityMethod::parse(opts.and_then(|m| m.get("method")))?;
+        if method == ReachabilityMethod::Icmp {
+            return Err(
+                "ICMP ping unavailable: std/net Phase 1 defaults to unprivileged TCP fallback; use method: 'auto' or 'tcp' unless the runtime adds ICMP capability support"
+                    .to_string(),
+            );
+        }
+
+        let allow_private = parse_bool_option(opts, "allow_private", false)?;
+        let timeout_ms = parse_u64_option(opts, "timeout_ms", DEFAULT_TIMEOUT_MS)?
+            .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
+        let tcp_ports = parse_tcp_ports(opts)?;
+
+        let probe = tcp_reachability(
+            host,
+            &tcp_ports,
+            Duration::from_millis(timeout_ms),
+            allow_private,
+        )?;
+        let mut result = HashMap::new();
+        result.insert("host".to_string(), Value::String(host.to_string()));
+        result.insert("reachable".to_string(), Value::Bool(probe.reachable));
+        result.insert("method".to_string(), Value::String("tcp".to_string()));
+        if method == ReachabilityMethod::Auto {
+            result.insert(
+                "fallback_from".to_string(),
+                Value::String("icmp".to_string()),
+            );
+            result.insert("permission_limited".to_string(), Value::Bool(true));
+        } else {
+            result.insert("permission_limited".to_string(), Value::Bool(false));
+        }
+        result.insert(
+            "ports_tried".to_string(),
+            Value::Array(tcp_ports.iter().map(|p| Value::Int(*p as i64)).collect()),
+        );
+        if let Some(port) = probe.connected_port {
+            result.insert("connected_port".to_string(), Value::Int(port as i64));
+        } else {
+            result.insert("connected_port".to_string(), Value::none());
+            result.insert("reason".to_string(), Value::String(probe.reason));
+        }
+        if let Some(latency_ms) = probe.latency_ms {
+            result.insert("latency_ms".to_string(), Value::Float(latency_ms));
+        }
+        Ok(Value::Map(result))
+    })()))
+}
+
+#[derive(Debug)]
+struct TcpProbeResult {
+    reachable: bool,
+    connected_port: Option<u16>,
+    latency_ms: Option<f64>,
+    reason: String,
+}
+
+fn tcp_reachability(
+    host: &str,
+    ports: &[u16],
+    timeout: Duration,
+    allow_private: bool,
+) -> Result<TcpProbeResult, String> {
+    let mut last_reason = "unreachable".to_string();
+    for port in ports {
+        let addrs: Vec<SocketAddr> = (host, *port)
+            .to_socket_addrs()
+            .map_err(|e| format!("failed to resolve {}:{}: {}", host, port, e))?
+            .collect();
+        if addrs.is_empty() {
+            last_reason = "no resolved addresses".to_string();
+            continue;
+        }
+        for addr in addrs {
+            enforce_target_policy(addr.ip(), allow_private)?;
+            let start = Instant::now();
+            match TcpStream::connect_timeout(&addr, timeout) {
+                Ok(stream) => {
+                    drop(stream);
+                    return Ok(TcpProbeResult {
+                        reachable: true,
+                        connected_port: Some(*port),
+                        latency_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
+                        reason: "connected".to_string(),
+                    });
+                }
+                Err(e) => {
+                    last_reason = e.kind().to_string();
+                }
+            }
+        }
+    }
+    Ok(TcpProbeResult {
+        reachable: false,
+        connected_port: None,
+        latency_ms: None,
+        reason: last_reason,
+    })
+}
+
+fn parse_ip(input: &str) -> Result<ParsedInput, String> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err("IP/CIDR input cannot be empty".to_string());
+    }
+
+    let (ip_part, prefix_part) = match input.split_once('/') {
+        Some((ip, prefix)) => (ip, Some(prefix)),
+        None => (input, None),
+    };
+
+    let ip: IpAddr = ip_part
+        .parse()
+        .map_err(|_| format!("invalid IP address: {}", ip_part))?;
+    let (family, original_ip) = ip_to_u128(ip);
+    let bits = family.bits();
+    let prefix = match prefix_part {
+        Some(prefix) => {
+            let parsed: u8 = prefix
+                .parse()
+                .map_err(|_| format!("invalid CIDR prefix: {}", prefix))?;
+            if parsed > bits {
+                return Err(format!(
+                    "CIDR prefix /{} is invalid for IPv{}",
+                    parsed,
+                    family.version()
+                ));
+            }
+            parsed
+        }
+        None => bits,
+    };
+    let mask = mask_for(family, prefix);
+
+    Ok(ParsedInput {
+        input: input.to_string(),
+        original_ip,
+        network: Network {
+            family,
+            network: original_ip & mask,
+            prefix,
+        },
+        kind: if prefix_part.is_some() {
+            "network"
+        } else {
+            "address"
+        },
+    })
+}
+
+fn parsed_to_map(parsed: &ParsedInput) -> HashMap<String, Value> {
+    let network = &parsed.network;
+    let ip = ip_to_string(network.family, parsed.original_ip);
+    let network_ip = ip_to_string(network.family, network.network);
+    let first = ip_to_string(network.family, network.network);
+    let last = ip_to_string(network.family, network.last());
+
+    let mut map = HashMap::new();
+    map.insert("input".to_string(), Value::String(input_cidr_or_ip(parsed)));
+    map.insert("kind".to_string(), Value::String(parsed.kind.to_string()));
+    map.insert("version".to_string(), Value::Int(network.family.version()));
+    map.insert("ip".to_string(), Value::String(ip));
+    map.insert("prefix".to_string(), Value::Int(network.prefix as i64));
+    map.insert("network".to_string(), Value::String(network_ip));
+    map.insert("first".to_string(), Value::String(first));
+    map.insert("last".to_string(), Value::String(last));
+    map.insert(
+        "total_addresses".to_string(),
+        Value::String(network.total_addresses_string()),
+    );
+    map.insert(
+        "reverse_zone".to_string(),
+        reverse_zone(network).map_or_else(Value::none, Value::String),
+    );
+
+    match network.family {
+        Family::V4 => add_ipv4_fields(&mut map, parsed),
+        Family::V6 => add_ipv6_fields(&mut map, parsed),
+    }
+
+    map
+}
+
+fn input_cidr_or_ip(parsed: &ParsedInput) -> String {
+    parsed.input.clone()
+}
+
+fn add_ipv4_fields(map: &mut HashMap<String, Value>, parsed: &ParsedInput) {
+    let network = &parsed.network;
+    let ip = Ipv4Addr::from(parsed.original_ip as u32);
+    let mask = mask_for(Family::V4, network.prefix) as u32;
+    let wildcard = !mask;
+    let total = 1u128 << (32 - network.prefix);
+    let usable = match network.prefix {
+        0..=30 => total.saturating_sub(2),
+        31 => 2,
+        32 => 1,
+        _ => 0,
+    };
+
+    map.insert(
+        "broadcast".to_string(),
+        Value::String(ip_to_string(Family::V4, network.last())),
+    );
+    map.insert(
+        "netmask".to_string(),
+        Value::String(Ipv4Addr::from(mask).to_string()),
+    );
+    map.insert(
+        "wildcard_mask".to_string(),
+        Value::String(Ipv4Addr::from(wildcard).to_string()),
+    );
+    map.insert(
+        "usable_hosts".to_string(),
+        Value::String(usable.to_string()),
+    );
+    map.insert("expanded".to_string(), Value::String(ip.to_string()));
+    add_common_classification(map, IpAddr::V4(ip));
+}
+
+fn add_ipv6_fields(map: &mut HashMap<String, Value>, parsed: &ParsedInput) {
+    let ip = Ipv6Addr::from(parsed.original_ip);
+    map.insert("broadcast".to_string(), Value::none());
+    map.insert("netmask".to_string(), Value::none());
+    map.insert("wildcard_mask".to_string(), Value::none());
+    map.insert("usable_hosts".to_string(), Value::none());
+    map.insert("expanded".to_string(), Value::String(expand_ipv6(ip)));
+    add_common_classification(map, IpAddr::V6(ip));
+}
+
+fn add_common_classification(map: &mut HashMap<String, Value>, ip: IpAddr) {
+    let classification = classify_ip(ip);
+    map.insert(
+        "is_private".to_string(),
+        Value::Bool(classification.is_private),
+    );
+    map.insert(
+        "is_loopback".to_string(),
+        Value::Bool(classification.is_loopback),
+    );
+    map.insert(
+        "is_link_local".to_string(),
+        Value::Bool(classification.is_link_local),
+    );
+    map.insert(
+        "is_multicast".to_string(),
+        Value::Bool(classification.is_multicast),
+    );
+    map.insert(
+        "is_unspecified".to_string(),
+        Value::Bool(classification.is_unspecified),
+    );
+    map.insert(
+        "is_documentation".to_string(),
+        Value::Bool(classification.is_documentation),
+    );
+    map.insert(
+        "is_unique_local".to_string(),
+        Value::Bool(classification.is_unique_local),
+    );
+}
+
+#[derive(Debug)]
+struct IpClassification {
+    is_private: bool,
+    is_loopback: bool,
+    is_link_local: bool,
+    is_multicast: bool,
+    is_unspecified: bool,
+    is_documentation: bool,
+    is_unique_local: bool,
+}
+
+fn classify_ip(ip: IpAddr) -> IpClassification {
+    match ip {
+        IpAddr::V4(ip) => IpClassification {
+            is_private: ip.is_private(),
+            is_loopback: ip.is_loopback(),
+            is_link_local: ip.is_link_local(),
+            is_multicast: ip.is_multicast(),
+            is_unspecified: ip.is_unspecified(),
+            is_documentation: is_ipv4_documentation(ip),
+            is_unique_local: false,
+        },
+        IpAddr::V6(ip) => {
+            let first_segment = ip.segments()[0];
+            let is_unique_local = (first_segment & 0xfe00) == 0xfc00;
+            let is_link_local = (first_segment & 0xffc0) == 0xfe80;
+            let is_documentation = ip.segments()[0] == 0x2001 && ip.segments()[1] == 0x0db8;
+            IpClassification {
+                is_private: is_unique_local,
+                is_loopback: ip.is_loopback(),
+                is_link_local,
+                is_multicast: ip.is_multicast(),
+                is_unspecified: ip.is_unspecified(),
+                is_documentation,
+                is_unique_local,
+            }
+        }
+    }
+}
+
+fn is_ipv4_documentation(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    matches!(
+        octets,
+        [192, 0, 2, _] | [198, 51, 100, _] | [203, 0, 113, _]
+    )
+}
+
+fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> {
+    let classification = classify_ip(ip);
+    let denied_by_default = classification.is_private
+        || classification.is_loopback
+        || classification.is_link_local
+        || classification.is_unspecified;
+    if !denied_by_default {
+        return Ok(());
+    }
+    if !allow_private || !process_allows_private_targets() {
+        return Err(
+            "Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn process_allows_private_targets() -> bool {
+    matches!(
+        std::env::var("NTNT_NET_ALLOW_PRIVATE").as_deref(),
+        Ok("1") | Ok("true") | Ok("yes")
+    ) || matches!(
+        std::env::var("NTNT_ALLOW_PRIVATE_IPS").as_deref(),
+        Ok("1") | Ok("true") | Ok("yes")
+    )
+}
+
+fn ensure_same_family(a: &Network, b: &Network) -> Result<(), String> {
+    if a.family != b.family {
+        return Err("mixed IPv4/IPv6 families are not comparable".to_string());
+    }
+    Ok(())
+}
+
+fn parse_max_results(opts: Option<&HashMap<String, Value>>, key: &str) -> Result<usize, String> {
+    let Some(opts) = opts else {
+        return Ok(DEFAULT_MAX_RESULTS);
+    };
+    let Some(value) = opts.get("max_results") else {
+        return Ok(DEFAULT_MAX_RESULTS);
+    };
+    let Value::Int(raw) = value else {
+        return Err(format!("{} must be Int", key));
+    };
+    if *raw <= 0 {
+        return Err(format!("{} must be positive", key));
+    }
+    let requested = usize::try_from(*raw).map_err(|_| format!("{} is too large", key))?;
+    Ok(min(requested, HARD_MAX_RESULTS))
+}
+
+fn parse_bool_option(
+    opts: Option<&HashMap<String, Value>>,
+    key: &str,
+    default: bool,
+) -> Result<bool, String> {
+    match opts.and_then(|m| m.get(key)) {
+        None => Ok(default),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(other) => Err(format!(
+            "option '{}' must be Bool, got {}",
+            key,
+            other.type_name()
+        )),
+    }
+}
+
+fn parse_u64_option(
+    opts: Option<&HashMap<String, Value>>,
+    key: &str,
+    default: u64,
+) -> Result<u64, String> {
+    match opts.and_then(|m| m.get(key)) {
+        None => Ok(default),
+        Some(Value::Int(value)) if *value >= 0 => Ok(*value as u64),
+        Some(Value::Int(_)) => Err(format!("option '{}' must be non-negative", key)),
+        Some(other) => Err(format!(
+            "option '{}' must be Int, got {}",
+            key,
+            other.type_name()
+        )),
+    }
+}
+
+fn parse_tcp_ports(opts: Option<&HashMap<String, Value>>) -> Result<Vec<u16>, String> {
+    let Some(value) = opts.and_then(|m| m.get("tcp_ports")) else {
+        return Ok(DEFAULT_TCP_PORTS.to_vec());
+    };
+    let Value::Array(values) = value else {
+        return Err("option 'tcp_ports' must be Array<Int>".to_string());
+    };
+    if values.is_empty() {
+        return Err("option 'tcp_ports' cannot be empty".to_string());
+    }
+    if values.len() > MAX_TCP_PORTS {
+        return Err(format!(
+            "option 'tcp_ports' supports at most {} ports",
+            MAX_TCP_PORTS
+        ));
+    }
+    let mut ports = Vec::with_capacity(values.len());
+    for value in values {
+        let Value::Int(port) = value else {
+            return Err("option 'tcp_ports' must be Array<Int>".to_string());
+        };
+        if *port < 1 || *port > 65_535 {
+            return Err(format!("invalid TCP port: {}", port));
+        }
+        let port = *port as u16;
+        if !ports.contains(&port) {
+            ports.push(port);
+        }
+    }
+    Ok(ports)
+}
+
+fn mask_for(family: Family, prefix: u8) -> u128 {
+    let bits = family.bits();
+    if prefix == 0 {
+        0
+    } else {
+        (!0u128 << (bits - prefix)) & family.max_value()
+    }
+}
+
+fn block_size(family: Family, prefix: u8) -> u128 {
+    let host_bits = family.bits() - prefix;
+    if host_bits == 128 {
+        u128::MAX
+    } else {
+        1u128 << host_bits
+    }
+}
+
+fn ip_to_u128(ip: IpAddr) -> (Family, u128) {
+    match ip {
+        IpAddr::V4(ip) => (Family::V4, u32::from(ip) as u128),
+        IpAddr::V6(ip) => (Family::V6, u128::from(ip)),
+    }
+}
+
+fn ip_to_string(family: Family, value: u128) -> String {
+    match family {
+        Family::V4 => Ipv4Addr::from(value as u32).to_string(),
+        Family::V6 => Ipv6Addr::from(value).to_string(),
+    }
+}
+
+fn expand_ipv6(ip: Ipv6Addr) -> String {
+    ip.segments()
+        .iter()
+        .map(|segment| format!("{:04x}", segment))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+fn pow2_decimal(exp: u32) -> String {
+    match exp {
+        0..=127 => (1u128 << exp).to_string(),
+        128 => "340282366920938463463374607431768211456".to_string(),
+        _ => unreachable!("IP address families only use up to 128 bits"),
+    }
+}
+
+fn reverse_zone(network: &Network) -> Option<String> {
+    match network.family {
+        Family::V4 => {
+            if network.prefix % 8 != 0 {
+                return None;
+            }
+            let octets = Ipv4Addr::from(network.network as u32).octets();
+            let count = (network.prefix / 8) as usize;
+            let labels: Vec<String> = octets[..count]
+                .iter()
+                .rev()
+                .map(|octet| octet.to_string())
+                .collect();
+            Some(if labels.is_empty() {
+                "in-addr.arpa".to_string()
+            } else {
+                format!("{}.in-addr.arpa", labels.join("."))
+            })
+        }
+        Family::V6 => {
+            if network.prefix % 4 != 0 {
+                return None;
+            }
+            let nibbles = (network.prefix / 4) as usize;
+            let expanded = format!("{:032x}", network.network);
+            let mut labels: Vec<String> = expanded
+                .chars()
+                .take(nibbles)
+                .map(|ch| ch.to_string())
+                .collect();
+            labels.reverse();
+            Some(if labels.is_empty() {
+                "ip6.arpa".to_string()
+            } else {
+                format!("{}.ip6.arpa", labels.join("."))
+            })
+        }
+    }
+}
+
+fn range_to_networks(
+    family: Family,
+    mut start: u128,
+    end: u128,
+    max_results: usize,
+) -> Result<Vec<Network>, String> {
+    if start > end {
+        return Err("range start must be <= end".to_string());
+    }
+    if start == 0 && end == family.max_value() {
+        return Ok(vec![Network {
+            family,
+            network: 0,
+            prefix: 0,
+        }]);
+    }
+    let bits = family.bits();
+    let mut output = Vec::new();
+    while start <= end {
+        if output.len() >= max_results {
+            return Err(format!(
+                "too many CIDRs: range would produce more than {} results",
+                max_results
+            ));
+        }
+
+        let remaining = end - start + 1;
+        let alignment_prefix = if start == 0 {
+            0
+        } else {
+            bits - min(start.trailing_zeros() as u8, bits)
+        };
+        let remaining_prefix = bits - floor_log2(remaining) as u8;
+        let prefix = max(alignment_prefix, remaining_prefix);
+        let size = block_size(family, prefix);
+        output.push(Network {
+            family,
+            network: start,
+            prefix,
+        });
+        if size == 0 || start > u128::MAX - size {
+            break;
+        }
+        start += size;
+    }
+    Ok(output)
+}
+
+fn floor_log2(value: u128) -> u32 {
+    debug_assert!(value > 0);
+    127 - value.leading_zeros()
+}

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -889,7 +889,7 @@ fn is_ipv4_documentation(ip: Ipv4Addr) -> bool {
 }
 
 fn is_ipv4_metadata_endpoint(ip: Ipv4Addr) -> bool {
-    ip.octets() == [169, 254, 169, 254]
+    matches!(ip.octets(), [169, 254, 169, 254] | [169, 254, 170, 2])
 }
 
 fn is_ipv6_metadata_endpoint(ip: Ipv6Addr) -> bool {
@@ -1194,14 +1194,18 @@ mod tests {
     #[test]
     fn target_policy_never_allows_metadata_or_special_ranges() {
         let metadata = "169.254.169.254:80".parse::<SocketAddr>().unwrap();
+        let ecs_metadata = "169.254.170.2:80".parse::<SocketAddr>().unwrap();
         let mapped_metadata = "[::ffff:169.254.169.254]:80".parse::<SocketAddr>().unwrap();
+        let mapped_ecs_metadata = "[::ffff:169.254.170.2]:80".parse::<SocketAddr>().unwrap();
         let multicast = "224.0.0.1:80".parse::<SocketAddr>().unwrap();
         let documentation = "192.0.2.1:80".parse::<SocketAddr>().unwrap();
         let broadcast = "255.255.255.255:80".parse::<SocketAddr>().unwrap();
 
         for target in [
             metadata,
+            ecs_metadata,
             mapped_metadata,
+            mapped_ecs_metadata,
             multicast,
             documentation,
             broadcast,

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -836,6 +836,7 @@ struct IpClassification {
     is_multicast: bool,
     is_unspecified: bool,
     is_documentation: bool,
+    is_broadcast: bool,
     is_unique_local: bool,
 }
 
@@ -848,6 +849,7 @@ fn classify_ip(ip: IpAddr) -> IpClassification {
             is_multicast: ip.is_multicast(),
             is_unspecified: ip.is_unspecified(),
             is_documentation: is_ipv4_documentation(ip),
+            is_broadcast: ip.is_broadcast(),
             is_unique_local: false,
         },
         IpAddr::V6(ip) => {
@@ -865,6 +867,7 @@ fn classify_ip(ip: IpAddr) -> IpClassification {
                 is_multicast: ip.is_multicast(),
                 is_unspecified: ip.is_unspecified(),
                 is_documentation,
+                is_broadcast: false,
                 is_unique_local,
             }
         }
@@ -887,7 +890,7 @@ fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> 
         || classification.is_unspecified
         || classification.is_multicast
         || classification.is_documentation
-        || matches!(ip, IpAddr::V4(ipv4) if ipv4.is_broadcast());
+        || classification.is_broadcast;
     if !denied_by_default {
         return Ok(());
     }
@@ -1158,10 +1161,12 @@ mod tests {
         let multicast = "224.0.0.1:80".parse::<SocketAddr>().unwrap();
         let documentation = "192.0.2.1:80".parse::<SocketAddr>().unwrap();
         let broadcast = "255.255.255.255:80".parse::<SocketAddr>().unwrap();
+        let mapped_broadcast = "[::ffff:255.255.255.255]:80".parse::<SocketAddr>().unwrap();
 
         assert!(enforce_resolved_target_policy(&[(80, multicast)], false).is_err());
         assert!(enforce_resolved_target_policy(&[(80, documentation)], false).is_err());
         assert!(enforce_resolved_target_policy(&[(80, broadcast)], false).is_err());
+        assert!(enforce_resolved_target_policy(&[(80, mapped_broadcast)], false).is_err());
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -13,8 +13,8 @@ const HARD_MAX_RESULTS: usize = 65_536;
 const DEFAULT_TIMEOUT_MS: u64 = 2_000;
 const MIN_TIMEOUT_MS: u64 = 50;
 const MAX_TIMEOUT_MS: u64 = 30_000;
-const DEFAULT_PING_COUNT: usize = 1;
-const MAX_PING_COUNT: usize = 10;
+const DEFAULT_PROBE_COUNT: usize = 1;
+const MAX_PROBE_COUNT: usize = 10;
 const DEFAULT_INTERVAL_MS: u64 = 0;
 const MAX_INTERVAL_MS: u64 = 5_000;
 const MAX_TCP_PORTS: usize = 10;
@@ -91,39 +91,29 @@ impl Network {
 
 #[derive(Debug, Clone)]
 struct ParsedInput {
-    input: String,
     original_ip: u128,
     network: Network,
     kind: &'static str,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PingMethod {
-    Auto,
-    Icmp,
-}
-
-impl PingMethod {
-    fn parse_for_ping(value: Option<&Value>) -> Result<Self, String> {
-        match value {
-            None => Ok(PingMethod::Auto),
-            Some(Value::String(method)) => match method.as_str() {
-                "auto" => Ok(PingMethod::Auto),
-                "icmp" => Ok(PingMethod::Icmp),
-                "tcp" => Err(
-                    "ping() does not perform TCP probes; use tcp_connect() for a TCP port check or reachable() for explicit fallback reachability"
-                        .to_string(),
-                ),
-                other => Err(format!(
-                    "ping() method must be 'auto' or 'icmp', got '{}'",
-                    other
-                )),
-            },
-            Some(other) => Err(format!(
-                "ping() option 'method' must be String, got {}",
-                other.type_name()
+fn validate_ping_method(value: Option<&Value>) -> Result<(), String> {
+    match value {
+        None => Ok(()),
+        Some(Value::String(method)) => match method.as_str() {
+            "auto" | "icmp" => Ok(()),
+            "tcp" => Err(
+                "ping() does not perform TCP probes; use tcp_connect() for a TCP port check or reachable() for explicit fallback reachability"
+                    .to_string(),
+            ),
+            other => Err(format!(
+                "ping() method must be 'auto' or 'icmp', got '{}'",
+                other
             )),
-        }
+        },
+        Some(other) => Err(format!(
+            "ping() option 'method' must be String, got {}",
+            other.type_name()
+        )),
     }
 }
 
@@ -147,11 +137,11 @@ pub fn init() -> HashMap<String, Value> {
             arity: 1,
             max_arity: 1,
             requires: None,
-            func: |args| match string_arg(args, 0, "ip_parse") {
-                Ok(input) => Ok(result_from(
-                    parse_ip(input).map(|parsed| parsed_to_map(&parsed)),
-                )),
-                Err(e) => Err(e),
+            func: |args| {
+                let input = string_arg(args, 0, "ip_parse")?;
+                Ok(result_value(parse_ip(input).map(|parsed| {
+                    Value::Map(parsed_to_map(input.trim(), &parsed))
+                })))
             },
         },
     );
@@ -370,19 +360,10 @@ fn opts_arg<'a>(
     }
 }
 
-fn result_from<T>(result: Result<T, String>) -> Value
-where
-    T: Into<Value>,
-{
+fn result_value(result: Result<Value, String>) -> Value {
     match result {
-        Ok(value) => Value::ok(value.into()),
+        Ok(value) => Value::ok(value),
         Err(err) => Value::err(Value::String(err)),
-    }
-}
-
-impl From<HashMap<String, Value>> for Value {
-    fn from(value: HashMap<String, Value>) -> Self {
-        Value::Map(value)
     }
 }
 
@@ -391,16 +372,10 @@ fn binary_network_bool(
     fn_name: &str,
     op: fn(&Network, &Network) -> bool,
 ) -> Result<Value, IntentError> {
-    let a = match string_arg(args, 0, fn_name) {
-        Ok(s) => s,
-        Err(e) => return Err(e),
-    };
-    let b = match string_arg(args, 1, fn_name) {
-        Ok(s) => s,
-        Err(e) => return Err(e),
-    };
+    let a = string_arg(args, 0, fn_name)?;
+    let b = string_arg(args, 1, fn_name)?;
 
-    Ok(result_from((|| {
+    Ok(result_value((|| {
         let left = parse_ip(a)?.network;
         let right = parse_ip(b)?.network;
         ensure_same_family(&left, &right)?;
@@ -413,7 +388,7 @@ fn subnet_split_fn(args: &[Value]) -> Result<Value, IntentError> {
     let new_prefix = int_arg(args, 1, "subnet_split")?;
     let opts = opts_arg(args, 2, "subnet_split")?;
 
-    Ok(result_from((|| {
+    Ok(result_value((|| {
         let network = parse_ip(cidr)?.network;
         let bits = network.bits();
         if new_prefix < 0 || new_prefix > bits as i64 {
@@ -460,7 +435,7 @@ fn subnet_split_fn(args: &[Value]) -> Result<Value, IntentError> {
 
 fn subnet_supernet_fn(args: &[Value]) -> Result<Value, IntentError> {
     let cidr = string_arg(args, 0, "subnet_supernet")?;
-    Ok(result_from((|| {
+    Ok(result_value((|| {
         let network = parse_ip(cidr)?.network;
         let new_prefix = if args.len() > 1 {
             let explicit = int_arg(args, 1, "subnet_supernet").map_err(|e| e.to_string())?;
@@ -507,7 +482,7 @@ fn subnet_summarize_fn(args: &[Value]) -> Result<Value, IntentError> {
         }
     };
 
-    Ok(result_from((|| {
+    Ok(result_value((|| {
         if values.len() > DEFAULT_MAX_RESULTS {
             return Err(format!(
                 "too many CIDRs: maximum is {}",
@@ -568,7 +543,7 @@ fn ip_range_to_cidrs_fn(args: &[Value]) -> Result<Value, IntentError> {
     let start = string_arg(args, 0, "ip_range_to_cidrs")?;
     let end = string_arg(args, 1, "ip_range_to_cidrs")?;
 
-    Ok(result_from((|| {
+    Ok(result_value((|| {
         let start = parse_ip(start)?;
         let end = parse_ip(end)?;
         if start.network.prefix != start.network.bits() || end.network.prefix != end.network.bits()
@@ -598,8 +573,8 @@ fn ping_fn(args: &[Value]) -> Result<Value, IntentError> {
     let _host = string_arg(args, 0, "ping")?;
     let opts = opts_arg(args, 1, "ping")?;
 
-    Ok(result_from::<Value>((|| {
-        let _method = PingMethod::parse_for_ping(opts.and_then(|m| m.get("method")))?;
+    Ok(result_value((|| {
+        validate_ping_method(opts.and_then(|m| m.get("method")))?;
         Err(icmp_unavailable_message())
     })()))
 }
@@ -609,7 +584,7 @@ fn tcp_connect_fn(args: &[Value]) -> Result<Value, IntentError> {
     let raw_port = int_arg(args, 1, "tcp_connect")?;
     let opts = opts_arg(args, 2, "tcp_connect")?;
 
-    Ok(result_from((|| {
+    Ok(result_value((|| {
         let port = validate_tcp_port_arg(raw_port, "tcp_connect")?;
         let options = parse_probe_options(opts)?;
         let attempts = tcp_reachability_attempts_for_host(
@@ -628,7 +603,7 @@ fn reachable_fn(args: &[Value]) -> Result<Value, IntentError> {
     let host = string_arg(args, 0, "reachable")?;
     let opts = opts_arg(args, 1, "reachable")?;
 
-    Ok(result_from((|| {
+    Ok(result_value((|| {
         let options = parse_probe_options(opts)?;
         let tcp_ports = parse_tcp_ports(opts, "reachable")?;
         let attempts = tcp_reachability_attempts_for_host(
@@ -797,10 +772,16 @@ fn tcp_reachability_result_map(
     let sent = attempts.len();
     let received = attempts.iter().filter(|attempt| attempt.reachable).count();
     let failed = sent.saturating_sub(received);
-    let latencies: Vec<f64> = attempts
-        .iter()
-        .filter_map(|attempt| attempt.latency_ms)
-        .collect();
+    let mut latency_count = 0usize;
+    let mut latency_sum = 0.0;
+    let mut min_ms = f64::INFINITY;
+    let mut max_ms = f64::NEG_INFINITY;
+    for latency_ms in attempts.iter().filter_map(|attempt| attempt.latency_ms) {
+        latency_count += 1;
+        latency_sum += latency_ms;
+        min_ms = min_ms.min(latency_ms);
+        max_ms = max_ms.max(latency_ms);
+    }
 
     let mut result = HashMap::new();
     result.insert("host".to_string(), Value::String(host.to_string()));
@@ -859,10 +840,8 @@ fn tcp_reachability_result_map(
         }
     }
 
-    if !latencies.is_empty() {
-        let min_ms = latencies.iter().copied().fold(f64::INFINITY, f64::min);
-        let max_ms = latencies.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-        let avg_ms = latencies.iter().sum::<f64>() / latencies.len() as f64;
+    if latency_count > 0 {
+        let avg_ms = latency_sum / latency_count as f64;
         result.insert("min_ms".to_string(), Value::Float(min_ms));
         result.insert("avg_ms".to_string(), Value::Float(avg_ms));
         result.insert("max_ms".to_string(), Value::Float(max_ms));
@@ -964,7 +943,6 @@ fn parse_ip(input: &str) -> Result<ParsedInput, String> {
     let mask = mask_for(family, prefix);
 
     Ok(ParsedInput {
-        input: input.to_string(),
         original_ip,
         network: Network {
             family,
@@ -979,21 +957,20 @@ fn parse_ip(input: &str) -> Result<ParsedInput, String> {
     })
 }
 
-fn parsed_to_map(parsed: &ParsedInput) -> HashMap<String, Value> {
+fn parsed_to_map(input: &str, parsed: &ParsedInput) -> HashMap<String, Value> {
     let network = &parsed.network;
     let ip = ip_to_string(network.family, parsed.original_ip);
     let network_ip = ip_to_string(network.family, network.network);
-    let first = ip_to_string(network.family, network.network);
     let last = ip_to_string(network.family, network.last());
 
     let mut map = HashMap::new();
-    map.insert("input".to_string(), Value::String(input_cidr_or_ip(parsed)));
+    map.insert("input".to_string(), Value::String(input.to_string()));
     map.insert("kind".to_string(), Value::String(parsed.kind.to_string()));
     map.insert("version".to_string(), Value::Int(network.family.version()));
     map.insert("ip".to_string(), Value::String(ip));
     map.insert("prefix".to_string(), Value::Int(network.prefix as i64));
-    map.insert("network".to_string(), Value::String(network_ip));
-    map.insert("first".to_string(), Value::String(first));
+    map.insert("network".to_string(), Value::String(network_ip.clone()));
+    map.insert("first".to_string(), Value::String(network_ip));
     map.insert("last".to_string(), Value::String(last));
     map.insert(
         "total_addresses".to_string(),
@@ -1010,10 +987,6 @@ fn parsed_to_map(parsed: &ParsedInput) -> HashMap<String, Value> {
     }
 
     map
-}
-
-fn input_cidr_or_ip(parsed: &ParsedInput) -> String {
-    parsed.input.clone()
 }
 
 fn add_ipv4_fields(map: &mut HashMap<String, Value>, parsed: &ParsedInput) {
@@ -1254,10 +1227,10 @@ fn parse_u64_option(
 
 fn parse_count_option(opts: Option<&HashMap<String, Value>>) -> Result<usize, String> {
     match opts.and_then(|m| m.get("count")) {
-        None => Ok(DEFAULT_PING_COUNT),
+        None => Ok(DEFAULT_PROBE_COUNT),
         Some(Value::Int(value)) if *value > 0 => {
             let count = usize::try_from(*value).map_err(|_| "option 'count' is too large")?;
-            Ok(min(count, MAX_PING_COUNT))
+            Ok(min(count, MAX_PROBE_COUNT))
         }
         Some(Value::Int(_)) => Err("option 'count' must be positive".to_string()),
         Some(other) => Err(format!(
@@ -1549,14 +1522,14 @@ mod tests {
 
     #[test]
     fn ping_count_is_positive_and_clamped() {
-        assert_eq!(parse_count_option(None).unwrap(), DEFAULT_PING_COUNT);
+        assert_eq!(parse_count_option(None).unwrap(), DEFAULT_PROBE_COUNT);
         assert_eq!(
             parse_count_option(Some(&HashMap::from([(
                 "count".to_string(),
-                Value::Int((MAX_PING_COUNT as i64) + 50),
+                Value::Int((MAX_PROBE_COUNT as i64) + 50),
             )])))
             .unwrap(),
-            MAX_PING_COUNT
+            MAX_PROBE_COUNT
         );
         assert!(parse_count_option(Some(&HashMap::from([
             ("count".to_string(), Value::Int(0),)

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3806,7 +3806,9 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("subnet_supernet", ["cidr" => Type::String, "new_prefix" => Type::Int], result_string, required(1));
             sig!("subnet_summarize", ["cidrs" => Type::Array(Box::new(Type::String))], result_string_array.clone());
             sig!("ip_range_to_cidrs", ["start_ip" => Type::String, "end_ip" => Type::String], result_string_array);
-            sig!("ping", ["host" => Type::String, "opts" => opts], result_map, required(1));
+            sig!("ping", ["host" => Type::String, "opts" => opts.clone()], result_map.clone(), required(1));
+            sig!("tcp_connect", ["host" => Type::String, "port" => Type::Int, "opts" => opts.clone()], result_map.clone(), required(2));
+            sig!("reachable", ["host" => Type::String, "opts" => opts], result_map, required(1));
         }
         "std/path" => {
             sig!("join_path", ["parts" => Type::String], Type::String, variadic);

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3771,6 +3771,43 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("join", ["base" => Type::String, "path" => Type::String], Type::String);
             // deprecated alias
         }
+        "std/net" => {
+            let result_map = Type::Generic {
+                name: "Result".to_string(),
+                args: vec![
+                    Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                    Type::String,
+                ],
+            };
+            let result_bool = Type::Generic {
+                name: "Result".to_string(),
+                args: vec![Type::Bool, Type::String],
+            };
+            let result_string = Type::Generic {
+                name: "Result".to_string(),
+                args: vec![Type::String, Type::String],
+            };
+            let result_string_array = Type::Generic {
+                name: "Result".to_string(),
+                args: vec![Type::Array(Box::new(Type::String)), Type::String],
+            };
+            let opts = Type::Map {
+                key_type: Box::new(Type::String),
+                value_type: Box::new(Type::Any),
+            };
+
+            sig!("ip_parse", ["ip_or_cidr" => Type::String], result_map.clone());
+            sig!("subnet_contains", ["cidr" => Type::String, "ip_or_cidr" => Type::String], result_bool.clone());
+            sig!("subnet_overlaps", ["a" => Type::String, "b" => Type::String], result_bool);
+            sig!("subnet_split", ["cidr" => Type::String, "new_prefix" => Type::Int, "opts" => opts.clone()], result_string_array.clone(), required(2));
+            sig!("subnet_supernet", ["cidr" => Type::String, "new_prefix" => Type::Int], result_string, required(1));
+            sig!("subnet_summarize", ["cidrs" => Type::Array(Box::new(Type::String))], result_string_array.clone());
+            sig!("ip_range_to_cidrs", ["start_ip" => Type::String, "end_ip" => Type::String], result_string_array);
+            sig!("ping", ["host" => Type::String, "opts" => opts], result_map, required(1));
+        }
         "std/path" => {
             sig!("join_path", ["parts" => Type::String], Type::String, variadic);
             sig!("join", ["parts" => Type::String], Type::String, variadic); // deprecated alias

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -1,0 +1,239 @@
+//! Integration tests for std/net Phase 1.
+//!
+//! These exercise the public ntnt stdlib surface. They intentionally start red
+//! before the std/net module exists.
+
+use std::fs;
+use std::io::Write;
+use std::net::TcpListener;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_test_file(prefix: &str) -> String {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let temp_dir = std::env::temp_dir();
+    temp_dir
+        .join(format!(
+            "ntnt_std_net_{}_{}_{}.tnt",
+            prefix,
+            std::process::id(),
+            counter
+        ))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn ntnt_binary() -> String {
+    let exe = std::env::consts::EXE_SUFFIX;
+    let debug_path = format!("./target/debug/ntnt{}", exe);
+    let release_path = format!("./target/release/ntnt{}", exe);
+
+    if std::path::Path::new(&debug_path).exists() {
+        debug_path
+    } else if std::path::Path::new(&release_path).exists() {
+        release_path
+    } else {
+        panic!("No ntnt binary found. Run 'cargo build' first.");
+    }
+}
+
+fn run_ntnt_code(code: &str) -> (String, String, i32) {
+    run_ntnt_code_with_env(code, &[])
+}
+
+fn run_ntnt_code_with_env(code: &str, envs: &[(&str, &str)]) -> (String, String, i32) {
+    let test_file = unique_test_file("test");
+
+    let mut file = fs::File::create(&test_file).expect("Failed to create test file");
+    writeln!(file, "{}", code).expect("Failed to write test file");
+    drop(file);
+
+    let mut cmd = Command::new(ntnt_binary());
+    cmd.args(["run", &test_file])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("NTNT_ENV", "development");
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+
+    let output = cmd.output().expect("Failed to execute ntnt");
+    let _ = fs::remove_file(&test_file);
+
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn ip_parse_reports_ipv4_network_calculator_fields() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { ip_parse } from "std/net"
+
+match ip_parse("192.168.1.0/24") {
+    Ok(info) => {
+        print(info["version"])
+        print(info["network"])
+        print(info["broadcast"])
+        print(info["netmask"])
+        print(info["wildcard_mask"])
+        print(info["total_addresses"])
+        print(info["usable_hosts"])
+        print(info["is_private"])
+    },
+    Err(e) => print("ERR: " + e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    let lines: Vec<&str> = stdout.lines().map(str::trim).collect();
+    assert!(lines.contains(&"4"), "stdout: {stdout}");
+    assert!(lines.contains(&"192.168.1.0"), "stdout: {stdout}");
+    assert!(lines.contains(&"192.168.1.255"), "stdout: {stdout}");
+    assert!(lines.contains(&"255.255.255.0"), "stdout: {stdout}");
+    assert!(lines.contains(&"0.0.0.255"), "stdout: {stdout}");
+    assert!(lines.contains(&"256"), "stdout: {stdout}");
+    assert!(lines.contains(&"254"), "stdout: {stdout}");
+    assert!(lines.contains(&"true"), "stdout: {stdout}");
+}
+
+#[test]
+fn ip_parse_reports_ipv6_without_overflow() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { ip_parse } from "std/net"
+
+match ip_parse("2001:db8::/64") {
+    Ok(info) => {
+        print(info["version"])
+        print(info["ip"])
+        print(info["network"])
+        print(info["first"])
+        print(info["last"])
+        print(info["total_addresses"])
+        print(info["is_documentation"])
+    },
+    Err(e) => print("ERR: " + e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("6"), "stdout: {stdout}");
+    assert!(stdout.contains("2001:db8::"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("2001:db8::ffff:ffff:ffff:ffff"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("18446744073709551616"), "stdout: {stdout}");
+    assert!(stdout.contains("true"), "stdout: {stdout}");
+}
+
+#[test]
+fn subnet_helpers_cover_contains_overlaps_split_supernet_and_summarize() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { join } from "std/string"
+import { subnet_contains, subnet_overlaps, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs } from "std/net"
+
+match subnet_contains("10.0.0.0/8", "10.50.0.0/16") { Ok(v) => print("contains=" + str(v)), Err(e) => print("ERR " + e) }
+match subnet_overlaps("10.0.0.0/24", "10.0.0.128/25") { Ok(v) => print("overlaps=" + str(v)), Err(e) => print("ERR " + e) }
+match subnet_split("192.168.1.0/24", 26) { Ok(v) => print("split=" + join(v, ",")), Err(e) => print("ERR " + e) }
+match subnet_supernet("192.168.1.0/24") { Ok(v) => print("supernet=" + v), Err(e) => print("ERR " + e) }
+match subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"]) { Ok(v) => print("summary=" + join(v, ",")), Err(e) => print("ERR " + e) }
+match ip_range_to_cidrs("192.168.1.20", "192.168.1.31") { Ok(v) => print("range=" + join(v, ",")), Err(e) => print("ERR " + e) }
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("contains=true"), "stdout: {stdout}");
+    assert!(stdout.contains("overlaps=true"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("split=192.168.1.0/26,192.168.1.64/26,192.168.1.128/26,192.168.1.192/26"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("supernet=192.168.0.0/23"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("summary=10.0.0.0/24"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("range=192.168.1.20/30,192.168.1.24/29"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn subnet_split_rejects_explosive_results() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { subnet_split } from "std/net"
+
+match subnet_split("2001:db8::/64", 128) {
+    Ok(v) => print("unexpected"),
+    Err(e) => print(e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("too many subnets"), "stdout: {stdout}");
+}
+
+#[test]
+fn ping_auto_uses_unprivileged_tcp_fallback_for_private_monitoring() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+    let port = listener.local_addr().unwrap().port();
+    let handle = std::thread::spawn(move || {
+        let _ = listener.accept();
+    });
+
+    let code = format!(
+        r#"
+import {{ ping }} from "std/net"
+
+match ping("127.0.0.1", map {{ "allow_private": true, "tcp_ports": [{port}], "timeout_ms": 1000 }}) {{
+    Ok(info) => {{
+        print(info["reachable"])
+        print(info["method"])
+        print(info["connected_port"])
+    }},
+    Err(e) => print("ERR: " + e)
+}}
+"#
+    );
+
+    let (stdout, stderr, exit_code) =
+        run_ntnt_code_with_env(&code, &[("NTNT_NET_ALLOW_PRIVATE", "1")]);
+    let _ = handle.join();
+
+    assert_eq!(exit_code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("true"), "stdout: {stdout}");
+    assert!(stdout.contains("tcp"), "stdout: {stdout}");
+    assert!(stdout.contains(&port.to_string()), "stdout: {stdout}");
+}
+
+#[test]
+fn ping_private_target_requires_process_level_opt_in() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { ping } from "std/net"
+
+match ping("127.0.0.1", map { "allow_private": true, "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected"),
+    Err(e) => print(e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("private targets require NTNT_NET_ALLOW_PRIVATE=1"),
+        "stdout: {stdout}"
+    );
+}

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -1,7 +1,4 @@
-//! Integration tests for std/net Phase 1.
-//!
-//! These exercise the public ntnt stdlib surface. They intentionally start red
-//! before the std/net module exists.
+//! Integration tests for std/net Phase 1 public behavior.
 
 use std::fs;
 use std::io::Write;

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -263,6 +263,11 @@ match ping("255.255.255.255", map { "method": "tcp", "tcp_ports": [9], "timeout_
     Ok(info) => print("unexpected broadcast"),
     Err(e) => print("broadcast=" + e)
 }
+
+match ping("::ffff:255.255.255.255", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected mapped broadcast"),
+    Err(e) => print("mapped_broadcast=" + e)
+}
 "#,
     );
 
@@ -281,6 +286,10 @@ match ping("255.255.255.255", map { "method": "tcp", "tcp_ports": [9], "timeout_
     );
     assert!(
         stdout.contains("broadcast=Network target denied by policy"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("mapped_broadcast=Network target denied by policy"),
         "stdout: {stdout}"
     );
 }

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -186,22 +186,30 @@ match subnet_split("2001:db8::/64", 128) {
 }
 
 #[test]
-fn ping_auto_uses_unprivileged_tcp_fallback_for_private_monitoring() {
+fn ping_tcp_method_uses_explicit_ports_and_multiple_attempts() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
     let port = listener.local_addr().unwrap().port();
+    let count = 3;
     let handle = std::thread::spawn(move || {
-        let _ = listener.accept();
+        for _ in 0..count {
+            let _ = listener.accept();
+        }
     });
 
     let code = format!(
         r#"
 import {{ ping }} from "std/net"
 
-match ping("127.0.0.1", map {{ "allow_private": true, "tcp_ports": [{port}], "timeout_ms": 1000 }}) {{
+match ping("127.0.0.1", map {{ "method": "tcp", "allow_private": true, "tcp_ports": [{port}], "count": {count}, "timeout_ms": 1000 }}) {{
     Ok(info) => {{
         print(info["reachable"])
         print(info["method"])
         print(info["connected_port"])
+        print(info["sent"])
+        print(info["received"])
+        print(info["failed"])
+        print(info["loss_percent"])
+        print(len(info["attempts"]))
     }},
     Err(e) => print("ERR: " + e)
 }}
@@ -213,9 +221,36 @@ match ping("127.0.0.1", map {{ "allow_private": true, "tcp_ports": [{port}], "ti
     let _ = handle.join();
 
     assert_eq!(exit_code, 0, "stderr: {stderr}\nstdout: {stdout}");
-    assert!(stdout.contains("true"), "stdout: {stdout}");
-    assert!(stdout.contains("tcp"), "stdout: {stdout}");
-    assert!(stdout.contains(&port.to_string()), "stdout: {stdout}");
+    let lines: Vec<&str> = stdout.lines().map(str::trim).collect();
+    assert!(lines.contains(&"true"), "stdout: {stdout}");
+    assert!(lines.contains(&"tcp"), "stdout: {stdout}");
+    let port_string = port.to_string();
+    assert!(lines.contains(&port_string.as_str()), "stdout: {stdout}");
+    assert!(
+        lines.iter().filter(|line| **line == "3").count() >= 3,
+        "stdout: {stdout}"
+    );
+    assert!(lines.contains(&"0"), "stdout: {stdout}");
+}
+
+#[test]
+fn ping_auto_returns_icmp_unavailable_without_tcp_fallback() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { ping } from "std/net"
+
+match ping("example.com") {
+    Ok(info) => print("unexpected"),
+    Err(e) => print(e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("does not fall back to TCP automatically"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -237,3 +237,41 @@ match ping("127.0.0.1", map { "allow_private": true, "method": "tcp", "tcp_ports
         "stdout: {stdout}"
     );
 }
+
+#[test]
+fn ping_rejects_ipv4_mapped_and_special_ranges_by_default() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { ping } from "std/net"
+
+match ping("::ffff:127.0.0.1", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected mapped"),
+    Err(e) => print("mapped=" + e)
+}
+
+match ping("224.0.0.1", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected multicast"),
+    Err(e) => print("multicast=" + e)
+}
+
+match ping("192.0.2.1", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected documentation"),
+    Err(e) => print("documentation=" + e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("mapped=Network target denied by policy"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("multicast=Network target denied by policy"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("documentation=Network target denied by policy"),
+        "stdout: {stdout}"
+    );
+}

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -186,7 +186,7 @@ match subnet_split("2001:db8::/64", 128) {
 }
 
 #[test]
-fn ping_tcp_method_uses_explicit_ports_and_multiple_attempts() {
+fn tcp_connect_uses_explicit_port_and_multiple_attempts() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
     let port = listener.local_addr().unwrap().port();
     let count = 3;
@@ -198,13 +198,16 @@ fn ping_tcp_method_uses_explicit_ports_and_multiple_attempts() {
 
     let code = format!(
         r#"
-import {{ ping }} from "std/net"
+import {{ tcp_connect }} from "std/net"
 
-match ping("127.0.0.1", map {{ "method": "tcp", "allow_private": true, "tcp_ports": [{port}], "count": {count}, "timeout_ms": 1000 }}) {{
+match tcp_connect("127.0.0.1", {port}, map {{ "allow_private": true, "count": {count}, "timeout_ms": 1000 }}) {{
     Ok(info) => {{
-        print(info["reachable"])
+        print(info["connected"])
         print(info["method"])
+        print(info["port"])
         print(info["connected_port"])
+        print(info["remote_addr"])
+        print(info["local_addr"])
         print(info["sent"])
         print(info["received"])
         print(info["failed"])
@@ -220,17 +223,94 @@ match ping("127.0.0.1", map {{ "method": "tcp", "allow_private": true, "tcp_port
         run_ntnt_code_with_env(&code, &[("NTNT_NET_ALLOW_PRIVATE", "1")]);
     let _ = handle.join();
 
-    assert_eq!(exit_code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert_eq!(
+        exit_code, 0,
+        "stderr: {stderr}
+stdout: {stdout}"
+    );
     let lines: Vec<&str> = stdout.lines().map(str::trim).collect();
     assert!(lines.contains(&"true"), "stdout: {stdout}");
     assert!(lines.contains(&"tcp"), "stdout: {stdout}");
     let port_string = port.to_string();
     assert!(lines.contains(&port_string.as_str()), "stdout: {stdout}");
     assert!(
+        stdout.contains(&format!("127.0.0.1:{port}")),
+        "stdout: {stdout}"
+    );
+    assert!(
         lines.iter().filter(|line| **line == "3").count() >= 3,
         "stdout: {stdout}"
     );
     assert!(lines.contains(&"0"), "stdout: {stdout}");
+}
+
+#[test]
+fn tcp_connect_closed_port_returns_connected_false() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let code = format!(
+        r#"
+import {{ tcp_connect }} from "std/net"
+
+match tcp_connect("127.0.0.1", {port}, map {{ "allow_private": true, "timeout_ms": 100 }}) {{
+    Ok(info) => {{
+        print(info["connected"])
+        print(info["reachable"])
+        print(info["reason"])
+    }},
+    Err(e) => print("ERR: " + e)
+}}
+"#
+    );
+
+    let (stdout, stderr, exit_code) =
+        run_ntnt_code_with_env(&code, &[("NTNT_NET_ALLOW_PRIVATE", "1")]);
+
+    assert_eq!(exit_code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    let lines: Vec<&str> = stdout.lines().map(str::trim).collect();
+    assert!(lines.contains(&"false"), "stdout: {stdout}");
+    assert!(!stdout.contains("ERR:"), "stdout: {stdout}");
+}
+
+#[test]
+fn reachable_uses_explicit_tcp_fallback_without_calling_it_ping() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+    let port = listener.local_addr().unwrap().port();
+    let handle = std::thread::spawn(move || {
+        let _ = listener.accept();
+    });
+
+    let code = format!(
+        r#"
+import {{ reachable }} from "std/net"
+
+match reachable("127.0.0.1", map {{ "allow_private": true, "tcp_ports": [{port}], "timeout_ms": 1000 }}) {{
+    Ok(info) => {{
+        print(info["reachable"])
+        print(info["method"])
+        print(info["fallback_from"])
+        print(info["connected_port"])
+    }},
+    Err(e) => print("ERR: " + e)
+}}
+"#
+    );
+
+    let (stdout, stderr, exit_code) =
+        run_ntnt_code_with_env(&code, &[("NTNT_NET_ALLOW_PRIVATE", "1")]);
+    let _ = handle.join();
+
+    assert_eq!(
+        exit_code, 0,
+        "stderr: {stderr}
+stdout: {stdout}"
+    );
+    assert!(stdout.contains("true"), "stdout: {stdout}");
+    assert!(stdout.contains("tcp"), "stdout: {stdout}");
+    assert!(stdout.contains("icmp"), "stdout: {stdout}");
+    assert!(stdout.contains(&port.to_string()), "stdout: {stdout}");
 }
 
 #[test]
@@ -254,12 +334,12 @@ match ping("example.com") {
 }
 
 #[test]
-fn ping_private_target_requires_process_level_opt_in() {
+fn tcp_connect_private_target_requires_process_level_opt_in() {
     let (stdout, stderr, code) = run_ntnt_code(
         r#"
-import { ping } from "std/net"
+import { tcp_connect } from "std/net"
 
-match ping("127.0.0.1", map { "allow_private": true, "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+match tcp_connect("127.0.0.1", 9, map { "allow_private": true, "timeout_ms": 100 }) {
     Ok(info) => print("unexpected"),
     Err(e) => print(e)
 }
@@ -274,32 +354,32 @@ match ping("127.0.0.1", map { "allow_private": true, "method": "tcp", "tcp_ports
 }
 
 #[test]
-fn ping_rejects_ipv4_mapped_and_special_ranges_by_default() {
+fn tcp_connect_rejects_ipv4_mapped_and_special_ranges_by_default() {
     let (stdout, stderr, code) = run_ntnt_code(
         r#"
-import { ping } from "std/net"
+import { tcp_connect } from "std/net"
 
-match ping("::ffff:127.0.0.1", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+match tcp_connect("::ffff:127.0.0.1", 9, map { "timeout_ms": 100 }) {
     Ok(info) => print("unexpected mapped"),
     Err(e) => print("mapped=" + e)
 }
 
-match ping("224.0.0.1", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+match tcp_connect("224.0.0.1", 9, map { "timeout_ms": 100 }) {
     Ok(info) => print("unexpected multicast"),
     Err(e) => print("multicast=" + e)
 }
 
-match ping("192.0.2.1", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+match tcp_connect("192.0.2.1", 9, map { "timeout_ms": 100 }) {
     Ok(info) => print("unexpected documentation"),
     Err(e) => print("documentation=" + e)
 }
 
-match ping("255.255.255.255", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+match tcp_connect("255.255.255.255", 9, map { "timeout_ms": 100 }) {
     Ok(info) => print("unexpected broadcast"),
     Err(e) => print("broadcast=" + e)
 }
 
-match ping("::ffff:255.255.255.255", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+match tcp_connect("::ffff:255.255.255.255", 9, map { "timeout_ms": 100 }) {
     Ok(info) => print("unexpected mapped broadcast"),
     Err(e) => print("mapped_broadcast=" + e)
 }
@@ -330,37 +410,37 @@ match ping("::ffff:255.255.255.255", map { "method": "tcp", "tcp_ports": [9], "t
 }
 
 #[test]
-fn ping_rejects_never_allowed_targets_even_with_private_opt_in() {
+fn tcp_connect_rejects_never_allowed_targets_even_with_private_opt_in() {
     let (stdout, stderr, code) = run_ntnt_code_with_env(
         r#"
-import { ping } from "std/net"
+import { tcp_connect } from "std/net"
 
-match ping("169.254.169.254", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
+match tcp_connect("169.254.169.254", 80, map { "allow_private": true, "timeout_ms": 100 }) {
     Ok(info) => print("unexpected metadata"),
     Err(e) => print("metadata=" + e)
 }
 
-match ping("169.254.170.2", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
+match tcp_connect("169.254.170.2", 80, map { "allow_private": true, "timeout_ms": 100 }) {
     Ok(info) => print("unexpected ecs metadata"),
     Err(e) => print("ecs_metadata=" + e)
 }
 
-match ping("::ffff:169.254.169.254", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
+match tcp_connect("::ffff:169.254.169.254", 80, map { "allow_private": true, "timeout_ms": 100 }) {
     Ok(info) => print("unexpected mapped metadata"),
     Err(e) => print("mapped_metadata=" + e)
 }
 
-match ping("::ffff:169.254.170.2", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
+match tcp_connect("::ffff:169.254.170.2", 80, map { "allow_private": true, "timeout_ms": 100 }) {
     Ok(info) => print("unexpected mapped ecs metadata"),
     Err(e) => print("mapped_ecs_metadata=" + e)
 }
 
-match ping("224.0.0.1", map { "allow_private": true, "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+match tcp_connect("224.0.0.1", 9, map { "timeout_ms": 100 }) {
     Ok(info) => print("unexpected multicast"),
     Err(e) => print("multicast=" + e)
 }
 
-match ping("255.255.255.255", map { "allow_private": true, "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+match tcp_connect("255.255.255.255", 9, map { "timeout_ms": 100 }) {
     Ok(info) => print("unexpected broadcast"),
     Err(e) => print("broadcast=" + e)
 }

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -258,6 +258,11 @@ match ping("192.0.2.1", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 1
     Ok(info) => print("unexpected documentation"),
     Err(e) => print("documentation=" + e)
 }
+
+match ping("255.255.255.255", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected broadcast"),
+    Err(e) => print("broadcast=" + e)
+}
 "#,
     );
 
@@ -272,6 +277,10 @@ match ping("192.0.2.1", map { "method": "tcp", "tcp_ports": [9], "timeout_ms": 1
     );
     assert!(
         stdout.contains("documentation=Network target denied by policy"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("broadcast=Network target denied by policy"),
         "stdout: {stdout}"
     );
 }

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -293,3 +293,57 @@ match ping("::ffff:255.255.255.255", map { "method": "tcp", "tcp_ports": [9], "t
         "stdout: {stdout}"
     );
 }
+
+#[test]
+fn ping_rejects_never_allowed_targets_even_with_private_opt_in() {
+    let (stdout, stderr, code) = run_ntnt_code_with_env(
+        r#"
+import { ping } from "std/net"
+
+match ping("169.254.169.254", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected metadata"),
+    Err(e) => print("metadata=" + e)
+}
+
+match ping("::ffff:169.254.169.254", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected mapped metadata"),
+    Err(e) => print("mapped_metadata=" + e)
+}
+
+match ping("224.0.0.1", map { "allow_private": true, "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected multicast"),
+    Err(e) => print("multicast=" + e)
+}
+
+match ping("255.255.255.255", map { "allow_private": true, "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected broadcast"),
+    Err(e) => print("broadcast=" + e)
+}
+"#,
+        &[("NTNT_NET_ALLOW_PRIVATE", "1")],
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains(
+            "metadata=Network target denied by policy: special-purpose targets are not allowed"
+        ),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("mapped_metadata=Network target denied by policy: special-purpose targets are not allowed"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "multicast=Network target denied by policy: special-purpose targets are not allowed"
+        ),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "broadcast=Network target denied by policy: special-purpose targets are not allowed"
+        ),
+        "stdout: {stdout}"
+    );
+}

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -305,9 +305,19 @@ match ping("169.254.169.254", map { "allow_private": true, "method": "tcp", "tcp
     Err(e) => print("metadata=" + e)
 }
 
+match ping("169.254.170.2", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected ecs metadata"),
+    Err(e) => print("ecs_metadata=" + e)
+}
+
 match ping("::ffff:169.254.169.254", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
     Ok(info) => print("unexpected mapped metadata"),
     Err(e) => print("mapped_metadata=" + e)
+}
+
+match ping("::ffff:169.254.170.2", map { "allow_private": true, "method": "tcp", "tcp_ports": [80], "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected mapped ecs metadata"),
+    Err(e) => print("mapped_ecs_metadata=" + e)
 }
 
 match ping("224.0.0.1", map { "allow_private": true, "method": "tcp", "tcp_ports": [9], "timeout_ms": 100 }) {
@@ -331,7 +341,17 @@ match ping("255.255.255.255", map { "allow_private": true, "method": "tcp", "tcp
         "stdout: {stdout}"
     );
     assert!(
+        stdout.contains(
+            "ecs_metadata=Network target denied by policy: special-purpose targets are not allowed"
+        ),
+        "stdout: {stdout}"
+    );
+    assert!(
         stdout.contains("mapped_metadata=Network target denied by policy: special-purpose targets are not allowed"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("mapped_ecs_metadata=Network target denied by policy: special-purpose targets are not allowed"),
         "stdout: {stdout}"
     );
     assert!(

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1096,7 +1096,7 @@ let x: Int = first([1, 2, 3])
 #[test]
 fn test_std_net_phase1_signatures_accept_valid_usage() {
     let source = r#"
-import { ip_parse, subnet_contains, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs, ping } from "std/net"
+import { ip_parse, subnet_contains, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs, ping, tcp_connect, reachable } from "std/net"
 
 let parsed = ip_parse("192.168.1.0/24")
 let contains = subnet_contains("10.0.0.0/8", "10.1.0.0/16")
@@ -1105,7 +1105,9 @@ let split_with_opts = subnet_split("192.168.1.0/24", 28, map { "max_results": 32
 let parent = subnet_supernet("192.168.1.0/24")
 let summary = subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"])
 let range = ip_range_to_cidrs("192.168.1.20", "192.168.1.31")
-let reachability = ping("example.com", map { "method": "tcp", "tcp_ports": [443], "timeout_ms": 1000 })
+let icmp = ping("example.com", map { "method": "icmp", "timeout_ms": 1000 })
+let tcp = tcp_connect("example.com", 443, map { "timeout_ms": 1000 })
+let reachability = reachable("example.com", map { "tcp_ports": [443], "timeout_ms": 1000 })
 "#;
     let (stdout, _stderr, _exit_code) = lint_code(source);
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1092,3 +1092,48 @@ let x: Int = first([1, 2, 3])
         "first<T>([Int]) assigned to Int should not error"
     );
 }
+
+#[test]
+fn test_std_net_phase1_signatures_accept_valid_usage() {
+    let source = r#"
+import { ip_parse, subnet_contains, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs, ping } from "std/net"
+
+let parsed = ip_parse("192.168.1.0/24")
+let contains = subnet_contains("10.0.0.0/8", "10.1.0.0/16")
+let split = subnet_split("192.168.1.0/24", 28)
+let split_with_opts = subnet_split("192.168.1.0/24", 28, map { "max_results": 32 })
+let parent = subnet_supernet("192.168.1.0/24")
+let summary = subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"])
+let range = ip_range_to_cidrs("192.168.1.20", "192.168.1.31")
+let reachability = ping("example.com", map { "method": "tcp", "tcp_ports": [443], "timeout_ms": 1000 })
+"#;
+    let (stdout, _stderr, _exit_code) = lint_code(source);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let errors = json["summary"]["errors"].as_i64().unwrap_or(0);
+    assert_eq!(
+        errors, 0,
+        "std/net valid usage should not type error: {stdout}"
+    );
+}
+
+#[test]
+fn test_std_net_phase1_signatures_reject_wrong_argument_types() {
+    let source = r#"
+import { subnet_split, ping } from "std/net"
+
+let split = subnet_split("192.168.1.0/24", "28")
+let reachability = ping(123)
+"#;
+    let (stdout, _stderr, exit_code) = lint_code(source);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let errors = json["summary"]["errors"].as_i64().unwrap_or(0);
+    assert!(
+        errors > 0,
+        "wrong std/net argument types should error: {stdout}"
+    );
+    assert_ne!(exit_code, 0);
+    assert!(
+        stdout.contains("expected Int") || stdout.contains("expected String"),
+        "type errors should mention expected argument types: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `std/net` Phase 1 with IPv4/IPv6 IPAM helpers: `ip_parse`, `subnet_contains`, `subnet_overlaps`, `subnet_split`, `subnet_supernet`, `subnet_summarize`, and `ip_range_to_cidrs`.
- Keep `ping(host, opts?)` protocol-honest: Phase 1 returns a clear ICMP-unavailable `Err(String)` instead of silently switching to TCP.
- Add explicit TCP reachability APIs:
  - `tcp_connect(host, port, opts?)` for one chosen TCP port, returning `connected`, latency/attempt summaries, and `Ok(... connected: false ...)` for ordinary refused/timeout outcomes.
  - `reachable(host, opts?)` for high-level reachability fallback, requiring caller-provided `tcp_ports` and reporting `method: "tcp"` plus `fallback_from: "icmp"` instead of calling TCP “ping.”
- Register `std/net` in the stdlib/typechecker, generate stdlib docs, update the AI guide/design doc, and keep the runnable IPAM example.

## Safety / behavior notes
- No implicit TCP fallback inside `ping()` and no random default ports.
- Private/internal probe targets require process opt-in (`NTNT_NET_ALLOW_PRIVATE=1` or existing private-IP env) plus per-call `allow_private: true`.
- DNS resolution policy is applied to every resolved address before probing.
- IPv4-mapped IPv6, metadata, multicast, broadcast, unspecified, and documentation/special-purpose targets are denied by policy.
- `tcp_connect()` treats refused/timeout/closed ports as data (`Ok(map { "connected": false, ... })`), while invalid input, resolver/system failure, or policy denial remain `Err(String)`.
- Large IPv6 address counts are returned as strings to avoid overflow; split/range helpers enforce result caps.

## Verification
- `cargo fmt -- --check`
- `git diff --check`
- `cargo build --profile dev-release`
- `cargo test`
- `cargo test --test std_net_tests -- --nocapture`
- `cargo test --lib stdlib::net::tests -- --nocapture`
- `./target/dev-release/ntnt docs --generate`
- `./target/dev-release/ntnt validate examples/`
- `./target/dev-release/ntnt lint examples/` (0 errors; existing suggestions/warnings only)
- strict typechecker smoke: `tcp_connect`/`reachable` imports pass and bad `tcp_connect(..., "443")` is rejected as `expected Int, got String`

## Design status
- DD-046 PR 1 status now reflects IPAM + protocol-honest `ping()` + explicit `tcp_connect()` + `reachable()`.
- DNS, bounded port scan, and TLS info remain planned follow-up slices.