### PR TITLE
Add std/net DNS lookup helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +810,18 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
 
 [[package]]
 name = "equivalent"
@@ -1118,6 +1136,51 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 1.1.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hmac"
@@ -1453,6 +1516,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.1",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1646,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "matchit"
@@ -1702,6 +1793,7 @@ dependencies = [
  "deadpool-postgres",
  "flume",
  "hex",
+ "hickory-resolver",
  "hmac",
  "hyper 1.8.1",
  "hyper-util",
@@ -2333,6 +2425,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -3422,6 +3520,12 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ redis = "0.27"
 # JWT for auth
 jsonwebtoken = "9"
 pulldown-cmark = "0.13.0"
+hickory-resolver = "0.24.4"
 
 [build-dependencies]
 # Doc comment scanner (build.rs extracts /// @ntnt blocks)

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -1,6 +1,6 @@
 # DD-046: `std/net` — Safe Network Primitives for ntnt
 
-**Status:** PR 1 merged; PR 2 DNS A/AAAA/PTR in progress; scan/TLS slices planned
+**Status:** PR 1 merged; PR 2 DNS lookup types in progress; scan/TLS slices planned
 **Author:** Larri
 **Created:** 2026-03-22
 **Updated:** 2026-06-03
@@ -589,20 +589,40 @@ Tests:
 
 ### `dns_lookup(name, record_type?, opts?) -> Result<Array<Map>, String>`
 
-Supported initial record types:
+Supported record types:
 
 - `A`
 - `AAAA`
-- `PTR`
-
-Candidate follow-up record types once the shape is proven:
-
-- `MX`
-- `TXT`
-- `NS`
+- `ANAME`
+- `CAA`
+- `CDNSKEY`
+- `CDS`
 - `CNAME`
+- `CSYNC`
+- `DNSKEY`
+- `DS`
+- `HINFO`
+- `HTTPS`
+- `KEY`
+- `MX`
+- `NAPTR`
+- `NS`
+- `NSEC`
+- `NSEC3`
+- `NSEC3PARAM`
+- `NULL`
+- `OPENPGPKEY`
+- `PTR`
+- `RRSIG`
+- `SIG`
 - `SOA`
 - `SRV`
+- `SSHFP`
+- `SVCB`
+- `TLSA`
+- `TXT`
+
+Operational/meta query types such as `ANY`, `AXFR`, `IXFR`, `OPT`, `TSIG`, and `ZERO` remain unsupported.
 
 ```ntnt
 import { dns_lookup } from "std/net"
@@ -629,14 +649,15 @@ Implementation notes:
 - Build a resolver abstraction or local/mock DNS test fixture before adding many record types.
 - `dns_lookup` uses the system resolver and does not expose custom nameserver configuration in this slice.
 - DNS answers are returned as DNS data; target probing/safety policy still applies to connect-style functions (`tcp_connect`, `reachable`, future `port_scan`) rather than filtering A/AAAA answers from lookup results.
+- Record maps report the actual returned DNS record type. If a resolver includes related records in a response, those records are not relabeled as the requested type.
 - Custom nameserver support is deferred until safety implications are explicit. A `server` option can bypass enterprise DNS policy and should not be a casual Phase 1 feature.
 
 Tests:
 
-- record-type parser
+- record-type parser accepts the supported data-bearing query types and rejects operational/meta/unknown types
 - no-answer behavior
 - invalid type returns `Err`
-- local/mock resolver results for A/AAAA/PTR
+- deterministic result rendering for generic record maps
 - optional external DNS smoke test gated behind env var, not default CI
 
 ---
@@ -772,7 +793,7 @@ SNMP is a real network-monitoring need, but it is its own protocol family. It sh
 As of 2026-06-03:
 
 - [x] **PR 1 — `std/net` shell + IPAM helpers + protocol-honest reachability**: merged in [PR #113](https://github.com/ntntlang/ntnt/pull/113).
-- [ ] **PR 2 — DNS A/AAAA/PTR**: in progress on branch `feat/std-net-dns`; adds `dns_lookup` and `dns_reverse` with deterministic tests and opt-in external DNS smoke coverage.
+- [ ] **PR 2 — DNS lookup types**: in progress on branch `feat/std-net-dns`; adds `dns_lookup` and `dns_reverse` with broad supported record types, deterministic tests, and opt-in external DNS smoke coverage.
 - [ ] **PR 3 — Bounded port scan**: planned after DNS.
 - [ ] **PR 4 — TLS info**: planned after port scan/dependency decision.
 
@@ -811,13 +832,13 @@ Acceptance:
 - [x] no new dependency unless clearly justified; any ICMP dependency must preserve no-implicit-TCP-fallback semantics
 - [x] `cargo build --profile dev-release`, `cargo test`, docs generation, example validation pass
 
-### PR 2 — DNS A/AAAA/PTR
+### PR 2 — DNS lookup types
 
 Status: **in progress on `feat/std-net-dns`.**
 
 Scope:
 
-- [x] `dns_lookup`
+- [x] broad supported record-type set for data-bearing DNS lookup records
 - [x] `dns_reverse`
 - [x] `hickory-resolver` dependency decision
 - [x] deterministic parser/result-shaping tests; external DNS smoke coverage gated behind env var
@@ -826,7 +847,7 @@ Acceptance:
 
 - [x] deterministic CI tests
 - [x] no public DNS dependency by default
-- [x] initial records limited to A/AAAA/PTR unless implementation remains small and clean
+- [x] operational/meta records (`ANY`, `AXFR`, `IXFR`, `OPT`, `TSIG`, `ZERO`) rejected rather than treated as ordinary lookup records
 
 ### PR 3 — Bounded port scan
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -1,6 +1,6 @@
 # DD-046: `std/net` — Safe Network Primitives for ntnt
 
-**Status:** PR 1 implemented and under review; includes IPAM helpers, ICMP-honest `ping()`, explicit `tcp_connect()`, and high-level `reachable()`; DNS/scan/TLS slices planned
+**Status:** PR 1 merged; PR 2 DNS A/AAAA/PTR in progress; scan/TLS slices planned
 **Author:** Larri
 **Created:** 2026-03-22
 **Updated:** 2026-06-03
@@ -627,6 +627,8 @@ Implementation notes:
 - Use `hickory-resolver` only when ready to add the dependency intentionally.
 - Do not rely on public DNS in CI.
 - Build a resolver abstraction or local/mock DNS test fixture before adding many record types.
+- `dns_lookup` uses the system resolver and does not expose custom nameserver configuration in this slice.
+- DNS answers are returned as DNS data; target probing/safety policy still applies to connect-style functions (`tcp_connect`, `reachable`, future `port_scan`) rather than filtering A/AAAA answers from lookup results.
 - Custom nameserver support is deferred until safety implications are explicit. A `server` option can bypass enterprise DNS policy and should not be a casual Phase 1 feature.
 
 Tests:
@@ -767,19 +769,18 @@ SNMP is a real network-monitoring need, but it is its own protocol family. It sh
 
 ### Status Dashboard
 
-As of 2026-06-02:
+As of 2026-06-03:
 
-- [x] **PR 1 — `std/net` shell + IPAM helpers + `ping`**: implemented in [PR #113](https://github.com/ntntlang/ntnt/pull/113). Status: open, mergeable, CI green, no unresolved review threads.
-- [ ] **PR 2 — Dedicated TCP probe refinement**: next planned slice. Reuses the Phase 1 explicit TCP reachability helper as public `tcp_connect`.
-- [ ] **PR 3 — DNS A/AAAA/PTR**: planned after TCP probe.
-- [ ] **PR 4 — Bounded port scan**: planned after DNS.
-- [ ] **PR 5 — TLS info**: planned after port scan/dependency decision.
+- [x] **PR 1 — `std/net` shell + IPAM helpers + protocol-honest reachability**: merged in [PR #113](https://github.com/ntntlang/ntnt/pull/113).
+- [ ] **PR 2 — DNS A/AAAA/PTR**: in progress on branch `feat/std-net-dns`; adds `dns_lookup` and `dns_reverse` with deterministic tests and opt-in external DNS smoke coverage.
+- [ ] **PR 3 — Bounded port scan**: planned after DNS.
+- [ ] **PR 4 — TLS info**: planned after port scan/dependency decision.
 
 PR 1 shipped the core module registration, runtime functions, typechecker signatures, generated docs, deterministic examples, and tests for Phase 1. Review hardening added policy fixes for private, link-local, multicast, documentation, mapped-address, and broadcast-style targets.
 
 ### PR 1 — `std/net` shell + IPAM helpers + protocol-honest reachability
 
-Status: **implemented in PR #113; awaiting merge/review completion.**
+Status: **merged in PR #113.**
 
 Scope:
 
@@ -812,18 +813,20 @@ Acceptance:
 
 ### PR 2 — DNS A/AAAA/PTR
 
+Status: **in progress on `feat/std-net-dns`.**
+
 Scope:
 
-- [ ] `dns_lookup`
-- [ ] `dns_reverse`
-- [ ] `hickory-resolver` or equivalent dependency decision
-- [ ] resolver abstraction or mock/local fixture
+- [x] `dns_lookup`
+- [x] `dns_reverse`
+- [x] `hickory-resolver` dependency decision
+- [x] deterministic parser/result-shaping tests; external DNS smoke coverage gated behind env var
 
 Acceptance:
 
-- [ ] deterministic CI tests
-- [ ] no public DNS dependency by default
-- [ ] initial records limited to A/AAAA/PTR unless implementation remains small and clean
+- [x] deterministic CI tests
+- [x] no public DNS dependency by default
+- [x] initial records limited to A/AAAA/PTR unless implementation remains small and clean
 
 ### PR 3 — Bounded port scan
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -972,10 +972,10 @@ Both `fetch(map { "url": url, ... })` and `fetch(url, map { ... })` work. The tw
 
 ### Network/IPAM Helpers (`std/net`)
 
-`std/net` provides deterministic IPv4/IPv6 CIDR helpers, protocol-honest ICMP ping, explicit TCP connect probes, and a high-level reachability helper:
+`std/net` provides deterministic IPv4/IPv6 CIDR helpers, protocol-honest ICMP ping, explicit TCP connect probes, high-level reachability, and DNS lookups:
 
 ```ntnt
-import { ip_parse, subnet_contains, subnet_split, subnet_summarize, tcp_connect, reachable } from "std/net"
+import { ip_parse, subnet_contains, subnet_split, subnet_summarize, tcp_connect, reachable, dns_lookup, dns_reverse } from "std/net"
 
 let info = unwrap(ip_parse("192.168.1.0/24"))
 let contains = unwrap(subnet_contains("10.0.0.0/8", "10.42.0.0/16"))
@@ -983,6 +983,8 @@ let children = unwrap(subnet_split("192.168.1.0/24", 28))
 let summary = unwrap(subnet_summarize(["10.0.0.0/25", "10.0.0.128/25"]))
 let tcp = unwrap(tcp_connect("example.com", 443))
 let reachability = unwrap(reachable("example.com", map { "tcp_ports": [443] }))
+let records = unwrap(dns_lookup("example.com", "A"))
+let ptr_names = unwrap(dns_reverse("8.8.8.8"))
 ```
 
 These helpers return `Result<..., String>`; use `unwrap(...)` for quick scripts/examples, or `match`/`otherwise` when the app should handle invalid input or policy denial.
@@ -1001,6 +1003,15 @@ let reachability = reachable("example.com", map {
 ```
 
 `tcp_connect()` and `reachable()` support optional `count` (1-10), `timeout_ms`, and `interval_ms`, returning per-attempt results plus `sent`, `received`, `failed`, and `loss_percent` summary fields.
+
+`dns_lookup(name, record_type?, opts?)` supports `A`, `AAAA`, and `PTR` records in this slice. It returns `Ok([])` for ordinary no-answer DNS responses and `Err(String)` for invalid record types, invalid options, resolver configuration failures, or DNS transport failures. `dns_reverse(ip, opts?)` returns all PTR names as an array because PTR can legitimately have zero, one, or multiple names.
+
+```ntnt
+let a_records = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
+let ptr_names = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
+```
+
+When passing `dns_lookup` options, include the record type explicitly: `dns_lookup(name, "A", opts)`. The shorter `dns_lookup(name)` form defaults to `A`; `dns_lookup(name, opts)` is intentionally rejected so the call shape stays unambiguous.
 
 Private/internal targets are denied by default. Monitoring apps must opt in at process scope **and** call scope:
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1004,10 +1004,12 @@ let reachability = reachable("example.com", map {
 
 `tcp_connect()` and `reachable()` support optional `count` (1-10), `timeout_ms`, and `interval_ms`, returning per-attempt results plus `sent`, `received`, `failed`, and `loss_percent` summary fields.
 
-`dns_lookup(name, record_type?, opts?)` supports `A`, `AAAA`, and `PTR` records in this slice. It returns `Ok([])` for ordinary no-answer DNS responses and `Err(String)` for invalid record types, invalid options, resolver configuration failures, or DNS transport failures. `dns_reverse(ip, opts?)` returns all PTR names as an array because PTR can legitimately have zero, one, or multiple names.
+`dns_lookup(name, record_type?, opts?)` supports common data-bearing DNS record types, including `A`, `AAAA`, `MX`, `TXT`, `NS`, `CNAME`, `SOA`, `SRV`, `CAA`, `TLSA`, `HTTPS`, and `SVCB`. It returns `Ok([])` for ordinary no-answer DNS responses and `Err(String)` for invalid record types, invalid options, resolver configuration failures, or DNS transport failures. Record maps use the actual returned DNS type, so a resolver response that includes related records reports those records honestly instead of relabeling everything as the requested type. `dns_reverse(ip, opts?)` returns all PTR names as an array because PTR can legitimately have zero, one, or multiple names.
 
 ```ntnt
 let a_records = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
+let mx_records = dns_lookup("example.com", "MX", map { "timeout_ms": 1000 })
+let txt_records = dns_lookup("example.com", "TXT", map { "timeout_ms": 1000 })
 let ptr_names = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
 ```
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -9694,7 +9694,7 @@ import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
 
 | Function | Description |
 |----------|-------------|
-| [`dns_lookup`](#dnslookup) | Looks up DNS records for a name. Phase 3 supports A, AAAA, and PTR records. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String). |
+| [`dns_lookup`](#dnslookup) | Looks up DNS records for a name. Supports A, AAAA, ANAME, CAA, CDNSKEY, CDS, CNAME, CSYNC, DNSKEY, DS, HINFO, HTTPS, KEY, MX, NAPTR, NS, NSEC, NSEC3, NSEC3PARAM, NULL, OPENPGPKEY, PTR, RRSIG, SIG, SOA, SRV, SSHFP, SVCB, TLSA, and TXT records. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String). |
 | [`dns_reverse`](#dnsreverse) | Performs a reverse DNS/PTR lookup for an IPv4 or IPv6 address. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String). |
 | [`ip_parse`](#ipparse) | Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields. |
 | [`ip_range_to_cidrs`](#iprangetocidrs) | Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover. |
@@ -9713,15 +9713,15 @@ import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
 dns_lookup(name: String, record_type?: String, opts?: Map) -> Result<Array<Map>, String>
 ```
 
-Looks up DNS records for a name. Phase 3 supports A, AAAA, and PTR records. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String).
+Looks up DNS records for a name. Supports A, AAAA, ANAME, CAA, CDNSKEY, CDS, CNAME, CSYNC, DNSKEY, DS, HINFO, HTTPS, KEY, MX, NAPTR, NS, NSEC, NSEC3, NSEC3PARAM, NULL, OPENPGPKEY, PTR, RRSIG, SIG, SOA, SRV, SSHFP, SVCB, TLSA, and TXT records. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String).
 
 **Parameters:**
 
 - `name` — DNS name to query
-- `record_type` — Optional DNS record type: A, AAAA, or PTR. Defaults to A.
+- `record_type` — Optional supported DNS record type. Defaults to A.
 - `opts` — Optional map with timeout_ms. When passing opts, include an explicit record_type such as "A".
 
-**Returns:** Result containing an array of records with type, name, value, and ttl
+**Returns:** Result containing an array of records with actual returned type, name, value, and ttl
 
 **Examples:**
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -9694,6 +9694,8 @@ import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
 
 | Function | Description |
 |----------|-------------|
+| [`dns_lookup`](#dnslookup) | Looks up DNS records for a name. Phase 3 supports A, AAAA, and PTR records. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String). |
+| [`dns_reverse`](#dnsreverse) | Performs a reverse DNS/PTR lookup for an IPv4 or IPv6 address. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String). |
 | [`ip_parse`](#ipparse) | Parses an IPv4/IPv6 address or CIDR and returns canonical IPAM fields. |
 | [`ip_range_to_cidrs`](#iprangetocidrs) | Converts an inclusive IPv4/IPv6 range into the minimal CIDR cover. |
 | [`ping`](#ping) | Performs an ICMP ping when ICMP support is available. It is protocol-honest: ping() does not fall back to TCP ports. Apps that want TCP port checks should use tcp_connect(); apps that want explicit ICMP-then-TCP reachability should use reachable(). |
@@ -9704,6 +9706,57 @@ import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
 | [`subnet_summarize`](#subnetsummarize) | Summarizes adjacent or overlapping CIDRs into the shortest equivalent route list. |
 | [`subnet_supernet`](#subnetsupernet) | Returns the parent/supernet of a CIDR. Defaults to one bit shorter. |
 | [`tcp_connect`](#tcpconnect) | Performs a bounded TCP connect probe to one explicit port. Closed, refused, or timed-out ports return Ok(map { "connected": false, ... }); invalid input, policy denial, and resolver/system failures return Err(String). |
+
+#### `dns_lookup`
+
+```ntnt
+dns_lookup(name: String, record_type?: String, opts?: Map) -> Result<Array<Map>, String>
+```
+
+Looks up DNS records for a name. Phase 3 supports A, AAAA, and PTR records. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String).
+
+**Parameters:**
+
+- `name` — DNS name to query
+- `record_type` — Optional DNS record type: A, AAAA, or PTR. Defaults to A.
+- `opts` — Optional map with timeout_ms
+
+**Returns:** Result containing an array of records with type, name, value, and ttl
+
+**Examples:**
+
+```ntnt
+dns_lookup("example.com", "A")  // Look up IPv4 DNS records
+```
+
+*Since v0.4.10*
+
+---
+
+#### `dns_reverse`
+
+```ntnt
+dns_reverse(ip: String, opts?: Map) -> Result<Array<String>, String>
+```
+
+Performs a reverse DNS/PTR lookup for an IPv4 or IPv6 address. No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String).
+
+**Parameters:**
+
+- `ip` — IPv4 or IPv6 address
+- `opts` — Optional map with timeout_ms
+
+**Returns:** Result containing zero or more PTR hostnames
+
+**Examples:**
+
+```ntnt
+dns_reverse("8.8.8.8")  // Look up PTR hostnames for an IP address
+```
+
+*Since v0.4.10*
+
+---
 
 #### `ip_parse`
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -9719,7 +9719,7 @@ Looks up DNS records for a name. Phase 3 supports A, AAAA, and PTR records. No-a
 
 - `name` — DNS name to query
 - `record_type` — Optional DNS record type: A, AAAA, or PTR. Defaults to A.
-- `opts` — Optional map with timeout_ms
+- `opts` — Optional map with timeout_ms. When passing opts, include an explicit record_type such as "A".
 
 **Returns:** Result containing an array of records with type, name, value, and ttl
 

--- a/examples/std_net_dns.tnt
+++ b/examples/std_net_dns.tnt
@@ -1,0 +1,11 @@
+// std/net DNS lookup examples
+
+import { dns_lookup, dns_reverse } from "std/net"
+
+let a_records = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
+let aaaa_records = dns_lookup("example.com", "AAAA", map { "timeout_ms": 1000 })
+let ptr_names = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
+
+print(a_records)
+print(aaaa_records)
+print(ptr_names)

--- a/examples/std_net_dns.tnt
+++ b/examples/std_net_dns.tnt
@@ -1,15 +1,23 @@
 // std/net DNS lookup examples
+//
+// Public DNS lookups are opt-in so default example validation/runs stay offline-safe.
+// Run with: NTNT_NET_EXTERNAL_DNS_EXAMPLES=1 ntnt run examples/std_net_dns.tnt
 
+import { get_env } from "std/env"
 import { dns_lookup, dns_reverse } from "std/net"
 
-let a_records = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
-let aaaa_records = dns_lookup("example.com", "AAAA", map { "timeout_ms": 1000 })
-let mx_records = dns_lookup("example.com", "MX", map { "timeout_ms": 1000 })
-let txt_records = dns_lookup("example.com", "TXT", map { "timeout_ms": 1000 })
-let ptr_names = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
+if (get_env("NTNT_NET_EXTERNAL_DNS_EXAMPLES") ?? "") == "1" {
+    let a_records = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
+    let aaaa_records = dns_lookup("example.com", "AAAA", map { "timeout_ms": 1000 })
+    let mx_records = dns_lookup("example.com", "MX", map { "timeout_ms": 1000 })
+    let txt_records = dns_lookup("example.com", "TXT", map { "timeout_ms": 1000 })
+    let ptr_names = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
 
-print(a_records)
-print(aaaa_records)
-print(mx_records)
-print(txt_records)
-print(ptr_names)
+    print(a_records)
+    print(aaaa_records)
+    print(mx_records)
+    print(txt_records)
+    print(ptr_names)
+} else {
+    print("Set NTNT_NET_EXTERNAL_DNS_EXAMPLES=1 to run public DNS lookup examples")
+}

--- a/examples/std_net_dns.tnt
+++ b/examples/std_net_dns.tnt
@@ -4,8 +4,12 @@ import { dns_lookup, dns_reverse } from "std/net"
 
 let a_records = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
 let aaaa_records = dns_lookup("example.com", "AAAA", map { "timeout_ms": 1000 })
+let mx_records = dns_lookup("example.com", "MX", map { "timeout_ms": 1000 })
+let txt_records = dns_lookup("example.com", "TXT", map { "timeout_ms": 1000 })
 let ptr_names = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
 
 print(a_records)
 print(aaaa_records)
+print(mx_records)
+print(txt_records)
 print(ptr_names)

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -4,11 +4,12 @@ use crate::error::IntentError;
 use crate::interpreter::Value;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::error::{ResolveError, ResolveErrorKind};
-use hickory_resolver::proto::rr::{RData, RecordType};
+use hickory_resolver::proto::rr::RecordType;
 use hickory_resolver::Resolver;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
+use std::str::FromStr;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -100,46 +101,75 @@ struct ParsedInput {
     kind: &'static str,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DnsRecordType {
-    A,
-    Aaaa,
-    Ptr,
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DnsRecordType {
+    name: String,
+    record_type: RecordType,
 }
 
 impl DnsRecordType {
     fn parse(value: &str) -> Result<Self, String> {
-        match value.to_ascii_uppercase().as_str() {
-            "A" => Ok(Self::A),
-            "AAAA" => Ok(Self::Aaaa),
-            "PTR" => Ok(Self::Ptr),
-            other => Err(format!(
-                "dns_lookup() record_type must be A, AAAA, or PTR, got '{}'",
-                other
-            )),
-        }
+        let name = value.trim().to_ascii_uppercase();
+        let record_type = match RecordType::from_str(&name) {
+            Ok(record_type) if SUPPORTED_DNS_RECORD_TYPES.contains(&name.as_str()) => record_type,
+            _ => return Err(unsupported_dns_record_type(&name)),
+        };
+        Ok(Self { name, record_type })
     }
 
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::A => "A",
-            Self::Aaaa => "AAAA",
-            Self::Ptr => "PTR",
-        }
+    fn as_str(&self) -> &str {
+        &self.name
     }
 
-    fn hickory_type(self) -> RecordType {
-        match self {
-            Self::A => RecordType::A,
-            Self::Aaaa => RecordType::AAAA,
-            Self::Ptr => RecordType::PTR,
-        }
+    fn hickory_type(&self) -> RecordType {
+        self.record_type
     }
+}
+
+const SUPPORTED_DNS_RECORD_TYPES: &[&str] = &[
+    "A",
+    "AAAA",
+    "ANAME",
+    "CAA",
+    "CDNSKEY",
+    "CDS",
+    "CNAME",
+    "CSYNC",
+    "DNSKEY",
+    "DS",
+    "HINFO",
+    "HTTPS",
+    "KEY",
+    "MX",
+    "NAPTR",
+    "NS",
+    "NSEC",
+    "NSEC3",
+    "NSEC3PARAM",
+    "NULL",
+    "OPENPGPKEY",
+    "PTR",
+    "RRSIG",
+    "SIG",
+    "SOA",
+    "SRV",
+    "SSHFP",
+    "SVCB",
+    "TLSA",
+    "TXT",
+];
+
+fn unsupported_dns_record_type(record_type: &str) -> String {
+    format!(
+        "dns_lookup() record_type must be one of {}, got '{}'",
+        SUPPORTED_DNS_RECORD_TYPES.join(", "),
+        record_type
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DnsAnswer {
-    record_type: DnsRecordType,
+    record_type: String,
     name: String,
     value: String,
     ttl: u32,
@@ -367,12 +397,15 @@ pub fn init() -> HashMap<String, Value> {
     // @ntnt dns_lookup
     // @module std/net
     // @signature dns_lookup(name: String, record_type?: String, opts?: Map) -> Result<Array<Map>, String>
-    // Looks up DNS records for a name. Phase 3 supports A, AAAA, and PTR records.
+    // Looks up DNS records for a name. Supports A, AAAA, ANAME, CAA, CDNSKEY, CDS,
+    // CNAME, CSYNC, DNSKEY, DS, HINFO, HTTPS, KEY, MX, NAPTR, NS, NSEC,
+    // NSEC3, NSEC3PARAM, NULL, OPENPGPKEY, PTR, RRSIG, SIG, SOA, SRV,
+    // SSHFP, SVCB, TLSA, and TXT records.
     // No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String).
     // @param name DNS name to query
-    // @param record_type Optional DNS record type: A, AAAA, or PTR. Defaults to A.
+    // @param record_type Optional supported DNS record type. Defaults to A.
     // @param opts Optional map with timeout_ms. When passing opts, include an explicit record_type such as "A".
-    // @returns Result containing an array of records with type, name, value, and ttl
+    // @returns Result containing an array of records with actual returned type, name, value, and ttl
     // @since v0.4.10
     // @tags #network
     // @example dns_lookup("example.com", "A") ~ "Look up IPv4 DNS records"
@@ -803,21 +836,16 @@ fn dns_lookup_records(
         let Some(data) = record.data() else {
             continue;
         };
-        let value = match (record_type, data) {
-            (DnsRecordType::A | DnsRecordType::Aaaa, data) => {
-                data.ip_addr().map(|ip| ip.to_string())
-            }
-            (DnsRecordType::Ptr, RData::PTR(ptr)) => Some(ptr.to_utf8()),
-            _ => None,
-        };
-        if let Some(value) = value {
-            answers.push(DnsAnswer {
-                record_type,
-                name: record.name().to_utf8(),
-                value,
-                ttl: record.ttl(),
-            });
-        }
+        let value = data
+            .ip_addr()
+            .map(|ip| ip.to_string())
+            .unwrap_or_else(|| data.to_string());
+        answers.push(DnsAnswer {
+            record_type: record.record_type().to_string(),
+            name: record.name().to_utf8(),
+            value,
+            ttl: record.ttl(),
+        });
     }
     Ok(answers)
 }
@@ -840,10 +868,7 @@ fn dns_answers_to_value(answers: Vec<DnsAnswer>) -> Value {
             .into_iter()
             .map(|answer| {
                 let mut map = HashMap::new();
-                map.insert(
-                    "type".to_string(),
-                    Value::String(answer.record_type.as_str().to_string()),
-                );
+                map.insert("type".to_string(), Value::String(answer.record_type));
                 map.insert("name".to_string(), Value::String(answer.name));
                 map.insert("value".to_string(), Value::String(answer.value));
                 map.insert("ttl".to_string(), Value::Int(answer.ttl as i64));
@@ -1771,28 +1796,76 @@ mod tests {
     }
 
     #[test]
-    fn dns_record_type_parser_accepts_initial_phase_types_only() {
-        assert_eq!(DnsRecordType::parse("a").unwrap(), DnsRecordType::A);
-        assert_eq!(DnsRecordType::parse("AAAA").unwrap(), DnsRecordType::Aaaa);
-        assert_eq!(DnsRecordType::parse("ptr").unwrap(), DnsRecordType::Ptr);
-        assert!(DnsRecordType::parse("MX")
-            .unwrap_err()
-            .contains("A, AAAA, or PTR"));
+    fn dns_record_type_parser_accepts_supported_lookup_types() {
+        for record_type in [
+            "a",
+            "AAAA",
+            "aname",
+            "CAA",
+            "CDNSKEY",
+            "CDS",
+            "CNAME",
+            "CSYNC",
+            "DNSKEY",
+            "DS",
+            "HINFO",
+            "HTTPS",
+            "KEY",
+            "MX",
+            "NAPTR",
+            "NS",
+            "NSEC",
+            "NSEC3",
+            "NSEC3PARAM",
+            "NULL",
+            "OPENPGPKEY",
+            "PTR",
+            "RRSIG",
+            "SIG",
+            "SOA",
+            "SRV",
+            "SSHFP",
+            "SVCB",
+            "TLSA",
+            "TXT",
+        ] {
+            assert_eq!(
+                DnsRecordType::parse(record_type).unwrap().as_str(),
+                record_type.to_ascii_uppercase()
+            );
+        }
+    }
+
+    #[test]
+    fn dns_record_type_parser_rejects_meta_and_unknown_types() {
+        for record_type in ["ANY", "AXFR", "IXFR", "OPT", "TSIG", "ZERO", "BOGUS"] {
+            assert!(DnsRecordType::parse(record_type)
+                .unwrap_err()
+                .contains("record_type must be one of"));
+        }
     }
 
     #[test]
     fn dns_answers_render_stable_record_maps() {
-        let value = dns_answers_to_value(vec![DnsAnswer {
-            record_type: DnsRecordType::A,
-            name: "example.com.".to_string(),
-            value: "93.184.216.34".to_string(),
-            ttl: 300,
-        }]);
+        let value = dns_answers_to_value(vec![
+            DnsAnswer {
+                record_type: "A".to_string(),
+                name: "example.com.".to_string(),
+                value: "93.184.216.34".to_string(),
+                ttl: 300,
+            },
+            DnsAnswer {
+                record_type: "MX".to_string(),
+                name: "example.com.".to_string(),
+                value: "10 mail.example.com.".to_string(),
+                ttl: 600,
+            },
+        ]);
 
         let Value::Array(records) = value else {
             panic!("expected DNS records array");
         };
-        assert_eq!(records.len(), 1);
+        assert_eq!(records.len(), 2);
         let Value::Map(record) = &records[0] else {
             panic!("expected DNS record map");
         };
@@ -1804,6 +1877,15 @@ mod tests {
             matches!(record.get("value"), Some(Value::String(value)) if value == "93.184.216.34")
         );
         assert!(matches!(record.get("ttl"), Some(Value::Int(300))));
+
+        let Value::Map(record) = &records[1] else {
+            panic!("expected DNS record map");
+        };
+        assert!(matches!(record.get("type"), Some(Value::String(value)) if value == "MX"));
+        assert!(
+            matches!(record.get("value"), Some(Value::String(value)) if value == "10 mail.example.com.")
+        );
+        assert!(matches!(record.get("ttl"), Some(Value::Int(600))));
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -2,6 +2,10 @@
 
 use crate::error::IntentError;
 use crate::interpreter::Value;
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::error::{ResolveError, ResolveErrorKind};
+use hickory_resolver::proto::rr::{RData, RecordType};
+use hickory_resolver::Resolver;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
@@ -94,6 +98,51 @@ struct ParsedInput {
     original_ip: u128,
     network: Network,
     kind: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DnsRecordType {
+    A,
+    Aaaa,
+    Ptr,
+}
+
+impl DnsRecordType {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value.to_ascii_uppercase().as_str() {
+            "A" => Ok(Self::A),
+            "AAAA" => Ok(Self::Aaaa),
+            "PTR" => Ok(Self::Ptr),
+            other => Err(format!(
+                "dns_lookup() record_type must be A, AAAA, or PTR, got '{}'",
+                other
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::A => "A",
+            Self::Aaaa => "AAAA",
+            Self::Ptr => "PTR",
+        }
+    }
+
+    fn hickory_type(self) -> RecordType {
+        match self {
+            Self::A => RecordType::A,
+            Self::Aaaa => RecordType::AAAA,
+            Self::Ptr => RecordType::PTR,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DnsAnswer {
+    record_type: DnsRecordType,
+    name: String,
+    value: String,
+    ttl: u32,
 }
 
 fn validate_ping_method(value: Option<&Value>) -> Result<(), String> {
@@ -312,6 +361,51 @@ pub fn init() -> HashMap<String, Value> {
             max_arity: 2,
             requires: None,
             func: reachable_fn,
+        },
+    );
+
+    // @ntnt dns_lookup
+    // @module std/net
+    // @signature dns_lookup(name: String, record_type?: String, opts?: Map) -> Result<Array<Map>, String>
+    // Looks up DNS records for a name. Phase 3 supports A, AAAA, and PTR records.
+    // No-answer DNS responses return Ok([]); invalid input and resolver/system failures return Err(String).
+    // @param name DNS name to query
+    // @param record_type Optional DNS record type: A, AAAA, or PTR. Defaults to A.
+    // @param opts Optional map with timeout_ms. When passing opts, include an explicit record_type such as "A".
+    // @returns Result containing an array of records with type, name, value, and ttl
+    // @since v0.4.10
+    // @tags #network
+    // @example dns_lookup("example.com", "A") ~ "Look up IPv4 DNS records"
+    module.insert(
+        "dns_lookup".to_string(),
+        Value::NativeFunction {
+            name: "dns_lookup".to_string(),
+            arity: 1,
+            max_arity: 3,
+            requires: None,
+            func: dns_lookup_fn,
+        },
+    );
+
+    // @ntnt dns_reverse
+    // @module std/net
+    // @signature dns_reverse(ip: String, opts?: Map) -> Result<Array<String>, String>
+    // Performs a reverse DNS/PTR lookup for an IPv4 or IPv6 address. No-answer
+    // DNS responses return Ok([]); invalid input and resolver/system failures return Err(String).
+    // @param ip IPv4 or IPv6 address
+    // @param opts Optional map with timeout_ms
+    // @returns Result containing zero or more PTR hostnames
+    // @since v0.4.10
+    // @tags #network
+    // @example dns_reverse("8.8.8.8") ~ "Look up PTR hostnames for an IP address"
+    module.insert(
+        "dns_reverse".to_string(),
+        Value::NativeFunction {
+            name: "dns_reverse".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: dns_reverse_fn,
         },
     );
 
@@ -618,6 +712,145 @@ fn reachable_fn(args: &[Value]) -> Result<Value, IntentError> {
             host, &tcp_ports, &attempts,
         )))
     })()))
+}
+
+fn dns_lookup_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let name = string_arg(args, 0, "dns_lookup")?;
+    let (record_type, opts) = dns_lookup_args(args)?;
+
+    Ok(result_value((|| {
+        let record_type = DnsRecordType::parse(record_type)?;
+        let resolver = dns_resolver(opts)?;
+        let answers = dns_lookup_records(&resolver, name, record_type)?;
+        Ok(dns_answers_to_value(answers))
+    })()))
+}
+
+fn dns_reverse_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let ip = string_arg(args, 0, "dns_reverse")?;
+    let opts = opts_arg(args, 1, "dns_reverse")?;
+
+    Ok(result_value((|| {
+        let ip: IpAddr = ip.parse().map_err(|_| {
+            format!(
+                "dns_reverse() argument 1 must be a valid IP address, got {}",
+                ip
+            )
+        })?;
+        let resolver = dns_resolver(opts)?;
+        let names = dns_reverse_names(&resolver, ip)?;
+        Ok(Value::Array(names.into_iter().map(Value::String).collect()))
+    })()))
+}
+
+fn dns_lookup_args(args: &[Value]) -> Result<(&str, Option<&HashMap<String, Value>>), IntentError> {
+    if args.len() <= 1 {
+        return Ok(("A", None));
+    }
+
+    let Value::String(record_type) = &args[1] else {
+        return Err(IntentError::type_error(format!(
+            "dns_lookup() argument 2 must be String record_type, got {}",
+            args[1].type_name()
+        )));
+    };
+    let opts = opts_arg(args, 2, "dns_lookup")?;
+    Ok((record_type, opts))
+}
+
+fn dns_resolver(opts: Option<&HashMap<String, Value>>) -> Result<Resolver, String> {
+    let timeout_ms = parse_u64_option(opts, "timeout_ms", DEFAULT_TIMEOUT_MS)?
+        .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
+    let (config, mut resolver_opts) = system_resolver_config()?;
+    resolver_opts.timeout = Duration::from_millis(timeout_ms);
+    resolver_opts.attempts = 1;
+    Resolver::new(config, resolver_opts)
+        .map_err(|e| format!("failed to initialize DNS resolver: {}", e))
+}
+
+fn system_resolver_config() -> Result<(ResolverConfig, ResolverOpts), String> {
+    #[cfg(any(unix, target_os = "windows"))]
+    {
+        hickory_resolver::system_conf::read_system_conf()
+            .map_err(|e| format!("failed to read system DNS configuration: {}", e))
+    }
+    #[cfg(not(any(unix, target_os = "windows")))]
+    {
+        Ok((ResolverConfig::default(), ResolverOpts::default()))
+    }
+}
+
+fn dns_lookup_records(
+    resolver: &Resolver,
+    name: &str,
+    record_type: DnsRecordType,
+) -> Result<Vec<DnsAnswer>, String> {
+    let lookup = match resolver.lookup(name, record_type.hickory_type()) {
+        Ok(lookup) => lookup,
+        Err(err) if is_dns_no_records(&err) => return Ok(vec![]),
+        Err(err) => {
+            return Err(format!(
+                "DNS lookup failed for {} {}: {}",
+                name,
+                record_type.as_str(),
+                err
+            ))
+        }
+    };
+
+    let mut answers = Vec::new();
+    for record in lookup.record_iter() {
+        let Some(data) = record.data() else {
+            continue;
+        };
+        let value = match (record_type, data) {
+            (DnsRecordType::A | DnsRecordType::Aaaa, data) => {
+                data.ip_addr().map(|ip| ip.to_string())
+            }
+            (DnsRecordType::Ptr, RData::PTR(ptr)) => Some(ptr.to_utf8()),
+            _ => None,
+        };
+        if let Some(value) = value {
+            answers.push(DnsAnswer {
+                record_type,
+                name: record.name().to_utf8(),
+                value,
+                ttl: record.ttl(),
+            });
+        }
+    }
+    Ok(answers)
+}
+
+fn dns_reverse_names(resolver: &Resolver, ip: IpAddr) -> Result<Vec<String>, String> {
+    match resolver.reverse_lookup(ip) {
+        Ok(lookup) => Ok(lookup.iter().map(|name| name.to_utf8()).collect()),
+        Err(err) if is_dns_no_records(&err) => Ok(vec![]),
+        Err(err) => Err(format!("reverse DNS lookup failed for {}: {}", ip, err)),
+    }
+}
+
+fn is_dns_no_records(err: &ResolveError) -> bool {
+    matches!(err.kind(), ResolveErrorKind::NoRecordsFound { .. })
+}
+
+fn dns_answers_to_value(answers: Vec<DnsAnswer>) -> Value {
+    Value::Array(
+        answers
+            .into_iter()
+            .map(|answer| {
+                let mut map = HashMap::new();
+                map.insert(
+                    "type".to_string(),
+                    Value::String(answer.record_type.as_str().to_string()),
+                );
+                map.insert("name".to_string(), Value::String(answer.name));
+                map.insert("value".to_string(), Value::String(answer.value));
+                map.insert("ttl".to_string(), Value::Int(answer.ttl as i64));
+                Value::Map(map)
+            })
+            .collect(),
+    )
 }
 
 fn icmp_unavailable_message() -> String {
@@ -1535,6 +1768,42 @@ mod tests {
             ("count".to_string(), Value::Int(0),)
         ])))
         .is_err());
+    }
+
+    #[test]
+    fn dns_record_type_parser_accepts_initial_phase_types_only() {
+        assert_eq!(DnsRecordType::parse("a").unwrap(), DnsRecordType::A);
+        assert_eq!(DnsRecordType::parse("AAAA").unwrap(), DnsRecordType::Aaaa);
+        assert_eq!(DnsRecordType::parse("ptr").unwrap(), DnsRecordType::Ptr);
+        assert!(DnsRecordType::parse("MX")
+            .unwrap_err()
+            .contains("A, AAAA, or PTR"));
+    }
+
+    #[test]
+    fn dns_answers_render_stable_record_maps() {
+        let value = dns_answers_to_value(vec![DnsAnswer {
+            record_type: DnsRecordType::A,
+            name: "example.com.".to_string(),
+            value: "93.184.216.34".to_string(),
+            ttl: 300,
+        }]);
+
+        let Value::Array(records) = value else {
+            panic!("expected DNS records array");
+        };
+        assert_eq!(records.len(), 1);
+        let Value::Map(record) = &records[0] else {
+            panic!("expected DNS record map");
+        };
+        assert!(matches!(record.get("type"), Some(Value::String(value)) if value == "A"));
+        assert!(
+            matches!(record.get("name"), Some(Value::String(value)) if value == "example.com.")
+        );
+        assert!(
+            matches!(record.get("value"), Some(Value::String(value)) if value == "93.184.216.34")
+        );
+        assert!(matches!(record.get("ttl"), Some(Value::Int(300))));
     }
 
     #[test]

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3794,6 +3794,16 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                 name: "Result".to_string(),
                 args: vec![Type::Array(Box::new(Type::String)), Type::String],
             };
+            let result_map_array = Type::Generic {
+                name: "Result".to_string(),
+                args: vec![
+                    Type::Array(Box::new(Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    })),
+                    Type::String,
+                ],
+            };
             let opts = Type::Map {
                 key_type: Box::new(Type::String),
                 value_type: Box::new(Type::Any),
@@ -3805,10 +3815,12 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("subnet_split", ["cidr" => Type::String, "new_prefix" => Type::Int, "opts" => opts.clone()], result_string_array.clone(), required(2));
             sig!("subnet_supernet", ["cidr" => Type::String, "new_prefix" => Type::Int], result_string, required(1));
             sig!("subnet_summarize", ["cidrs" => Type::Array(Box::new(Type::String))], result_string_array.clone());
-            sig!("ip_range_to_cidrs", ["start_ip" => Type::String, "end_ip" => Type::String], result_string_array);
+            sig!("ip_range_to_cidrs", ["start_ip" => Type::String, "end_ip" => Type::String], result_string_array.clone());
             sig!("ping", ["host" => Type::String, "opts" => opts.clone()], result_map.clone(), required(1));
             sig!("tcp_connect", ["host" => Type::String, "port" => Type::Int, "opts" => opts.clone()], result_map.clone(), required(2));
-            sig!("reachable", ["host" => Type::String, "opts" => opts], result_map, required(1));
+            sig!("reachable", ["host" => Type::String, "opts" => opts.clone()], result_map, required(1));
+            sig!("dns_lookup", ["name" => Type::String, "record_type" => Type::String, "opts" => opts.clone()], result_map_array, required(1));
+            sig!("dns_reverse", ["ip" => Type::String, "opts" => opts], result_string_array, required(1));
         }
         "std/path" => {
             sig!("join_path", ["parts" => Type::String], Type::String, variadic);

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -183,6 +183,67 @@ match subnet_split("2001:db8::/64", 128) {
 }
 
 #[test]
+fn dns_lookup_rejects_unsupported_initial_record_types_as_result_error() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { dns_lookup } from "std/net"
+
+match dns_lookup("example.com", "MX", map { "timeout_ms": 100 }) {
+    Ok(records) => print("unexpected"),
+    Err(e) => print(e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("A, AAAA, or PTR"), "stdout: {stdout}");
+}
+
+#[test]
+fn dns_reverse_rejects_invalid_ip_as_result_error() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { dns_reverse } from "std/net"
+
+match dns_reverse("not-an-ip", map { "timeout_ms": 100 }) {
+    Ok(records) => print("unexpected"),
+    Err(e) => print(e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("valid IP address"), "stdout: {stdout}");
+}
+
+#[test]
+fn dns_lookup_external_smoke_is_opt_in() {
+    if std::env::var("NTNT_NET_EXTERNAL_DNS_TESTS").as_deref() != Ok("1") {
+        return;
+    }
+
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { dns_lookup, dns_reverse } from "std/net"
+
+match dns_lookup("example.com", "A", map { "timeout_ms": 2000 }) {
+    Ok(records) => print(len(records) >= 0),
+    Err(e) => print("lookup=" + e)
+}
+
+match dns_reverse("8.8.8.8", map { "timeout_ms": 2000 }) {
+    Ok(names) => print(len(names) >= 0),
+    Err(e) => print("reverse=" + e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(!stdout.contains("lookup="), "stdout: {stdout}");
+    assert!(!stdout.contains("reverse="), "stdout: {stdout}");
+}
+
+#[test]
 fn tcp_connect_uses_explicit_port_and_multiple_attempts() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
     let port = listener.local_addr().unwrap().port();

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -183,12 +183,12 @@ match subnet_split("2001:db8::/64", 128) {
 }
 
 #[test]
-fn dns_lookup_rejects_unsupported_initial_record_types_as_result_error() {
+fn dns_lookup_rejects_unknown_record_types_as_result_error() {
     let (stdout, stderr, code) = run_ntnt_code(
         r#"
 import { dns_lookup } from "std/net"
 
-match dns_lookup("example.com", "MX", map { "timeout_ms": 100 }) {
+match dns_lookup("example.com", "BOGUS", map { "timeout_ms": 100 }) {
     Ok(records) => print("unexpected"),
     Err(e) => print(e)
 }
@@ -196,7 +196,29 @@ match dns_lookup("example.com", "MX", map { "timeout_ms": 100 }) {
     );
 
     assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
-    assert!(stdout.contains("A, AAAA, or PTR"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("record_type must be one of"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn dns_lookup_rejects_operational_meta_record_types_as_result_error() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { dns_lookup } from "std/net"
+
+for record_type in ["ANY", "AXFR", "IXFR", "OPT", "TSIG", "ZERO"] {
+    match dns_lookup("example.com", record_type, map { "timeout_ms": 100 }) {
+        Ok(records) => print("unexpected"),
+        Err(e) => print(contains(e, "record_type must be one of"))
+    }
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert_eq!(stdout.matches("true").count(), 6, "stdout: {stdout}");
 }
 
 #[test]

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1096,7 +1096,7 @@ let x: Int = first([1, 2, 3])
 #[test]
 fn test_std_net_phase1_signatures_accept_valid_usage() {
     let source = r#"
-import { ip_parse, subnet_contains, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs, ping, tcp_connect, reachable } from "std/net"
+import { ip_parse, subnet_contains, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs, ping, tcp_connect, reachable, dns_lookup, dns_reverse } from "std/net"
 
 let parsed = ip_parse("192.168.1.0/24")
 let contains = subnet_contains("10.0.0.0/8", "10.1.0.0/16")
@@ -1108,6 +1108,8 @@ let range = ip_range_to_cidrs("192.168.1.20", "192.168.1.31")
 let icmp = ping("example.com", map { "method": "icmp", "timeout_ms": 1000 })
 let tcp = tcp_connect("example.com", 443, map { "timeout_ms": 1000 })
 let reachability = reachable("example.com", map { "tcp_ports": [443], "timeout_ms": 1000 })
+let dns = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
+let reverse_dns = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
 "#;
     let (stdout, _stderr, _exit_code) = lint_code(source);
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
@@ -1121,10 +1123,11 @@ let reachability = reachable("example.com", map { "tcp_ports": [443], "timeout_m
 #[test]
 fn test_std_net_phase1_signatures_reject_wrong_argument_types() {
     let source = r#"
-import { subnet_split, ping } from "std/net"
+import { subnet_split, ping, dns_lookup } from "std/net"
 
 let split = subnet_split("192.168.1.0/24", "28")
 let reachability = ping(123)
+let dns = dns_lookup("example.com", map { "timeout_ms": 1000 })
 "#;
     let (stdout, _stderr, exit_code) = lint_code(source);
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1109,6 +1109,7 @@ let icmp = ping("example.com", map { "method": "icmp", "timeout_ms": 1000 })
 let tcp = tcp_connect("example.com", 443, map { "timeout_ms": 1000 })
 let reachability = reachable("example.com", map { "tcp_ports": [443], "timeout_ms": 1000 })
 let dns = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
+let mx_dns = dns_lookup("example.com", "MX", map { "timeout_ms": 1000 })
 let reverse_dns = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
 "#;
     let (stdout, _stderr, _exit_code) = lint_code(source);


### PR DESCRIPTION
## Summary

Adds the DD-046 DNS slice for `std/net`:

- `dns_lookup(name, record_type?, opts?) -> Result<Array<Map>, String>`
  - Defaults `record_type` to `A`.
  - Supports data-bearing DNS lookup records: `A`, `AAAA`, `ANAME`, `CAA`, `CDNSKEY`, `CDS`, `CNAME`, `CSYNC`, `DNSKEY`, `DS`, `HINFO`, `HTTPS`, `KEY`, `MX`, `NAPTR`, `NS`, `NSEC`, `NSEC3`, `NSEC3PARAM`, `NULL`, `OPENPGPKEY`, `PTR`, `RRSIG`, `SIG`, `SOA`, `SRV`, `SSHFP`, `SVCB`, `TLSA`, `TXT`.
  - Rejects operational/meta record types like `ANY`, `AXFR`, `IXFR`, `OPT`, `TSIG`, and `ZERO` rather than treating them as normal app-level lookups.
  - Uses the system resolver only; custom nameserver support remains deferred because it can bypass DNS policy.
  - Returns record maps with actual returned `type`, `name`, `value`, and `ttl`.
- `dns_reverse(ip, opts?) -> Result<Array<String>, String>`
  - Returns all PTR names for IPv4/IPv6 reverse lookup.
- Keeps no-answer DNS responses as `Ok([])` and invalid input / resolver setup / transport failures as `Err(String)`.
- Updates generated stdlib docs, AI guide, DD-046, typechecker signatures, and `examples/std_net_dns.tnt`.

## Test Plan

- [x] `cargo fmt -- --check`
- [x] `git diff --check`
- [x] `cargo check --profile dev-release`
- [x] `cargo test --lib stdlib::net::tests -- --nocapture`
- [x] `cargo test --test std_net_tests -- --nocapture`
- [x] `cargo test --test type_checker_tests std_net_phase1 -- --nocapture`
- [x] `cargo build --profile dev-release && ./target/dev-release/ntnt docs --generate`
- [x] `./target/dev-release/ntnt validate examples/`
- [x] `./target/dev-release/ntnt lint examples/std_net_dns.tnt`
- [x] `cargo test`
- [x] `NTNT_NET_EXTERNAL_DNS_TESTS=1 cargo test --test std_net_tests dns_lookup_external_smoke_is_opt_in -- --nocapture`

## Notes

External DNS smoke coverage stays opt-in so default CI is deterministic and does not depend on public DNS/network availability.
