### PR TITLE
feat(std-net): add TLS certificate inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +781,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,12 +917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fd-lock"
 version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,21 +960,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1321,16 +1353,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
- "bytes",
+ "futures-util",
+ "http 0.2.12",
  "hyper 0.14.32",
- "native-tls",
+ "rustls 0.21.12",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1695,6 +1728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,23 +1761,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1774,6 +1796,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "ntnt"
 version = "0.4.10"
 dependencies = [
@@ -1805,11 +1837,14 @@ dependencies = [
  "pretty_assertions",
  "pulldown-cmark",
  "rand 0.8.5",
+ "rcgen",
  "redis",
  "regex",
  "reqwest",
  "rusqlite",
  "rust_decimal",
+ "rustls 0.23.40",
+ "rustls-pki-types",
  "rustyline",
  "serde",
  "serde_json",
@@ -1825,6 +1860,8 @@ dependencies = [
  "tower-http",
  "urlencoding",
  "uuid",
+ "webpki-root-certs",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1887,6 +1924,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,50 +1949,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.113",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2310,6 +2312,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redis"
 version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,16 +2415,16 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2417,12 +2432,13 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2507,6 +2523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,12 +2545,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2563,48 +2644,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "serde"
@@ -2898,19 +2957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tempfile"
-version = "3.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,16 +3093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3116,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
 ]
 
 [[package]]
@@ -3511,6 +3557,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3891,10 +3952,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fd-lock"
 version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +966,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1353,17 +1374,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.24.2"
+name = "hyper-tls"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "futures-util",
- "http 0.2.12",
+ "bytes",
  "hyper 0.14.32",
- "rustls 0.21.12",
+ "native-tls",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1764,6 +1784,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,7 +1880,7 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "rust_decimal",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "rustyline",
  "serde",
@@ -1949,6 +1986,50 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2415,16 +2496,16 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2432,13 +2513,12 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -2546,18 +2626,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -2565,7 +2633,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2586,16 +2654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -2644,26 +2702,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -2957,6 +3037,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,6 +3186,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-postgres"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,16 +3219,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
 ]
 
 [[package]]
@@ -3564,12 +3657,6 @@ checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,13 @@ lazy_static = "1.4"
 urlencoding = "2.1"
 
 # HTTP Client
-reqwest = { version = "0.11", features = ["blocking", "json", "multipart", "cookies"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "multipart", "cookies", "rustls-tls"] }
+
+# TLS certificate inspection
+rustls = { version = "0.23", default-features = false, features = ["std", "ring", "tls12"] }
+rustls-pki-types = "1"
+webpki-root-certs = "1"
+x509-parser = "0.18"
 
 # HTTP Server (Axum + Tokio for high-concurrency in production)
 tokio = { version = "1", features = ["full"] }
@@ -100,8 +106,9 @@ serde_json = "1.0"
 [dev-dependencies]
 pretty_assertions = "1.4"
 serde_json = "1.0"
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
 libc = "0.2"
+rcgen = "0.13"
 
 [[bin]]
 name = "ntnt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ lazy_static = "1.4"
 urlencoding = "2.1"
 
 # HTTP Client
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "multipart", "cookies", "rustls-tls"] }
+reqwest = { version = "0.11", features = ["blocking", "json", "multipart", "cookies"] }
 
 # TLS certificate inspection
 rustls = { version = "0.23", default-features = false, features = ["std", "ring", "tls12"] }
@@ -106,7 +106,7 @@ serde_json = "1.0"
 [dev-dependencies]
 pretty_assertions = "1.4"
 serde_json = "1.0"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11", features = ["blocking"] }
 libc = "0.2"
 rcgen = "0.13"
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -91,7 +91,7 @@ As of the v0.4.9 baseline:
 
 4. **Synchronous first, honest about it.** Current stdlib native functions are synchronous. Do not claim async/non-blocking behavior unless the implementation actually has an async execution model. Long-running checks belong in `std/jobs` or `std/concurrent`, not inline in latency-sensitive route handlers.
 
-5. **No shellouts.** The implementation should not invoke `ping`, `dig`, `nmap`, `openssl`, `whois`, or `ssh`. If a capability requires a large/privileged dependency, defer it rather than pretending it is simple.
+5. **No shellouts.** The implementation should not invoke external command-line network tools. If a capability requires a large/privileged dependency, defer it rather than pretending it is simple.
 
 6. **No permission hell, no silent protocol switch.** Default APIs should not require root, `CAP_NET_RAW`, Docker `cap_add`, or sysctl tuning. If ICMP is unavailable in the current runtime, `ping()` should return a clear `Err(String)` rather than quietly trying TCP ports. TCP reachability is available as an explicit developer choice through `tcp_connect()`, or through `reachable()` when the app intentionally wants high-level reachability semantics with default TCP 80/443 plus optional extra `tcp_ports`.
 
@@ -740,10 +740,9 @@ Ok(map {
 })
 ```
 
-Implementation decision required before coding:
+Implementation decision:
 
-- Either use `native-tls` / platform cert store and an X.509 parser, or explicitly add `rustls`, roots, and `x509-parser`.
-- Do not claim `rustls` is already available via `reqwest`; current dependency state does not justify that.
+- Use `rustls`, roots, and `x509-parser`.
 
 Tests:
 
@@ -850,8 +849,6 @@ Acceptance:
 
 ### PR 3 — Bounded port scan
 
-Status: **implemented on `feat/std-net-port-scan`; pending PR review.**
-
 Scope:
 
 - [x] `port_scan` over explicit port arrays
@@ -868,16 +865,16 @@ Acceptance:
 
 Scope:
 
-- [ ] dependency choice
-- [ ] `tls_info`
-- [ ] local TLS test server
-- [ ] generated docs and examples
+- [x] Rustls-based TLS connection and certificate validation
+- [x] `tls_info`
+- [x] local TLS test server
+- [x] generated docs and examples
 
 Acceptance:
 
-- [ ] returns certificate details for valid and validation-failing certs
-- [ ] no dependency claim mismatch
-- [ ] no public internet dependency by default
+- [x] returns certificate details for valid and validation-failing certs
+- [x] no dependency claim mismatch
+- [x] no public internet dependency by default
 
 ---
 
@@ -954,9 +951,9 @@ For network-specific PRs:
 
    Recommendation: no. Start with explicit arrays; add ranges only after runtime/typechecker handling is confirmed.
 
-5. Should TLS inspection use `native-tls` or `rustls`?
+5. Should TLS inspection use Rustls?
 
-   Recommendation: decide in the TLS PR based on cert-chain extraction quality and dependency weight. Do not block IP/TCP/DNS on this.
+   Decision: yes. `tls_info` uses Rustls for the TLS connection and validation probe, while keeping metadata extraction available for diagnostic failures.
 
 6. Should `ping()` mean strict ICMP or pragmatic reachability?
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -972,10 +972,10 @@ Both `fetch(map { "url": url, ... })` and `fetch(url, map { ... })` work. The tw
 
 ### Network/IPAM Helpers (`std/net`)
 
-`std/net` provides deterministic IPv4/IPv6 CIDR helpers, protocol-honest ICMP ping, explicit TCP connect probes, bounded port scans, high-level reachability, and DNS lookups:
+`std/net` provides deterministic IPv4/IPv6 CIDR helpers, protocol-honest ICMP ping, explicit TCP connect probes, bounded port scans, high-level reachability, DNS lookups, and TLS certificate inspection:
 
 ```ntnt
-import { ip_parse, subnet_contains, subnet_split, subnet_summarize, tcp_connect, port_scan, reachable, dns_lookup, dns_reverse } from "std/net"
+import { ip_parse, subnet_contains, subnet_split, subnet_summarize, tcp_connect, port_scan, reachable, dns_lookup, dns_reverse, tls_info } from "std/net"
 
 let info = unwrap(ip_parse("192.168.1.0/24"))
 let contains = unwrap(subnet_contains("10.0.0.0/8", "10.42.0.0/16"))
@@ -986,6 +986,7 @@ let ports = unwrap(port_scan("example.com", [80, 443], map { "timeout_ms": 500 }
 let reachability = unwrap(reachable("example.com", map { "tcp_ports": [8080] }))
 let records = unwrap(dns_lookup("example.com", "A"))
 let ptr_names = unwrap(dns_reverse("8.8.8.8"))
+let cert = unwrap(tls_info("example.com"))
 ```
 
 These helpers return `Result<..., String>`; use `unwrap(...)` for quick scripts/examples, or `match`/`otherwise` when the app should handle invalid input or policy denial.
@@ -1025,6 +1026,17 @@ let ptr_names = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
 ```
 
 When passing `dns_lookup` options, include the record type explicitly: `dns_lookup(name, "A", opts)`. The shorter `dns_lookup(name)` form defaults to `A`; `dns_lookup(name, opts)` is intentionally rejected so the call shape stays unambiguous.
+
+`tls_info(host, opts?)` opens a bounded TLS connection, returns the peer certificate metadata, and separately reports validation status. The result includes `subject`, `issuer`, common names, RFC3339 `not_before`/`not_after`, `days_left`, `san`, `serial`, `signature_algorithm`, `protocol`, `cipher`, `chain_len`, `valid`, and `validation_error`. Use `server_name` to override SNI/hostname verification when connecting by IP, and `port` for non-443 services:
+
+```ntnt
+let cert = tls_info("example.com", map { "timeout_ms": 1000 })
+let by_ip = tls_info("93.184.216.34", map {
+    "server_name": "example.com",
+    "port": 443,
+    "timeout_ms": 1000
+})
+```
 
 Private/internal targets are denied by default. Monitoring apps must opt in at process scope **and** call scope:
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -975,7 +975,7 @@ Both `fetch(map { "url": url, ... })` and `fetch(url, map { ... })` work. The tw
 `std/net` provides deterministic IPv4/IPv6 CIDR helpers, protocol-honest ICMP ping, explicit TCP connect probes, bounded port scans, high-level reachability, DNS lookups, and TLS certificate inspection:
 
 ```ntnt
-import { ip_parse, subnet_contains, subnet_split, subnet_summarize, tcp_connect, port_scan, reachable, dns_lookup, dns_reverse, tls_info } from "std/net"
+import { ip_parse, subnet_contains, subnet_split, subnet_summarize, tcp_connect, port_scan, reachable, dns_lookup, dns_reverse } from "std/net"
 
 let info = unwrap(ip_parse("192.168.1.0/24"))
 let contains = unwrap(subnet_contains("10.0.0.0/8", "10.42.0.0/16"))
@@ -986,7 +986,8 @@ let ports = unwrap(port_scan("example.com", [80, 443], map { "timeout_ms": 500 }
 let reachability = unwrap(reachable("example.com", map { "tcp_ports": [8080] }))
 let records = unwrap(dns_lookup("example.com", "A"))
 let ptr_names = unwrap(dns_reverse("8.8.8.8"))
-let cert = unwrap(tls_info("example.com"))
+// TLS inspection performs a network connection; use it in opt-in examples.
+// let cert = unwrap(tls_info("example.com"))
 ```
 
 These helpers return `Result<..., String>`; use `unwrap(...)` for quick scripts/examples, or `match`/`otherwise` when the app should handle invalid input or policy denial.

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -9707,6 +9707,7 @@ import { ip_parse, subnet_contains, subnet_overlaps } from "std/net"
 | [`subnet_summarize`](#subnetsummarize) | Summarizes adjacent or overlapping CIDRs into the shortest equivalent route list. |
 | [`subnet_supernet`](#subnetsupernet) | Returns the parent/supernet of a CIDR. Defaults to one bit shorter. |
 | [`tcp_connect`](#tcpconnect) | Performs a bounded TCP connect probe to one explicit port. Closed, refused, or timed-out ports return Ok(map { "connected": false, ... }); invalid input, policy denial, and resolver/system failures return Err(String). |
+| [`tls_info`](#tlsinfo) | Opens a bounded TLS connection and returns certificate metadata. Validation failures still return Ok(map { "valid": false, ... }) when a certificate is available. |
 
 #### `dns_lookup`
 
@@ -9938,6 +9939,31 @@ Performs a bounded TCP connect probe to one explicit port. Closed, refused, or t
 
 ```ntnt
 tcp_connect("example.com", 443)  // Check whether TCP 443 accepts connections
+```
+
+*Since v0.4.10*
+
+---
+
+#### `tls_info`
+
+```ntnt
+tls_info(host: String, opts?: Map) -> Result<Map, String>
+```
+
+Opens a bounded TLS connection and returns certificate metadata. Validation failures still return Ok(map { "valid": false, ... }) when a certificate is available.
+
+**Parameters:**
+
+- `host` — Hostname or IP address to connect to
+- `opts` — Optional map with port, timeout_ms, server_name, and allow_private
+
+**Returns:** Result containing certificate subject, issuer, validity window, SANs, serial, protocol, and validation status
+
+**Examples:**
+
+```ntnt
+tls_info("example.com")  // Inspect the HTTPS certificate for example.com
 ```
 
 *Since v0.4.10*

--- a/examples/std_net_tls.tnt
+++ b/examples/std_net_tls.tnt
@@ -1,0 +1,31 @@
+// std/net TLS certificate inspection example
+//
+// Public TLS connections are opt-in so default example validation/runs stay offline-safe.
+// Run with: NTNT_NET_TLS_EXAMPLES=1 ntnt run examples/std_net_tls.tnt
+
+import { tls_info } from "std/net"
+import { get_env } from "std/env"
+
+match get_env("NTNT_NET_TLS_EXAMPLES") {
+    Some(value) => {
+        if value != "1" {
+            print("Set NTNT_NET_TLS_EXAMPLES=1 to inspect example.com TLS metadata")
+            return
+        }
+    },
+    None => {
+        print("Set NTNT_NET_TLS_EXAMPLES=1 to inspect example.com TLS metadata")
+        return
+    }
+}
+
+match tls_info("example.com", map { "timeout_ms": 2000 }) {
+    Ok(info) => {
+        print("subject=" + info["subject"])
+        print("issuer=" + info["issuer"])
+        print("valid=" + str(info["valid"]))
+        print("days_left=" + str(info["days_left"]))
+        print("protocol=" + info["protocol"])
+    },
+    Err(e) => print("error=" + e)
+}

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -2,18 +2,27 @@
 
 use crate::error::IntentError;
 use crate::interpreter::Value;
+use chrono::{DateTime, SecondsFormat, Utc};
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::error::{ResolveError, ResolveErrorKind};
 use hickory_resolver::proto::rr::RecordType;
 use hickory_resolver::Resolver;
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::{
+    ClientConfig, ClientConnection, DigitallySignedStruct, RootCertStore, SignatureScheme,
+};
+use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
 #[cfg(target_os = "linux")]
 use std::process::Command;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
+use x509_parser::extensions::GeneralName;
+use x509_parser::prelude::*;
 
 const DEFAULT_MAX_RESULTS: usize = 4096;
 const HARD_MAX_RESULTS: usize = 65_536;
@@ -468,6 +477,28 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt tls_info
+    // @module std/net
+    // @signature tls_info(host: String, opts?: Map) -> Result<Map, String>
+    // Opens a bounded TLS connection and returns certificate metadata. Validation
+    // failures still return Ok(map { "valid": false, ... }) when a certificate is available.
+    // @param host Hostname or IP address to connect to
+    // @param opts Optional map with port, timeout_ms, server_name, and allow_private
+    // @returns Result containing certificate subject, issuer, validity window, SANs, serial, protocol, and validation status
+    // @since v0.4.10
+    // @tags #network
+    // @example tls_info("example.com") ~ "Inspect the HTTPS certificate for example.com"
+    module.insert(
+        "tls_info".to_string(),
+        Value::NativeFunction {
+            name: "tls_info".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: tls_info_fn,
+        },
+    );
+
     module
 }
 
@@ -836,6 +867,305 @@ fn dns_reverse_fn(args: &[Value]) -> Result<Value, IntentError> {
         let names = dns_reverse_names(&resolver, ip)?;
         Ok(Value::Array(names.into_iter().map(Value::String).collect()))
     })()))
+}
+
+fn tls_info_fn(args: &[Value]) -> Result<Value, IntentError> {
+    let host = string_arg(args, 0, "tls_info")?;
+    let opts = opts_arg(args, 1, "tls_info")?;
+
+    Ok(result_value((|| {
+        let port = parse_tls_port(opts)?;
+        let timeout_ms = parse_u64_option(opts, "timeout_ms", DEFAULT_TIMEOUT_MS)?
+            .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
+        let server_name = parse_string_option(opts, "server_name")?.unwrap_or(host);
+        let allow_private = parse_bool_option(opts, "allow_private", false)?;
+        let targets = resolve_tcp_targets(host, &[port])?;
+        enforce_resolved_target_policy(&targets, allow_private)?;
+        let mut last_error = None;
+        for (_, addr) in targets {
+            match tls_info_for_addr(
+                host,
+                server_name,
+                port,
+                addr,
+                Duration::from_millis(timeout_ms),
+            ) {
+                Ok(info) => return Ok(Value::Map(info)),
+                Err(err) => last_error = Some(err),
+            }
+        }
+        Err(last_error.unwrap_or_else(|| format!("failed to resolve {}:{}", host, port)))
+    })()))
+}
+
+#[derive(Debug)]
+struct MetadataVerifier;
+
+impl ServerCertVerifier for MetadataVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::ED25519,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+        ]
+    }
+}
+
+fn tls_info_for_addr(
+    host: &str,
+    server_name: &str,
+    port: u16,
+    addr: SocketAddr,
+    timeout: Duration,
+) -> Result<HashMap<String, Value>, String> {
+    let metadata_config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(MetadataVerifier))
+        .with_no_client_auth();
+    let metadata = connect_tls(
+        host,
+        server_name,
+        port,
+        addr,
+        timeout,
+        Arc::new(metadata_config),
+    )?;
+
+    let cert = metadata
+        .certificates
+        .first()
+        .ok_or_else(|| format!("TLS peer {}:{} did not present a certificate", host, port))?;
+    let mut result = tls_cert_to_map(cert.as_ref())?;
+    result.insert("host".to_string(), Value::String(host.to_string()));
+    result.insert(
+        "server_name".to_string(),
+        Value::String(server_name.to_string()),
+    );
+    result.insert("port".to_string(), Value::Int(port as i64));
+    result.insert("remote_addr".to_string(), Value::String(addr.to_string()));
+    result.insert("local_addr".to_string(), Value::String(metadata.local_addr));
+    result.insert("protocol".to_string(), Value::String(metadata.protocol));
+    result.insert("cipher".to_string(), Value::String(metadata.cipher));
+    result.insert(
+        "chain_len".to_string(),
+        Value::Int(metadata.certificates.len() as i64),
+    );
+
+    let validation_error = match verified_tls_config() {
+        Ok(config) => connect_tls(host, server_name, port, addr, timeout, Arc::new(config))
+            .err()
+            .map(|err| validation_probe_error(&err)),
+        Err(e) => Some(format!("certificate validation unavailable: {}", e)),
+    };
+    let valid = validation_error.is_none();
+    result.insert("valid".to_string(), Value::Bool(valid));
+    result.insert(
+        "validation_error".to_string(),
+        validation_error.map_or_else(Value::none, Value::String),
+    );
+
+    Ok(result)
+}
+
+struct TlsConnectionMetadata {
+    local_addr: String,
+    protocol: String,
+    cipher: String,
+    certificates: Vec<CertificateDer<'static>>,
+}
+
+fn verified_tls_config() -> Result<ClientConfig, String> {
+    let mut roots = RootCertStore::empty();
+    let (added, _) =
+        roots.add_parsable_certificates(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned());
+    if added == 0 {
+        return Err("no TLS trust roots available".to_string());
+    }
+    Ok(ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth())
+}
+
+fn validation_probe_error(err: &str) -> String {
+    let lower = err.to_ascii_lowercase();
+    if lower.contains("certificate") || lower.contains("cert") || lower.contains("unknownissuer") {
+        format!("certificate validation failed: {}", err)
+    } else {
+        format!("TLS validation probe failed: {}", err)
+    }
+}
+
+fn connect_tls(
+    host: &str,
+    server_name: &str,
+    port: u16,
+    addr: SocketAddr,
+    timeout: Duration,
+    config: Arc<ClientConfig>,
+) -> Result<TlsConnectionMetadata, String> {
+    let name = ServerName::try_from(server_name.to_string()).map_err(|_| {
+        format!(
+            "tls_info() server_name must be a valid DNS name or IP address, got {}",
+            server_name
+        )
+    })?;
+    let mut stream = TcpStream::connect_timeout(&addr, timeout)
+        .map_err(|e| format!("TLS TCP connect failed for {}:{}: {}", host, port, e))?;
+    stream
+        .set_read_timeout(Some(timeout))
+        .map_err(|e| format!("failed to set TLS read timeout: {}", e))?;
+    stream
+        .set_write_timeout(Some(timeout))
+        .map_err(|e| format!("failed to set TLS write timeout: {}", e))?;
+    let local_addr = stream
+        .local_addr()
+        .map(|addr| addr.to_string())
+        .unwrap_or_default();
+    let mut conn = ClientConnection::new(config, name)
+        .map_err(|e| format!("failed to create TLS client: {}", e))?;
+    let deadline = Instant::now() + timeout;
+    while conn.is_handshaking() {
+        conn.complete_io(&mut stream)
+            .map_err(|e| format!("TLS handshake failed for {}:{}: {}", host, port, e))?;
+        if Instant::now() >= deadline {
+            return Err(format!("TLS handshake timed out for {}:{}", host, port));
+        }
+    }
+
+    Ok(TlsConnectionMetadata {
+        local_addr,
+        protocol: conn
+            .protocol_version()
+            .map(|version| format!("{:?}", version))
+            .unwrap_or_else(|| "unknown".to_string()),
+        cipher: conn
+            .negotiated_cipher_suite()
+            .map(|suite| format!("{:?}", suite.suite()))
+            .unwrap_or_else(|| "unknown".to_string()),
+        certificates: conn.peer_certificates().unwrap_or(&[]).to_vec(),
+    })
+}
+
+fn tls_cert_to_map(cert_der: &[u8]) -> Result<HashMap<String, Value>, String> {
+    let (_, cert) = X509Certificate::from_der(cert_der)
+        .map_err(|e| format!("failed to parse TLS certificate: {}", e))?;
+    let mut map = HashMap::new();
+    let subject = cert.subject().to_string();
+    let issuer = cert.issuer().to_string();
+    map.insert("subject".to_string(), Value::String(subject));
+    map.insert("issuer".to_string(), Value::String(issuer));
+    map.insert(
+        "subject_common_name".to_string(),
+        x509_common_name(cert.subject()).map_or_else(Value::none, Value::String),
+    );
+    map.insert(
+        "issuer_common_name".to_string(),
+        x509_common_name(cert.issuer()).map_or_else(Value::none, Value::String),
+    );
+    map.insert(
+        "not_before".to_string(),
+        Value::String(asn1_time_to_rfc3339(cert.validity().not_before.timestamp())),
+    );
+    map.insert(
+        "not_after".to_string(),
+        Value::String(asn1_time_to_rfc3339(cert.validity().not_after.timestamp())),
+    );
+    let now = Utc::now().timestamp();
+    let days_left = ((cert.validity().not_after.timestamp() - now) / 86_400).max(0);
+    map.insert("days_left".to_string(), Value::Int(days_left));
+    map.insert(
+        "serial".to_string(),
+        Value::String(cert.raw_serial_as_string()),
+    );
+    map.insert(
+        "signature_algorithm".to_string(),
+        Value::String(cert.signature_algorithm.algorithm.to_string()),
+    );
+    map.insert(
+        "san".to_string(),
+        Value::Array(
+            cert_subject_alt_names(&cert)
+                .into_iter()
+                .map(Value::String)
+                .collect(),
+        ),
+    );
+    Ok(map)
+}
+
+fn x509_common_name(name: &X509Name<'_>) -> Option<String> {
+    name.iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .map(str::to_string)
+}
+
+fn cert_subject_alt_names(cert: &X509Certificate<'_>) -> Vec<String> {
+    let Ok(Some(san)) = cert.subject_alternative_name() else {
+        return Vec::new();
+    };
+    san.value
+        .general_names
+        .iter()
+        .filter_map(|name| match name {
+            GeneralName::DNSName(value) => Some((*value).to_string()),
+            GeneralName::IPAddress(bytes) => ip_address_from_san(bytes),
+            _ => None,
+        })
+        .collect()
+}
+
+fn ip_address_from_san(bytes: &[u8]) -> Option<String> {
+    match bytes.len() {
+        4 => Some(Ipv4Addr::new(bytes[0], bytes[1], bytes[2], bytes[3]).to_string()),
+        16 => {
+            let mut octets = [0u8; 16];
+            octets.copy_from_slice(bytes);
+            Some(Ipv6Addr::from(octets).to_string())
+        }
+        _ => None,
+    }
+}
+
+fn asn1_time_to_rfc3339(timestamp: i64) -> String {
+    DateTime::<Utc>::from_timestamp(timestamp, 0)
+        .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Secs, true))
+        .unwrap_or_else(|| timestamp.to_string())
 }
 
 fn dns_lookup_args(args: &[Value]) -> Result<(&str, Option<&HashMap<String, Value>>), IntentError> {
@@ -2003,6 +2333,32 @@ fn parse_bool_option(
         Some(other) => Err(format!(
             "option '{}' must be Bool, got {}",
             key,
+            other.type_name()
+        )),
+    }
+}
+
+fn parse_string_option<'a>(
+    opts: Option<&'a HashMap<String, Value>>,
+    key: &str,
+) -> Result<Option<&'a str>, String> {
+    match opts.and_then(|m| m.get(key)) {
+        None => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.as_str())),
+        Some(other) => Err(format!(
+            "option '{}' must be String, got {}",
+            key,
+            other.type_name()
+        )),
+    }
+}
+
+fn parse_tls_port(opts: Option<&HashMap<String, Value>>) -> Result<u16, String> {
+    match opts.and_then(|m| m.get("port")) {
+        None => Ok(443),
+        Some(Value::Int(port)) => validate_tcp_port_arg(*port, "tls_info"),
+        Some(other) => Err(format!(
+            "option 'port' must be Int, got {}",
             other.type_name()
         )),
     }

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -8,6 +8,7 @@ use hickory_resolver::error::{ResolveError, ResolveErrorKind};
 use hickory_resolver::proto::rr::RecordType;
 use hickory_resolver::Resolver;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::client::WebPkiServerVerifier;
 use rustls::{
     ClientConfig, ClientConnection, DigitallySignedStruct, RootCertStore, SignatureScheme,
 };
@@ -881,20 +882,21 @@ fn tls_info_fn(args: &[Value]) -> Result<Value, IntentError> {
         let allow_private = parse_bool_option(opts, "allow_private", false)?;
         let targets = resolve_tcp_targets(host, &[port])?;
         enforce_resolved_target_policy(&targets, allow_private)?;
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms);
         let mut last_error = None;
         for (_, addr) in targets {
-            match tls_info_for_addr(
-                host,
-                server_name,
-                port,
-                addr,
-                Duration::from_millis(timeout_ms),
-            ) {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                break;
+            };
+            if remaining.is_zero() {
+                break;
+            }
+            match tls_info_for_addr(host, server_name, port, addr, remaining) {
                 Ok(info) => return Ok(Value::Map(info)),
                 Err(err) => last_error = Some(err),
             }
         }
-        Err(last_error.unwrap_or_else(|| format!("failed to resolve {}:{}", host, port)))
+        Err(last_error.unwrap_or_else(|| format!("TLS inspection timed out for {}:{}", host, port)))
     })()))
 }
 
@@ -986,12 +988,7 @@ fn tls_info_for_addr(
         Value::Int(metadata.certificates.len() as i64),
     );
 
-    let validation_error = match verified_tls_config() {
-        Ok(config) => connect_tls(host, server_name, port, addr, timeout, Arc::new(config))
-            .err()
-            .map(|err| validation_probe_error(&err)),
-        Err(e) => Some(format!("certificate validation unavailable: {}", e)),
-    };
+    let validation_error = verify_certificate_chain(server_name, &metadata.certificates)?;
     let valid = validation_error.is_none();
     result.insert("valid".to_string(), Value::Bool(valid));
     result.insert(
@@ -1009,25 +1006,38 @@ struct TlsConnectionMetadata {
     certificates: Vec<CertificateDer<'static>>,
 }
 
-fn verified_tls_config() -> Result<ClientConfig, String> {
+fn tls_root_store() -> Result<RootCertStore, String> {
     let mut roots = RootCertStore::empty();
     let (added, _) =
         roots.add_parsable_certificates(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned());
     if added == 0 {
         return Err("no TLS trust roots available".to_string());
     }
-    Ok(ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth())
+    Ok(roots)
 }
 
-fn validation_probe_error(err: &str) -> String {
-    let lower = err.to_ascii_lowercase();
-    if lower.contains("certificate") || lower.contains("cert") || lower.contains("unknownissuer") {
-        format!("certificate validation failed: {}", err)
-    } else {
-        format!("TLS validation probe failed: {}", err)
-    }
+fn verify_certificate_chain(
+    server_name: &str,
+    certificates: &[CertificateDer<'static>],
+) -> Result<Option<String>, String> {
+    let Some((end_entity, intermediates)) = certificates.split_first() else {
+        return Ok(Some(
+            "certificate validation failed: peer did not present a certificate".to_string(),
+        ));
+    };
+    let name = ServerName::try_from(server_name.to_string()).map_err(|_| {
+        format!(
+            "tls_info() server_name must be a valid DNS name or IP address, got {}",
+            server_name
+        )
+    })?;
+    let verifier = WebPkiServerVerifier::builder(Arc::new(tls_root_store()?))
+        .build()
+        .map_err(|e| format!("certificate validation unavailable: {}", e))?;
+    Ok(verifier
+        .verify_server_cert(end_entity, intermediates, &name, &[], UnixTime::now())
+        .err()
+        .map(|err| format!("certificate validation failed: {}", err)))
 }
 
 fn connect_tls(

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -1040,6 +1040,12 @@ fn verify_certificate_chain(
         .map(|err| format!("certificate validation failed: {}", err)))
 }
 
+fn sleep_until_tls_deadline(deadline: Instant) {
+    if let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        thread::sleep(min(remaining, Duration::from_millis(10)));
+    }
+}
+
 fn connect_tls(
     host: &str,
     server_name: &str,
@@ -1054,26 +1060,33 @@ fn connect_tls(
             server_name
         )
     })?;
+    let deadline = Instant::now() + timeout;
     let mut stream = TcpStream::connect_timeout(&addr, timeout)
         .map_err(|e| format!("TLS TCP connect failed for {}:{}: {}", host, port, e))?;
+    if Instant::now() >= deadline {
+        return Err(format!("TLS handshake timed out for {}:{}", host, port));
+    }
     stream
-        .set_read_timeout(Some(timeout))
-        .map_err(|e| format!("failed to set TLS read timeout: {}", e))?;
-    stream
-        .set_write_timeout(Some(timeout))
-        .map_err(|e| format!("failed to set TLS write timeout: {}", e))?;
+        .set_nonblocking(true)
+        .map_err(|e| format!("failed to set TLS socket nonblocking mode: {}", e))?;
     let local_addr = stream
         .local_addr()
         .map(|addr| addr.to_string())
         .unwrap_or_default();
     let mut conn = ClientConnection::new(config, name)
         .map_err(|e| format!("failed to create TLS client: {}", e))?;
-    let deadline = Instant::now() + timeout;
     while conn.is_handshaking() {
-        conn.complete_io(&mut stream)
-            .map_err(|e| format!("TLS handshake failed for {}:{}: {}", host, port, e))?;
-        if Instant::now() >= deadline {
+        let now = Instant::now();
+        if now >= deadline {
             return Err(format!("TLS handshake timed out for {}:{}", host, port));
+        }
+        match conn.complete_io(&mut stream) {
+            Ok((0, 0)) => sleep_until_tls_deadline(deadline),
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                sleep_until_tls_deadline(deadline)
+            }
+            Err(e) => return Err(format!("TLS handshake failed for {}:{}: {}", host, port, e)),
         }
     }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3821,7 +3821,8 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("reachable", ["host" => Type::String, "opts" => opts.clone()], result_map.clone(), required(1));
             sig!("port_scan", ["host" => Type::String, "ports" => Type::Array(Box::new(Type::Int)), "opts" => opts.clone()], result_map_array.clone(), required(2));
             sig!("dns_lookup", ["name" => Type::String, "record_type" => Type::String, "opts" => opts.clone()], result_map_array, required(1));
-            sig!("dns_reverse", ["ip" => Type::String, "opts" => opts], result_string_array, required(1));
+            sig!("dns_reverse", ["ip" => Type::String, "opts" => opts.clone()], result_string_array, required(1));
+            sig!("tls_info", ["host" => Type::String, "opts" => opts], result_map, required(1));
         }
         "std/path" => {
             sig!("join_path", ["parts" => Type::String], Type::String, variadic);

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -791,7 +791,7 @@ match port_scan("127.0.0.1", [9], map { "allow_private": true, "timeout_ms": 100
 
 #[test]
 fn tls_info_returns_certificate_metadata_when_validation_fails() {
-    let (port, handle) = start_local_tls_server(2);
+    let (port, handle) = start_local_tls_server(1);
     let code = format!(
         r#"
 import {{ join }} from "std/string"
@@ -820,9 +820,9 @@ match tls_info("127.0.0.1", map {{ "port": {port}, "server_name": "localhost", "
     let accepted = handle.join().expect("TLS helper should not panic");
 
     assert_eq!(exit_code, 0, "stderr: {stderr}\nstdout: {stdout}");
-    assert!(
-        accepted >= 1,
-        "TLS helper did not accept a connection; stdout: {stdout}"
+    assert_eq!(
+        accepted, 1,
+        "TLS helper did not accept the metadata connection; stdout: {stdout}"
     );
     assert!(!stdout.contains("ERR:"), "stdout: {stdout}");
     assert!(stdout.contains("localhost"), "stdout: {stdout}");

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -1,10 +1,14 @@
 //! Integration tests for std/net Phase 1 public behavior.
 
+use rcgen::generate_simple_self_signed;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::{ServerConfig, ServerConnection};
 use std::fs;
 use std::io::Write;
 use std::net::TcpListener;
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -64,6 +68,56 @@ fn run_ntnt_code_with_env(code: &str, envs: &[(&str, &str)]) -> (String, String,
         String::from_utf8_lossy(&output.stderr).to_string(),
         output.status.code().unwrap_or(-1),
     )
+}
+
+fn start_local_tls_server(expected_connections: usize) -> (u16, std::thread::JoinHandle<usize>) {
+    let certified = generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("generate local TLS certificate");
+    let cert = CertificateDer::from(certified.cert.der().to_vec());
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(certified.key_pair.serialize_der()));
+    let config = Arc::new(
+        ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .expect("build local TLS server config"),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local TLS listener");
+    listener
+        .set_nonblocking(true)
+        .expect("make local TLS listener nonblocking");
+    let port = listener.local_addr().unwrap().port();
+
+    let handle = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut completed = 0;
+        while completed < expected_connections && Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+                    let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+                    let Ok(mut conn) = ServerConnection::new(config.clone()) else {
+                        continue;
+                    };
+                    while conn.is_handshaking() && Instant::now() < deadline {
+                        match conn.complete_io(&mut stream) {
+                            Ok(_) => {}
+                            Err(_) => break,
+                        }
+                    }
+                    if !conn.is_handshaking() {
+                        completed += 1;
+                    }
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => break,
+            }
+        }
+        completed
+    });
+
+    (port, handle)
 }
 
 #[test]
@@ -724,6 +778,73 @@ fn port_scan_private_target_requires_process_level_opt_in() {
 import { port_scan } from "std/net"
 
 match port_scan("127.0.0.1", [9], map { "allow_private": true, "timeout_ms": 100 }) {
+    Ok(info) => print("unexpected"),
+    Err(e) => print(e)
+}
+"#,
+    );
+
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("private targets require NTNT_NET_ALLOW_PRIVATE=1"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn tls_info_returns_certificate_metadata_when_validation_fails() {
+    let (port, handle) = start_local_tls_server(2);
+    let code = format!(
+        r#"
+import {{ join }} from "std/string"
+import {{ tls_info }} from "std/net"
+
+match tls_info("127.0.0.1", map {{ "port": {port}, "server_name": "localhost", "allow_private": true, "timeout_ms": 2000 }}) {{
+    Ok(info) => {{
+        print(info["subject"])
+        print(info["issuer"])
+        print(info["subject_common_name"])
+        print(info["not_before"])
+        print(info["not_after"])
+        print(join(info["san"], ","))
+        print(info["valid"])
+        print(info["validation_error"])
+        print(info["protocol"])
+        print(info["cipher"])
+    }},
+    Err(e) => print("ERR:" + e)
+}}
+"#
+    );
+
+    let (stdout, stderr, exit_code) =
+        run_ntnt_code_with_env(&code, &[("NTNT_NET_ALLOW_PRIVATE", "1")]);
+    let completed = handle.join().expect("TLS helper should not panic");
+
+    assert_eq!(exit_code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        completed >= 1,
+        "TLS helper did not complete a handshake; stdout: {stdout}"
+    );
+    assert!(!stdout.contains("ERR:"), "stdout: {stdout}");
+    assert!(stdout.contains("localhost"), "stdout: {stdout}");
+    assert!(stdout.contains("T"), "stdout: {stdout}");
+    assert!(stdout.contains("Z"), "stdout: {stdout}");
+    assert!(stdout.contains("false"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("certificate validation failed"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("TLS"), "stdout: {stdout}");
+}
+
+#[test]
+fn tls_info_private_target_requires_process_level_opt_in() {
+    let (stdout, stderr, code) = run_ntnt_code(
+        r#"
+import { tls_info } from "std/net"
+
+match tls_info("127.0.0.1", map { "allow_private": true, "timeout_ms": 100 }) {
     Ok(info) => print("unexpected"),
     Err(e) => print(e)
 }

--- a/tests/std_net_tests.rs
+++ b/tests/std_net_tests.rs
@@ -89,10 +89,11 @@ fn start_local_tls_server(expected_connections: usize) -> (u16, std::thread::Joi
 
     let handle = std::thread::spawn(move || {
         let deadline = Instant::now() + Duration::from_secs(5);
-        let mut completed = 0;
-        while completed < expected_connections && Instant::now() < deadline {
+        let mut accepted = 0;
+        while accepted < expected_connections && Instant::now() < deadline {
             match listener.accept() {
                 Ok((mut stream, _)) => {
+                    accepted += 1;
                     let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
                     let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
                     let Ok(mut conn) = ServerConnection::new(config.clone()) else {
@@ -104,9 +105,6 @@ fn start_local_tls_server(expected_connections: usize) -> (u16, std::thread::Joi
                             Err(_) => break,
                         }
                     }
-                    if !conn.is_handshaking() {
-                        completed += 1;
-                    }
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
                     std::thread::sleep(Duration::from_millis(10));
@@ -114,7 +112,7 @@ fn start_local_tls_server(expected_connections: usize) -> (u16, std::thread::Joi
                 Err(_) => break,
             }
         }
-        completed
+        accepted
     });
 
     (port, handle)
@@ -819,12 +817,12 @@ match tls_info("127.0.0.1", map {{ "port": {port}, "server_name": "localhost", "
 
     let (stdout, stderr, exit_code) =
         run_ntnt_code_with_env(&code, &[("NTNT_NET_ALLOW_PRIVATE", "1")]);
-    let completed = handle.join().expect("TLS helper should not panic");
+    let accepted = handle.join().expect("TLS helper should not panic");
 
     assert_eq!(exit_code, 0, "stderr: {stderr}\nstdout: {stdout}");
     assert!(
-        completed >= 1,
-        "TLS helper did not complete a handshake; stdout: {stdout}"
+        accepted >= 1,
+        "TLS helper did not accept a connection; stdout: {stdout}"
     );
     assert!(!stdout.contains("ERR:"), "stdout: {stdout}");
     assert!(stdout.contains("localhost"), "stdout: {stdout}");

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1096,7 +1096,7 @@ let x: Int = first([1, 2, 3])
 #[test]
 fn test_std_net_phase1_signatures_accept_valid_usage() {
     let source = r#"
-import { ip_parse, subnet_contains, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs, ping, tcp_connect, reachable, port_scan, dns_lookup, dns_reverse } from "std/net"
+import { ip_parse, subnet_contains, subnet_split, subnet_supernet, subnet_summarize, ip_range_to_cidrs, ping, tcp_connect, reachable, port_scan, dns_lookup, dns_reverse, tls_info } from "std/net"
 
 let parsed = ip_parse("192.168.1.0/24")
 let contains = subnet_contains("10.0.0.0/8", "10.1.0.0/16")
@@ -1112,6 +1112,7 @@ let scan = port_scan("example.com", [80, 443], map { "timeout_ms": 1000, "concur
 let dns = dns_lookup("example.com", "A", map { "timeout_ms": 1000 })
 let mx_dns = dns_lookup("example.com", "MX", map { "timeout_ms": 1000 })
 let reverse_dns = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
+let cert = tls_info("example.com", map { "port": 443, "timeout_ms": 1000, "server_name": "example.com" })
 "#;
     let (stdout, _stderr, _exit_code) = lint_code(source);
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
@@ -1125,12 +1126,13 @@ let reverse_dns = dns_reverse("8.8.8.8", map { "timeout_ms": 1000 })
 #[test]
 fn test_std_net_phase1_signatures_reject_wrong_argument_types() {
     let source = r#"
-import { subnet_split, ping, port_scan, dns_lookup } from "std/net"
+import { subnet_split, ping, port_scan, dns_lookup, tls_info } from "std/net"
 
 let split = subnet_split("192.168.1.0/24", "28")
 let reachability = ping(123)
 let scan = port_scan("example.com", ["80"])
-let dns = dns_lookup("example.com", map { "timeout_ms": 1000 })
+let dns = dns_lookup("example.com", 123)
+let cert = tls_info(443)
 "#;
     let (stdout, _stderr, exit_code) = lint_code(source);
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();


### PR DESCRIPTION
## Summary
- Adds `std/net.tls_info(host, opts?)` for bounded TLS certificate inspection.
- Returns certificate subject/issuer details, common names, SANs, validity timestamps, days remaining, serial, signature algorithm, TLS protocol/cipher, chain length, and validation status.
- Keeps private/special target policy aligned with the rest of `std/net`.
- Adds local TLS fixture coverage, typechecker coverage, generated stdlib docs, AI guide docs, and an opt-in public example.

## Verification
- `cargo test --locked`
- `cargo build --profile dev-release --locked`
- `./target/dev-release/ntnt docs --generate`
- `./target/dev-release/ntnt validate examples/`
- `./target/dev-release/ntnt lint examples/`
- `./target/dev-release/ntnt validate examples/std_net_tls.tnt`
- `./target/dev-release/ntnt lint examples/std_net_tls.tnt`
- `NTNT_NET_TLS_EXAMPLES=1 ./target/dev-release/ntnt run examples/std_net_tls.tnt`
- `git diff --check`
- independent cold review
