### PR TITLE
refactor(std-net): add probe backend foundation

### DIFF
--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -3,7 +3,7 @@
 **Status:** Complete — shipped across PRs [#113](https://github.com/ntntlang/ntnt/pull/113), [#114](https://github.com/ntntlang/ntnt/pull/114), [#115](https://github.com/ntntlang/ntnt/pull/115), and [#117](https://github.com/ntntlang/ntnt/pull/117)
 **Author:** Larri
 **Created:** 2026-03-22
-**Updated:** 2026-06-07
+**Updated:** 2026-06-08
 **Target baseline:** v0.4.10 (`std/net` track)
 
 ---
@@ -12,7 +12,7 @@
 
 Add a focused `std/net` module for safe, bounded network primitives: IP/CIDR utilities, first-shot host reachability checks, TCP connectivity probes, DNS lookup, limited port scanning, and TLS certificate inspection.
 
-This is **not** a grab-bag for every network-adjacent operation. The first version should make common monitoring and diagnostics possible without shelling out, while preserving ntnt's safety posture for apps that run on the public web.
+This is **not** a grab-bag for every network-adjacent operation. The first version made common monitoring and diagnostics possible while preserving ntnt's safety posture for apps that run on the public web. The next version should replace the tactical Linux `ping` bridge with a Rust-native probe backend that can support ICMP ping, traceroute, and richer TCP/UDP probes without depending on external binaries.
 
 Initial scope:
 
@@ -32,7 +32,7 @@ Initial scope:
 
 Explicitly deferred:
 
-- `traceroute` and other raw packet path-discovery tools
+- raw-packet traceroute and path-discovery tools until the Rust-native probe backend follow-up lands
 - SSH remote command execution
 - SNMP polling/walking
 - WHOIS
@@ -753,11 +753,129 @@ Tests:
 
 ---
 
+## Follow-up Track — Rust-Native Probe Backend
+
+The shipped `std/net` surface is useful, but the implementation should not stay a pile of per-function probes forever. If NetBacon/ntnt is going to become a real network monitoring substrate, the next `std/net` work should refactor around a shared Rust-native probe backend.
+
+Strategic dependency direction:
+
+- Use `socket2` as the low-level socket foundation. It is much more widely adopted than ping-specific crates and gives control over socket options, TTL/hop-limit, bind/source address, and raw/datagram sockets.
+- Use `pnet_packet` for packet encode/decode when constructing or parsing ICMP packets manually.
+- Treat `surge-ping` as useful reference material or a temporary spike, not the strategic foundation, because traceroute and richer probes will push below a ping-only abstraction.
+
+### Phase 6 — Probe Backend Foundation
+
+Goal: introduce shared internals without changing public APIs yet.
+
+Files:
+
+- Split or carve internals out of `src/stdlib/net.rs` only when the diff justifies it. Candidate modules:
+  - `src/stdlib/net/probe.rs` — shared options, target policy, timing, result structs, capability errors
+  - `src/stdlib/net/tcp.rs` — TCP connect primitive
+  - `src/stdlib/net/icmp.rs` — ICMP socket primitive
+  - `src/stdlib/net/traceroute.rs` — later path discovery
+- Keep `src/stdlib/net.rs` as the public ntnt binding/registration layer if possible.
+
+Work:
+
+- Define a shared internal `ProbeOptions` / `ProbeError` model that preserves current public result shapes.
+- Add capability detection/errors for ICMP/raw socket support: permission denied, unsupported platform, missing socket family, and policy-denied target should be distinct internally and mapped to clear `Err(String)` externally.
+- Keep the existing target safety policy: process-level `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private: true`.
+- Add deterministic unit tests for option parsing, error mapping, and target-policy behavior before touching packet I/O.
+
+Acceptance:
+
+- No public API behavior changes.
+- Existing `std/net` tests continue to pass.
+- The backend is small enough to review. If the split creates abstraction theater, stop. We already own enough haunted furniture.
+
+### Phase 7 — Replace `ping()` With Rust-Native ICMP
+
+Goal: delete and replace the current Linux system `ping` bridge with Rust ICMP packet I/O.
+
+Work:
+
+- Remove `Command::new("ping")` from `std/net`.
+- Implement ICMP echo request/reply using `socket2` plus `pnet_packet` or a deliberately chosen ICMP crate if the spike proves it is cleaner.
+- Preserve public `ping(host, opts?)` semantics:
+  - ICMP only
+  - no TCP fallback
+  - `method: "icmp"`
+  - `sent`, `received`, `loss_percent`, `min_ms`, `avg_ms`, `max_ms`, `attempts`
+  - clear `Err` when ICMP permissions/capabilities are unavailable
+- Support IPv4 first; add IPv6 in the same PR only if it stays small and testable.
+
+Acceptance:
+
+- No dependency on `/bin/ping` or `iputils-ping`.
+- Linux capability failures return actionable errors.
+- CI-safe tests use mocked/parsing/unit paths by default; raw-socket smoke tests are gated behind `NTNT_RUN_RAW_NET_TESTS=1`.
+- NetBacon Docker docs can drop `iputils-ping`, but still need `NET_RAW` or equivalent when ICMP is enabled.
+
+### Phase 8 — Rebase TCP Probes on the Shared Backend
+
+Goal: decide whether `tcp_connect()`, `reachable()`, and `port_scan()` should keep current `std::net` implementation details or move to the shared `socket2` substrate.
+
+Work:
+
+- Keep public APIs stable.
+- Refactor only if `socket2` buys real capability:
+  - source address binding
+  - local interface/source selection
+  - TTL/hop-limit control
+  - consistent timeout behavior across connect/scan/reachability
+  - reusable result/error mapping
+- Preserve ordinary probe outcomes as `Ok(map { "connected": false ... })`, not `Err`.
+- Keep port-scan bounds and concurrency limits unchanged.
+
+Acceptance:
+
+- Existing TCP/scan behavior does not regress.
+- Any new options are explicit and documented; no surprise broad scanning, no hidden fallback behavior.
+- If `std::net::TcpStream::connect_timeout` remains simpler for the basic case, keep it and only use `socket2` for advanced options. Boring code is allowed to win.
+
+### Phase 9 — Add `traceroute(host, opts?)`
+
+Goal: add path discovery only after the ICMP/backend foundation is real.
+
+Initial public shape:
+
+```ntnt
+import { traceroute } from "std/net"
+
+traceroute("8.8.8.8", map {
+  "max_hops": 30,
+  "probes": 3,
+  "timeout_ms": 2000,
+  "method": "icmp"
+})
+// Ok([
+//   map { "hop": 1, "ip": "192.168.1.1", "hostname": "router.local", "rtt_ms": 1.2, "responded": true },
+//   map { "hop": 2, "ip": None, "hostname": None, "rtt_ms": None, "responded": false },
+//   ...
+// ])
+```
+
+Work:
+
+- Start with ICMP traceroute using TTL/hop-limit increments and ICMP Time Exceeded replies.
+- Add reverse DNS per hop only as an option, default off or bounded, because traceroute should not become surprise DNS latency soup.
+- Consider UDP or TCP traceroute modes after ICMP mode is correct.
+- Return `*`-style non-responses as structured hop maps, not string output.
+
+Acceptance:
+
+- Requires capability detection and clear errors when raw/ICMP sockets are unavailable.
+- Tests do not require public internet or raw sockets by default.
+- Public docs clearly separate `ping`, `tcp_connect`, `reachable`, and `traceroute` semantics.
+
+---
+
 ## Deferred / Out of Scope for Initial `std/net`
 
-### `traceroute` and raw packet tooling
+### Raw packet tooling beyond traceroute
 
-Traceroute and other raw packet path-discovery tools require a separate capability story:
+Traceroute is now included in the Rust-native probe backend follow-up above. Other raw packet/path-discovery tools remain deferred until the backend proves itself:
 
 - runtime capability detection or `net_capabilities()` helper
 - clear Docker docs (`cap_add: [NET_RAW]`) for APIs that truly require raw sockets
@@ -765,7 +883,7 @@ Traceroute and other raw packet path-discovery tools require a separate capabili
 - graceful `Err` when unavailable
 - no default CI dependency on raw sockets
 
-`ping()` is **not** deferred. It belongs in Phase 1, but its default `auto` method must avoid lying: when ICMP is unavailable, return a clear `Err` rather than falling back to TCP reachability. TCP reachability remains explicit app/developer intent.
+`ping()` already exists, but the shipped implementation should be replaced by the Phase 7 Rust-native ICMP backend. It must stay protocol-honest: when ICMP is unavailable, return a clear `Err` rather than falling back to TCP reachability. TCP reachability remains explicit app/developer intent.
 
 ### WHOIS
 
@@ -794,6 +912,10 @@ As of 2026-06-07:
 - [x] **PR 3 — Bounded port scan**: merged in [PR #115](https://github.com/ntntlang/ntnt/pull/115).
 - [x] **PR 4 — TLS certificate inspection**: merged in [PR #117](https://github.com/ntntlang/ntnt/pull/117).
 - [x] **Superseded PR**: [PR #116](https://github.com/ntntlang/ntnt/pull/116) was closed in favor of the cleaner PR #117 branch.
+- [ ] **Follow-up PR 5 — Rust-native probe backend foundation**: split shared probe internals and capability/error handling without public API changes.
+- [ ] **Follow-up PR 6 — Replace `ping()` implementation**: delete the Linux system `ping` bridge and implement ICMP echo with `socket2` + `pnet_packet` or a proven Rust ICMP backend.
+- [ ] **Follow-up PR 7 — Rebase TCP probes if useful**: move `tcp_connect`, `reachable`, and `port_scan` onto shared socket/probe internals only where it buys source binding, TTL/hop-limit, or cleaner timeout/error behavior.
+- [ ] **Follow-up PR 8 — `traceroute`**: add structured ICMP traceroute after the shared backend and ICMP implementation are real.
 
 The DD-046 initial scope is complete. The merged implementation includes runtime registration, typechecker signatures, generated stdlib docs, AI guide coverage, deterministic examples, CI-safe tests, public-network smoke tests gated behind environment variables, and review hardening for target policy, bounded scans, and TLS validation behavior.
 
@@ -961,6 +1083,12 @@ For network-specific PRs:
 
 7. Internal targets are easy to enable for monitoring, but only as an explicit deployment choice: `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private: true`.
 
+8. The follow-up network-monitoring direction is a shared Rust-native probe backend, not more per-function subprocesses. Prefer `socket2` as the strategic low-level foundation and `pnet_packet` for packet construction/parsing; use `surge-ping` only if a spike proves it stays cleaner than owning the ICMP logic directly.
+
+9. The current `ping()` implementation should be deleted/replaced, not decorated. The replacement must remove the Linux `ping` binary dependency while preserving public `ping()` semantics.
+
+10. `tcp_connect()`, `reachable()`, and `port_scan()` should be refactored only where shared socket internals buy concrete capability or simpler correctness. Do not replace boring working TCP code with ceremonial abstraction.
+
 ---
 
 ## Bottom Line
@@ -972,7 +1100,7 @@ The refined `std/net` path shipped as four reviewable PRs:
 3. DNS lookup/reverse lookup with CI-safe tests
 4. bounded port scan and TLS certificate inspection
 
-That gives ntnt real network-diagnostic capability without making users trip over `CAP_NET_RAW`, and without smuggling in traceroute, SSH, SNMP, broad scanners, public-network CI flakes, or SSRF footguns in one heroic PR. Heroic PRs are where bugs go to get tenure.
+That gives ntnt real network-diagnostic capability without smuggling in SSH, SNMP, broad scanners, public-network CI flakes, or SSRF footguns in one heroic PR. The next DD-046 track is deliberately narrower: build the probe substrate, replace `ping()` properly, refactor TCP only where it earns its keep, then add traceroute. Heroic PRs are where bugs go to get tenure.
 
 ---
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -3,7 +3,7 @@
 **Status:** Complete — shipped across PRs [#113](https://github.com/ntntlang/ntnt/pull/113), [#114](https://github.com/ntntlang/ntnt/pull/114), [#115](https://github.com/ntntlang/ntnt/pull/115), and [#117](https://github.com/ntntlang/ntnt/pull/117)
 **Author:** Larri
 **Created:** 2026-03-22
-**Updated:** 2026-06-08
+**Updated:** 2026-06-07
 **Target baseline:** v0.4.10 (`std/net` track)
 
 ---
@@ -12,7 +12,7 @@
 
 Add a focused `std/net` module for safe, bounded network primitives: IP/CIDR utilities, first-shot host reachability checks, TCP connectivity probes, DNS lookup, limited port scanning, and TLS certificate inspection.
 
-This is **not** a grab-bag for every network-adjacent operation. The first version made common monitoring and diagnostics possible while preserving ntnt's safety posture for apps that run on the public web. The next version should replace the tactical Linux `ping` bridge with a Rust-native probe backend that can support ICMP ping, traceroute, and richer TCP/UDP probes without depending on external binaries.
+This is **not** a grab-bag for every network-adjacent operation. The first version should make common monitoring and diagnostics possible without shelling out, while preserving ntnt's safety posture for apps that run on the public web.
 
 Initial scope:
 
@@ -32,7 +32,7 @@ Initial scope:
 
 Explicitly deferred:
 
-- raw-packet traceroute and path-discovery tools until the Rust-native probe backend follow-up lands
+- `traceroute` and other raw packet path-discovery tools
 - SSH remote command execution
 - SNMP polling/walking
 - WHOIS
@@ -753,129 +753,11 @@ Tests:
 
 ---
 
-## Follow-up Track — Rust-Native Probe Backend
-
-The shipped `std/net` surface is useful, but the implementation should not stay a pile of per-function probes forever. If NetBacon/ntnt is going to become a real network monitoring substrate, the next `std/net` work should refactor around a shared Rust-native probe backend.
-
-Strategic dependency direction:
-
-- Use `socket2` as the low-level socket foundation. It is much more widely adopted than ping-specific crates and gives control over socket options, TTL/hop-limit, bind/source address, and raw/datagram sockets.
-- Use `pnet_packet` for packet encode/decode when constructing or parsing ICMP packets manually.
-- Treat `surge-ping` as useful reference material or a temporary spike, not the strategic foundation, because traceroute and richer probes will push below a ping-only abstraction.
-
-### Phase 6 — Probe Backend Foundation
-
-Goal: introduce shared internals without changing public APIs yet.
-
-Files:
-
-- Split or carve internals out of `src/stdlib/net.rs` only when the diff justifies it. Candidate modules:
-  - `src/stdlib/net/probe.rs` — shared options, target policy, timing, result structs, capability errors
-  - `src/stdlib/net/tcp.rs` — TCP connect primitive
-  - `src/stdlib/net/icmp.rs` — ICMP socket primitive
-  - `src/stdlib/net/traceroute.rs` — later path discovery
-- Keep `src/stdlib/net.rs` as the public ntnt binding/registration layer if possible.
-
-Work:
-
-- Define a shared internal `ProbeOptions` / `ProbeError` model that preserves current public result shapes.
-- Add capability detection/errors for ICMP/raw socket support: permission denied, unsupported platform, missing socket family, and policy-denied target should be distinct internally and mapped to clear `Err(String)` externally.
-- Keep the existing target safety policy: process-level `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private: true`.
-- Add deterministic unit tests for option parsing, error mapping, and target-policy behavior before touching packet I/O.
-
-Acceptance:
-
-- No public API behavior changes.
-- Existing `std/net` tests continue to pass.
-- The backend is small enough to review. If the split creates abstraction theater, stop. We already own enough haunted furniture.
-
-### Phase 7 — Replace `ping()` With Rust-Native ICMP
-
-Goal: delete and replace the current Linux system `ping` bridge with Rust ICMP packet I/O.
-
-Work:
-
-- Remove `Command::new("ping")` from `std/net`.
-- Implement ICMP echo request/reply using `socket2` plus `pnet_packet` or a deliberately chosen ICMP crate if the spike proves it is cleaner.
-- Preserve public `ping(host, opts?)` semantics:
-  - ICMP only
-  - no TCP fallback
-  - `method: "icmp"`
-  - `sent`, `received`, `loss_percent`, `min_ms`, `avg_ms`, `max_ms`, `attempts`
-  - clear `Err` when ICMP permissions/capabilities are unavailable
-- Support IPv4 first; add IPv6 in the same PR only if it stays small and testable.
-
-Acceptance:
-
-- No dependency on `/bin/ping` or `iputils-ping`.
-- Linux capability failures return actionable errors.
-- CI-safe tests use mocked/parsing/unit paths by default; raw-socket smoke tests are gated behind `NTNT_RUN_RAW_NET_TESTS=1`.
-- NetBacon Docker docs can drop `iputils-ping`, but still need `NET_RAW` or equivalent when ICMP is enabled.
-
-### Phase 8 — Rebase TCP Probes on the Shared Backend
-
-Goal: decide whether `tcp_connect()`, `reachable()`, and `port_scan()` should keep current `std::net` implementation details or move to the shared `socket2` substrate.
-
-Work:
-
-- Keep public APIs stable.
-- Refactor only if `socket2` buys real capability:
-  - source address binding
-  - local interface/source selection
-  - TTL/hop-limit control
-  - consistent timeout behavior across connect/scan/reachability
-  - reusable result/error mapping
-- Preserve ordinary probe outcomes as `Ok(map { "connected": false ... })`, not `Err`.
-- Keep port-scan bounds and concurrency limits unchanged.
-
-Acceptance:
-
-- Existing TCP/scan behavior does not regress.
-- Any new options are explicit and documented; no surprise broad scanning, no hidden fallback behavior.
-- If `std::net::TcpStream::connect_timeout` remains simpler for the basic case, keep it and only use `socket2` for advanced options. Boring code is allowed to win.
-
-### Phase 9 — Add `traceroute(host, opts?)`
-
-Goal: add path discovery only after the ICMP/backend foundation is real.
-
-Initial public shape:
-
-```ntnt
-import { traceroute } from "std/net"
-
-traceroute("8.8.8.8", map {
-  "max_hops": 30,
-  "probes": 3,
-  "timeout_ms": 2000,
-  "method": "icmp"
-})
-// Ok([
-//   map { "hop": 1, "ip": "192.168.1.1", "hostname": "router.local", "rtt_ms": 1.2, "responded": true },
-//   map { "hop": 2, "ip": None, "hostname": None, "rtt_ms": None, "responded": false },
-//   ...
-// ])
-```
-
-Work:
-
-- Start with ICMP traceroute using TTL/hop-limit increments and ICMP Time Exceeded replies.
-- Add reverse DNS per hop only as an option, default off or bounded, because traceroute should not become surprise DNS latency soup.
-- Consider UDP or TCP traceroute modes after ICMP mode is correct.
-- Return `*`-style non-responses as structured hop maps, not string output.
-
-Acceptance:
-
-- Requires capability detection and clear errors when raw/ICMP sockets are unavailable.
-- Tests do not require public internet or raw sockets by default.
-- Public docs clearly separate `ping`, `tcp_connect`, `reachable`, and `traceroute` semantics.
-
----
-
 ## Deferred / Out of Scope for Initial `std/net`
 
-### Raw packet tooling beyond traceroute
+### `traceroute` and raw packet tooling
 
-Traceroute is now included in the Rust-native probe backend follow-up above. Other raw packet/path-discovery tools remain deferred until the backend proves itself:
+Traceroute and other raw packet path-discovery tools require a separate capability story:
 
 - runtime capability detection or `net_capabilities()` helper
 - clear Docker docs (`cap_add: [NET_RAW]`) for APIs that truly require raw sockets
@@ -883,7 +765,7 @@ Traceroute is now included in the Rust-native probe backend follow-up above. Oth
 - graceful `Err` when unavailable
 - no default CI dependency on raw sockets
 
-`ping()` already exists, but the shipped implementation should be replaced by the Phase 7 Rust-native ICMP backend. It must stay protocol-honest: when ICMP is unavailable, return a clear `Err` rather than falling back to TCP reachability. TCP reachability remains explicit app/developer intent.
+`ping()` is **not** deferred. It belongs in Phase 1, but its default `auto` method must avoid lying: when ICMP is unavailable, return a clear `Err` rather than falling back to TCP reachability. TCP reachability remains explicit app/developer intent.
 
 ### WHOIS
 
@@ -912,10 +794,6 @@ As of 2026-06-07:
 - [x] **PR 3 — Bounded port scan**: merged in [PR #115](https://github.com/ntntlang/ntnt/pull/115).
 - [x] **PR 4 — TLS certificate inspection**: merged in [PR #117](https://github.com/ntntlang/ntnt/pull/117).
 - [x] **Superseded PR**: [PR #116](https://github.com/ntntlang/ntnt/pull/116) was closed in favor of the cleaner PR #117 branch.
-- [ ] **Follow-up PR 5 — Rust-native probe backend foundation**: split shared probe internals and capability/error handling without public API changes.
-- [ ] **Follow-up PR 6 — Replace `ping()` implementation**: delete the Linux system `ping` bridge and implement ICMP echo with `socket2` + `pnet_packet` or a proven Rust ICMP backend.
-- [ ] **Follow-up PR 7 — Rebase TCP probes if useful**: move `tcp_connect`, `reachable`, and `port_scan` onto shared socket/probe internals only where it buys source binding, TTL/hop-limit, or cleaner timeout/error behavior.
-- [ ] **Follow-up PR 8 — `traceroute`**: add structured ICMP traceroute after the shared backend and ICMP implementation are real.
 
 The DD-046 initial scope is complete. The merged implementation includes runtime registration, typechecker signatures, generated stdlib docs, AI guide coverage, deterministic examples, CI-safe tests, public-network smoke tests gated behind environment variables, and review hardening for target policy, bounded scans, and TLS validation behavior.
 
@@ -1083,12 +961,6 @@ For network-specific PRs:
 
 7. Internal targets are easy to enable for monitoring, but only as an explicit deployment choice: `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private: true`.
 
-8. The follow-up network-monitoring direction is a shared Rust-native probe backend, not more per-function subprocesses. Prefer `socket2` as the strategic low-level foundation and `pnet_packet` for packet construction/parsing; use `surge-ping` only if a spike proves it stays cleaner than owning the ICMP logic directly.
-
-9. The current `ping()` implementation should be deleted/replaced, not decorated. The replacement must remove the Linux `ping` binary dependency while preserving public `ping()` semantics.
-
-10. `tcp_connect()`, `reachable()`, and `port_scan()` should be refactored only where shared socket internals buy concrete capability or simpler correctness. Do not replace boring working TCP code with ceremonial abstraction.
-
 ---
 
 ## Bottom Line
@@ -1100,7 +972,7 @@ The refined `std/net` path shipped as four reviewable PRs:
 3. DNS lookup/reverse lookup with CI-safe tests
 4. bounded port scan and TLS certificate inspection
 
-That gives ntnt real network-diagnostic capability without smuggling in SSH, SNMP, broad scanners, public-network CI flakes, or SSRF footguns in one heroic PR. The next DD-046 track is deliberately narrower: build the probe substrate, replace `ping()` properly, refactor TCP only where it earns its keep, then add traceroute. Heroic PRs are where bugs go to get tenure.
+That gives ntnt real network-diagnostic capability without making users trip over `CAP_NET_RAW`, and without smuggling in traceroute, SSH, SNMP, broad scanners, public-network CI flakes, or SSRF footguns in one heroic PR. Heroic PRs are where bugs go to get tenure.
 
 ---
 

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -1411,10 +1411,10 @@ fn run_linux_ping(
             "ICMP ping unavailable: system ping failed: {}",
             ping_failure_message(&stdout, &stderr, output.status.code())
         );
-        if linux_ping_permission_error(&message) {
-            return Err(icmp_ping_process_error(message));
+        if linux_ping_target_failure(&message) {
+            return Ok(failed_ping_result(display_host, target_ip, message));
         }
-        return Ok(failed_ping_result(display_host, target_ip, message));
+        return Err(icmp_ping_process_error(message));
     }
 
     Ok(result)
@@ -1632,6 +1632,15 @@ fn linux_ping_permission_error(message: &str) -> bool {
     lower.contains("operation not permitted")
         || lower.contains("permission denied")
         || lower.contains("cap_net_raw")
+}
+
+#[cfg(target_os = "linux")]
+fn linux_ping_target_failure(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("network is unreachable")
+        || lower.contains("no route to host")
+        || lower.contains("destination host unreachable")
+        || lower.contains("destination net unreachable")
 }
 
 #[cfg(target_os = "linux")]
@@ -3070,6 +3079,23 @@ mod tests {
         assert!(matches!(
             result.attempts.first().and_then(|attempt| attempt.error.as_deref()),
             Some(message) if message.contains("Network is unreachable")
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_ping_failure_classifier_separates_target_from_backend_errors() {
+        assert!(linux_ping_target_failure(
+            "ICMP ping unavailable: system ping failed: connect: Network is unreachable"
+        ));
+        assert!(linux_ping_target_failure(
+            "ICMP ping unavailable: system ping failed: connect: No route to host"
+        ));
+        assert!(!linux_ping_target_failure(
+            "ICMP ping unavailable: system ping failed: ping: invalid option -- '-'"
+        ));
+        assert!(!linux_ping_target_failure(
+            "ICMP ping unavailable: system ping failed: usage: ping [-aAbBdDfhLnOqrRUvV64]"
         ));
     }
 

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -1,5 +1,8 @@
 //! std/net module - IPAM-grade IP/CIDR helpers and reachability probes.
 
+mod probe;
+
+use self::probe::{ProbeError, ProbeOptions, ProbeProtocol};
 use crate::error::IntentError;
 use crate::interpreter::Value;
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -763,7 +766,8 @@ fn ping_fn(args: &[Value]) -> Result<Value, IntentError> {
         let options = parse_probe_options(opts)?;
         let targets = resolve_ping_targets(host)?;
         enforce_resolved_target_policy(&targets, options.allow_private)?;
-        system_ping(host, options.timeout, options.count)
+        let command_target = validated_probe_ip(&targets)?;
+        system_ping(host, command_target, options.timeout, options.count)
     })()))
 }
 
@@ -1319,13 +1323,21 @@ struct IcmpPingResult {
 fn resolve_ping_targets(host: &str) -> Result<Vec<(u16, SocketAddr)>, String> {
     let resolved: Vec<SocketAddr> = (host, 0)
         .to_socket_addrs()
-        .map_err(|e| format!("failed to resolve {}: {}", host, e))?
+        .map_err(|e| {
+            ProbeError::resolve_failed(host, format!("failed to resolve {}: {}", host, e))
+                .to_string()
+        })?
         .collect();
     Ok(resolved.into_iter().map(|addr| (0, addr)).collect())
 }
 
 #[cfg(target_os = "linux")]
-fn system_ping(host: &str, timeout: Duration, count: usize) -> Result<Value, String> {
+fn system_ping(
+    display_host: &str,
+    command_target: IpAddr,
+    timeout: Duration,
+    count: usize,
+) -> Result<Value, String> {
     let timeout_secs = max(
         1,
         timeout
@@ -1339,26 +1351,42 @@ fn system_ping(host: &str, timeout: Duration, count: usize) -> Result<Value, Str
         .arg("-W")
         .arg(timeout_secs.to_string())
         .arg("--")
-        .arg(host)
+        .arg(command_target.to_string())
         .output()
-        .map_err(|e| format!("ICMP ping unavailable: failed to run ping: {}", e))?;
+        .map_err(|e| {
+            ProbeError::capability_unavailable(
+                ProbeProtocol::Icmp,
+                format!("ICMP ping unavailable: failed to run ping: {}", e),
+            )
+            .to_string()
+        })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !output.status.success() && !linux_ping_output_has_packet_summary(&stdout) {
-        return Err(format!(
+        let message = format!(
             "ICMP ping unavailable: system ping failed: {}",
             ping_failure_message(&stdout, &stderr, output.status.code())
-        ));
+        );
+        return Err(icmp_ping_process_error(message).to_string());
     }
 
-    let parsed = parse_linux_ping_output(host, &stdout, &stderr, count);
+    let parsed = parse_linux_ping_output(display_host, &stdout, &stderr, count);
     Ok(Value::Map(icmp_ping_result_map(parsed)))
 }
 
 #[cfg(not(target_os = "linux"))]
-fn system_ping(_host: &str, _timeout: Duration, _count: usize) -> Result<Value, String> {
-    Err("ICMP ping unavailable on this platform".to_string())
+fn system_ping(
+    _display_host: &str,
+    _command_target: IpAddr,
+    _timeout: Duration,
+    _count: usize,
+) -> Result<Value, String> {
+    Err(ProbeError::unsupported_platform(
+        ProbeProtocol::Icmp,
+        "ICMP ping unavailable on this platform",
+    )
+    .to_string())
 }
 
 fn icmp_ping_for_host(
@@ -1367,13 +1395,28 @@ fn icmp_ping_for_host(
 ) -> Result<HashMap<String, Value>, String> {
     let targets = resolve_ping_targets(host)?;
     enforce_resolved_target_policy(&targets, options.allow_private)?;
-    match system_ping(host, options.timeout, options.count)? {
+    let command_target = validated_probe_ip(&targets)?;
+    match system_ping(host, command_target, options.timeout, options.count)? {
         Value::Map(map) => Ok(map),
-        other => Err(format!(
-            "ICMP ping unavailable: unexpected ping result {}",
-            other.type_name()
-        )),
+        other => Err(ProbeError::unexpected_result(
+            ProbeProtocol::Icmp,
+            format!(
+                "ICMP ping unavailable: unexpected ping result {}",
+                other.type_name()
+            ),
+        )
+        .to_string()),
     }
+}
+
+fn validated_probe_ip(targets: &[(u16, SocketAddr)]) -> Result<IpAddr, String> {
+    targets.first().map(|(_, addr)| addr.ip()).ok_or_else(|| {
+        ProbeError::resolve_failed(
+            "",
+            "failed to resolve target: resolver returned no usable addresses",
+        )
+        .to_string()
+    })
 }
 
 fn linux_ping_output_has_packet_summary(output: &str) -> bool {
@@ -1394,6 +1437,19 @@ fn ping_failure_message(stdout: &str, stderr: &str, status_code: Option<i32>) ->
             Some(code) => format!("exit status {}", code),
             None => "terminated by signal".to_string(),
         })
+}
+
+#[cfg(target_os = "linux")]
+fn icmp_ping_process_error(message: String) -> ProbeError {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("operation not permitted")
+        || lower.contains("permission denied")
+        || lower.contains("cap_net_raw")
+    {
+        ProbeError::permission_denied(ProbeProtocol::Icmp, message)
+    } else {
+        ProbeError::system_failure(ProbeProtocol::Icmp, message)
+    }
 }
 
 fn parse_linux_ping_output(
@@ -1517,7 +1573,10 @@ fn icmp_ping_result_map(result: IcmpPingResult) -> HashMap<String, Value> {
     let mut map = HashMap::new();
     map.insert("host".to_string(), Value::String(result.host));
     map.insert("reachable".to_string(), Value::Bool(result.received > 0));
-    map.insert("method".to_string(), Value::String("icmp".to_string()));
+    map.insert(
+        "method".to_string(),
+        Value::String(ProbeProtocol::Icmp.as_str().to_string()),
+    );
     map.insert("permission_limited".to_string(), Value::Bool(false));
     map.insert("sent".to_string(), Value::Int(result.sent as i64));
     map.insert("received".to_string(), Value::Int(result.received as i64));
@@ -1555,7 +1614,10 @@ fn icmp_ping_result_map(result: IcmpPingResult) -> HashMap<String, Value> {
 fn icmp_attempt_to_value(attempt: &IcmpPingAttempt) -> Value {
     let mut map = HashMap::new();
     map.insert("reachable".to_string(), Value::Bool(attempt.reachable));
-    map.insert("method".to_string(), Value::String("icmp".to_string()));
+    map.insert(
+        "method".to_string(),
+        Value::String(ProbeProtocol::Icmp.as_str().to_string()),
+    );
     if let Some(seq) = attempt.seq {
         map.insert("seq".to_string(), Value::Int(seq));
     }
@@ -1597,13 +1659,6 @@ fn parse_f64_after(text: &str, needle: &str) -> Option<f64> {
             .next()
             .and_then(|value| value.parse::<f64>().ok())
     })
-}
-
-struct ProbeOptions {
-    timeout: Duration,
-    count: usize,
-    interval: Duration,
-    allow_private: bool,
 }
 
 fn parse_probe_options(opts: Option<&HashMap<String, Value>>) -> Result<ProbeOptions, String> {
@@ -1812,9 +1867,16 @@ fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> Tc
 fn resolve_tcp_targets(host: &str, ports: &[u16]) -> Result<Vec<(u16, SocketAddr)>, String> {
     let mut targets = Vec::new();
     for port in ports {
+        let target = format!("{}:{}", host, port);
         let addrs: Vec<SocketAddr> = (host, *port)
             .to_socket_addrs()
-            .map_err(|e| format!("failed to resolve {}:{}: {}", host, port, e))?
+            .map_err(|e| {
+                ProbeError::resolve_failed(
+                    target.clone(),
+                    format!("failed to resolve {}:{}: {}", host, port, e),
+                )
+                .to_string()
+            })?
             .collect();
         targets.extend(addrs.into_iter().map(|addr| (*port, addr)));
     }
@@ -1828,7 +1890,10 @@ fn resolve_port_scan_targets(host: &str, ports: &[u16]) -> Result<Vec<(u16, Sock
 
     let resolved: Vec<SocketAddr> = (host, seed_port)
         .to_socket_addrs()
-        .map_err(|e| format!("failed to resolve {}: {}", host, e))?
+        .map_err(|e| {
+            ProbeError::resolve_failed(host, format!("failed to resolve {}: {}", host, e))
+                .to_string()
+        })?
         .collect();
 
     let mut ips = Vec::with_capacity(resolved.len());
@@ -1850,8 +1915,15 @@ fn enforce_resolved_target_policy(
     targets: &[(u16, SocketAddr)],
     allow_private: bool,
 ) -> Result<(), String> {
+    enforce_resolved_target_policy_error(targets, allow_private).map_err(|err| err.to_string())
+}
+
+fn enforce_resolved_target_policy_error(
+    targets: &[(u16, SocketAddr)],
+    allow_private: bool,
+) -> Result<(), ProbeError> {
     for (_, addr) in targets {
-        enforce_target_policy(addr.ip(), allow_private)?;
+        enforce_target_policy_error(addr.ip(), allow_private)?;
     }
     Ok(())
 }
@@ -1878,7 +1950,10 @@ fn tcp_reachability_result_map(
     let mut result = HashMap::new();
     result.insert("host".to_string(), Value::String(host.to_string()));
     result.insert("reachable".to_string(), Value::Bool(received > 0));
-    result.insert("method".to_string(), Value::String("tcp".to_string()));
+    result.insert(
+        "method".to_string(),
+        Value::String(ProbeProtocol::Tcp.as_str().to_string()),
+    );
     result.insert("permission_limited".to_string(), Value::Bool(false));
     result.insert("sent".to_string(), Value::Int(sent as i64));
     result.insert("received".to_string(), Value::Int(received as i64));
@@ -1967,7 +2042,7 @@ fn reachable_result_map(
     let mut tcp_result = tcp_reachability_result_map(host, ports, attempts);
     tcp_result.insert(
         "fallback_from".to_string(),
-        Value::String("icmp".to_string()),
+        Value::String(ProbeProtocol::Icmp.as_str().to_string()),
     );
 
     let tcp_ports = Value::Array(ports.iter().map(|p| Value::Int(*p as i64)).collect());
@@ -2018,7 +2093,10 @@ fn port_scan_result_to_value(result: PortScanResult) -> Value {
     let mut map = HashMap::new();
     map.insert("port".to_string(), Value::Int(result.port as i64));
     map.insert("open".to_string(), Value::Bool(result.open));
-    map.insert("method".to_string(), Value::String("tcp".to_string()));
+    map.insert(
+        "method".to_string(),
+        Value::String(ProbeProtocol::Tcp.as_str().to_string()),
+    );
     if let Some(latency_ms) = result.latency_ms {
         map.insert("latency_ms".to_string(), Value::Float(latency_ms));
     }
@@ -2035,7 +2113,10 @@ fn port_scan_result_to_value(result: PortScanResult) -> Value {
 fn tcp_attempt_to_value(attempt: &TcpProbeResult) -> Value {
     let mut map = HashMap::new();
     map.insert("reachable".to_string(), Value::Bool(attempt.reachable));
-    map.insert("method".to_string(), Value::String("tcp".to_string()));
+    map.insert(
+        "method".to_string(),
+        Value::String(ProbeProtocol::Tcp.as_str().to_string()),
+    );
     map.insert(
         "connected_port".to_string(),
         attempt
@@ -2282,7 +2363,7 @@ fn is_ipv6_metadata_endpoint(ip: Ipv6Addr) -> bool {
     ip.segments() == [0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254]
 }
 
-fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> {
+fn enforce_target_policy_error(ip: IpAddr, allow_private: bool) -> Result<(), ProbeError> {
     let classification = classify_ip(ip);
     let never_allowed = classification.is_metadata_endpoint
         || classification.is_unspecified
@@ -2290,9 +2371,10 @@ fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> 
         || classification.is_documentation
         || classification.is_broadcast;
     if never_allowed {
-        return Err(
-            "Network target denied by policy: special-purpose targets are not allowed".to_string(),
-        );
+        return Err(ProbeError::policy_denied(
+            ip.to_string(),
+            "Network target denied by policy: special-purpose targets are not allowed",
+        ));
     }
 
     let private_target = classification.is_private
@@ -2303,10 +2385,10 @@ fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> 
         return Ok(());
     }
     if !allow_private || !process_allows_private_targets() {
-        return Err(
-            "Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1"
-                .to_string(),
-        );
+        return Err(ProbeError::policy_denied(
+            ip.to_string(),
+            "Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1",
+        ));
     }
     Ok(())
 }
@@ -2644,6 +2726,7 @@ fn floor_log2(value: u128) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use super::probe::{ProbeError, ProbeErrorKind, ProbeProtocol};
     use super::*;
 
     fn assert_result_err_contains(value: Value, expected: &str) {
@@ -2732,6 +2815,55 @@ mod tests {
 
         let err = enforce_resolved_target_policy(&targets, false).unwrap_err();
         assert!(err.contains("Network target denied by policy"));
+    }
+
+    #[test]
+    fn ping_uses_policy_validated_ip_as_command_target() {
+        let public = "93.184.216.34:0".parse::<SocketAddr>().unwrap();
+        let targets = [(0, public)];
+
+        assert_eq!(
+            validated_probe_ip(&targets).unwrap(),
+            "93.184.216.34".parse::<IpAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn ping_command_target_rejects_empty_resolution_set() {
+        let err = validated_probe_ip(&[]).unwrap_err();
+
+        assert_eq!(
+            err,
+            "failed to resolve target: resolver returned no usable addresses"
+        );
+    }
+
+    #[test]
+    fn target_policy_errors_keep_structured_kind_and_stable_public_message() {
+        let metadata = "169.254.169.254:80".parse::<SocketAddr>().unwrap();
+        let err = enforce_resolved_target_policy_error(&[(80, metadata)], true).unwrap_err();
+
+        assert_eq!(err.kind(), ProbeErrorKind::PolicyDenied);
+        assert_eq!(err.protocol(), None);
+        assert_eq!(
+            err.to_string(),
+            "Network target denied by policy: special-purpose targets are not allowed"
+        );
+    }
+
+    #[test]
+    fn probe_capability_errors_carry_protocol_without_changing_display_text() {
+        let err = ProbeError::permission_denied(
+            ProbeProtocol::Icmp,
+            "ICMP ping unavailable: raw socket permission denied",
+        );
+
+        assert_eq!(err.kind(), ProbeErrorKind::PermissionDenied);
+        assert_eq!(err.protocol(), Some(ProbeProtocol::Icmp));
+        assert_eq!(
+            err.to_string(),
+            "ICMP ping unavailable: raw socket permission denied"
+        );
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -766,8 +766,8 @@ fn ping_fn(args: &[Value]) -> Result<Value, IntentError> {
         let options = parse_probe_options(opts)?;
         let targets = resolve_ping_targets(host)?;
         enforce_resolved_target_policy(&targets, options.allow_private)?;
-        let command_target = validated_probe_ip(&targets)?;
-        system_ping(host, command_target, options.timeout, options.count)
+        let command_targets = validated_probe_ips(&targets)?;
+        system_ping(host, &command_targets, options.timeout, options.count)
     })()))
 }
 
@@ -1334,7 +1334,7 @@ fn resolve_ping_targets(host: &str) -> Result<Vec<(u16, SocketAddr)>, String> {
 #[cfg(target_os = "linux")]
 fn system_ping(
     display_host: &str,
-    command_target: IpAddr,
+    command_targets: &[IpAddr],
     timeout: Duration,
     count: usize,
 ) -> Result<Value, String> {
@@ -1344,6 +1344,40 @@ fn system_ping(
             .as_secs()
             .saturating_add(if timeout.subsec_millis() > 0 { 1 } else { 0 }),
     );
+
+    let mut last_result = None;
+    let mut last_error = None;
+    for command_target in command_targets {
+        match run_linux_ping(display_host, *command_target, timeout_secs, count) {
+            Ok(result) if result.received > 0 => {
+                return Ok(Value::Map(icmp_ping_result_map(result)))
+            }
+            Ok(result) => last_result = Some(result),
+            Err(err) => last_error = Some(err),
+        }
+    }
+
+    if let Some(result) = last_result {
+        return Ok(Value::Map(icmp_ping_result_map(result)));
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| {
+            ProbeError::resolve_failed(
+                display_host,
+                "failed to resolve target: resolver returned no usable addresses",
+            )
+        })
+        .to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn run_linux_ping(
+    display_host: &str,
+    command_target: IpAddr,
+    timeout_secs: u64,
+    count: usize,
+) -> Result<IcmpPingResult, ProbeError> {
     let output = Command::new("ping")
         .arg("-n")
         .arg("-c")
@@ -1358,7 +1392,6 @@ fn system_ping(
                 ProbeProtocol::Icmp,
                 format!("ICMP ping unavailable: failed to run ping: {}", e),
             )
-            .to_string()
         })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1368,17 +1401,21 @@ fn system_ping(
             "ICMP ping unavailable: system ping failed: {}",
             ping_failure_message(&stdout, &stderr, output.status.code())
         );
-        return Err(icmp_ping_process_error(message).to_string());
+        return Err(icmp_ping_process_error(message));
     }
 
-    let parsed = parse_linux_ping_output(display_host, &stdout, &stderr, count);
-    Ok(Value::Map(icmp_ping_result_map(parsed)))
+    Ok(parse_linux_ping_output(
+        display_host,
+        &stdout,
+        &stderr,
+        count,
+    ))
 }
 
 #[cfg(not(target_os = "linux"))]
 fn system_ping(
     _display_host: &str,
-    _command_target: IpAddr,
+    _command_targets: &[IpAddr],
     _timeout: Duration,
     _count: usize,
 ) -> Result<Value, String> {
@@ -1395,8 +1432,8 @@ fn icmp_ping_for_host(
 ) -> Result<HashMap<String, Value>, String> {
     let targets = resolve_ping_targets(host)?;
     enforce_resolved_target_policy(&targets, options.allow_private)?;
-    let command_target = validated_probe_ip(&targets)?;
-    match system_ping(host, command_target, options.timeout, options.count)? {
+    let command_targets = validated_probe_ips(&targets)?;
+    match system_ping(host, &command_targets, options.timeout, options.count)? {
         Value::Map(map) => Ok(map),
         other => Err(ProbeError::unexpected_result(
             ProbeProtocol::Icmp,
@@ -1409,14 +1446,22 @@ fn icmp_ping_for_host(
     }
 }
 
-fn validated_probe_ip(targets: &[(u16, SocketAddr)]) -> Result<IpAddr, String> {
-    targets.first().map(|(_, addr)| addr.ip()).ok_or_else(|| {
-        ProbeError::resolve_failed(
+fn validated_probe_ips(targets: &[(u16, SocketAddr)]) -> Result<Vec<IpAddr>, String> {
+    let mut ips = Vec::new();
+    for (_, addr) in targets {
+        let ip = addr.ip();
+        if !ips.contains(&ip) {
+            ips.push(ip);
+        }
+    }
+    if ips.is_empty() {
+        return Err(ProbeError::resolve_failed(
             "",
             "failed to resolve target: resolver returned no usable addresses",
         )
-        .to_string()
-    })
+        .to_string());
+    }
+    Ok(ips)
 }
 
 fn linux_ping_output_has_packet_summary(output: &str) -> bool {
@@ -2818,19 +2863,24 @@ mod tests {
     }
 
     #[test]
-    fn ping_uses_policy_validated_ip_as_command_target() {
-        let public = "93.184.216.34:0".parse::<SocketAddr>().unwrap();
-        let targets = [(0, public)];
+    fn ping_uses_policy_validated_ips_as_command_targets() {
+        let public_v6 = "[2001:4860:4860::8888]:0".parse::<SocketAddr>().unwrap();
+        let public_v4 = "93.184.216.34:0".parse::<SocketAddr>().unwrap();
+        let duplicate_v4 = "93.184.216.34:0".parse::<SocketAddr>().unwrap();
+        let targets = [(0, public_v6), (0, public_v4), (0, duplicate_v4)];
 
         assert_eq!(
-            validated_probe_ip(&targets).unwrap(),
-            "93.184.216.34".parse::<IpAddr>().unwrap()
+            validated_probe_ips(&targets).unwrap(),
+            vec![
+                "2001:4860:4860::8888".parse::<IpAddr>().unwrap(),
+                "93.184.216.34".parse::<IpAddr>().unwrap(),
+            ]
         );
     }
 
     #[test]
-    fn ping_command_target_rejects_empty_resolution_set() {
-        let err = validated_probe_ip(&[]).unwrap_err();
+    fn ping_command_targets_reject_empty_resolution_set() {
+        let err = validated_probe_ips(&[]).unwrap_err();
 
         assert_eq!(
             err,

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -1320,6 +1320,52 @@ struct IcmpPingResult {
     attempts: Vec<IcmpPingAttempt>,
 }
 
+fn merge_icmp_ping_results(host: &str, results: Vec<IcmpPingResult>) -> Option<IcmpPingResult> {
+    if results.is_empty() {
+        return None;
+    }
+
+    let sent: usize = results.iter().map(|result| result.sent).sum();
+    let received: usize = results.iter().map(|result| result.received).sum();
+    let target_addr = results
+        .iter()
+        .find(|result| result.received > 0)
+        .and_then(|result| result.target_addr.clone())
+        .or_else(|| results.iter().find_map(|result| result.target_addr.clone()));
+    let attempts: Vec<IcmpPingAttempt> = results
+        .into_iter()
+        .flat_map(|result| result.attempts)
+        .collect();
+    let latencies: Vec<f64> = attempts
+        .iter()
+        .filter_map(|attempt| attempt.latency_ms)
+        .collect();
+    let min_ms = latencies.iter().copied().reduce(f64::min);
+    let max_ms = latencies.iter().copied().reduce(f64::max);
+    let avg_ms = if latencies.is_empty() {
+        None
+    } else {
+        Some(latencies.iter().sum::<f64>() / latencies.len() as f64)
+    };
+    let loss_percent = if sent == 0 {
+        100.0
+    } else {
+        ((sent.saturating_sub(received)) as f64 / sent as f64) * 100.0
+    };
+
+    Some(IcmpPingResult {
+        host: host.to_string(),
+        target_addr,
+        sent,
+        received,
+        loss_percent,
+        min_ms,
+        avg_ms,
+        max_ms,
+        attempts,
+    })
+}
+
 fn resolve_ping_targets(host: &str) -> Result<Vec<(u16, SocketAddr)>, String> {
     let resolved: Vec<SocketAddr> = (host, 0)
         .to_socket_addrs()
@@ -1338,26 +1384,49 @@ fn system_ping(
     timeout: Duration,
     count: usize,
 ) -> Result<Value, String> {
-    let timeout_secs = max(
-        1,
-        timeout
-            .as_secs()
-            .saturating_add(if timeout.subsec_millis() > 0 { 1 } else { 0 }),
-    );
-
-    let mut last_result = None;
+    let deadline = Instant::now() + timeout;
+    let mut results = Vec::new();
+    let mut sent = 0usize;
     let mut last_error = None;
+
     for command_target in command_targets {
-        match run_linux_ping(display_host, *command_target, timeout_secs, count) {
+        if sent >= count {
+            break;
+        }
+        let Some(timeout_secs) = ping_remaining_timeout_secs(deadline) else {
+            break;
+        };
+        let probe_count = ping_probe_count_for_target(command_targets.len(), sent, count);
+        match run_linux_ping(display_host, *command_target, timeout_secs, probe_count) {
             Ok(result) if result.received > 0 => {
-                return Ok(Value::Map(icmp_ping_result_map(result)))
+                sent += result.sent;
+                results.push(result);
+                let remaining_count = count.saturating_sub(sent);
+                if remaining_count > 0 {
+                    if let Some(timeout_secs) = ping_remaining_timeout_secs(deadline) {
+                        if let Ok(result) = run_linux_ping(
+                            display_host,
+                            *command_target,
+                            timeout_secs,
+                            remaining_count,
+                        ) {
+                            results.push(result);
+                        }
+                    }
+                }
+                return Ok(Value::Map(icmp_ping_result_map(
+                    merge_icmp_ping_results(display_host, results).expect("ping result recorded"),
+                )));
             }
-            Ok(result) => last_result = Some(result),
+            Ok(result) => {
+                sent += result.sent;
+                results.push(result);
+            }
             Err(err) => last_error = Some(err),
         }
     }
 
-    if let Some(result) = last_result {
+    if let Some(result) = merge_icmp_ping_results(display_host, results) {
         return Ok(Value::Map(icmp_ping_result_map(result)));
     }
 
@@ -1372,6 +1441,30 @@ fn system_ping(
 }
 
 #[cfg(target_os = "linux")]
+fn ping_probe_count_for_target(target_count: usize, sent: usize, requested_count: usize) -> usize {
+    let remaining = requested_count.saturating_sub(sent);
+    if target_count <= 1 {
+        remaining
+    } else {
+        remaining.min(1)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn ping_remaining_timeout_secs(deadline: Instant) -> Option<u64> {
+    let remaining = deadline.checked_duration_since(Instant::now())?;
+    if remaining.is_zero() {
+        return None;
+    }
+    Some(max(
+        1,
+        remaining
+            .as_secs()
+            .saturating_add(if remaining.subsec_millis() > 0 { 1 } else { 0 }),
+    ))
+}
+
+#[cfg(target_os = "linux")]
 fn run_linux_ping(
     display_host: &str,
     command_target: IpAddr,
@@ -1383,6 +1476,8 @@ fn run_linux_ping(
         .arg("-c")
         .arg(count.to_string())
         .arg("-W")
+        .arg(timeout_secs.to_string())
+        .arg("-w")
         .arg(timeout_secs.to_string())
         .arg("--")
         .arg(command_target.to_string())
@@ -2886,6 +2981,76 @@ mod tests {
             err,
             "failed to resolve target: resolver returned no usable addresses"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn ping_probe_count_shares_requested_count_across_targets() {
+        assert_eq!(ping_probe_count_for_target(1, 0, 3), 3);
+        assert_eq!(ping_probe_count_for_target(2, 0, 3), 1);
+        assert_eq!(ping_probe_count_for_target(2, 2, 3), 1);
+        assert_eq!(ping_probe_count_for_target(2, 3, 3), 0);
+    }
+
+    #[test]
+    fn merged_ping_results_report_aggregate_attempts_and_reachable_target() {
+        let first = IcmpPingResult {
+            host: "example.com".to_string(),
+            target_addr: Some("2001:db8::1".to_string()),
+            sent: 1,
+            received: 0,
+            loss_percent: 100.0,
+            min_ms: None,
+            avg_ms: None,
+            max_ms: None,
+            attempts: vec![IcmpPingAttempt {
+                seq: Some(1),
+                reachable: false,
+                from: None,
+                ttl: None,
+                latency_ms: None,
+                error: Some("timeout".to_string()),
+            }],
+        };
+        let second = IcmpPingResult {
+            host: "example.com".to_string(),
+            target_addr: Some("93.184.216.34".to_string()),
+            sent: 2,
+            received: 2,
+            loss_percent: 0.0,
+            min_ms: Some(10.0),
+            avg_ms: Some(12.0),
+            max_ms: Some(14.0),
+            attempts: vec![
+                IcmpPingAttempt {
+                    seq: Some(1),
+                    reachable: true,
+                    from: Some("93.184.216.34".to_string()),
+                    ttl: Some(57),
+                    latency_ms: Some(10.0),
+                    error: None,
+                },
+                IcmpPingAttempt {
+                    seq: Some(2),
+                    reachable: true,
+                    from: Some("93.184.216.34".to_string()),
+                    ttl: Some(57),
+                    latency_ms: Some(14.0),
+                    error: None,
+                },
+            ],
+        };
+
+        let merged = merge_icmp_ping_results("example.com", vec![first, second]).unwrap();
+
+        assert_eq!(merged.sent, 3);
+        assert_eq!(merged.received, 2);
+        assert!((merged.loss_percent - (100.0 / 3.0)).abs() < 1e-9);
+        assert_eq!(merged.target_addr.as_deref(), Some("93.184.216.34"));
+        assert_eq!(merged.attempts.len(), 3);
+        assert_eq!(merged.min_ms, Some(10.0));
+        assert_eq!(merged.avg_ms, Some(12.0));
+        assert_eq!(merged.max_ms, Some(14.0));
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -18,9 +18,11 @@ use rustls::{
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
+#[cfg(target_os = "linux")]
+use std::io::Read;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
 #[cfg(target_os = "linux")]
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
@@ -1319,10 +1321,39 @@ struct IcmpPingResult {
 #[cfg(target_os = "linux")]
 fn icmp_ping(
     display_host: &str,
-    target_ip: IpAddr,
+    target_ips: &[IpAddr],
     options: &ProbeOptions,
 ) -> Result<IcmpPingResult, ProbeError> {
-    run_linux_ping(display_host, target_ip, options.timeout, options.count)
+    let deadline = Instant::now() + options.timeout;
+    let mut results = Vec::new();
+
+    for (index, target_ip) in target_ips.iter().enumerate() {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            break;
+        };
+        let target_budget = ping_target_budget(remaining, target_ips.len() - index);
+        let target_deadline = Instant::now() + target_budget;
+        let result = run_linux_ping(display_host, *target_ip, target_deadline, options.count)?;
+        let reachable = result.received > 0;
+        results.push(result);
+        if reachable {
+            break;
+        }
+    }
+
+    Ok(combine_icmp_ping_attempts(display_host, results))
+}
+
+#[cfg(target_os = "linux")]
+fn ping_target_budget(remaining: Duration, remaining_targets: usize) -> Duration {
+    if remaining_targets <= 1 {
+        return remaining;
+    }
+    let slice_ms = max(
+        1,
+        (remaining.as_millis() / remaining_targets as u128) as u64,
+    );
+    min(Duration::from_millis(slice_ms), remaining)
 }
 
 #[cfg(target_os = "linux")]
@@ -1339,11 +1370,15 @@ fn ping_timeout_secs(timeout: Duration) -> u64 {
 fn run_linux_ping(
     display_host: &str,
     target_ip: IpAddr,
-    timeout: Duration,
+    deadline: Instant,
     count: usize,
 ) -> Result<IcmpPingResult, ProbeError> {
+    let Some(timeout) = deadline.checked_duration_since(Instant::now()) else {
+        return Ok(timeout_ping_result(display_host, target_ip));
+    };
     let timeout_secs = ping_timeout_secs(timeout);
-    let output = Command::new("ping")
+    let mut command = Command::new("ping");
+    command
         .arg("-n")
         .arg("-c")
         .arg(count.to_string())
@@ -1352,19 +1387,26 @@ fn run_linux_ping(
         .arg("-w")
         .arg(timeout_secs.to_string())
         .arg("--")
-        .arg(target_ip.to_string())
-        .output()
-        .map_err(|e| {
-            ProbeError::capability_unavailable(
-                ProbeProtocol::Icmp,
-                format!("ICMP ping unavailable: failed to run ping: {}", e),
-            )
-        })?;
+        .arg(target_ip.to_string());
+
+    let (output, timed_out) = run_command_with_deadline(command, deadline).map_err(|e| {
+        ProbeError::capability_unavailable(
+            ProbeProtocol::Icmp,
+            format!("ICMP ping unavailable: failed to run ping: {}", e),
+        )
+    })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let has_packet_summary = linux_ping_output_has_packet_summary(&stdout);
-    if !output.status.success() && !has_packet_summary {
+    let mut result = parse_linux_ping_output(display_host, &stdout, &stderr, count);
+    if result.target_addr.is_none() {
+        result.target_addr = Some(target_ip.to_string());
+    }
+    if timed_out && !has_packet_summary {
+        normalize_timed_out_ping_result(&mut result);
+    }
+    if !output.status.success() && !has_packet_summary && result.received == 0 && !timed_out {
         let message = format!(
             "ICMP ping unavailable: system ping failed: {}",
             ping_failure_message(&stdout, &stderr, output.status.code())
@@ -1372,18 +1414,85 @@ fn run_linux_ping(
         return Err(icmp_ping_process_error(message));
     }
 
-    Ok(parse_linux_ping_output(
-        display_host,
-        &stdout,
-        &stderr,
-        count,
+    Ok(result)
+}
+
+#[cfg(target_os = "linux")]
+fn run_command_with_deadline(
+    mut command: Command,
+    deadline: Instant,
+) -> std::io::Result<(Output, bool)> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut timed_out = false;
+    loop {
+        if child.try_wait()?.is_some() {
+            break;
+        }
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            timed_out = true;
+            let _ = child.kill();
+            break;
+        };
+        thread::sleep(min(Duration::from_millis(5), remaining));
+    }
+
+    let status = child.wait()?;
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        pipe.read_to_end(&mut stdout)?;
+    }
+    if let Some(mut pipe) = child.stderr.take() {
+        pipe.read_to_end(&mut stderr)?;
+    }
+
+    Ok((
+        Output {
+            status,
+            stdout,
+            stderr,
+        },
+        timed_out,
     ))
+}
+
+#[cfg(target_os = "linux")]
+fn normalize_timed_out_ping_result(result: &mut IcmpPingResult) {
+    result.sent = result.attempts.len().max(1);
+    result.received = result
+        .attempts
+        .iter()
+        .filter(|attempt| attempt.reachable)
+        .count();
+    result.loss_percent = if result.sent == 0 {
+        0.0
+    } else {
+        ((result.sent.saturating_sub(result.received)) as f64 / result.sent as f64) * 100.0
+    };
+}
+
+#[cfg(target_os = "linux")]
+fn timeout_ping_result(host: &str, target_ip: IpAddr) -> IcmpPingResult {
+    IcmpPingResult {
+        host: host.to_string(),
+        target_addr: Some(target_ip.to_string()),
+        sent: 0,
+        received: 0,
+        loss_percent: 100.0,
+        min_ms: None,
+        avg_ms: None,
+        max_ms: None,
+        attempts: Vec::new(),
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
 fn icmp_ping(
     _display_host: &str,
-    _target_ip: IpAddr,
+    _target_ips: &[IpAddr],
     _options: &ProbeOptions,
 ) -> Result<IcmpPingResult, ProbeError> {
     Err(ProbeError::unsupported_platform(
@@ -1397,11 +1506,8 @@ fn icmp_ping_for_host(
     options: &ProbeOptions,
 ) -> Result<HashMap<String, Value>, String> {
     let targets = resolve_probe_targets(host, &[0], options.allow_private)?;
-    let target_ip = unique_target_ips(&targets)?
-        .into_iter()
-        .next()
-        .ok_or_else(|| empty_probe_targets_error().to_string())?;
-    let result = icmp_ping(host, target_ip, options).map_err(|err| err.to_string())?;
+    let target_ips = unique_target_ips(&targets)?;
+    let result = icmp_ping(host, &target_ips, options).map_err(|err| err.to_string())?;
     Ok(icmp_ping_result_map(result))
 }
 
@@ -1421,6 +1527,58 @@ fn unique_target_ips(targets: &[(u16, SocketAddr)]) -> Result<Vec<IpAddr>, Strin
         return Err(empty_probe_targets_error().to_string());
     }
     Ok(ips)
+}
+
+fn combine_icmp_ping_attempts(host: &str, results: Vec<IcmpPingResult>) -> IcmpPingResult {
+    let mut sent = 0usize;
+    let mut received = 0usize;
+    let mut target_addr = results
+        .iter()
+        .find(|result| result.received > 0)
+        .and_then(|result| result.target_addr.clone())
+        .or_else(|| {
+            results
+                .first()
+                .and_then(|result| result.target_addr.clone())
+        });
+    let mut attempts = Vec::new();
+    for mut result in results {
+        sent = sent.saturating_add(result.sent);
+        received = received.saturating_add(result.received);
+        attempts.append(&mut result.attempts);
+        if target_addr.is_none() {
+            target_addr = result.target_addr;
+        }
+    }
+
+    let mut min_ms: Option<f64> = None;
+    let mut max_ms: Option<f64> = None;
+    let mut latency_total = 0.0;
+    let mut latency_count = 0usize;
+    for latency_ms in attempts.iter().filter_map(|attempt| attempt.latency_ms) {
+        min_ms = Some(min_ms.map_or(latency_ms, |current| current.min(latency_ms)));
+        max_ms = Some(max_ms.map_or(latency_ms, |current| current.max(latency_ms)));
+        latency_total += latency_ms;
+        latency_count += 1;
+    }
+    let avg_ms = (latency_count > 0).then(|| latency_total / latency_count as f64);
+    let loss_percent = if sent == 0 {
+        100.0
+    } else {
+        ((sent.saturating_sub(received)) as f64 / sent as f64) * 100.0
+    };
+
+    IcmpPingResult {
+        host: host.to_string(),
+        target_addr,
+        sent,
+        received,
+        loss_percent,
+        min_ms,
+        avg_ms,
+        max_ms,
+        attempts,
+    }
 }
 
 fn linux_ping_output_has_packet_summary(output: &str) -> bool {
@@ -2776,6 +2934,86 @@ mod tests {
         assert_eq!(result.received, 1);
         assert_eq!(result.loss_percent, 50.0);
         assert_eq!(result.attempts.len(), 1);
+        assert!(result.attempts[0].reachable);
+    }
+
+    #[test]
+    fn combine_icmp_ping_attempts_aggregates_multi_address_fallback() {
+        let unreachable = IcmpPingResult {
+            host: "example.com".to_string(),
+            target_addr: Some("2001:db8::1".to_string()),
+            sent: 1,
+            received: 0,
+            loss_percent: 100.0,
+            min_ms: None,
+            avg_ms: None,
+            max_ms: None,
+            attempts: vec![IcmpPingAttempt {
+                seq: Some(1),
+                reachable: false,
+                from: Some("2001:db8::1".to_string()),
+                ttl: None,
+                latency_ms: None,
+                error: Some("Destination unreachable".to_string()),
+            }],
+        };
+        let reachable = IcmpPingResult {
+            host: "example.com".to_string(),
+            target_addr: Some("93.184.216.34".to_string()),
+            sent: 1,
+            received: 1,
+            loss_percent: 0.0,
+            min_ms: Some(12.0),
+            avg_ms: Some(12.0),
+            max_ms: Some(12.0),
+            attempts: vec![IcmpPingAttempt {
+                seq: Some(1),
+                reachable: true,
+                from: Some("93.184.216.34".to_string()),
+                ttl: Some(58),
+                latency_ms: Some(12.0),
+                error: None,
+            }],
+        };
+
+        let result = combine_icmp_ping_attempts("example.com", vec![unreachable, reachable]);
+
+        assert_eq!(result.target_addr.as_deref(), Some("93.184.216.34"));
+        assert_eq!(result.sent, 2);
+        assert_eq!(result.received, 1);
+        assert_eq!(result.loss_percent, 50.0);
+        assert_eq!(result.attempts.len(), 2);
+        assert_eq!(result.avg_ms, Some(12.0));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn ping_target_budget_splits_short_deadlines_across_addresses() {
+        assert_eq!(
+            ping_target_budget(Duration::from_millis(50), 4),
+            Duration::from_millis(12)
+        );
+        assert_eq!(
+            ping_target_budget(Duration::from_millis(50), 1),
+            Duration::from_millis(50)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn timed_out_ping_result_keeps_partial_replies_reachable() {
+        let mut result = parse_linux_ping_output(
+            "example.com",
+            "64 bytes from 93.184.216.34: icmp_seq=1 ttl=58 time=12.3 ms\n",
+            "",
+            2,
+        );
+
+        normalize_timed_out_ping_result(&mut result);
+
+        assert_eq!(result.sent, 1);
+        assert_eq!(result.received, 1);
+        assert_eq!(result.loss_percent, 0.0);
         assert!(result.attempts[0].reachable);
     }
 

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -20,7 +20,7 @@ use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
 #[cfg(target_os = "linux")]
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
@@ -764,10 +764,7 @@ fn ping_fn(args: &[Value]) -> Result<Value, IntentError> {
     Ok(result_value((|| {
         validate_ping_method(opts.and_then(|m| m.get("method")))?;
         let options = parse_probe_options(opts)?;
-        let targets = resolve_ping_targets(host)?;
-        enforce_resolved_target_policy(&targets, options.allow_private)?;
-        let command_targets = validated_probe_ips(&targets)?;
-        system_ping(host, &command_targets, options.timeout, options.count)
+        Ok(Value::Map(icmp_ping_for_host(host, &options)?))
     })()))
 }
 
@@ -884,8 +881,7 @@ fn tls_info_fn(args: &[Value]) -> Result<Value, IntentError> {
             .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
         let server_name = parse_string_option(opts, "server_name")?.unwrap_or(host);
         let allow_private = parse_bool_option(opts, "allow_private", false)?;
-        let targets = resolve_tcp_targets(host, &[port])?;
-        enforce_resolved_target_policy(&targets, allow_private)?;
+        let targets = resolve_probe_targets(host, &[port], allow_private)?;
         let deadline = Instant::now() + Duration::from_millis(timeout_ms);
         let mut last_error = None;
         for (_, addr) in targets {
@@ -1320,120 +1316,13 @@ struct IcmpPingResult {
     attempts: Vec<IcmpPingAttempt>,
 }
 
-fn merge_icmp_ping_results(host: &str, results: Vec<IcmpPingResult>) -> Option<IcmpPingResult> {
-    if results.is_empty() {
-        return None;
-    }
-
-    let sent: usize = results.iter().map(|result| result.sent).sum();
-    let received: usize = results.iter().map(|result| result.received).sum();
-    let target_addr = results
-        .iter()
-        .find(|result| result.received > 0)
-        .and_then(|result| result.target_addr.clone())
-        .or_else(|| results.iter().find_map(|result| result.target_addr.clone()));
-    let attempts: Vec<IcmpPingAttempt> = results
-        .into_iter()
-        .flat_map(|result| result.attempts)
-        .collect();
-    let latencies: Vec<f64> = attempts
-        .iter()
-        .filter_map(|attempt| attempt.latency_ms)
-        .collect();
-    let min_ms = latencies.iter().copied().reduce(f64::min);
-    let max_ms = latencies.iter().copied().reduce(f64::max);
-    let avg_ms = if latencies.is_empty() {
-        None
-    } else {
-        Some(latencies.iter().sum::<f64>() / latencies.len() as f64)
-    };
-    let loss_percent = if sent == 0 {
-        100.0
-    } else {
-        ((sent.saturating_sub(received)) as f64 / sent as f64) * 100.0
-    };
-
-    Some(IcmpPingResult {
-        host: host.to_string(),
-        target_addr,
-        sent,
-        received,
-        loss_percent,
-        min_ms,
-        avg_ms,
-        max_ms,
-        attempts,
-    })
-}
-
-fn resolve_ping_targets(host: &str) -> Result<Vec<(u16, SocketAddr)>, String> {
-    let resolved: Vec<SocketAddr> = (host, 0)
-        .to_socket_addrs()
-        .map_err(|e| {
-            ProbeError::resolve_failed(host, format!("failed to resolve {}: {}", host, e))
-                .to_string()
-        })?
-        .collect();
-    Ok(resolved.into_iter().map(|addr| (0, addr)).collect())
-}
-
 #[cfg(target_os = "linux")]
-fn system_ping(
+fn icmp_ping(
     display_host: &str,
-    command_targets: &[IpAddr],
-    timeout: Duration,
-    count: usize,
-) -> Result<Value, String> {
-    if command_targets.len() == 1 {
-        let result = run_linux_ping(display_host, command_targets[0], timeout, count)
-            .map_err(|err| err.to_string())?;
-        return Ok(Value::Map(icmp_ping_result_map(result)));
-    }
-
-    let started = Instant::now();
-    let discovery_timeout = ping_timeout_slice(timeout, command_targets.len());
-    let mut results = Vec::new();
-    let mut last_error = None;
-
-    for command_target in command_targets {
-        match run_linux_ping(display_host, *command_target, discovery_timeout, 1) {
-            Ok(result) if result.received > 0 => {
-                results.push(result);
-                let sent: usize = results.iter().map(|result| result.sent).sum();
-                let remaining_count = count.saturating_sub(sent);
-                if remaining_count > 0 {
-                    if let Some(remaining_timeout) = timeout.checked_sub(started.elapsed()) {
-                        let result = run_linux_ping(
-                            display_host,
-                            *command_target,
-                            remaining_timeout,
-                            remaining_count,
-                        )
-                        .map_err(|err| err.to_string())?;
-                        results.push(result);
-                    }
-                }
-                return Ok(Value::Map(icmp_ping_result_map(
-                    merge_icmp_ping_results(display_host, results).expect("ping result recorded"),
-                )));
-            }
-            Ok(result) => results.push(result),
-            Err(err) => last_error = Some(err),
-        }
-    }
-
-    if let Some(result) = merge_icmp_ping_results(display_host, results) {
-        return Ok(Value::Map(icmp_ping_result_map(result)));
-    }
-
-    Err(last_error
-        .unwrap_or_else(|| {
-            ProbeError::resolve_failed(
-                display_host,
-                "failed to resolve target: resolver returned no usable addresses",
-            )
-        })
-        .to_string())
+    target_ip: IpAddr,
+    options: &ProbeOptions,
+) -> Result<IcmpPingResult, ProbeError> {
+    run_linux_ping(display_host, target_ip, options.timeout, options.count)
 }
 
 #[cfg(target_os = "linux")]
@@ -1447,88 +1336,14 @@ fn ping_timeout_secs(timeout: Duration) -> u64 {
 }
 
 #[cfg(target_os = "linux")]
-fn ping_timeout_slice(timeout: Duration, target_count: usize) -> Duration {
-    let target_count = target_count.max(1) as u128;
-    let timeout_ms = timeout.as_millis().max(1);
-    let slice_ms = timeout_ms.saturating_add(target_count - 1) / target_count;
-    Duration::from_millis(slice_ms.min(u64::MAX as u128) as u64)
-}
-
-#[cfg(target_os = "linux")]
-struct TimedCommandOutput {
-    output: std::process::Output,
-    timed_out: bool,
-}
-
-#[cfg(target_os = "linux")]
-fn wait_with_timeout(
-    mut child: std::process::Child,
-    timeout: Duration,
-) -> Result<TimedCommandOutput, std::io::Error> {
-    let started = Instant::now();
-    loop {
-        if child.try_wait()?.is_some() {
-            return child.wait_with_output().map(|output| TimedCommandOutput {
-                output,
-                timed_out: false,
-            });
-        }
-        if started.elapsed() >= timeout {
-            match child.kill() {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::InvalidInput => {}
-                Err(err) => return Err(err),
-            }
-            return child.wait_with_output().map(|output| TimedCommandOutput {
-                output,
-                timed_out: true,
-            });
-        }
-        let remaining = timeout
-            .checked_sub(started.elapsed())
-            .unwrap_or_else(|| Duration::from_millis(1));
-        thread::sleep(min(Duration::from_millis(5), remaining));
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn linux_ping_timeout_result(
-    display_host: &str,
-    command_target: IpAddr,
-    count: usize,
-) -> IcmpPingResult {
-    let attempts = (1..=count)
-        .map(|seq| IcmpPingAttempt {
-            seq: Some(seq as i64),
-            reachable: false,
-            from: None,
-            ttl: None,
-            latency_ms: None,
-            error: Some("timeout".to_string()),
-        })
-        .collect();
-    IcmpPingResult {
-        host: display_host.to_string(),
-        target_addr: Some(command_target.to_string()),
-        sent: count,
-        received: 0,
-        loss_percent: 100.0,
-        min_ms: None,
-        avg_ms: None,
-        max_ms: None,
-        attempts,
-    }
-}
-
-#[cfg(target_os = "linux")]
 fn run_linux_ping(
     display_host: &str,
-    command_target: IpAddr,
+    target_ip: IpAddr,
     timeout: Duration,
     count: usize,
 ) -> Result<IcmpPingResult, ProbeError> {
     let timeout_secs = ping_timeout_secs(timeout);
-    let child = Command::new("ping")
+    let output = Command::new("ping")
         .arg("-n")
         .arg("-c")
         .arg(count.to_string())
@@ -1537,18 +1352,9 @@ fn run_linux_ping(
         .arg("-w")
         .arg(timeout_secs.to_string())
         .arg("--")
-        .arg(command_target.to_string())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+        .arg(target_ip.to_string())
+        .output()
         .map_err(|e| {
-            ProbeError::capability_unavailable(
-                ProbeProtocol::Icmp,
-                format!("ICMP ping unavailable: failed to run ping: {}", e),
-            )
-        })?;
-    let TimedCommandOutput { output, timed_out } =
-        wait_with_timeout(child, timeout).map_err(|e| {
             ProbeError::capability_unavailable(
                 ProbeProtocol::Icmp,
                 format!("ICMP ping unavailable: failed to run ping: {}", e),
@@ -1558,17 +1364,6 @@ fn run_linux_ping(
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let has_packet_summary = linux_ping_output_has_packet_summary(&stdout);
-    let parsed = parse_linux_ping_output(display_host, &stdout, &stderr, count);
-    if timed_out && !has_packet_summary {
-        if parsed.attempts.is_empty() {
-            return Ok(linux_ping_timeout_result(
-                display_host,
-                command_target,
-                count,
-            ));
-        }
-        return Ok(parsed);
-    }
     if !output.status.success() && !has_packet_summary {
         let message = format!(
             "ICMP ping unavailable: system ping failed: {}",
@@ -1577,44 +1372,44 @@ fn run_linux_ping(
         return Err(icmp_ping_process_error(message));
     }
 
-    Ok(parsed)
+    Ok(parse_linux_ping_output(
+        display_host,
+        &stdout,
+        &stderr,
+        count,
+    ))
 }
 
 #[cfg(not(target_os = "linux"))]
-fn system_ping(
+fn icmp_ping(
     _display_host: &str,
-    _command_targets: &[IpAddr],
-    _timeout: Duration,
-    _count: usize,
-) -> Result<Value, String> {
+    _target_ip: IpAddr,
+    _options: &ProbeOptions,
+) -> Result<IcmpPingResult, ProbeError> {
     Err(ProbeError::unsupported_platform(
         ProbeProtocol::Icmp,
         "ICMP ping unavailable on this platform",
-    )
-    .to_string())
+    ))
 }
 
 fn icmp_ping_for_host(
     host: &str,
     options: &ProbeOptions,
 ) -> Result<HashMap<String, Value>, String> {
-    let targets = resolve_ping_targets(host)?;
-    enforce_resolved_target_policy(&targets, options.allow_private)?;
-    let command_targets = validated_probe_ips(&targets)?;
-    match system_ping(host, &command_targets, options.timeout, options.count)? {
-        Value::Map(map) => Ok(map),
-        other => Err(ProbeError::unexpected_result(
-            ProbeProtocol::Icmp,
-            format!(
-                "ICMP ping unavailable: unexpected ping result {}",
-                other.type_name()
-            ),
-        )
-        .to_string()),
-    }
+    let targets = resolve_probe_targets(host, &[0], options.allow_private)?;
+    let target_ip = unique_target_ips(&targets)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| empty_probe_targets_error().to_string())?;
+    let result = icmp_ping(host, target_ip, options).map_err(|err| err.to_string())?;
+    Ok(icmp_ping_result_map(result))
 }
 
-fn validated_probe_ips(targets: &[(u16, SocketAddr)]) -> Result<Vec<IpAddr>, String> {
+fn empty_probe_targets_error() -> ProbeError {
+    ProbeError::resolve_failed("failed to resolve target: resolver returned no usable addresses")
+}
+
+fn unique_target_ips(targets: &[(u16, SocketAddr)]) -> Result<Vec<IpAddr>, String> {
     let mut ips = Vec::new();
     for (_, addr) in targets {
         let ip = addr.ip();
@@ -1623,11 +1418,7 @@ fn validated_probe_ips(targets: &[(u16, SocketAddr)]) -> Result<Vec<IpAddr>, Str
         }
     }
     if ips.is_empty() {
-        return Err(ProbeError::resolve_failed(
-            "",
-            "failed to resolve target: resolver returned no usable addresses",
-        )
-        .to_string());
+        return Err(empty_probe_targets_error().to_string());
     }
     Ok(ips)
 }
@@ -1917,8 +1708,7 @@ fn tcp_reachability_attempts_for_host(
     interval: Duration,
     allow_private: bool,
 ) -> Result<Vec<TcpProbeResult>, String> {
-    let targets = resolve_tcp_targets(host, ports)?;
-    enforce_resolved_target_policy(&targets, allow_private)?;
+    let targets = resolve_probe_targets(host, ports, allow_private)?;
     Ok(tcp_reachability_attempts(
         &targets, timeout, count, interval,
     ))
@@ -2077,22 +1867,27 @@ fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> Tc
     }
 }
 
-fn resolve_tcp_targets(host: &str, ports: &[u16]) -> Result<Vec<(u16, SocketAddr)>, String> {
+fn resolve_probe_targets(
+    host: &str,
+    ports: &[u16],
+    allow_private: bool,
+) -> Result<Vec<(u16, SocketAddr)>, String> {
     let mut targets = Vec::new();
     for port in ports {
-        let target = format!("{}:{}", host, port);
         let addrs: Vec<SocketAddr> = (host, *port)
             .to_socket_addrs()
             .map_err(|e| {
-                ProbeError::resolve_failed(
-                    target.clone(),
-                    format!("failed to resolve {}:{}: {}", host, port, e),
-                )
-                .to_string()
+                let message = if *port == 0 {
+                    format!("failed to resolve {}: {}", host, e)
+                } else {
+                    format!("failed to resolve {}:{}: {}", host, port, e)
+                };
+                ProbeError::resolve_failed(message).to_string()
             })?
             .collect();
         targets.extend(addrs.into_iter().map(|addr| (*port, addr)));
     }
+    enforce_resolved_target_policy(&targets, allow_private)?;
     Ok(targets)
 }
 
@@ -2104,8 +1899,7 @@ fn resolve_port_scan_targets(host: &str, ports: &[u16]) -> Result<Vec<(u16, Sock
     let resolved: Vec<SocketAddr> = (host, seed_port)
         .to_socket_addrs()
         .map_err(|e| {
-            ProbeError::resolve_failed(host, format!("failed to resolve {}: {}", host, e))
-                .to_string()
+            ProbeError::resolve_failed(format!("failed to resolve {}: {}", host, e)).to_string()
         })?
         .collect();
 
@@ -2585,7 +2379,6 @@ fn enforce_target_policy_error(ip: IpAddr, allow_private: bool) -> Result<(), Pr
         || classification.is_broadcast;
     if never_allowed {
         return Err(ProbeError::policy_denied(
-            ip.to_string(),
             "Network target denied by policy: special-purpose targets are not allowed",
         ));
     }
@@ -2599,7 +2392,6 @@ fn enforce_target_policy_error(ip: IpAddr, allow_private: bool) -> Result<(), Pr
     }
     if !allow_private || !process_allows_private_targets() {
         return Err(ProbeError::policy_denied(
-            ip.to_string(),
             "Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1",
         ));
     }
@@ -3044,14 +2836,14 @@ mod tests {
     }
 
     #[test]
-    fn ping_uses_policy_validated_ips_as_command_targets() {
+    fn unique_target_ips_preserves_resolver_order_without_duplicates() {
         let public_v6 = "[2001:4860:4860::8888]:0".parse::<SocketAddr>().unwrap();
         let public_v4 = "93.184.216.34:0".parse::<SocketAddr>().unwrap();
         let duplicate_v4 = "93.184.216.34:0".parse::<SocketAddr>().unwrap();
         let targets = [(0, public_v6), (0, public_v4), (0, duplicate_v4)];
 
         assert_eq!(
-            validated_probe_ips(&targets).unwrap(),
+            unique_target_ips(&targets).unwrap(),
             vec![
                 "2001:4860:4860::8888".parse::<IpAddr>().unwrap(),
                 "93.184.216.34".parse::<IpAddr>().unwrap(),
@@ -3060,114 +2852,13 @@ mod tests {
     }
 
     #[test]
-    fn ping_command_targets_reject_empty_resolution_set() {
-        let err = validated_probe_ips(&[]).unwrap_err();
+    fn unique_target_ips_rejects_empty_resolution_set() {
+        let err = unique_target_ips(&[]).unwrap_err();
 
         assert_eq!(
             err,
             "failed to resolve target: resolver returned no usable addresses"
         );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn ping_timeout_slice_shares_discovery_timeout_across_targets() {
-        assert_eq!(ping_timeout_secs(Duration::from_millis(2_000)), 2);
-        assert_eq!(
-            ping_timeout_slice(Duration::from_millis(2_000), 1),
-            Duration::from_millis(2_000)
-        );
-        assert_eq!(
-            ping_timeout_slice(Duration::from_millis(2_000), 2),
-            Duration::from_millis(1_000)
-        );
-        assert_eq!(
-            ping_timeout_slice(Duration::from_millis(3_500), 2),
-            Duration::from_millis(1_750)
-        );
-        assert_eq!(
-            ping_timeout_slice(Duration::from_millis(50), 4),
-            Duration::from_millis(13)
-        );
-        assert_eq!(
-            ping_timeout_slice(Duration::from_millis(2_000), 0),
-            Duration::from_millis(2_000)
-        );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn linux_ping_timeout_result_reports_attempt_timeout() {
-        let result =
-            linux_ping_timeout_result("example.com", "93.184.216.34".parse::<IpAddr>().unwrap(), 2);
-
-        assert_eq!(result.sent, 2);
-        assert_eq!(result.received, 0);
-        assert_eq!(result.loss_percent, 100.0);
-        assert_eq!(result.target_addr.as_deref(), Some("93.184.216.34"));
-        assert_eq!(result.attempts.len(), 2);
-        assert_eq!(result.attempts[0].error.as_deref(), Some("timeout"));
-    }
-
-    #[test]
-    fn merged_ping_results_report_aggregate_attempts_and_reachable_target() {
-        let first = IcmpPingResult {
-            host: "example.com".to_string(),
-            target_addr: Some("2001:db8::1".to_string()),
-            sent: 1,
-            received: 0,
-            loss_percent: 100.0,
-            min_ms: None,
-            avg_ms: None,
-            max_ms: None,
-            attempts: vec![IcmpPingAttempt {
-                seq: Some(1),
-                reachable: false,
-                from: None,
-                ttl: None,
-                latency_ms: None,
-                error: Some("timeout".to_string()),
-            }],
-        };
-        let second = IcmpPingResult {
-            host: "example.com".to_string(),
-            target_addr: Some("93.184.216.34".to_string()),
-            sent: 2,
-            received: 2,
-            loss_percent: 0.0,
-            min_ms: Some(10.0),
-            avg_ms: Some(12.0),
-            max_ms: Some(14.0),
-            attempts: vec![
-                IcmpPingAttempt {
-                    seq: Some(1),
-                    reachable: true,
-                    from: Some("93.184.216.34".to_string()),
-                    ttl: Some(57),
-                    latency_ms: Some(10.0),
-                    error: None,
-                },
-                IcmpPingAttempt {
-                    seq: Some(2),
-                    reachable: true,
-                    from: Some("93.184.216.34".to_string()),
-                    ttl: Some(57),
-                    latency_ms: Some(14.0),
-                    error: None,
-                },
-            ],
-        };
-
-        let merged = merge_icmp_ping_results("example.com", vec![first, second]).unwrap();
-
-        assert_eq!(merged.sent, 3);
-        assert_eq!(merged.received, 2);
-        assert!((merged.loss_percent - (100.0 / 3.0)).abs() < 1e-9);
-        assert_eq!(merged.target_addr.as_deref(), Some("93.184.216.34"));
-        assert_eq!(merged.attempts.len(), 3);
-        assert_eq!(merged.min_ms, Some(10.0));
-        assert_eq!(merged.avg_ms, Some(12.0));
-        assert_eq!(merged.max_ms, Some(14.0));
     }
 
     #[test]
@@ -3206,8 +2897,8 @@ mod tests {
     }
 
     #[test]
-    fn resolve_ping_targets_accepts_ipv6_literals() {
-        let targets = resolve_ping_targets("::1").unwrap();
+    fn resolve_probe_targets_accepts_ipv6_literals() {
+        let targets = resolve_probe_targets("2001:4860:4860::8888", &[0], false).unwrap();
         assert!(targets.iter().any(|(_, addr)| addr.ip().is_ipv6()));
     }
 

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -1384,44 +1384,45 @@ fn system_ping(
     timeout: Duration,
     count: usize,
 ) -> Result<Value, String> {
-    let deadline = Instant::now() + timeout;
+    if command_targets.len() == 1 {
+        let result = run_linux_ping(
+            display_host,
+            command_targets[0],
+            ping_timeout_secs(timeout),
+            count,
+        )
+        .map_err(|err| err.to_string())?;
+        return Ok(Value::Map(icmp_ping_result_map(result)));
+    }
+
+    let started = Instant::now();
+    let discovery_timeout_secs = ping_timeout_slice_secs(timeout, command_targets.len());
     let mut results = Vec::new();
-    let mut sent = 0usize;
     let mut last_error = None;
 
     for command_target in command_targets {
-        if sent >= count {
-            break;
-        }
-        let Some(timeout_secs) = ping_remaining_timeout_secs(deadline) else {
-            break;
-        };
-        let probe_count = ping_probe_count_for_target(command_targets.len(), sent, count);
-        match run_linux_ping(display_host, *command_target, timeout_secs, probe_count) {
+        match run_linux_ping(display_host, *command_target, discovery_timeout_secs, 1) {
             Ok(result) if result.received > 0 => {
-                sent += result.sent;
                 results.push(result);
+                let sent: usize = results.iter().map(|result| result.sent).sum();
                 let remaining_count = count.saturating_sub(sent);
                 if remaining_count > 0 {
-                    if let Some(timeout_secs) = ping_remaining_timeout_secs(deadline) {
-                        if let Ok(result) = run_linux_ping(
+                    if let Some(remaining_timeout) = timeout.checked_sub(started.elapsed()) {
+                        let result = run_linux_ping(
                             display_host,
                             *command_target,
-                            timeout_secs,
+                            ping_timeout_secs(remaining_timeout),
                             remaining_count,
-                        ) {
-                            results.push(result);
-                        }
+                        )
+                        .map_err(|err| err.to_string())?;
+                        results.push(result);
                     }
                 }
                 return Ok(Value::Map(icmp_ping_result_map(
                     merge_icmp_ping_results(display_host, results).expect("ping result recorded"),
                 )));
             }
-            Ok(result) => {
-                sent += result.sent;
-                results.push(result);
-            }
+            Ok(result) => results.push(result),
             Err(err) => last_error = Some(err),
         }
     }
@@ -1441,27 +1442,21 @@ fn system_ping(
 }
 
 #[cfg(target_os = "linux")]
-fn ping_probe_count_for_target(target_count: usize, sent: usize, requested_count: usize) -> usize {
-    let remaining = requested_count.saturating_sub(sent);
-    if target_count <= 1 {
-        remaining
-    } else {
-        remaining.min(1)
-    }
+fn ping_timeout_secs(timeout: Duration) -> u64 {
+    max(
+        1,
+        timeout
+            .as_secs()
+            .saturating_add(if timeout.subsec_millis() > 0 { 1 } else { 0 }),
+    )
 }
 
 #[cfg(target_os = "linux")]
-fn ping_remaining_timeout_secs(deadline: Instant) -> Option<u64> {
-    let remaining = deadline.checked_duration_since(Instant::now())?;
-    if remaining.is_zero() {
-        return None;
-    }
-    Some(max(
-        1,
-        remaining
-            .as_secs()
-            .saturating_add(if remaining.subsec_millis() > 0 { 1 } else { 0 }),
-    ))
+fn ping_timeout_slice_secs(timeout: Duration, target_count: usize) -> u64 {
+    let target_count = target_count.max(1) as u128;
+    let timeout_ms = timeout.as_millis();
+    let slice_ms = timeout_ms.saturating_add(target_count - 1) / target_count;
+    ping_timeout_secs(Duration::from_millis(slice_ms.min(u64::MAX as u128) as u64))
 }
 
 #[cfg(target_os = "linux")]
@@ -2985,11 +2980,12 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn ping_probe_count_shares_requested_count_across_targets() {
-        assert_eq!(ping_probe_count_for_target(1, 0, 3), 3);
-        assert_eq!(ping_probe_count_for_target(2, 0, 3), 1);
-        assert_eq!(ping_probe_count_for_target(2, 2, 3), 1);
-        assert_eq!(ping_probe_count_for_target(2, 3, 3), 0);
+    fn ping_timeout_slice_shares_discovery_timeout_across_targets() {
+        assert_eq!(ping_timeout_secs(Duration::from_millis(2_000)), 2);
+        assert_eq!(ping_timeout_slice_secs(Duration::from_millis(2_000), 1), 2);
+        assert_eq!(ping_timeout_slice_secs(Duration::from_millis(2_000), 2), 1);
+        assert_eq!(ping_timeout_slice_secs(Duration::from_millis(3_500), 2), 2);
+        assert_eq!(ping_timeout_slice_secs(Duration::from_millis(2_000), 0), 2);
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -1411,7 +1411,10 @@ fn run_linux_ping(
             "ICMP ping unavailable: system ping failed: {}",
             ping_failure_message(&stdout, &stderr, output.status.code())
         );
-        return Err(icmp_ping_process_error(message));
+        if linux_ping_permission_error(&message) {
+            return Err(icmp_ping_process_error(message));
+        }
+        return Ok(failed_ping_result(display_host, target_ip, message));
     }
 
     Ok(result)
@@ -1486,6 +1489,28 @@ fn timeout_ping_result(host: &str, target_ip: IpAddr) -> IcmpPingResult {
         avg_ms: None,
         max_ms: None,
         attempts: Vec::new(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn failed_ping_result(host: &str, target_ip: IpAddr, message: String) -> IcmpPingResult {
+    IcmpPingResult {
+        host: host.to_string(),
+        target_addr: Some(target_ip.to_string()),
+        sent: 1,
+        received: 0,
+        loss_percent: 100.0,
+        min_ms: None,
+        avg_ms: None,
+        max_ms: None,
+        attempts: vec![IcmpPingAttempt {
+            seq: None,
+            reachable: false,
+            from: Some(target_ip.to_string()),
+            ttl: None,
+            latency_ms: None,
+            error: Some(message),
+        }],
     }
 }
 
@@ -1602,12 +1627,16 @@ fn ping_failure_message(stdout: &str, stderr: &str, status_code: Option<i32>) ->
 }
 
 #[cfg(target_os = "linux")]
-fn icmp_ping_process_error(message: String) -> ProbeError {
+fn linux_ping_permission_error(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
-    if lower.contains("operation not permitted")
+    lower.contains("operation not permitted")
         || lower.contains("permission denied")
         || lower.contains("cap_net_raw")
-    {
+}
+
+#[cfg(target_os = "linux")]
+fn icmp_ping_process_error(message: String) -> ProbeError {
+    if linux_ping_permission_error(&message) {
         ProbeError::permission_denied(ProbeProtocol::Icmp, message)
     } else {
         ProbeError::system_failure(ProbeProtocol::Icmp, message)
@@ -3015,6 +3044,33 @@ mod tests {
         assert_eq!(result.received, 1);
         assert_eq!(result.loss_percent, 0.0);
         assert!(result.attempts[0].reachable);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn target_ping_failure_can_be_aggregated_with_later_success() {
+        let failed = failed_ping_result(
+            "example.com",
+            "2001:db8::1".parse::<IpAddr>().unwrap(),
+            "ICMP ping unavailable: system ping failed: connect: Network is unreachable"
+                .to_string(),
+        );
+        let success = parse_linux_ping_output(
+            "example.com",
+            "PING example.com (93.184.216.34) 56(84) bytes of data.\n64 bytes from 93.184.216.34: icmp_seq=1 ttl=58 time=12.3 ms\n\n--- example.com ping statistics ---\n1 packets transmitted, 1 received, 0% packet loss, time 0ms\nrtt min/avg/max/mdev = 12.300/12.300/12.300/0.000 ms\n",
+            "",
+            1,
+        );
+
+        let result = combine_icmp_ping_attempts("example.com", vec![failed, success]);
+
+        assert_eq!(result.target_addr.as_deref(), Some("93.184.216.34"));
+        assert_eq!(result.sent, 2);
+        assert_eq!(result.received, 1);
+        assert!(matches!(
+            result.attempts.first().and_then(|attempt| attempt.error.as_deref()),
+            Some(message) if message.contains("Network is unreachable")
+        ));
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -20,7 +20,7 @@ use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
 #[cfg(target_os = "linux")]
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
@@ -1385,23 +1385,18 @@ fn system_ping(
     count: usize,
 ) -> Result<Value, String> {
     if command_targets.len() == 1 {
-        let result = run_linux_ping(
-            display_host,
-            command_targets[0],
-            ping_timeout_secs(timeout),
-            count,
-        )
-        .map_err(|err| err.to_string())?;
+        let result = run_linux_ping(display_host, command_targets[0], timeout, count)
+            .map_err(|err| err.to_string())?;
         return Ok(Value::Map(icmp_ping_result_map(result)));
     }
 
     let started = Instant::now();
-    let discovery_timeout_secs = ping_timeout_slice_secs(timeout, command_targets.len());
+    let discovery_timeout = ping_timeout_slice(timeout, command_targets.len());
     let mut results = Vec::new();
     let mut last_error = None;
 
     for command_target in command_targets {
-        match run_linux_ping(display_host, *command_target, discovery_timeout_secs, 1) {
+        match run_linux_ping(display_host, *command_target, discovery_timeout, 1) {
             Ok(result) if result.received > 0 => {
                 results.push(result);
                 let sent: usize = results.iter().map(|result| result.sent).sum();
@@ -1411,7 +1406,7 @@ fn system_ping(
                         let result = run_linux_ping(
                             display_host,
                             *command_target,
-                            ping_timeout_secs(remaining_timeout),
+                            remaining_timeout,
                             remaining_count,
                         )
                         .map_err(|err| err.to_string())?;
@@ -1452,21 +1447,88 @@ fn ping_timeout_secs(timeout: Duration) -> u64 {
 }
 
 #[cfg(target_os = "linux")]
-fn ping_timeout_slice_secs(timeout: Duration, target_count: usize) -> u64 {
+fn ping_timeout_slice(timeout: Duration, target_count: usize) -> Duration {
     let target_count = target_count.max(1) as u128;
-    let timeout_ms = timeout.as_millis();
+    let timeout_ms = timeout.as_millis().max(1);
     let slice_ms = timeout_ms.saturating_add(target_count - 1) / target_count;
-    ping_timeout_secs(Duration::from_millis(slice_ms.min(u64::MAX as u128) as u64))
+    Duration::from_millis(slice_ms.min(u64::MAX as u128) as u64)
+}
+
+#[cfg(target_os = "linux")]
+struct TimedCommandOutput {
+    output: std::process::Output,
+    timed_out: bool,
+}
+
+#[cfg(target_os = "linux")]
+fn wait_with_timeout(
+    mut child: std::process::Child,
+    timeout: Duration,
+) -> Result<TimedCommandOutput, std::io::Error> {
+    let started = Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output().map(|output| TimedCommandOutput {
+                output,
+                timed_out: false,
+            });
+        }
+        if started.elapsed() >= timeout {
+            match child.kill() {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::InvalidInput => {}
+                Err(err) => return Err(err),
+            }
+            return child.wait_with_output().map(|output| TimedCommandOutput {
+                output,
+                timed_out: true,
+            });
+        }
+        let remaining = timeout
+            .checked_sub(started.elapsed())
+            .unwrap_or_else(|| Duration::from_millis(1));
+        thread::sleep(min(Duration::from_millis(5), remaining));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_ping_timeout_result(
+    display_host: &str,
+    command_target: IpAddr,
+    count: usize,
+) -> IcmpPingResult {
+    let attempts = (1..=count)
+        .map(|seq| IcmpPingAttempt {
+            seq: Some(seq as i64),
+            reachable: false,
+            from: None,
+            ttl: None,
+            latency_ms: None,
+            error: Some("timeout".to_string()),
+        })
+        .collect();
+    IcmpPingResult {
+        host: display_host.to_string(),
+        target_addr: Some(command_target.to_string()),
+        sent: count,
+        received: 0,
+        loss_percent: 100.0,
+        min_ms: None,
+        avg_ms: None,
+        max_ms: None,
+        attempts,
+    }
 }
 
 #[cfg(target_os = "linux")]
 fn run_linux_ping(
     display_host: &str,
     command_target: IpAddr,
-    timeout_secs: u64,
+    timeout: Duration,
     count: usize,
 ) -> Result<IcmpPingResult, ProbeError> {
-    let output = Command::new("ping")
+    let timeout_secs = ping_timeout_secs(timeout);
+    let child = Command::new("ping")
         .arg("-n")
         .arg("-c")
         .arg(count.to_string())
@@ -1476,8 +1538,17 @@ fn run_linux_ping(
         .arg(timeout_secs.to_string())
         .arg("--")
         .arg(command_target.to_string())
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| {
+            ProbeError::capability_unavailable(
+                ProbeProtocol::Icmp,
+                format!("ICMP ping unavailable: failed to run ping: {}", e),
+            )
+        })?;
+    let TimedCommandOutput { output, timed_out } =
+        wait_with_timeout(child, timeout).map_err(|e| {
             ProbeError::capability_unavailable(
                 ProbeProtocol::Icmp,
                 format!("ICMP ping unavailable: failed to run ping: {}", e),
@@ -1486,6 +1557,13 @@ fn run_linux_ping(
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    if timed_out && !linux_ping_output_has_packet_summary(&stdout) {
+        return Ok(linux_ping_timeout_result(
+            display_host,
+            command_target,
+            count,
+        ));
+    }
     if !output.status.success() && !linux_ping_output_has_packet_summary(&stdout) {
         let message = format!(
             "ICMP ping unavailable: system ping failed: {}",
@@ -2982,10 +3060,40 @@ mod tests {
     #[test]
     fn ping_timeout_slice_shares_discovery_timeout_across_targets() {
         assert_eq!(ping_timeout_secs(Duration::from_millis(2_000)), 2);
-        assert_eq!(ping_timeout_slice_secs(Duration::from_millis(2_000), 1), 2);
-        assert_eq!(ping_timeout_slice_secs(Duration::from_millis(2_000), 2), 1);
-        assert_eq!(ping_timeout_slice_secs(Duration::from_millis(3_500), 2), 2);
-        assert_eq!(ping_timeout_slice_secs(Duration::from_millis(2_000), 0), 2);
+        assert_eq!(
+            ping_timeout_slice(Duration::from_millis(2_000), 1),
+            Duration::from_millis(2_000)
+        );
+        assert_eq!(
+            ping_timeout_slice(Duration::from_millis(2_000), 2),
+            Duration::from_millis(1_000)
+        );
+        assert_eq!(
+            ping_timeout_slice(Duration::from_millis(3_500), 2),
+            Duration::from_millis(1_750)
+        );
+        assert_eq!(
+            ping_timeout_slice(Duration::from_millis(50), 4),
+            Duration::from_millis(13)
+        );
+        assert_eq!(
+            ping_timeout_slice(Duration::from_millis(2_000), 0),
+            Duration::from_millis(2_000)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_ping_timeout_result_reports_attempt_timeout() {
+        let result =
+            linux_ping_timeout_result("example.com", "93.184.216.34".parse::<IpAddr>().unwrap(), 2);
+
+        assert_eq!(result.sent, 2);
+        assert_eq!(result.received, 0);
+        assert_eq!(result.loss_percent, 100.0);
+        assert_eq!(result.target_addr.as_deref(), Some("93.184.216.34"));
+        assert_eq!(result.attempts.len(), 2);
+        assert_eq!(result.attempts[0].error.as_deref(), Some("timeout"));
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -1557,14 +1557,19 @@ fn run_linux_ping(
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if timed_out && !linux_ping_output_has_packet_summary(&stdout) {
-        return Ok(linux_ping_timeout_result(
-            display_host,
-            command_target,
-            count,
-        ));
+    let has_packet_summary = linux_ping_output_has_packet_summary(&stdout);
+    let parsed = parse_linux_ping_output(display_host, &stdout, &stderr, count);
+    if timed_out && !has_packet_summary {
+        if parsed.attempts.is_empty() {
+            return Ok(linux_ping_timeout_result(
+                display_host,
+                command_target,
+                count,
+            ));
+        }
+        return Ok(parsed);
     }
-    if !output.status.success() && !linux_ping_output_has_packet_summary(&stdout) {
+    if !output.status.success() && !has_packet_summary {
         let message = format!(
             "ICMP ping unavailable: system ping failed: {}",
             ping_failure_message(&stdout, &stderr, output.status.code())
@@ -1572,12 +1577,7 @@ fn run_linux_ping(
         return Err(icmp_ping_process_error(message));
     }
 
-    Ok(parse_linux_ping_output(
-        display_host,
-        &stdout,
-        &stderr,
-        count,
-    ))
+    Ok(parsed)
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -2972,6 +2972,19 @@ mod tests {
         assert!(result.attempts[0].reachable);
         assert_eq!(result.attempts[0].ttl, Some(58));
         assert_eq!(result.attempts[0].latency_ms, Some(12.3));
+    }
+
+    #[test]
+    fn parses_linux_ping_partial_output_without_summary() {
+        let output = "PING example.com (93.184.216.34) 56(84) bytes of data.\n64 bytes from 93.184.216.34: icmp_seq=1 ttl=58 time=12.3 ms\n";
+        let result = parse_linux_ping_output("example.com", output, "", 2);
+
+        assert_eq!(result.target_addr.as_deref(), Some("93.184.216.34"));
+        assert_eq!(result.sent, 2);
+        assert_eq!(result.received, 1);
+        assert_eq!(result.loss_percent, 50.0);
+        assert_eq!(result.attempts.len(), 1);
+        assert!(result.attempts[0].reachable);
     }
 
     #[test]

--- a/src/stdlib/net.rs
+++ b/src/stdlib/net.rs
@@ -22,7 +22,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
 #[cfg(target_os = "linux")]
-use std::process::{Command, Output, Stdio};
+use std::process::{Command, ExitStatus, Output, Stdio};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
@@ -1430,8 +1430,10 @@ fn run_command_with_deadline(
         .stderr(Stdio::piped())
         .spawn()?;
     let mut timed_out = false;
+    let mut status: Option<ExitStatus> = None;
     loop {
-        if child.try_wait()?.is_some() {
+        if let Some(child_status) = child.try_wait()? {
+            status = Some(child_status);
             break;
         }
         let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
@@ -1442,7 +1444,10 @@ fn run_command_with_deadline(
         thread::sleep(min(Duration::from_millis(5), remaining));
     }
 
-    let status = child.wait()?;
+    let status = match status {
+        Some(child_status) => child_status,
+        None => child.wait()?,
+    };
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     if let Some(mut pipe) = child.stdout.take() {
@@ -2068,20 +2073,33 @@ fn resolve_probe_targets(
     ports: &[u16],
     allow_private: bool,
 ) -> Result<Vec<(u16, SocketAddr)>, String> {
-    let mut targets = Vec::new();
+    let Some(seed_port) = ports.first().copied() else {
+        return Ok(Vec::new());
+    };
+
+    let resolved: Vec<SocketAddr> = (host, seed_port)
+        .to_socket_addrs()
+        .map_err(|e| {
+            let message = if seed_port == 0 {
+                format!("failed to resolve {}: {}", host, e)
+            } else {
+                format!("failed to resolve {}:{}: {}", host, seed_port, e)
+            };
+            ProbeError::resolve_failed(message).to_string()
+        })?
+        .collect();
+
+    let mut ips = Vec::with_capacity(resolved.len());
+    let mut seen = HashSet::with_capacity(resolved.len());
+    for addr in resolved {
+        if seen.insert(addr.ip()) {
+            ips.push(addr.ip());
+        }
+    }
+
+    let mut targets = Vec::with_capacity(ports.len() * ips.len());
     for port in ports {
-        let addrs: Vec<SocketAddr> = (host, *port)
-            .to_socket_addrs()
-            .map_err(|e| {
-                let message = if *port == 0 {
-                    format!("failed to resolve {}: {}", host, e)
-                } else {
-                    format!("failed to resolve {}:{}: {}", host, port, e)
-                };
-                ProbeError::resolve_failed(message).to_string()
-            })?
-            .collect();
-        targets.extend(addrs.into_iter().map(|addr| (*port, addr)));
+        targets.extend(ips.iter().map(|ip| (*port, SocketAddr::new(*ip, *port))));
     }
     enforce_resolved_target_policy(&targets, allow_private)?;
     Ok(targets)
@@ -3220,6 +3238,19 @@ mod tests {
     fn resolve_probe_targets_accepts_ipv6_literals() {
         let targets = resolve_probe_targets("2001:4860:4860::8888", &[0], false).unwrap();
         assert!(targets.iter().any(|(_, addr)| addr.ip().is_ipv6()));
+    }
+
+    #[test]
+    fn resolve_probe_targets_resolves_once_then_pairs_ports() {
+        let targets = resolve_probe_targets("93.184.216.34", &[80, 443], false).unwrap();
+
+        assert_eq!(
+            targets,
+            vec![
+                (80, "93.184.216.34:80".parse::<SocketAddr>().unwrap()),
+                (443, "93.184.216.34:443".parse::<SocketAddr>().unwrap()),
+            ]
+        );
     }
 
     #[test]

--- a/src/stdlib/net/probe.rs
+++ b/src/stdlib/net/probe.rs
@@ -25,14 +25,12 @@ pub(super) enum ProbeErrorKind {
     #[cfg(not(target_os = "linux"))]
     UnsupportedPlatform,
     SystemFailure,
-    UnexpectedResult,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ProbeError {
     kind: ProbeErrorKind,
     protocol: Option<ProbeProtocol>,
-    target: Option<String>,
     message: String,
 }
 
@@ -40,33 +38,21 @@ impl ProbeError {
     pub(super) fn new(
         kind: ProbeErrorKind,
         protocol: Option<ProbeProtocol>,
-        target: Option<String>,
         message: impl Into<String>,
     ) -> Self {
         Self {
             kind,
             protocol,
-            target,
             message: message.into(),
         }
     }
 
-    pub(super) fn resolve_failed(target: impl Into<String>, message: impl Into<String>) -> Self {
-        Self::new(
-            ProbeErrorKind::ResolveFailed,
-            None,
-            Some(target.into()),
-            message,
-        )
+    pub(super) fn resolve_failed(message: impl Into<String>) -> Self {
+        Self::new(ProbeErrorKind::ResolveFailed, None, message)
     }
 
-    pub(super) fn policy_denied(target: impl Into<String>, message: impl Into<String>) -> Self {
-        Self::new(
-            ProbeErrorKind::PolicyDenied,
-            None,
-            Some(target.into()),
-            message,
-        )
+    pub(super) fn policy_denied(message: impl Into<String>) -> Self {
+        Self::new(ProbeErrorKind::PolicyDenied, None, message)
     }
 
     pub(super) fn capability_unavailable(
@@ -76,18 +62,12 @@ impl ProbeError {
         Self::new(
             ProbeErrorKind::CapabilityUnavailable,
             Some(protocol),
-            None,
             message,
         )
     }
 
     pub(super) fn permission_denied(protocol: ProbeProtocol, message: impl Into<String>) -> Self {
-        Self::new(
-            ProbeErrorKind::PermissionDenied,
-            Some(protocol),
-            None,
-            message,
-        )
+        Self::new(ProbeErrorKind::PermissionDenied, Some(protocol), message)
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -95,25 +75,11 @@ impl ProbeError {
         protocol: ProbeProtocol,
         message: impl Into<String>,
     ) -> Self {
-        Self::new(
-            ProbeErrorKind::UnsupportedPlatform,
-            Some(protocol),
-            None,
-            message,
-        )
+        Self::new(ProbeErrorKind::UnsupportedPlatform, Some(protocol), message)
     }
 
     pub(super) fn system_failure(protocol: ProbeProtocol, message: impl Into<String>) -> Self {
-        Self::new(ProbeErrorKind::SystemFailure, Some(protocol), None, message)
-    }
-
-    pub(super) fn unexpected_result(protocol: ProbeProtocol, message: impl Into<String>) -> Self {
-        Self::new(
-            ProbeErrorKind::UnexpectedResult,
-            Some(protocol),
-            None,
-            message,
-        )
+        Self::new(ProbeErrorKind::SystemFailure, Some(protocol), message)
     }
 
     #[cfg(test)]

--- a/src/stdlib/net/probe.rs
+++ b/src/stdlib/net/probe.rs
@@ -1,0 +1,142 @@
+use std::fmt;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProbeProtocol {
+    Icmp,
+    Tcp,
+}
+
+impl ProbeProtocol {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Icmp => "icmp",
+            Self::Tcp => "tcp",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProbeErrorKind {
+    ResolveFailed,
+    PolicyDenied,
+    CapabilityUnavailable,
+    PermissionDenied,
+    #[cfg(not(target_os = "linux"))]
+    UnsupportedPlatform,
+    SystemFailure,
+    UnexpectedResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ProbeError {
+    kind: ProbeErrorKind,
+    protocol: Option<ProbeProtocol>,
+    target: Option<String>,
+    message: String,
+}
+
+impl ProbeError {
+    pub(super) fn new(
+        kind: ProbeErrorKind,
+        protocol: Option<ProbeProtocol>,
+        target: Option<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            protocol,
+            target,
+            message: message.into(),
+        }
+    }
+
+    pub(super) fn resolve_failed(target: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(
+            ProbeErrorKind::ResolveFailed,
+            None,
+            Some(target.into()),
+            message,
+        )
+    }
+
+    pub(super) fn policy_denied(target: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(
+            ProbeErrorKind::PolicyDenied,
+            None,
+            Some(target.into()),
+            message,
+        )
+    }
+
+    pub(super) fn capability_unavailable(
+        protocol: ProbeProtocol,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            ProbeErrorKind::CapabilityUnavailable,
+            Some(protocol),
+            None,
+            message,
+        )
+    }
+
+    pub(super) fn permission_denied(protocol: ProbeProtocol, message: impl Into<String>) -> Self {
+        Self::new(
+            ProbeErrorKind::PermissionDenied,
+            Some(protocol),
+            None,
+            message,
+        )
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub(super) fn unsupported_platform(
+        protocol: ProbeProtocol,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            ProbeErrorKind::UnsupportedPlatform,
+            Some(protocol),
+            None,
+            message,
+        )
+    }
+
+    pub(super) fn system_failure(protocol: ProbeProtocol, message: impl Into<String>) -> Self {
+        Self::new(ProbeErrorKind::SystemFailure, Some(protocol), None, message)
+    }
+
+    pub(super) fn unexpected_result(protocol: ProbeProtocol, message: impl Into<String>) -> Self {
+        Self::new(
+            ProbeErrorKind::UnexpectedResult,
+            Some(protocol),
+            None,
+            message,
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn kind(&self) -> ProbeErrorKind {
+        self.kind
+    }
+
+    #[cfg(test)]
+    pub(super) fn protocol(&self) -> Option<ProbeProtocol> {
+        self.protocol
+    }
+}
+
+impl fmt::Display for ProbeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ProbeOptions {
+    pub(super) timeout: Duration,
+    pub(super) count: usize,
+    pub(super) interval: Duration,
+    pub(super) allow_private: bool,
+}


### PR DESCRIPTION
## Summary

- Adds an internal `std/net` probe foundation with `ProbeOptions`, `ProbeProtocol`, and structured `ProbeError` kinds.
- Routes current ping/TCP policy, resolver, platform, permission, and backend-unavailable failures through the shared internal error model while preserving public `Result<..., String>` behavior.
- Tightens the current Linux system-ping bridge so it resolves once, policy-checks every resolved address, then invokes `ping` against the policy-validated resolved IPs instead of re-resolving the original hostname.
- Updates DD-046 with the phased probe-backend path: backend foundation, Rust-native ICMP replacement, optional TCP rebasing, then traceroute.

## Notes

This intentionally does **not** add Rust-native ICMP or traceroute yet. It is the Phase 6 foundation so those next phases have a sane internal shape instead of more subprocess archaeology.

## Test Plan

- [x] `cargo fmt -- --check`
- [x] `cargo build --profile dev-release`
- [x] `cargo test --lib stdlib::net::tests:: -- --test-threads=1`
- [x] `cargo test --test std_net_tests`
- [x] `env -u NTNT_ENV -u SITE_URL cargo test --lib -- --test-threads=1`
- [x] `./target/dev-release/ntnt docs --generate`
- [x] `git diff --check`
- [x] Static diff scan: hardcoded secrets / shell injection / dangerous eval / SQL injection = 0
- [x] Independent diff review pass
- [x] Addressed Greptile first-address pinning review by trying all policy-validated ping addresses

Known local note: `cargo clippy -- -D warnings` currently fails on pre-existing `build.rs` lints outside this diff.

