### PR TITLE
feat(lint): detect JavaScript-style ${} interpolation in string literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "ntnt"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntnt"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 authors = ["NTNT Language Team"]
 description = "NTNT (Intent) - A programming language designed for AI-driven development"

--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -127,7 +127,7 @@ Scoping also surfaced **two additional doc drifts** beyond the v2 findings: CLAU
 
 ### Progress at a glance
 
-- [ ] **PR-1** — `${}` interpolation detection (Rec 1) — S
+- [x] **PR-1** — `${}` interpolation detection (Rec 1) — S
 - [ ] **PR-2** — Doc-claim regression tests, CLAUDE.md truth, UFCS embrace (Rec 2) — M
 - [ ] **PR-3** — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M
 - [ ] **PR-4** — Diagnostics II: method bridge hints, unknown-method lint, IAL suggestions, `ntnt intent lint` (Rec 4b) — M
@@ -138,13 +138,13 @@ Scoping also surfaced **two additional doc drifts** beyond the v2 findings: CLAU
 
 Scope-resolved detection in two layers: lint warns (error under `--strict`) when a string literal contains `${ident}` and `ident` resolves to a variable in scope — this keeps legitimate shell/JS content (`${HOME}`, `${1}`) clean while catching the actual bug with near-certainty; plus a deduped runtime `[WARN]` at string evaluation following the `type_warn_dedup` pattern. Emitted from the typechecker (which runs in all lint modes and has scopes + line attribution), structurally excluding template strings.
 
-- [ ] Shared detector `find_js_interpolation_idents()` in `src/typechecker.rs` + unit tests
-- [ ] `DiagnosticKind::JsStyleInterpolation` emitted from `infer_expression` for `Expression::String` and `InterpolatedString` literal parts, with double-visit dedup set (required: expression statements are inferred twice)
-- [ ] Strict-mode promotion in `check_program_with_lint_mode`; distinct rule name `javascript_style_interpolation` in lint JSON (`src/main.rs` ~3350)
-- [ ] Runtime hook in `eval_expression` (`${` pre-check, scope-checked, deduped, silent in forgiving mode; stays WARN even in strict — hard failure belongs to `lint --strict`)
-- [ ] Fix three stale lint messages claiming NTNT interpolation is `"{variable}"` instead of `#{variable}` (`src/main.rs` ~3454, ~3826-3830)
-- [ ] `tests/js_interpolation_tests.rs` (~12 integration cases) + `docs/AI_AGENT_GUIDE.md` interpolation section
-- [ ] Grep `examples/` and test fixtures for `${` before merging (strict promotion may surface existing hits)
+- [x] Shared detector `find_js_interpolation_idents()` in `src/typechecker.rs` + unit tests
+- [x] `DiagnosticKind::JsStyleInterpolation` emitted from `infer_expression` for `Expression::String` and `InterpolatedString` literal parts, with double-visit dedup set (required: expression statements are inferred twice)
+- [x] Strict-mode promotion in `check_program_with_lint_mode`; distinct rule name `javascript_style_interpolation` in lint JSON (`src/main.rs` ~3350)
+- [x] Runtime hook in `eval_expression` (`${` pre-check, scope-checked, deduped, silent in forgiving mode; stays WARN even in strict — hard failure belongs to `lint --strict`)
+- [x] Fix three stale lint messages claiming NTNT interpolation is `"{variable}"` instead of `#{variable}` (`src/main.rs` ~3454, ~3826-3830)
+- [x] `tests/js_interpolation_tests.rs` (~12 integration cases) + `docs/AI_AGENT_GUIDE.md` interpolation section
+- [x] Grep `examples/` and test fixtures for `${` before merging (strict promotion may surface existing hits)
 
 Defaults applied (object before implementation if wrong): strict promotion **yes**; raw-string `r"..."` false-positive class accepted for v1 (concat/template-string workarounds documented); no out-of-scope-ident detection (protects precision; typo'd `${nmae}` stays uncaught in v1).
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -344,6 +344,20 @@ let msg = "Hello, {name}!"
 let msg = `Hello, ${name}!`
 ```
 
+A `${...}` in a regular string is output literally — it is not interpolation.
+When the identifier inside `${...}` is a variable in scope, the mistake is
+caught two ways:
+
+- `ntnt lint` reports rule `javascript_style_interpolation` (a warning; an
+  error under `lint --strict`)
+- `ntnt run` prints a deduplicated runtime `[WARN]` next to the literal output
+
+If you genuinely want literal `${...}` output (generating shell or JavaScript
+code), either build it with concatenation (`"$" + "{HOME}"`) or use a
+`"""template string"""` — template strings are never scanned for this rule.
+References to names that are *not* in scope (e.g. `"echo ${HOME}"`) are also
+left alone.
+
 ### 3. Route Patterns Auto-Detect `{param}`
 
 ```ntnt

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [ial.toml](ial.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.10
+> Last updated: v0.4.11
 
 IAL is a term rewriting engine that translates natural language assertions into executable tests
 

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [runtime.toml](runtime.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.10
+> Last updated: v0.4.11
 
 Runtime configuration, environment variables, and CLI commands for NTNT
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from source code doc comments** - Do not edit directly.
 >
-> Last updated: v0.4.10
+> Last updated: v0.4.11
 
 ## Table of Contents
 

--- a/docs/SYNTAX_REFERENCE.md
+++ b/docs/SYNTAX_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [syntax.toml](syntax.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.10
+> Last updated: v0.4.11
 
 ## Table of Contents
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -396,6 +396,20 @@ impl Environment {
         }
     }
 
+    /// True if `name` is bound to a non-function value, without cloning.
+    /// Used by the `${...}` interpolation warning: function and builtin
+    /// names (e.g. `${len}`, `${format}` in generated shell/JS content)
+    /// are skipped to match the lint rule, which only resolves variables.
+    pub fn has_data_binding(&self, name: &str) -> bool {
+        if let Some(value) = self.values.get(name) {
+            !matches!(value, Value::Function { .. } | Value::NativeFunction { .. })
+        } else if let Some(ref parent) = self.parent {
+            parent.borrow().has_data_binding(name)
+        } else {
+            false
+        }
+    }
+
     /// Collect all bindings from this scope and parent scopes (child overrides parent)
     pub fn all_bindings(&self) -> HashMap<String, Value> {
         let mut bindings = if let Some(ref parent) = self.parent {
@@ -5653,11 +5667,45 @@ impl Interpreter {
         Ok(result)
     }
 
+    /// Warn (deduped per site) when a string literal contains JavaScript-style
+    /// `${ident}` and `ident` is a data variable in the live environment.
+    /// NTNT interpolation is `#{expr}` — the `${...}` text is output literally.
+    /// Function and builtin names are skipped (matches the lint rule, which
+    /// only resolves variables). Stays a WARN even in strict mode: a literal
+    /// string is type-valid, and the hard failure belongs to `lint --strict`.
+    fn warn_js_style_interpolation(&self, s: &str) {
+        if get_type_mode() == TypeMode::Forgiving {
+            return;
+        }
+        for (ident, snippet) in crate::typechecker::find_js_interpolation_idents(s) {
+            if self.environment.borrow().has_data_binding(&ident) {
+                let file = self.current_file.as_deref().unwrap_or("");
+                let location = if file.is_empty() {
+                    format!("line {}", self.current_line)
+                } else {
+                    format!("{}, line {}", file, self.current_line)
+                };
+                type_warn_dedup(
+                    &format!("js_interp:{}:{}:{}", file, self.current_line, snippet),
+                    &format!(
+                        "String literal contains \"{}\" — NTNT interpolation is \"#{{{}}}\"; printed literally ({})",
+                        snippet, ident, location
+                    ),
+                );
+            }
+        }
+    }
+
     fn eval_expression(&mut self, expr: &Expression) -> Result<Value> {
         match expr {
             Expression::Integer(n) => Ok(Value::Int(*n)),
             Expression::Float(n) => Ok(Value::Float(*n)),
-            Expression::String(s) => Ok(Value::String(s.clone())),
+            Expression::String(s) => {
+                if s.contains("${") {
+                    self.warn_js_style_interpolation(s);
+                }
+                Ok(Value::String(s.clone()))
+            }
             Expression::Bool(b) => Ok(Value::Bool(*b)),
             Expression::Unit => Ok(Value::Unit),
 
@@ -7199,7 +7247,12 @@ impl Interpreter {
                 let mut result = String::new();
                 for part in parts {
                     match part {
-                        StringPart::Literal(s) => result.push_str(s),
+                        StringPart::Literal(s) => {
+                            if s.contains("${") {
+                                self.warn_js_style_interpolation(s);
+                            }
+                            result.push_str(s)
+                        }
                         StringPart::Expr(expr) => {
                             let value = self.eval_expression(expr)?;
                             result.push_str(&value.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2829,7 +2829,7 @@ fn inspect_project(path: &PathBuf, pretty: bool) -> anyhow::Result<()> {
             "critical_rules": {
                 "map_literals": "Use `map { \"key\": value }` NOT `{ \"key\": value }` - bare {} creates blocks",
                 "route_patterns": "Route builtins auto-detect {param} patterns: `get(\"/users/{id}\", handler)` - raw strings optional",
-                "string_interpolation": "Use `\"{variable}\"` for interpolation, NOT `${variable}` or backticks",
+                "string_interpolation": "Use `\"#{variable}\"` for interpolation, NOT `${variable}` or backticks",
                 "ranges": "Use `0..10` (exclusive) or `0..=10` (inclusive), NOT range()",
                 "imports": "Use `import { x } from \"std/module\"` with `/` separator",
                 "contracts": "Place requires/ensures AFTER return type, BEFORE body",
@@ -3186,11 +3186,17 @@ fn validate_project(path: &PathBuf) -> anyhow::Result<()> {
                     ntnt::typechecker::check_program_with_file(&ast, &source, &file_path_str);
                 let mut type_errors = Vec::new();
                 for diag in type_diagnostics {
+                    let rule = match diag.kind {
+                        ntnt::typechecker::DiagnosticKind::JsStyleInterpolation => {
+                            "javascript_style_interpolation"
+                        }
+                        _ => "type_check",
+                    };
                     let entry = json!({
                         "message": diag.message,
                         "line": if diag.line > 0 { Some(diag.line) } else { None::<usize> },
                         "hint": diag.hint,
-                        "rule": "type_check",
+                        "rule": rule,
                     });
                     match diag.severity {
                         ntnt::typechecker::Severity::Error => type_errors.push(entry),
@@ -3352,9 +3358,15 @@ fn lint_project(
                         ntnt::typechecker::Severity::Error => "error",
                         ntnt::typechecker::Severity::Warning => "warning",
                     };
+                    let rule = match diag.kind {
+                        ntnt::typechecker::DiagnosticKind::JsStyleInterpolation => {
+                            "javascript_style_interpolation"
+                        }
+                        _ => "type_check",
+                    };
                     issues.push(json!({
                         "severity": severity,
-                        "rule": "type_check",
+                        "rule": rule,
                         "message": diag.message,
                         "line": if diag.line > 0 { Some(diag.line) } else { None::<usize> },
                         "hint": diag.hint,
@@ -3378,21 +3390,39 @@ fn lint_project(
                     }));
 
                     if !quiet {
-                        let warn_str = if warning_count > 0 {
-                            format!("{} warnings", warning_count)
+                        // Per-file counts (the outer counters accumulate across files)
+                        let count_of = |sev: &str| {
+                            issues
+                                .iter()
+                                .filter(|i| i["severity"].as_str() == Some(sev))
+                                .count()
+                        };
+                        let (file_errors, file_warnings, file_suggestions) = (
+                            count_of("error"),
+                            count_of("warning"),
+                            count_of("suggestion"),
+                        );
+                        let err_str = if file_errors > 0 {
+                            format!("{} errors", file_errors)
                         } else {
                             String::new()
                         };
-                        let sug_str = if suggestion_count > 0 {
-                            format!("{} suggestions", suggestion_count)
+                        let warn_str = if file_warnings > 0 {
+                            format!("{} warnings", file_warnings)
                         } else {
                             String::new()
                         };
-                        let parts: Vec<&str> = [warn_str.as_str(), sug_str.as_str()]
-                            .iter()
-                            .filter(|s| !s.is_empty())
-                            .copied()
-                            .collect();
+                        let sug_str = if file_suggestions > 0 {
+                            format!("{} suggestions", file_suggestions)
+                        } else {
+                            String::new()
+                        };
+                        let parts: Vec<&str> =
+                            [err_str.as_str(), warn_str.as_str(), sug_str.as_str()]
+                                .iter()
+                                .filter(|s| !s.is_empty())
+                                .copied()
+                                .collect();
                         eprintln!("{} {} ({})", "⚠".yellow(), relative_path, parts.join(", "));
                     }
                 } else {
@@ -3451,7 +3481,7 @@ fn lint_project(
         output["syntax_hints"] = json!({
             "map_literals": "Use `map { \"key\": value }` not `{ \"key\": value }`",
             "route_patterns": "Route builtins auto-detect {param} patterns - raw strings are optional",
-            "string_interpolation": "Use `\"{variable}\"` not `\"${variable}\"`",
+            "string_interpolation": "Use `\"#{variable}\"` not `\"${variable}\"`",
             "ranges": "Use `0..10` (exclusive) or `0..=10` (inclusive), not `range()`",
             "imports": "Use `import { x } from \"std/module\"` with `/` path separator",
         });
@@ -3823,10 +3853,10 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
             issues.push(json!({
                 "severity": "warning",
                 "rule": "javascript_template_string",
-                "message": "Possible JavaScript-style template string detected. NTNT uses \"{variable}\" for interpolation, not `${variable}`.",
+                "message": "Possible JavaScript-style template string detected. NTNT uses \"#{variable}\" for interpolation, not `${variable}`.",
                 "line": line_num + 1,
                 "fix": {
-                    "description": "Replace `${var}` with \"{var}\" and remove backticks"
+                    "description": "Replace `${var}` with \"#{var}\" and remove backticks"
                 }
             }));
         }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -323,18 +323,26 @@ pub fn find_js_interpolation_idents(s: &str) -> Vec<(String, String)> {
             j += 1;
         }
         let ident_end = if j < n { chars[j].0 } else { s.len() };
-        // Require a closing `}` before the next newline
+        // Require a balanced closing `}` before the next newline, so nested
+        // content like "${PATH:-${name}}" yields the full outer span instead
+        // of a truncated "${PATH:-${name" snippet.
         let mut close = None;
         let mut k = j;
+        let mut depth = 1usize;
         while k < n {
             match chars[k].1 {
+                '{' => depth += 1,
                 '}' => {
-                    close = Some(chars[k].0);
-                    break;
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(chars[k].0);
+                        break;
+                    }
                 }
                 '\n' => break,
-                _ => k += 1,
+                _ => {}
             }
+            k += 1;
         }
         if let Some(close) = close {
             results.push((
@@ -4455,10 +4463,16 @@ mod tests {
         assert_eq!(
             found,
             vec![
-                ("PATH".to_string(), "${PATH:-${name}".to_string()),
+                ("PATH".to_string(), "${PATH:-${name}}".to_string()),
                 ("name".to_string(), "${name}".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn js_interp_detector_balances_plain_braces() {
+        let found = find_js_interpolation_idents("v ${a{b}c} w");
+        assert_eq!(found, vec![("a".to_string(), "${a{b}c}".to_string())]);
     }
 
     #[test]

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -28,6 +28,9 @@ pub enum DiagnosticKind {
     MissingReturnAnnotation,
     /// Missing type annotation on lambda parameter
     MissingLambdaParamAnnotation,
+    /// JavaScript-style `${ident}` interpolation in a string literal where
+    /// `ident` is a variable in scope (NTNT interpolation is `#{expr}`)
+    JsStyleInterpolation,
     /// General type error (mismatch, undefined, etc.)
     General,
 }
@@ -102,6 +105,11 @@ pub struct TypeContext {
     resolving_files: Vec<String>,
     /// Detected circular import cycles (accumulated from nested contexts)
     detected_cycles: Vec<String>,
+    /// Last attributed line per `${...}` interpolation finding (snippet + ident).
+    /// Suppresses the double-visit of expression statements
+    /// (check_statement + infer_statement_terminal_type) while still
+    /// reporting genuinely distinct later sites of the same snippet.
+    js_interp_reported: HashMap<String, usize>,
 }
 
 /// Returns true if NTNT_STRICT mode is enabled.
@@ -204,6 +212,7 @@ pub fn check_program_with_lint_mode(
                     DiagnosticKind::MissingParamAnnotation
                         | DiagnosticKind::MissingReturnAnnotation
                         | DiagnosticKind::MissingLambdaParamAnnotation
+                        | DiagnosticKind::JsStyleInterpolation
                 )
             {
                 d.severity = Severity::Error;
@@ -282,6 +291,62 @@ fn binary_op_str(op: &BinaryOp) -> &'static str {
         BinaryOp::Or => "||",
         BinaryOp::NullCoalesce => "??",
     }
+}
+
+/// Find JavaScript-style `${ident...}` interpolation candidates in a string literal.
+///
+/// Returns `(head_ident, full_snippet)` pairs, e.g. `("name", "${name}")` or
+/// `("user", "${user.name}")`. Only sequences whose first character after `${`
+/// can start an identifier (Unicode, matching NTNT identifiers) and that close
+/// with `}` before the next newline are reported; `${}`, `${1}`, and `${{` are
+/// skipped. Callers decide relevance by resolving the head identifier against
+/// their scope/environment.
+pub fn find_js_interpolation_idents(s: &str) -> Vec<(String, String)> {
+    let mut results = Vec::new();
+    let chars: Vec<(usize, char)> = s.char_indices().collect();
+    let n = chars.len();
+    let mut i = 0;
+    while i + 1 < n {
+        if chars[i].1 != '$' || chars[i + 1].1 != '{' {
+            i += 1;
+            continue;
+        }
+        let start = chars[i].0;
+        let mut j = i + 2;
+        // The first character after `${` must start an identifier
+        if j >= n || !(chars[j].1.is_alphabetic() || chars[j].1 == '_') {
+            i += 2;
+            continue;
+        }
+        let ident_start = chars[j].0;
+        while j < n && (chars[j].1.is_alphanumeric() || chars[j].1 == '_') {
+            j += 1;
+        }
+        let ident_end = if j < n { chars[j].0 } else { s.len() };
+        // Require a closing `}` before the next newline
+        let mut close = None;
+        let mut k = j;
+        while k < n {
+            match chars[k].1 {
+                '}' => {
+                    close = Some(chars[k].0);
+                    break;
+                }
+                '\n' => break,
+                _ => k += 1,
+            }
+        }
+        if let Some(close) = close {
+            results.push((
+                s[ident_start..ident_end].to_string(),
+                s[start..=close].to_string(),
+            ));
+        }
+        // Resume right after the head identifier so a nested `${...}` inside
+        // the same span (e.g. "${PATH:-${name}}") is still examined.
+        i = j;
+    }
+    results
 }
 
 /// Extract a search-friendly string from an Expression AST node.
@@ -399,6 +464,7 @@ impl TypeContext {
             module_cache: HashMap::new(),
             resolving_files: Vec::new(),
             detected_cycles: Vec::new(),
+            js_interp_reported: HashMap::new(),
         }
     }
 
@@ -470,6 +536,52 @@ impl TypeContext {
 
     fn warning(&mut self, message: String, line: usize, hint: Option<String>) {
         self.emit(Severity::Warning, message, line, hint);
+    }
+
+    /// Warn when a string literal contains JavaScript-style `${ident}` and
+    /// `ident` is a variable in scope. NTNT interpolation is `#{expr}`, so
+    /// the `${...}` text would be output literally.
+    fn check_js_style_interpolation(&mut self, s: &str) {
+        if !s.contains("${") {
+            return;
+        }
+        for (ident, snippet) in find_js_interpolation_idents(s) {
+            if self.lookup(&ident).is_none() {
+                continue;
+            }
+            // Locate by the `${ident` prefix: identifiers cannot contain
+            // escape sequences, so the prefix appears verbatim in the source
+            // even when the parsed snippet was decoded (e.g. holds a real tab).
+            let needle = format!("${{{}", ident);
+            let key = format!("{}#{}", snippet, ident);
+            let line = match self.js_interp_reported.get(&key).copied() {
+                // Seen before: report again only for a genuinely later site.
+                // The re-visit of the same expression statement falls back to
+                // an already-attributed (or earlier) line and is skipped.
+                Some(last) => {
+                    let l = self.find_line_near_from(&needle, last + 1);
+                    if l == 0 || l <= last {
+                        continue;
+                    }
+                    l
+                }
+                None => self.find_line_near(&needle),
+            };
+            self.js_interp_reported.insert(key, line);
+            self.emit_with_kind(
+                Severity::Warning,
+                DiagnosticKind::JsStyleInterpolation,
+                format!(
+                    "String literal contains \"{}\" — NTNT interpolation is \"#{{{}}}\"; the \"${{...}}\" text will be output literally",
+                    snippet, ident
+                ),
+                line,
+                Some(format!(
+                    "Use \"#{{{}}}\". If literal ${{...}} output is intended (shell/JS content), build it with concatenation (\"$\" + \"{{...}}\") or a \"\"\"template string\"\"\".",
+                    ident
+                )),
+            );
+        }
     }
 
     // ── Line number lookup ────────────────────────────────────────────
@@ -1711,7 +1823,10 @@ impl TypeContext {
         match expr {
             Expression::Integer(_) => Type::Int,
             Expression::Float(_) => Type::Float,
-            Expression::String(_) => Type::String,
+            Expression::String(s) => {
+                self.check_js_style_interpolation(s);
+                Type::String
+            }
             Expression::Bool(_) => Type::Bool,
             Expression::Unit => Type::Unit,
 
@@ -1985,6 +2100,12 @@ impl TypeContext {
             }
 
             Expression::InterpolatedString(parts) => {
+                // Literal segments can still carry js-style `${...}` (e.g. "hi #{a} and ${b}")
+                for part in parts {
+                    if let StringPart::Literal(s) = part {
+                        self.check_js_style_interpolation(s);
+                    }
+                }
                 // In strict mode, warn when interpolating complex types
                 if self.strict_lint {
                     for part in parts {
@@ -4291,6 +4412,65 @@ mod tests {
     use super::*;
     use crate::lexer::Lexer;
     use crate::parser::Parser;
+
+    #[test]
+    fn js_interp_detector_extracts_simple_ident() {
+        let found = find_js_interpolation_idents("hello ${name}!");
+        assert_eq!(found, vec![("name".to_string(), "${name}".to_string())]);
+    }
+
+    #[test]
+    fn js_interp_detector_extracts_head_ident_from_complex_content() {
+        let found = find_js_interpolation_idents("a ${user.name} b ${VAR:-default} c");
+        assert_eq!(
+            found,
+            vec![
+                ("user".to_string(), "${user.name}".to_string()),
+                ("VAR".to_string(), "${VAR:-default}".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn js_interp_detector_rejects_non_identifier_starts() {
+        assert!(find_js_interpolation_idents("pos ${1} empty ${} brace ${{x}").is_empty());
+    }
+
+    #[test]
+    fn js_interp_detector_requires_close_before_newline() {
+        assert!(find_js_interpolation_idents("open ${name\nrest }").is_empty());
+    }
+
+    #[test]
+    fn js_interp_detector_handles_multiple_occurrences() {
+        let found = find_js_interpolation_idents("${a} and ${b}");
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].0, "a");
+        assert_eq!(found[1].0, "b");
+    }
+
+    #[test]
+    fn js_interp_detector_finds_nested_interpolation() {
+        let found = find_js_interpolation_idents("echo ${PATH:-${name}} done");
+        assert_eq!(
+            found,
+            vec![
+                ("PATH".to_string(), "${PATH:-${name}".to_string()),
+                ("name".to_string(), "${name}".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn js_interp_detector_supports_unicode_identifiers() {
+        let found = find_js_interpolation_idents("héllo ${naïve}!");
+        assert_eq!(found, vec![("naïve".to_string(), "${naïve}".to_string())]);
+    }
+
+    #[test]
+    fn js_interp_detector_ignores_plain_dollars_and_braces() {
+        assert!(find_js_interpolation_idents("cost: $5 {not interp} $ {gap}").is_empty());
+    }
 
     fn check(source: &str) -> Vec<TypeDiagnostic> {
         let lexer = Lexer::new(source);

--- a/tests/js_interpolation_tests.rs
+++ b/tests/js_interpolation_tests.rs
@@ -1,0 +1,377 @@
+//! Integration tests for JavaScript-style `${...}` interpolation detection (DD-063 Rec 1).
+//!
+//! NTNT interpolation is `#{expr}`; a `${expr}` in a regular string is output
+//! literally. These tests cover the scope-aware lint rule
+//! `javascript_style_interpolation` and the deduplicated runtime [WARN].
+
+use std::fs;
+use std::io::Write;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a unique test file path
+fn unique_test_file(prefix: &str) -> String {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let thread_id = format!("{:?}", std::thread::current().id());
+    let temp_dir = std::env::temp_dir();
+    temp_dir
+        .join(format!(
+            "ntnt_{}_{}_{}_{}.tnt",
+            prefix,
+            std::process::id(),
+            thread_id.replace(|c: char| !c.is_alphanumeric(), "_"),
+            counter
+        ))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn ntnt_binary() -> std::path::PathBuf {
+    let exe = std::env::consts::EXE_SUFFIX;
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let debug_path = manifest.join(format!("target/debug/ntnt{}", exe));
+    let release_path = manifest.join(format!("target/release/ntnt{}", exe));
+
+    if debug_path.exists() {
+        debug_path
+    } else if release_path.exists() {
+        release_path
+    } else {
+        panic!("No ntnt binary found. Run 'cargo build' first.");
+    }
+}
+
+/// Run the ntnt binary with the given subcommand args on a code snippet.
+/// Returns (stdout, stderr, exit_code).
+fn run_ntnt(args: &[&str], code: &str, env_vars: &[(&str, &str)]) -> (String, String, i32) {
+    let test_file = unique_test_file("js_interp");
+    let mut file = fs::File::create(&test_file).expect("Failed to create test file");
+    writeln!(file, "{}", code).expect("Failed to write test file");
+
+    let mut cmd = Command::new(ntnt_binary());
+    cmd.args(args)
+        .arg(&test_file)
+        .current_dir(env!("CARGO_MANIFEST_DIR"));
+    for (k, v) in env_vars {
+        cmd.env(k, v);
+    }
+
+    let output = cmd.output().expect("Failed to execute ntnt");
+    let _ = fs::remove_file(&test_file);
+
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+fn lint(code: &str) -> (String, String, i32) {
+    run_ntnt(&["lint"], code, &[])
+}
+
+fn lint_strict(code: &str) -> (String, String, i32) {
+    run_ntnt(&["lint", "--strict"], code, &[])
+}
+
+fn run(code: &str, env_vars: &[(&str, &str)]) -> (String, String, i32) {
+    run_ntnt(&["run"], code, env_vars)
+}
+
+const RULE: &str = "javascript_style_interpolation";
+
+// ── Lint ───────────────────────────────────────────────────────────────
+
+#[test]
+fn lint_warns_when_interpolated_ident_is_in_scope() {
+    let code = r#"let name = "world"
+print("hello ${name}")"#;
+    let (stdout, _, exit_code) = lint(code);
+    assert!(
+        stdout.contains(RULE),
+        "expected {} finding, got: {}",
+        RULE,
+        stdout
+    );
+    assert!(
+        stdout.contains("#{name}"),
+        "hint should show the NTNT syntax #{{name}}: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("\"line\": 2"),
+        "finding should point at line 2: {}",
+        stdout
+    );
+    assert_eq!(exit_code, 0, "warnings must not fail default lint");
+}
+
+#[test]
+fn lint_strict_promotes_to_error_and_fails() {
+    let code = r#"fn greet(name: String) -> String {
+    return "hello ${name}"
+}
+print(greet("world"))"#;
+    let (stdout, _, exit_code) = lint_strict(code);
+    assert!(stdout.contains(RULE), "expected {} in: {}", RULE, stdout);
+    assert_eq!(
+        exit_code, 1,
+        "lint --strict must exit 1 on js-style interpolation (DD-063 acceptance criterion); stdout: {}",
+        stdout
+    );
+}
+
+#[test]
+fn lint_ignores_out_of_scope_idents() {
+    // Shell content: ${HOME} and ${1} are not NTNT variables in scope.
+    let code = r#"let script = "echo ${HOME} ${1}"
+print(script)"#;
+    let (stdout, _, exit_code) = lint(code);
+    assert!(
+        !stdout.contains(RULE),
+        "out-of-scope idents must not warn (shell false-positive guard): {}",
+        stdout
+    );
+    assert_eq!(exit_code, 0);
+}
+
+#[test]
+fn lint_ignores_template_strings() {
+    // Template strings are for generated code; embedded JS `${...}` is legitimate.
+    let code = r#"let b = 1
+let s = """const x = `${b}`;"""
+print("ok")"#;
+    let (stdout, _, _) = lint(code);
+    assert!(
+        !stdout.contains(RULE),
+        "template strings must never produce {}: {}",
+        RULE,
+        stdout
+    );
+}
+
+#[test]
+fn lint_mixed_interpolation_flags_only_js_part() {
+    let code = r#"let a = 1
+let b = 2
+print("hi #{a} and ${b}")"#;
+    let (stdout, _, _) = lint(code);
+    let count = stdout.matches(RULE).count();
+    assert_eq!(
+        count, 1,
+        "exactly one finding (for ${{b}} only), got {}: {}",
+        count, stdout
+    );
+    assert!(stdout.contains("#{b}"), "hint should target b: {}", stdout);
+}
+
+#[test]
+fn lint_reports_each_site_once() {
+    // Expression statements are type-inferred twice internally
+    // (check_statement + terminal-type inference) — findings must not double.
+    let code = r#"let name = "world"
+"hello ${name}"
+print("ok")"#;
+    let (stdout, _, _) = lint(code);
+    let count = stdout.matches(RULE).count();
+    assert_eq!(
+        count, 1,
+        "double-visited expression statement must report once, got {}: {}",
+        count, stdout
+    );
+}
+
+#[test]
+fn lint_reports_each_site_once_inside_function_body() {
+    // Block statements take the check_statement + infer_statement_terminal_type
+    // double-visit path — findings must not double there either.
+    let code = r#"fn f(name: String) -> String {
+    "x ${name} y"
+    return "done"
+}
+print(f("w"))"#;
+    let (stdout, _, _) = lint(code);
+    let count = stdout.matches(RULE).count();
+    assert_eq!(
+        count, 1,
+        "double-visited block statement must report once, got {}: {}",
+        count, stdout
+    );
+}
+
+#[test]
+fn lint_reports_distinct_sites_separately() {
+    let code = r#"let name = "world"
+let a = "first ${name}"
+let b = "second ${name}"
+print(a + b)"#;
+    let (stdout, _, _) = lint(code);
+    let count = stdout.matches(RULE).count();
+    assert_eq!(
+        count, 2,
+        "two distinct sites of the same snippet must both report, got {}: {}",
+        count, stdout
+    );
+    assert!(
+        stdout.contains("\"line\": 2") && stdout.contains("\"line\": 3"),
+        "findings should point at lines 2 and 3: {}",
+        stdout
+    );
+}
+
+#[test]
+fn lint_supports_unicode_identifiers() {
+    let code = "let naïve = \"x\"\nprint(\"h ${naïve}\")";
+    let (stdout, _, _) = lint(code);
+    assert!(
+        stdout.contains(RULE) && stdout.contains("#{naïve}"),
+        "unicode identifier in scope must be caught: {}",
+        stdout
+    );
+}
+
+#[test]
+fn no_warn_for_builtin_and_function_names() {
+    // Generated shell/JS content commonly references names that collide with
+    // builtins, prelude, or user functions — those are not data variables and
+    // must stay silent at lint AND runtime.
+    let code = r#"fn helper(x: Int) -> Int { return x }
+print("use ${len} and ${format} and ${helper}")"#;
+    let (stdout, _, _) = lint(code);
+    assert!(
+        !stdout.contains(RULE),
+        "function names must not trigger lint: {}",
+        stdout
+    );
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("use ${len} and ${format} and ${helper}"));
+    assert!(
+        !stderr.contains("[WARN]"),
+        "function names must not trigger runtime warn: {}",
+        stderr
+    );
+}
+
+#[test]
+fn run_warns_for_nested_inner_ident() {
+    // `${PATH:-${name}}`: PATH is out of scope but the nested `${name}` is a
+    // real in-scope reference and must still be caught.
+    let code = r#"let name = "x"
+print("echo ${PATH:-${name}} done")"#;
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("echo ${PATH:-${name}} done"));
+    assert!(
+        stderr.contains("[WARN]") && stderr.contains("#{name}"),
+        "nested in-scope ident must warn: {}",
+        stderr
+    );
+}
+
+// ── Runtime ────────────────────────────────────────────────────────────
+
+#[test]
+fn run_warns_and_outputs_literally() {
+    let code = r#"let name = "world"
+print("hello ${name}")"#;
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains("hello ${name}"),
+        "the string is still output literally: {}",
+        stdout
+    );
+    assert!(
+        stderr.contains("[WARN]") && stderr.contains("#{name}"),
+        "runtime should warn with the NTNT syntax: {}",
+        stderr
+    );
+}
+
+#[test]
+fn run_warns_in_interpolated_string_literal_parts() {
+    let code = r#"let a = 1
+let b = 2
+print("hi #{a} and ${b}")"#;
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("hi 1 and ${b}"), "stdout: {}", stdout);
+    assert!(
+        stderr.contains("[WARN]") && stderr.contains("#{b}"),
+        "stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn run_warn_is_deduplicated_per_site() {
+    let code = r#"let name = "world"
+for i in 0..3 {
+    print("hello ${name}")
+}"#;
+    let (_, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0);
+    let count = stderr
+        .lines()
+        .filter(|l| l.contains("[WARN]") && l.contains("${name}"))
+        .count();
+    assert_eq!(
+        count, 1,
+        "one [WARN] per site, not per evaluation, got {}: {}",
+        count, stderr
+    );
+}
+
+#[test]
+fn run_forgiving_mode_is_silent() {
+    let code = r#"let name = "world"
+print("hello ${name}")"#;
+    let (stdout, stderr, exit_code) = run(code, &[("NTNT_TYPE_MODE", "forgiving")]);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("hello ${name}"));
+    assert!(
+        !stderr.contains("[WARN]"),
+        "forgiving mode must be silent: {}",
+        stderr
+    );
+}
+
+#[test]
+fn run_no_warn_for_out_of_scope_idents() {
+    let code = r#"print("path is ${UNDEFINED_THING}")"#;
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("path is ${UNDEFINED_THING}"));
+    assert!(
+        !stderr.contains("[WARN]"),
+        "out-of-scope ident must not warn: {}",
+        stderr
+    );
+}
+
+#[test]
+fn run_strict_type_mode_warns_but_still_executes() {
+    // A literal string is type-valid: strict runtime must not turn the warn
+    // into an error. The hard failure belongs to `lint --strict`.
+    let code = r#"let name = "world"
+print("hello ${name}")"#;
+    let (stdout, stderr, exit_code) = run(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_eq!(exit_code, 0, "strict mode must not abort: {}", stderr);
+    assert!(stdout.contains("hello ${name}"));
+    assert!(stderr.contains("[WARN]"), "stderr: {}", stderr);
+}
+
+#[test]
+fn run_strict_lint_mode_does_not_block_run_path() {
+    let code = r#"let name = "world"
+print("hello ${name}")"#;
+    let (stdout, _, exit_code) = run(code, &[("NTNT_LINT_MODE", "strict")]);
+    assert_eq!(
+        exit_code, 0,
+        "lint strict promotion applies to `ntnt lint`, not `ntnt run`"
+    );
+    assert!(stdout.contains("hello ${name}"));
+}


### PR DESCRIPTION
## Summary

Implements **DD-063 Rec 1 (PR-1)** — the top verified silent failure from the language assessment: `print("hello ${name}")` printed the literal text with no warning anywhere, and `ntnt lint --strict` passed it clean.

### What this adds

- **Lint rule `javascript_style_interpolation`** — emitted from the typechecker when a string literal contains `${ident}` and `ident` resolves to a **variable in scope**. Warning by default, **error under `lint --strict`** (exit 1). Distinct rule name in both `lint` and `validate` JSON output.
- **Runtime `[WARN]`** — deduplicated per file/line/snippet, printed adjacent to the literal output; silent in forgiving mode, stays a WARN in strict (a literal string is type-valid — the hard failure belongs to `lint --strict`).
- **Precision guards**: out-of-scope idents (`${HOME}`, `${1}`) pass clean, so generated shell/JS content doesn't false-positive; function/builtin names (`${len}`, `${format}`) are skipped via a non-cloning environment lookup; template strings are never scanned (legitimate embedded-JS surface). Escape hatches for intentional literal `${...}`: concatenation or template strings (documented in AI_AGENT_GUIDE).
- **Detector robustness**: Unicode identifiers (`${naïve}`), nested spans (`${PATH:-${name}}` still catches the inner in-scope ident), per-site line-aware dedup (two sites with the same snippet report twice, the typechecker's double visit of expression statements reports once).
- **Drive-by fixes**: three stale messages claiming NTNT interpolation is `"{variable}"` corrected to `#{variable}`; lint per-file summary no longer prints `⚠ file ()` for error-only files.

### Known v1 tradeoffs (per DD-063 scoping)

- Raw strings `r"..."` share `Expression::String`, so an in-scope name collision in raw shell content can warn — rare by construction, workarounds documented.
- Typo'd interpolations (`${nmae}` with nothing in scope) are not caught — same blind spot that makes shell vars safe.

## Test plan

- 8 detector unit tests (Unicode, nested, rejection cases)
- 18 integration tests in `tests/js_interpolation_tests.rs`: lint positive/negative/strict-promotion/dedup/distinct-sites/template-exclusion, runtime warn/dedup/forgiving/strict/builtin-skip/nested
- Full suite: 1,633 tests pass; `examples/` lints clean (the one `${` in examples is inside a template string)
- Verified the DD-063 acceptance criterion: `lint --strict` now exits 1 on the original failing case