### PR TITLE
feat(docs): truth-sync intentional syntax contracts and UFCS docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,15 +50,18 @@ let msg = "Hello, #{name}!"    // CORRECT
 let msg = "Hello, ${name}!"    // WRONG
 ```
 
-### 3. Free functions, not methods — dot reads properties
+### 3. Free functions are canonical — dot-call is UFCS sugar
+
+`x.f(a)` resolves to `f(x, a)` for any builtin, imported, or user-defined function. Both styles work; prefer free functions.
 
 ```ntnt
-len(s)              // CORRECT — free function transforms data
-s.len()             // WRONG — dot is for reading properties only
-trim(input)         // CORRECT
-input.trim()        // WRONG
-req.method          // CORRECT — reading a property
-req.params.id       // CORRECT — reading a map key
+len(s)              // CANONICAL — free function transforms data
+s.len()             // ALSO WORKS — UFCS sugar for len(s)
+5.double()          // works for user-defined fn double(x) too
+req.method          // dot WITHOUT parens reads a property
+req.params.id       // reading a map key
+m.keys              // reads the map key "keys" (None if missing)
+m.keys()            // parens ALWAYS mean a call: keys(m), even if a "keys" key exists
 ```
 
 ### 4. Route functions are GLOBAL builtins — never import them
@@ -73,7 +76,7 @@ Only import response builders: `json`, `html`, `text`, `redirect`, `status`, `pa
 
 ### 5. No semicolons — use newlines
 
-`;` silently corrupts parser state. Never use semicolons.
+Semicolons parse fine but are unnecessary; `ntnt lint` warns (`unnecessary_semicolon`). Omit them.
 
 ### 6. `otherwise` blocks MUST diverge
 
@@ -84,13 +87,17 @@ let data = parse_json(req) otherwise { status(400, "Bad JSON") }                
 
 ### 7. Ranges: `0..10` — `range()` doesn't exist
 
-### 8. Mutable variables need `mut`: `let mut counter = 0`
+### 8. Declare `mut` for anything you reassign: `let mut counter = 0`
+
+`mut` is enforced for indexed mutation (`arr[0] = x`, `m["k"] = v` error without it). Plain rebinding (`x = x + 1`) currently succeeds without `mut` — still declare `mut` for clarity and forward compatibility.
 
 ### 9. Closures: `fn(x) { x * 2 }` — pipe-style `|x| x * 2` doesn't exist
 
-### 10. Module-level `let` can't use `map {}` — move maps inside functions
+### 10. Closures stored in map values are not dot-callable
 
-### 11. `for..in` on strings does nothing — use `chars(s)` from `std/string`
+`m.f(x)` fails with E007 when `f` is a closure stored in map `m` (parens make it a UFCS call to a function named `f`). Bind first: `let f = m.f` then `f(x)`.
+
+### 11. `for..in` on strings skips with a runtime warning — use `chars(s)` from `std/string`
 
 ### 12. Template strings: `"""..{{expr}}.."""` — double braces, not single
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,15 +67,18 @@ let msg = "Hello, #{name}!"    // CORRECT
 let msg = "Hello, ${name}!"    // WRONG
 ```
 
-### 3. Free functions, not methods — dot reads properties
+### 3. Free functions are canonical — dot-call is UFCS sugar
+
+`x.f(a)` resolves to `f(x, a)` for any builtin, imported, or user-defined function. Both styles work; prefer free functions.
 
 ```ntnt
-len(s)              // CORRECT — free function transforms data
-s.len()             // WRONG — dot is for reading properties only
-trim(input)         // CORRECT
-input.trim()        // WRONG
-req.method          // CORRECT — reading a property
-req.params.id       // CORRECT — reading a map key
+len(s)              // CANONICAL — free function transforms data
+s.len()             // ALSO WORKS — UFCS sugar for len(s)
+5.double()          // works for user-defined fn double(x) too
+req.method          // dot WITHOUT parens reads a property
+req.params.id       // reading a map key
+m.keys              // reads the map key "keys" (None if missing)
+m.keys()            // parens ALWAYS mean a call: keys(m), even if a "keys" key exists
 ```
 
 ### 4. Route functions are GLOBAL builtins — never import them
@@ -90,7 +93,7 @@ Only import response builders: `json`, `html`, `text`, `redirect`, `status`, `pa
 
 ### 5. No semicolons — use newlines
 
-`;` silently corrupts parser state. Never use semicolons.
+Semicolons parse fine but are unnecessary; `ntnt lint` warns (`unnecessary_semicolon`). Omit them.
 
 ### 6. `otherwise` blocks MUST diverge
 
@@ -101,13 +104,17 @@ let data = parse_json(req) otherwise { status(400, "Bad JSON") }                
 
 ### 7. Ranges: `0..10` — `range()` doesn't exist
 
-### 8. Mutable variables need `mut`: `let mut counter = 0`
+### 8. Declare `mut` for anything you reassign: `let mut counter = 0`
+
+`mut` is enforced for indexed mutation (`arr[0] = x`, `m["k"] = v` error without it). Plain rebinding (`x = x + 1`) currently succeeds without `mut` — still declare `mut` for clarity and forward compatibility.
 
 ### 9. Closures: `fn(x) { x * 2 }` — pipe-style `|x| x * 2` doesn't exist
 
-### 10. Module-level `let` can't use `map {}` — move maps inside functions
+### 10. Closures stored in map values are not dot-callable
 
-### 11. `for..in` on strings does nothing — use `chars(s)` from `std/string`
+`m.f(x)` fails with E007 when `f` is a closure stored in map `m` (parens make it a UFCS call to a function named `f`). Bind first: `let f = m.f` then `f(x)`.
+
+### 11. `for..in` on strings skips with a runtime warning — use `chars(s)` from `std/string`
 
 ### 12. Template strings: `"""..{{expr}}.."""` — double braces, not single
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -67,15 +67,18 @@ let msg = "Hello, #{name}!"    // CORRECT
 let msg = "Hello, ${name}!"    // WRONG
 ```
 
-### 3. Free functions, not methods — dot reads properties
+### 3. Free functions are canonical — dot-call is UFCS sugar
+
+`x.f(a)` resolves to `f(x, a)` for any builtin, imported, or user-defined function. Both styles work; prefer free functions.
 
 ```ntnt
-len(s)              // CORRECT — free function transforms data
-s.len()             // WRONG — dot is for reading properties only
-trim(input)         // CORRECT
-input.trim()        // WRONG
-req.method          // CORRECT — reading a property
-req.params.id       // CORRECT — reading a map key
+len(s)              // CANONICAL — free function transforms data
+s.len()             // ALSO WORKS — UFCS sugar for len(s)
+5.double()          // works for user-defined fn double(x) too
+req.method          // dot WITHOUT parens reads a property
+req.params.id       // reading a map key
+m.keys              // reads the map key "keys" (None if missing)
+m.keys()            // parens ALWAYS mean a call: keys(m), even if a "keys" key exists
 ```
 
 ### 4. Route functions are GLOBAL builtins — never import them
@@ -90,7 +93,7 @@ Only import response builders: `json`, `html`, `text`, `redirect`, `status`, `pa
 
 ### 5. No semicolons — use newlines
 
-`;` silently corrupts parser state. Never use semicolons.
+Semicolons parse fine but are unnecessary; `ntnt lint` warns (`unnecessary_semicolon`). Omit them.
 
 ### 6. `otherwise` blocks MUST diverge
 
@@ -101,13 +104,17 @@ let data = parse_json(req) otherwise { status(400, "Bad JSON") }                
 
 ### 7. Ranges: `0..10` — `range()` doesn't exist
 
-### 8. Mutable variables need `mut`: `let mut counter = 0`
+### 8. Declare `mut` for anything you reassign: `let mut counter = 0`
+
+`mut` is enforced for indexed mutation (`arr[0] = x`, `m["k"] = v` error without it). Plain rebinding (`x = x + 1`) currently succeeds without `mut` — still declare `mut` for clarity and forward compatibility.
 
 ### 9. Closures: `fn(x) { x * 2 }` — pipe-style `|x| x * 2` doesn't exist
 
-### 10. Module-level `let` can't use `map {}` — move maps inside functions
+### 10. Closures stored in map values are not dot-callable
 
-### 11. `for..in` on strings does nothing — use `chars(s)` from `std/string`
+`m.f(x)` fails with E007 when `f` is a closure stored in map `m` (parens make it a UFCS call to a function named `f`). Bind first: `let f = m.f` then `f(x)`.
+
+### 11. `for..in` on strings skips with a runtime warning — use `chars(s)` from `std/string`
 
 ### 12. Template strings: `"""..{{expr}}.."""` — double braces, not single
 

--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -156,9 +156,9 @@ A narrower guardrail than the original scoping: test only the syntax contracts w
 - [x] CLAUDE.md corrections: rule 3 (UFCS works — reframed as "free functions are canonical, dot-call is sugar"), rule 5 (semicolons are lint warnings, not parser corruption), rule 8 (`mut` enforced only for indexed/deep mutation — documented actual semantics), rule 10 (module-level `map {}` works — replaced in place with the map-closure caveat to keep rule numbering stable), rule 11 (warning is emitted, not silent)
 - [x] `docs/AI_AGENT_GUIDE.md` + `syntax.toml` UFCS documentation; also corrected the same drift in `.github/copilot-instructions.md` and `CODEX.md` (both are agent-facing surfaces carrying the identical stale claims)
 - [x] Fix `collect_from_expr` unused-import lint bug exposed by UFCS embrace (dot-call method names are dropped, so imports used only via UFCS get flagged unused)
-- [ ] IAL primitive status honesty deferred to the IAL stub-gap PR rather than bundled into this lighter Rec 2 slice
+- [x] Keep `IAL_REFERENCE.md` honest about primitive status: `Sql` is marked not implemented, and `InvariantCheck` is marked as resolver-marker-only/direct execution fails unless expanded
 
-Maintainer decision applied after review: PR-2 should not lock every current CLAUDE.md behavior. It locks only resounding yes contracts and leaves questionable current behavior available for future language improvements.
+Maintainer decision applied after review: PR-2 should not lock every current CLAUDE.md behavior. It locks only resounding yes contracts and leaves questionable current behavior available for future language improvements. Greptile follow-up kept the IAL status honesty because generated docs must not tell agents that stubs are supported.
 
 ### PR-3 — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M, ~420 impl + ~380 tests
 

--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -128,7 +128,7 @@ Scoping also surfaced **two additional doc drifts** beyond the v2 findings: CLAU
 ### Progress at a glance
 
 - [x] **PR-1** — `${}` interpolation detection (Rec 1) — S
-- [ ] **PR-2** — Doc-claim regression tests, CLAUDE.md truth, UFCS embrace (Rec 2) — M
+- [x] **PR-2** — Doc-claim regression tests, CLAUDE.md truth, UFCS embrace (Rec 2) — M
 - [ ] **PR-3** — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M
 - [ ] **PR-4** — Diagnostics II: method bridge hints, unknown-method lint, IAL suggestions, `ntnt intent lint` (Rec 4b) — M
 - [ ] **PR-5** — Index out-of-bounds loudness (Rec 3) — M — **blocked on decisions**
@@ -152,14 +152,15 @@ Defaults applied (object before implementation if wrong): strict promotion **yes
 
 One regression test per behavioral claim in CLAUDE.md's 16 Critical Syntax Rules, locking *actual* binary behavior; rewrite the four wrong/stale rules; document UFCS as first-class sugar with its real gaps (map-stored closures not dot-callable; parens disambiguate call vs key lookup); make IAL_REFERENCE honest about unimplemented primitives.
 
-- [ ] `tests/doc_claims_tests.rs` (~26 tests; assert on error codes + short stable fragments, never full message lines)
-- [ ] CLAUDE.md corrections: rule 3 (UFCS works — reframe as "free functions are canonical, dot-call is sugar"), rule 5 (semicolons are lint warnings, not parser corruption), rule 8 (`mut` enforced only for indexed/deep mutation — document actual semantics), rule 10 (module-level `map {}` works — replace in place to keep rule numbering stable)
-- [ ] `docs/AI_AGENT_GUIDE.md` + `syntax.toml` UFCS documentation; review regenerated `.github/copilot-instructions.md` diff
-- [ ] Fix `collect_from_expr` unused-import lint bug exposed by UFCS embrace (dot-call method names are dropped, so imports used only via UFCS get flagged unused)
-- [ ] `ial.toml` status field for `sql`/`invariant_check` + Status column in `generate_ial_markdown` (and update the fixed key arrays in `src/main.rs`, or new rows silently render nothing)
-- [ ] Regenerate `docs/IAL_REFERENCE.md` / `STDLIB_REFERENCE.md` via `ntnt docs --generate`
+- [x] `tests/doc_claims_tests.rs` (32 tests; assert on error codes + short stable fragments, never full message lines)
+- [x] CLAUDE.md corrections: rule 3 (UFCS works — reframed as "free functions are canonical, dot-call is sugar"), rule 5 (semicolons are lint warnings, not parser corruption), rule 8 (`mut` enforced only for indexed/deep mutation — documented actual semantics), rule 10 (module-level `map {}` works — replaced in place with the map-closure caveat to keep rule numbering stable), rule 11 (warning is emitted, not silent)
+- [x] `docs/AI_AGENT_GUIDE.md` + `syntax.toml` UFCS documentation; also corrected the same drift in `.github/copilot-instructions.md` and `CODEX.md` (both are agent-facing surfaces carrying the identical stale claims)
+- [x] Fix `collect_from_expr` unused-import lint bug exposed by UFCS embrace (dot-call method names are dropped, so imports used only via UFCS get flagged unused)
+- [x] `ial.toml` status field for `sql`/`invariant_check` + Status column in `generate_ial_markdown`
+- [x] Regenerate `docs/IAL_REFERENCE.md` / `SYNTAX_REFERENCE.md` via `ntnt docs --generate`
+- [x] Optional Step 7: wire `find_suggestion` into the method-call E007 so dot-call typos (`5.doubl()`) get "did you mean" hints
 
-Maintainer decisions: **(a)** rule 8 — document current `mut` semantics (this plan) or fix enforcement for plain rebinding (breaking; would need its own DD)? **(b)** IAL `Sql` primitive — mark `not_implemented` in docs (this plan) or remove from `ial.toml` entirely until built?
+Maintainer decisions (defaults applied per plan; flagged in PR for confirmation): **(a)** rule 8 — documented current `mut` semantics (the `doc_rule08_plain_reassign_without_mut_succeeds` test locks the actual behavior; invert it in the same PR if enforcement is later added); **(b)** IAL `Sql` primitive — marked `not_implemented` in docs rather than removed.
 
 ### PR-3 — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M, ~420 impl + ~380 tests
 

--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -107,7 +107,7 @@ The highest-leverage problems are now narrow and concrete: one truly silent synt
 Deduplicated against existing DDs; items already covered elsewhere are deferred, not repeated.
 
 1. **Catch `${...}` in all strings.** Drop the backtick requirement from `javascript_template_string`; add a runtime warn (warn mode) when a string literal containing `${identifier}` is constructed. Hours of work; eliminates the worst remaining silent failure.
-2. **Establish doc-claim regression tests, then fix the drift.** Every behavioral claim in CLAUDE.md's critical-rules list gets a test asserting the actual behavior (the DD-054 pattern, extended); CI fails when docs and implementation diverge. Immediately: correct the semicolon and method-call rules, and decide the UFCS story (recommend: embrace and document it — it works, it matches agent priors, and `req.params.id` property access coexists with it today).
+2. **Establish intentional syntax contract tests, then fix the drift.** Stable language/agent contracts get regression tests; current-but-questionable behavior is documented honestly but not frozen as a forever rule. Immediately: correct the semicolon and method-call rules, and decide the UFCS story (recommend: embrace and document it — it works, it matches agent priors, and `req.params.id` property access coexists with it today).
 3. **Resolve the index/`Option` type-reality mismatch.** Decide direction: typechecker infers `Option<T>` for index expressions (honest, but breaking), or strict mode errors on out-of-bounds at runtime, or at minimum lint warns on unguarded index results flowing into typed positions. Needs a maintainer call on breaking-change tolerance — flagging rather than prescribing.
 4. **Upgrade the repair loop to match the error infrastructure.** (a) Parser error recovery, 3–5 errors per pass; (b) E004 contract violations get line numbers, source frames, and actual argument values; (c) unknown-method errors suggest the free-function form; typechecker diagnoses unknown methods instead of silently typing `Any`; (d) IAL unknown terms get Levenshtein suggestions from the loaded vocabulary, plus an `ntnt intent lint` that validates glossaries before execution.
 5. **Close the IAL stub gap — in code or in docs.** Implement invariant execution (small: expansion already works) and either implement the SQL primitive or remove both from IAL_REFERENCE until real. The flagship feature should not document capabilities it doesn't have.
@@ -128,7 +128,7 @@ Scoping also surfaced **two additional doc drifts** beyond the v2 findings: CLAU
 ### Progress at a glance
 
 - [x] **PR-1** — `${}` interpolation detection (Rec 1) — S
-- [x] **PR-2** — Doc-claim regression tests, CLAUDE.md truth, UFCS embrace (Rec 2) — M
+- [x] **PR-2** — Intentional syntax contract tests, CLAUDE.md truth, UFCS embrace (Rec 2) — S
 - [ ] **PR-3** — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M
 - [ ] **PR-4** — Diagnostics II: method bridge hints, unknown-method lint, IAL suggestions, `ntnt intent lint` (Rec 4b) — M
 - [ ] **PR-5** — Index out-of-bounds loudness (Rec 3) — M — **blocked on decisions**
@@ -148,19 +148,17 @@ Scope-resolved detection in two layers: lint warns (error under `--strict`) when
 
 Defaults applied (object before implementation if wrong): strict promotion **yes**; raw-string `r"..."` false-positive class accepted for v1 (concat/template-string workarounds documented); no out-of-scope-ident detection (protects precision; typo'd `${nmae}` stays uncaught in v1).
 
-### PR-2 — Doc-claim regression tests, CLAUDE.md truth, UFCS embrace (Rec 2) — M, ~70 impl + ~500 tests + doc edits
+### PR-2 — Intentional syntax contract tests, CLAUDE.md truth, UFCS embrace (Rec 2) — S, ~70 impl + ~170 tests + doc edits
 
-One regression test per behavioral claim in CLAUDE.md's 16 Critical Syntax Rules, locking *actual* binary behavior; rewrite the four wrong/stale rules; document UFCS as first-class sugar with its real gaps (map-stored closures not dot-callable; parens disambiguate call vs key lookup); make IAL_REFERENCE honest about unimplemented primitives.
+A narrower guardrail than the original scoping: test only the syntax contracts we are comfortable treating as stable language/agent behavior. Current-but-questionable behavior (partial `mut`, string iteration skip, route import limitations, semicolon permissiveness, etc.) is documented honestly where needed, but not frozen with regression tests. The PR still truth-syncs the stale agent-facing UFCS/semicolon docs and documents UFCS as first-class sugar.
 
-- [x] `tests/doc_claims_tests.rs` (32 tests; assert on error codes + short stable fragments, never full message lines)
+- [x] `tests/doc_claims_tests.rs` (8 intentional contract tests; assert on error codes, lint rule ids, and short stable fragments)
 - [x] CLAUDE.md corrections: rule 3 (UFCS works — reframed as "free functions are canonical, dot-call is sugar"), rule 5 (semicolons are lint warnings, not parser corruption), rule 8 (`mut` enforced only for indexed/deep mutation — documented actual semantics), rule 10 (module-level `map {}` works — replaced in place with the map-closure caveat to keep rule numbering stable), rule 11 (warning is emitted, not silent)
 - [x] `docs/AI_AGENT_GUIDE.md` + `syntax.toml` UFCS documentation; also corrected the same drift in `.github/copilot-instructions.md` and `CODEX.md` (both are agent-facing surfaces carrying the identical stale claims)
 - [x] Fix `collect_from_expr` unused-import lint bug exposed by UFCS embrace (dot-call method names are dropped, so imports used only via UFCS get flagged unused)
-- [x] `ial.toml` status field for `sql`/`invariant_check` + Status column in `generate_ial_markdown`
-- [x] Regenerate `docs/IAL_REFERENCE.md` / `SYNTAX_REFERENCE.md` via `ntnt docs --generate`
-- [x] Optional Step 7: wire `find_suggestion` into the method-call E007 so dot-call typos (`5.doubl()`) get "did you mean" hints
+- [ ] IAL primitive status honesty deferred to the IAL stub-gap PR rather than bundled into this lighter Rec 2 slice
 
-Maintainer decisions (defaults applied per plan; flagged in PR for confirmation): **(a)** rule 8 — documented current `mut` semantics (the `doc_rule08_plain_reassign_without_mut_succeeds` test locks the actual behavior; invert it in the same PR if enforcement is later added); **(b)** IAL `Sql` primitive — marked `not_implemented` in docs rather than removed.
+Maintainer decision applied after review: PR-2 should not lock every current CLAUDE.md behavior. It locks only resounding yes contracts and leaves questionable current behavior available for future language improvements.
 
 ### PR-3 — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M, ~420 impl + ~380 tests
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -82,7 +82,7 @@ After trying NTNT, set up persistent agent knowledge so every future session wri
 - String interpolation: `#{expr}` — hash-brace syntax, never `${expr}` or bare `{expr}`
 - Template strings: `"""..{{expr}}.."""` — double braces inside triple quotes
 - Semicolons are supported as statement separators, but newlines are still the normal style.
-- Free functions, not methods: `len(s)` not `s.len()`, `trim(s)` not `s.trim()`
+- Free functions are canonical; dot-call sugar also works: `s.len()` ≡ `len(s)` (UFCS)
 - Dot notation reads properties: `req.params.id`, `user.name`
 - Mutable variables: `let mut x = 0`
 - Ranges: `0..10` — `range()` doesn't exist
@@ -421,12 +421,25 @@ split(text, ",")        // create a new array from a string
 trim(input)             // create a new string
 push(arr, item)         // create a new array with item added
 int(form.age) ?? 0      // convert a value to a new type, handling parse failure
-
-// WRONG - method-style calls on stdlib functions
-"hello".len()           // Use len("hello")
-arr.push(item)          // Use push(arr, item)
-text.split(",")         // Use split(text, ",")
 ```
+
+**Dot-call sugar (UFCS):** `x.f(a)` resolves to `f(x, a)` for any builtin,
+imported, or user-defined function, so method-style calls also work:
+
+```ntnt
+"hello".len()           // ≡ len("hello") — works
+text.split(",")         // ≡ split(text, ",") — works
+5.double()              // works for user-defined fn double(x) too
+```
+
+Two rules to know:
+
+- **Parens always mean a call.** `m.keys` (no parens) reads the map key
+  `"keys"` (None if missing); `m.keys()` always calls `keys(m)`, even when a
+  `"keys"` key exists in the map.
+- **Closures stored in map values are not dot-callable.** `m.f(10)` fails with
+  E007 `Undefined function: f` because the parens make it a UFCS lookup for a
+  function named `f`. Bind first: `let f = m.f` then `f(10)`.
 
 **When to use dot vs brackets on maps:**
 - **Dot notation** for static keys known at write time: `req.params.id`
@@ -3266,7 +3279,7 @@ NTNT error messages include error codes (E001-E012), source snippets, line numbe
 | `unexpected token '{'` | Using `{}` for map literal | Add `map` keyword: `map { "key": "value" }` |
 | `unexpected token '$'` | Using `${expr}` interpolation | Use `#{expr}` — hash-brace syntax |
 | `expected identifier` | Inline lambda in route | Use named function: `fn handler(req) { ... }` |
-| `unexpected token '.'` | Method-style call on stdlib function | Use function style: `len(s)` not `s.len()`. Dot notation is for reading properties, not calling stdlib functions. |
+| `E007 Undefined function: f` on `m.f(x)` | Dot-calling a closure stored in a map value | Parens make `.f()` a UFCS function lookup. Bind the closure to a local first: `let f = m.f` then `f(x)`. |
 | `Required parameter 'x' cannot follow a parameter with a default value` | Non-default param after default | Move all required params before defaulted ones: `fn f(a, b = 1)` not `fn f(a = 1, b)` |
 
 ### Common Runtime Errors

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -22,17 +22,17 @@ IAL is a term rewriting engine that translates natural language assertions into 
 
 IAL primitives are the leaf nodes of term resolution - they execute directly
 
-| Primitive | Description | Context Sets |
-|-----------|-------------|---------------|
-| **Http** | Execute an HTTP request and capture response in context | `response.status`, `response.body`, `response.headers.*`, `response.time_ms` |
-| **Cli** | Execute a CLI command and capture output | `cli.exit_code`, `cli.stdout`, `cli.stderr` |
-| **CodeQuality** | Run lint/validation checks on source files | `code.quality.passed`, `code.quality.error_count`, `code.quality.warning_count`, `code.quality.errors` |
-| **Sql** | Execute a SQL query with parameters | `sql.result`, `sql.rows` |
-| **ReadFile** | Read file contents into context | `file.content`, `file.exists` |
-| **FunctionCall** | Call an NTNT function for unit testing | `result` |
-| **PropertyCheck** | Verify a function property (deterministic, idempotent, round-trips) | `property.passed`, `property.failures` |
-| **InvariantCheck** | Verify a named invariant holds for a value | `invariant.passed`, `invariant.failures` |
-| **Check** | Universal assertion - compare context value against expected |  |
+| Primitive | Description | Context Sets | Status |
+|-----------|-------------|---------------|--------|
+| **Http** | Execute an HTTP request and capture response in context | `response.status`, `response.body`, `response.headers.*`, `response.time_ms` | Implemented |
+| **Cli** | Execute a CLI command and capture output | `cli.exit_code`, `cli.stdout`, `cli.stderr` | Implemented |
+| **CodeQuality** | Run lint/validation checks on source files | `code.quality.passed`, `code.quality.error_count`, `code.quality.warning_count`, `code.quality.errors` | Implemented |
+| **Sql** | Execute a SQL query with parameters | `sql.result`, `sql.rows` | Not implemented — execution always fails |
+| **ReadFile** | Read file contents into context | `file.content`, `file.exists` | Implemented |
+| **FunctionCall** | Call an NTNT function for unit testing | `result` | Implemented |
+| **PropertyCheck** | Verify a function property (deterministic, idempotent, round-trips) | `property.passed`, `property.failures` | Implemented |
+| **InvariantCheck** | Verify a named invariant holds for a value | `invariant.passed`, `invariant.failures` | Partial — invariants expand at resolution time; these context keys are never set |
+| **Check** | Universal assertion - compare context value against expected |  | Implemented |
 
 ---
 

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -22,17 +22,17 @@ IAL is a term rewriting engine that translates natural language assertions into 
 
 IAL primitives are the leaf nodes of term resolution - they execute directly
 
-| Primitive | Description | Context Sets |
-|-----------|-------------|---------------|
-| **Http** | Execute an HTTP request and capture response in context | `response.status`, `response.body`, `response.headers.*`, `response.time_ms` |
-| **Cli** | Execute a CLI command and capture output | `cli.exit_code`, `cli.stdout`, `cli.stderr` |
-| **CodeQuality** | Run lint/validation checks on source files | `code.quality.passed`, `code.quality.error_count`, `code.quality.warning_count`, `code.quality.errors` |
-| **Sql** | Execute a SQL query with parameters | `sql.result`, `sql.rows` |
-| **ReadFile** | Read file contents into context | `file.content`, `file.exists` |
-| **FunctionCall** | Call an NTNT function for unit testing | `result` |
-| **PropertyCheck** | Verify a function property (deterministic, idempotent, round-trips) | `property.passed`, `property.failures` |
-| **InvariantCheck** | Verify a named invariant holds for a value | `invariant.passed`, `invariant.failures` |
-| **Check** | Universal assertion - compare context value against expected |  |
+| Primitive | Description | Context Sets | Status |
+|-----------|-------------|---------------|--------|
+| **Http** | Execute an HTTP request and capture response in context | `response.status`, `response.body`, `response.headers.*`, `response.time_ms` | Implemented |
+| **Cli** | Execute a CLI command and capture output | `cli.exit_code`, `cli.stdout`, `cli.stderr` | Implemented |
+| **CodeQuality** | Run lint/validation checks on source files | `code.quality.passed`, `code.quality.error_count`, `code.quality.warning_count`, `code.quality.errors` | Implemented |
+| **Sql** | Execute a SQL query with parameters | `sql.result`, `sql.rows` | Not implemented |
+| **ReadFile** | Read file contents into context | `file.content`, `file.exists` | Implemented |
+| **FunctionCall** | Call an NTNT function for unit testing | `result` | Implemented |
+| **PropertyCheck** | Verify a function property (deterministic, idempotent, round-trips) | `property.passed`, `property.failures` | Implemented |
+| **InvariantCheck** | Verify a named invariant holds for a value | `invariant.passed`, `invariant.failures` | Resolver marker only; direct execution fails unless expanded |
+| **Check** | Universal assertion - compare context value against expected |  | Implemented |
 
 ---
 

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -22,17 +22,17 @@ IAL is a term rewriting engine that translates natural language assertions into 
 
 IAL primitives are the leaf nodes of term resolution - they execute directly
 
-| Primitive | Description | Context Sets | Status |
-|-----------|-------------|---------------|--------|
-| **Http** | Execute an HTTP request and capture response in context | `response.status`, `response.body`, `response.headers.*`, `response.time_ms` | Implemented |
-| **Cli** | Execute a CLI command and capture output | `cli.exit_code`, `cli.stdout`, `cli.stderr` | Implemented |
-| **CodeQuality** | Run lint/validation checks on source files | `code.quality.passed`, `code.quality.error_count`, `code.quality.warning_count`, `code.quality.errors` | Implemented |
-| **Sql** | Execute a SQL query with parameters | `sql.result`, `sql.rows` | Not implemented — execution always fails |
-| **ReadFile** | Read file contents into context | `file.content`, `file.exists` | Implemented |
-| **FunctionCall** | Call an NTNT function for unit testing | `result` | Implemented |
-| **PropertyCheck** | Verify a function property (deterministic, idempotent, round-trips) | `property.passed`, `property.failures` | Implemented |
-| **InvariantCheck** | Verify a named invariant holds for a value | `invariant.passed`, `invariant.failures` | Partial — invariants expand at resolution time; these context keys are never set |
-| **Check** | Universal assertion - compare context value against expected |  | Implemented |
+| Primitive | Description | Context Sets |
+|-----------|-------------|---------------|
+| **Http** | Execute an HTTP request and capture response in context | `response.status`, `response.body`, `response.headers.*`, `response.time_ms` |
+| **Cli** | Execute a CLI command and capture output | `cli.exit_code`, `cli.stdout`, `cli.stderr` |
+| **CodeQuality** | Run lint/validation checks on source files | `code.quality.passed`, `code.quality.error_count`, `code.quality.warning_count`, `code.quality.errors` |
+| **Sql** | Execute a SQL query with parameters | `sql.result`, `sql.rows` |
+| **ReadFile** | Read file contents into context | `file.content`, `file.exists` |
+| **FunctionCall** | Call an NTNT function for unit testing | `result` |
+| **PropertyCheck** | Verify a function property (deterministic, idempotent, round-trips) | `property.passed`, `property.failures` |
+| **InvariantCheck** | Verify a named invariant holds for a value | `invariant.passed`, `invariant.failures` |
+| **Check** | Universal assertion - compare context value against expected |  |
 
 ---
 

--- a/docs/SYNTAX_REFERENCE.md
+++ b/docs/SYNTAX_REFERENCE.md
@@ -92,6 +92,7 @@ NTNT operators by precedence (lowest to highest)
 | null coalesce | `??` | Null coalescing — unwraps Some(x) to x, returns right side for None | `map["key"] ?? "default", get_env("PORT") ?? "8080"` |
 | postfix | `?` | Try operator — unwraps Ok/Some or early-returns Err/None from enclosing function | `let data = parse_json(body)?, let row = pg_query_one(pg, sql, params)? ?` |
 | member | `.`, `[]` | Member access and indexing | `user.name, arr[0], map["key"]` |
+| method call | `.()` | Method-call sugar (UFCS): x.f(a) resolves to f(x, a) for any builtin, imported, or user function; parens distinguish a call from a property read | `s.len(), value.double(), m.keys()` |
 | pipe | `|>` | Pipeline operator (passes left as first arg to right) | `data |> transform |> validate` |
 
 ---

--- a/docs/ial.toml
+++ b/docs/ial.toml
@@ -58,6 +58,7 @@ example = "PropertyCheck(hash, Deterministic, [\"test\", \"data\"])"
 [primitives.sql]
 name = "Sql"
 description = "Execute a SQL query with parameters"
+status = "Not implemented"
 parameters = ["query", "params"]
 context_sets = ["sql.result", "sql.rows"]
 example = "Sql(SELECT * FROM users WHERE id = $1, [42])"
@@ -65,6 +66,7 @@ example = "Sql(SELECT * FROM users WHERE id = $1, [42])"
 [primitives.invariant_check]
 name = "InvariantCheck"
 description = "Verify a named invariant holds for a value"
+status = "Resolver marker only; direct execution fails unless expanded"
 parameters = ["invariant_id", "value"]
 context_sets = ["invariant.passed", "invariant.failures"]
 example = "InvariantCheck(invariant.url_slug, \"hello-world\")"

--- a/docs/ial.toml
+++ b/docs/ial.toml
@@ -61,6 +61,7 @@ description = "Execute a SQL query with parameters"
 parameters = ["query", "params"]
 context_sets = ["sql.result", "sql.rows"]
 example = "Sql(SELECT * FROM users WHERE id = $1, [42])"
+status = "Not implemented — execution always fails"
 
 [primitives.invariant_check]
 name = "InvariantCheck"
@@ -68,6 +69,7 @@ description = "Verify a named invariant holds for a value"
 parameters = ["invariant_id", "value"]
 context_sets = ["invariant.passed", "invariant.failures"]
 example = "InvariantCheck(invariant.url_slug, \"hello-world\")"
+status = "Partial — invariants expand at resolution time; these context keys are never set"
 
 [primitives.check]
 name = "Check"

--- a/docs/ial.toml
+++ b/docs/ial.toml
@@ -61,7 +61,6 @@ description = "Execute a SQL query with parameters"
 parameters = ["query", "params"]
 context_sets = ["sql.result", "sql.rows"]
 example = "Sql(SELECT * FROM users WHERE id = $1, [42])"
-status = "Not implemented — execution always fails"
 
 [primitives.invariant_check]
 name = "InvariantCheck"
@@ -69,7 +68,6 @@ description = "Verify a named invariant holds for a value"
 parameters = ["invariant_id", "value"]
 context_sets = ["invariant.passed", "invariant.failures"]
 example = "InvariantCheck(invariant.url_slug, \"hello-world\")"
-status = "Partial — invariants expand at resolution time; these context keys are never set"
 
 [primitives.check]
 name = "Check"

--- a/docs/syntax.toml
+++ b/docs/syntax.toml
@@ -102,6 +102,11 @@ symbols = [".", "[]"]
 description = "Member access and indexing"
 example = "user.name, arr[0], map[\"key\"]"
 
+[operators.method_call]
+symbols = [".()"]
+description = "Method-call sugar (UFCS): x.f(a) resolves to f(x, a) for any builtin, imported, or user function; parens distinguish a call from a property read"
+example = "s.len(), value.double(), m.keys()"
+
 [operators.pipe]
 symbols = ["|>"]
 description = "Pipeline operator (passes left as first arg to right)"

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -7089,9 +7089,13 @@ impl Interpreter {
 
                     Ok(result)
                 } else {
+                    // Dot-call is UFCS sugar (x.f() resolves to f(x)), so a miss
+                    // is a missing free function — suggest a near-match by name.
+                    let candidates = self.environment.borrow().keys();
+                    let suggestion = crate::error::find_suggestion(method, &candidates);
                     Err(IntentError::UndefinedFunction {
                         name: method.clone(),
-                        suggestion: None,
+                        suggestion,
                         line: 0,
                     })
                 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -444,24 +444,6 @@ impl Environment {
         keys.dedup();
         keys
     }
-
-    /// Names of callable bindings (functions and builtins) in scope.
-    /// Used to suggest near-matches for a missed UFCS dot-call, so the hint
-    /// never points at a non-callable variable that would still fail.
-    pub fn function_names(&self) -> Vec<String> {
-        let mut names: Vec<_> = self
-            .values
-            .iter()
-            .filter(|(_, v)| matches!(v, Value::Function { .. } | Value::NativeFunction { .. }))
-            .map(|(k, _)| k.clone())
-            .collect();
-        if let Some(ref parent) = self.parent {
-            names.extend(parent.borrow().function_names());
-        }
-        names.sort();
-        names.dedup();
-        names
-    }
 }
 
 impl Default for Environment {
@@ -7107,14 +7089,9 @@ impl Interpreter {
 
                     Ok(result)
                 } else {
-                    // Dot-call is UFCS sugar (x.f() resolves to f(x)), so a miss
-                    // is a missing free function — suggest a near-match among
-                    // callable bindings only (never a non-callable variable).
-                    let candidates = self.environment.borrow().function_names();
-                    let suggestion = crate::error::find_suggestion(method, &candidates);
                     Err(IntentError::UndefinedFunction {
                         name: method.clone(),
-                        suggestion,
+                        suggestion: None,
                         line: 0,
                     })
                 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -444,6 +444,24 @@ impl Environment {
         keys.dedup();
         keys
     }
+
+    /// Names of callable bindings (functions and builtins) in scope.
+    /// Used to suggest near-matches for a missed UFCS dot-call, so the hint
+    /// never points at a non-callable variable that would still fail.
+    pub fn function_names(&self) -> Vec<String> {
+        let mut names: Vec<_> = self
+            .values
+            .iter()
+            .filter(|(_, v)| matches!(v, Value::Function { .. } | Value::NativeFunction { .. }))
+            .map(|(k, _)| k.clone())
+            .collect();
+        if let Some(ref parent) = self.parent {
+            names.extend(parent.borrow().function_names());
+        }
+        names.sort();
+        names.dedup();
+        names
+    }
 }
 
 impl Default for Environment {
@@ -7090,8 +7108,9 @@ impl Interpreter {
                     Ok(result)
                 } else {
                     // Dot-call is UFCS sugar (x.f() resolves to f(x)), so a miss
-                    // is a missing free function — suggest a near-match by name.
-                    let candidates = self.environment.borrow().keys();
+                    // is a missing free function — suggest a near-match among
+                    // callable bindings only (never a non-callable variable).
+                    let candidates = self.environment.borrow().function_names();
                     let suggestion = crate::error::find_suggestion(method, &candidates);
                     Err(IntentError::UndefinedFunction {
                         name: method.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6739,8 +6739,8 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
             md.push_str(&format!("{}\n\n", desc));
         }
 
-        md.push_str("| Primitive | Description | Context Sets | Status |\n");
-        md.push_str("|-----------|-------------|---------------|--------|\n");
+        md.push_str("| Primitive | Description | Context Sets |\n");
+        md.push_str("|-----------|-------------|---------------|\n");
 
         let prim_names = [
             "http",
@@ -6768,14 +6768,7 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
                             .join(", ")
                     })
                     .unwrap_or_default();
-                let status = p
-                    .get("status")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Implemented");
-                md.push_str(&format!(
-                    "| **{}** | {} | {} | {} |\n",
-                    name, desc, context, status
-                ));
+                md.push_str(&format!("| **{}** | {} | {} |\n", name, desc, context));
             }
         }
         md.push_str("\n---\n\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6739,8 +6739,8 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
             md.push_str(&format!("{}\n\n", desc));
         }
 
-        md.push_str("| Primitive | Description | Context Sets |\n");
-        md.push_str("|-----------|-------------|---------------|\n");
+        md.push_str("| Primitive | Description | Context Sets | Status |\n");
+        md.push_str("|-----------|-------------|---------------|--------|\n");
 
         let prim_names = [
             "http",
@@ -6768,7 +6768,14 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
                             .join(", ")
                     })
                     .unwrap_or_default();
-                md.push_str(&format!("| **{}** | {} | {} |\n", name, desc, context));
+                let status = p
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Implemented");
+                md.push_str(&format!(
+                    "| **{}** | {} | {} | {} |\n",
+                    name, desc, context, status
+                ));
             }
         }
         md.push_str("\n---\n\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4974,10 +4974,18 @@ fn collect_used_names(stmt: &ntnt::ast::Statement, names: &mut std::collections:
                 }
             }
 
-            // Method calls - object and arguments (method name is not a used identifier)
+            // Method calls — dot-call is UFCS sugar (x.f(a) resolves to f(x, a)),
+            // so the method name counts as usage of an imported function.
+            // Accepted false-negative: an unrelated dot-call sharing the name of
+            // a genuinely unused import (e.g. builtin m.keys() vs `import { keys }`)
+            // suppresses the unused_import warning for that name.
             Expression::MethodCall {
-                object, arguments, ..
+                object,
+                method,
+                arguments,
+                ..
             } => {
+                names.insert(method.clone());
                 collect_from_expr(object, names);
                 for arg in arguments {
                     collect_from_expr(arg, names);
@@ -6258,6 +6266,7 @@ fn generate_syntax_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
             "null_coalesce",
             "postfix",
             "member",
+            "method_call",
             "pipe",
         ];
 
@@ -6730,8 +6739,8 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
             md.push_str(&format!("{}\n\n", desc));
         }
 
-        md.push_str("| Primitive | Description | Context Sets |\n");
-        md.push_str("|-----------|-------------|---------------|\n");
+        md.push_str("| Primitive | Description | Context Sets | Status |\n");
+        md.push_str("|-----------|-------------|---------------|--------|\n");
 
         let prim_names = [
             "http",
@@ -6759,7 +6768,14 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
                             .join(", ")
                     })
                     .unwrap_or_default();
-                md.push_str(&format!("| **{}** | {} | {} |\n", name, desc, context));
+                let status = p
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Implemented");
+                md.push_str(&format!(
+                    "| **{}** | {} | {} | {} |\n",
+                    name, desc, context, status
+                ));
             }
         }
         md.push_str("\n---\n\n");

--- a/tests/doc_claims_tests.rs
+++ b/tests/doc_claims_tests.rs
@@ -1,0 +1,544 @@
+//! Doc-claim regression tests (DD-063 Rec 2).
+//!
+//! Each test locks a behavioral claim made in CLAUDE.md's "Critical Syntax
+//! Rules" against the actual binary. If one of these fails, the language
+//! changed — update CLAUDE.md and docs/AI_AGENT_GUIDE.md in the same PR,
+//! never let the agent-facing docs drift from the implementation again.
+//!
+//! Assertions use error codes (E002/E005/E006/E007), lint rule ids, and short
+//! stable fragments — never full message lines.
+
+use std::fs;
+use std::io::Write;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_test_file(prefix: &str) -> String {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let thread_id = format!("{:?}", std::thread::current().id());
+    let temp_dir = std::env::temp_dir();
+    temp_dir
+        .join(format!(
+            "ntnt_{}_{}_{}_{}.tnt",
+            prefix,
+            std::process::id(),
+            thread_id.replace(|c: char| !c.is_alphanumeric(), "_"),
+            counter
+        ))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn ntnt_binary() -> std::path::PathBuf {
+    let exe = std::env::consts::EXE_SUFFIX;
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let debug_path = manifest.join(format!("target/debug/ntnt{}", exe));
+    let release_path = manifest.join(format!("target/release/ntnt{}", exe));
+
+    if debug_path.exists() {
+        debug_path
+    } else if release_path.exists() {
+        release_path
+    } else {
+        panic!("No ntnt binary found. Run 'cargo build' first.");
+    }
+}
+
+/// Run `ntnt <subcommand> <file>` on a code snippet.
+/// Returns (stdout, stderr, exit_code).
+fn run_ntnt(subcommand: &str, code: &str) -> (String, String, i32) {
+    let test_file = unique_test_file("doc_claim");
+    let mut file = fs::File::create(&test_file).expect("Failed to create test file");
+    writeln!(file, "{}", code).expect("Failed to write test file");
+
+    let output = Command::new(ntnt_binary())
+        .arg(subcommand)
+        .arg(&test_file)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("Failed to execute ntnt");
+    let _ = fs::remove_file(&test_file);
+
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+fn run(code: &str) -> (String, String, i32) {
+    run_ntnt("run", code)
+}
+
+fn lint(code: &str) -> (String, String, i32) {
+    run_ntnt("lint", code)
+}
+
+// ── Rule 1: maps require `map` keyword — bare `{}` is a block ──────────
+
+#[test]
+fn doc_rule01_bare_brace_map_is_parse_error() {
+    let (_, stderr, exit_code) = run(r#"let user = { "name": "Alice" }
+print(user)"#);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("E002") && stderr.contains("Expected expression"),
+        "bare-brace map literal must be a loud parse error: {}",
+        stderr
+    );
+}
+
+#[test]
+fn doc_rule01_bare_brace_is_block_expression() {
+    let (stdout, _, exit_code) = run("let x = { 1 + 2 }\nprint(x)");
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains("3"),
+        "bare braces with an expression form a block: {}",
+        stdout
+    );
+}
+
+// ── Rule 2: interpolation is `#{expr}`, not `${expr}` ──────────────────
+
+#[test]
+fn doc_rule02_dollar_interpolation_is_literal() {
+    let code = r#"let name = "World"
+print("Hello, ${name}!")
+print("Hello, #{name}!")"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains("Hello, ${name}!"),
+        "${{}} must not interpolate: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Hello, World!"),
+        "#{{}} must interpolate: {}",
+        stdout
+    );
+}
+
+// ── Rule 3: dot-call is UFCS sugar — x.f(a) calls f(x, a) ───────────────
+
+#[test]
+fn doc_rule03_ufcs_builtin() {
+    let (stdout, _, exit_code) = run(r#"print("abc".len())"#);
+    assert_eq!(exit_code, 0, "UFCS on builtins must work");
+    assert!(stdout.contains("3"), "stdout: {}", stdout);
+}
+
+#[test]
+fn doc_rule03_ufcs_user_function() {
+    let code = r#"fn double(x: Int) -> Int { return x * 2 }
+print(5.double())"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0, "UFCS on user functions must work");
+    assert!(stdout.contains("10"), "stdout: {}", stdout);
+}
+
+#[test]
+fn doc_rule03_ufcs_imported_function() {
+    let code = r#"import { trim } from "std/string"
+print("  hi  ".trim())"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0, "UFCS on imported functions must work");
+    assert!(stdout.contains("hi"), "stdout: {}", stdout);
+}
+
+#[test]
+fn doc_rule03_ufcs_stdlib_without_import() {
+    let code = r#"let m = map { "a": 1 }
+print(m.keys())"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0, "stdlib functions are globally registered");
+    assert!(stdout.contains("a"), "stdout: {}", stdout);
+}
+
+#[test]
+fn doc_rule03_parens_disambiguate_map_key_shadow() {
+    // `m.keys` (no parens) reads the map key; `m.keys()` always calls keys(m).
+    let code = r#"let m = map { "keys": 42, "a": 1 }
+print(m.keys)
+print(m.keys())"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        lines.first().map(|l| l.contains("42")).unwrap_or(false),
+        "m.keys must read the stored key value: {}",
+        stdout
+    );
+    assert!(
+        lines.get(1).map(|l| l.contains("a")).unwrap_or(false)
+            && lines.get(1).map(|l| l.contains("keys")).unwrap_or(false),
+        "m.keys() must call keys(m), ignoring the key: {}",
+        stdout
+    );
+}
+
+#[test]
+fn doc_rule03_map_closure_not_dot_callable() {
+    // Documented UFCS gap: closures stored in map values are not dot-callable.
+    let code = r#"let m = map { "f": fn(x) { x + 1 } }
+print(m.f(10))"#;
+    let (_, stderr, exit_code) = run(code);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("E007") && stderr.contains("Undefined function: f"),
+        "map-stored closures must fail with E007 on dot-call: {}",
+        stderr
+    );
+}
+
+#[test]
+fn doc_rule03_lint_no_unused_import_for_ufcs() {
+    // An import used only via dot-call must count as used.
+    let code = r#"import { trim } from "std/string"
+print("  hi  ".trim())"#;
+    let (stdout, _, exit_code) = lint(code);
+    assert_eq!(exit_code, 0);
+    assert!(
+        !stdout.contains("unused_import"),
+        "UFCS usage must count as import usage: {}",
+        stdout
+    );
+}
+
+#[test]
+fn doc_rule03_ufcs_typo_suggests_near_match() {
+    // A misspelled dot-call resolves like a free-function miss and gets a hint.
+    let code = r#"fn double(x: Int) -> Int { return x * 2 }
+print(5.doubl())"#;
+    let (_, stderr, exit_code) = run(code);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("double"),
+        "a typo'd dot-call should suggest the near-match free function: {}",
+        stderr
+    );
+}
+
+// ── Rule 4: route functions are global builtins — never import them ────
+
+#[test]
+fn doc_rule04_route_fns_not_importable() {
+    let code = r#"import { get, listen } from "std/http/server""#;
+    let (_, stderr, exit_code) = run(code);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("is not exported from 'std/http/server'"),
+        "importing route builtins must fail loudly: {}",
+        stderr
+    );
+}
+
+// ── Rule 5: semicolons are unnecessary (lint warning, not corruption) ──
+
+#[test]
+fn doc_rule05_semicolons_execute_correctly() {
+    let (stdout, _, exit_code) = run("let x = 1; let y = 2; print(x + y);");
+    assert_eq!(exit_code, 0, "semicolons must not corrupt parsing");
+    assert!(stdout.contains("3"), "stdout: {}", stdout);
+}
+
+#[test]
+fn doc_rule05_semicolons_lint_warns() {
+    let (stdout, _, exit_code) = lint("let x = 1; print(x);");
+    assert_eq!(exit_code, 0, "semicolon warnings must not fail lint");
+    assert!(
+        stdout.contains("unnecessary_semicolon"),
+        "lint must flag semicolons: {}",
+        stdout
+    );
+}
+
+// ── Rule 6: `otherwise` blocks must diverge ────────────────────────────
+
+#[test]
+fn doc_rule06_otherwise_nondiverge_is_lint_error() {
+    let code = r#"fn main() -> Int {
+    let v = int("nope") otherwise { 0 }
+    return v
+}
+print(main())"#;
+    let (stdout, _, exit_code) = lint(code);
+    assert_eq!(exit_code, 1, "non-diverging otherwise must fail lint");
+    assert!(
+        stdout.contains("otherwise block does not diverge"),
+        "lint output: {}",
+        stdout
+    );
+}
+
+#[test]
+fn doc_rule06_otherwise_nondiverge_runtime_error_on_error_path() {
+    let code = r#"fn parse() -> Int {
+    let v = int("notanum") otherwise { 0 }
+    return v
+}
+print(parse())"#;
+    let (_, stderr, exit_code) = run(code);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("otherwise block must diverge"),
+        "runtime must reject non-diverging otherwise on the error path: {}",
+        stderr
+    );
+}
+
+#[test]
+fn doc_rule06_otherwise_diverging_recovers() {
+    let code = r#"fn parse() -> Int {
+    let v = int("notanum") otherwise { return 0 }
+    return v
+}
+print(parse())"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("0"), "stdout: {}", stdout);
+}
+
+// ── Rule 7: ranges are `0..10` — range() doesn't exist ─────────────────
+
+#[test]
+fn doc_rule07_range_function_undefined() {
+    let (_, stderr, exit_code) = run("for i in range(3) { print(i) }");
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("E006") && stderr.contains("range"),
+        "range() must be a loud undefined error: {}",
+        stderr
+    );
+}
+
+#[test]
+fn doc_rule07_range_syntax_works() {
+    let (stdout, _, exit_code) = run("for i in 0..3 { print(i) }");
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains("0") && stdout.contains("1") && stdout.contains("2"),
+        "stdout: {}",
+        stdout
+    );
+}
+
+// ── Rule 8: `mut` is enforced for indexed mutation only ────────────────
+
+#[test]
+fn doc_rule08_plain_reassign_without_mut_succeeds() {
+    // Locks ACTUAL current behavior: plain rebinding does not require `mut`.
+    // If the maintainer later decides to enforce `mut` for plain reassignment
+    // (a breaking change), INVERT this test in the same PR that changes it.
+    let (stdout, _, exit_code) = run("let x = 0\nx = x + 1\nprint(x)");
+    assert_eq!(
+        exit_code, 0,
+        "plain rebinding without mut currently succeeds"
+    );
+    assert!(stdout.contains("1"), "stdout: {}", stdout);
+}
+
+#[test]
+fn doc_rule08_index_assign_requires_mut() {
+    let (_, stderr, exit_code) = run("let arr = [1, 2, 3]\narr[0] = 99\nprint(arr)");
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("Cannot mutate 'arr'"),
+        "indexed mutation without mut must fail: {}",
+        stderr
+    );
+}
+
+#[test]
+fn doc_rule08_index_assign_with_mut_works() {
+    let (stdout, _, exit_code) = run("let mut arr = [1, 2, 3]\narr[0] = 99\nprint(arr)");
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("99"), "stdout: {}", stdout);
+}
+
+// ── Rule 9: closures are `fn(x) { ... }` — pipe syntax doesn't exist ───
+
+#[test]
+fn doc_rule09_pipe_closure_is_parse_error() {
+    let (_, stderr, exit_code) = run("let f = |x| x * 2\nprint(f(3))");
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("E002"),
+        "pipe-style closures must be a parse error: {}",
+        stderr
+    );
+}
+
+#[test]
+fn doc_rule09_fn_closure_works() {
+    let (stdout, _, exit_code) = run("let f = fn(x) { x * 2 }\nprint(f(3))");
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("6"), "stdout: {}", stdout);
+}
+
+// ── Rule 10 (replaced in docs): module-level `let` with `map {}` works ──
+
+#[test]
+fn doc_rule10_module_level_map_works() {
+    // Locks the un-stale behavior: the old rule claimed module-level `let`
+    // can't hold a map literal. It can.
+    let code = r#"let config = map { "k": "v" }
+print(config)"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0, "module-level map literals work");
+    assert!(
+        stdout.contains("k") && stdout.contains("v"),
+        "stdout: {}",
+        stdout
+    );
+}
+
+// ── Rule 11: for..in on a string skips with a warning — use chars() ────
+
+#[test]
+fn doc_rule11_for_in_string_zero_iterations_with_warning() {
+    let code = r#"for c in "ab" { print(c) }
+print("done")"#;
+    let (stdout, stderr, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        stdout.trim(),
+        "done",
+        "for..in on a string must not iterate: {}",
+        stdout
+    );
+    assert!(
+        stderr.contains("for..in on String"),
+        "the skip must warn, not be silent: {}",
+        stderr
+    );
+}
+
+#[test]
+fn doc_rule11_chars_iterates_string() {
+    let code = r#"import { chars } from "std/string"
+for c in chars("ab") { print(c) }"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains("a") && stdout.contains("b"),
+        "stdout: {}",
+        stdout
+    );
+}
+
+// ── Rule 12: template strings interpolate with {{expr}} ────────────────
+
+#[test]
+fn doc_rule12_template_double_braces() {
+    let code = r#"let name = "World"
+print("""Hello {{name}}""")
+print("Hello {name}")"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains("Hello World"),
+        "{{{{expr}}}} must interpolate in template strings: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Hello {name}"),
+        "single braces stay literal in regular strings: {}",
+        stdout
+    );
+}
+
+// ── Rule 13: contracts go after return type, before body ───────────────
+
+#[test]
+fn doc_rule13_contract_placement_parses_and_runs() {
+    let code = r#"fn divide(a: Int, b: Int) -> Int
+    requires b != 0
+    ensures result * b == a
+{
+    return a / b
+}
+print(divide(10, 2))"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("5"), "stdout: {}", stdout);
+}
+
+// ── Rule 14: 0 is truthy; falsy are false, "", None, [], map {} ────────
+
+#[test]
+fn doc_rule14_truthiness() {
+    let code = r#"if 0 { print("zero-truthy") } else { print("zero-falsy") }
+if "" { print("str-truthy") } else { print("str-falsy") }
+if [] { print("arr-truthy") } else { print("arr-falsy") }
+if map {} { print("map-truthy") } else { print("map-falsy") }"#;
+    let (stdout, stderr, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("zero-truthy"), "0 is truthy: {}", stdout);
+    assert!(stdout.contains("str-falsy"), "\"\" is falsy: {}", stdout);
+    assert!(stdout.contains("arr-falsy"), "[] is falsy: {}", stdout);
+    assert!(
+        stdout.contains("map-falsy"),
+        "map {{}} is falsy: {}",
+        stdout
+    );
+    assert!(
+        stderr.contains("Non-boolean condition"),
+        "non-boolean conditions warn: {}",
+        stderr
+    );
+}
+
+// ── Rule 15: missing map keys return None — use has_key() ──────────────
+
+#[test]
+fn doc_rule15_missing_map_key_returns_none() {
+    let code = r#"let m = map { "a": 1 }
+print(m["missing"])
+print(has_key(m, "missing"))
+print(m.missing)"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        lines.first().map(|l| l.contains("none")).unwrap_or(false),
+        "m[\"missing\"] is none: {}",
+        stdout
+    );
+    assert!(
+        lines.get(1).map(|l| l.contains("false")).unwrap_or(false),
+        "has_key is false: {}",
+        stdout
+    );
+    assert!(
+        lines.get(2).map(|l| l.contains("none")).unwrap_or(false),
+        "m.missing is none: {}",
+        stdout
+    );
+}
+
+// ── Rule 16: `for k in map` iterates keys — entries() for pairs ────────
+
+#[test]
+fn doc_rule16_for_map_iterates_keys() {
+    // Entry maps print with nondeterministic field order — always read
+    // e.key / e.value, never assert on a printed entry map.
+    let code = r#"let m = map { "a": 1, "b": 2 }
+for k in m { print("key:" + k) }
+for e in entries(m) { print(e.key + "=" + str(e.value)) }"#;
+    let (stdout, _, exit_code) = run(code);
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains("key:a") && stdout.contains("key:b"),
+        "for..in map yields keys: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("a=1") && stdout.contains("b=2"),
+        "entries() yields key/value pairs: {}",
+        stdout
+    );
+}

--- a/tests/doc_claims_tests.rs
+++ b/tests/doc_claims_tests.rs
@@ -222,6 +222,22 @@ print(5.doubl())"#;
     );
 }
 
+#[test]
+fn doc_rule03_ufcs_suggestion_skips_non_callable_binding() {
+    // A variable named `doubl` is an exact match for the typo, but it is not
+    // callable — the suggestion must point at the callable `double` instead.
+    let code = r#"let doubl = 5
+fn double(x: Int) -> Int { return x * 2 }
+print(7.doubl())"#;
+    let (_, stderr, exit_code) = run(code);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("double"),
+        "suggestion must name the callable function, not the variable: {}",
+        stderr
+    );
+}
+
 // ── Rule 4: route functions are global builtins — never import them ────
 
 #[test]

--- a/tests/doc_claims_tests.rs
+++ b/tests/doc_claims_tests.rs
@@ -1,12 +1,9 @@
-//! Doc-claim regression tests (DD-063 Rec 2).
+//! Intentional syntax contract tests (DD-063 Rec 2).
 //!
-//! Each test locks a behavioral claim made in CLAUDE.md's "Critical Syntax
-//! Rules" against the actual binary. If one of these fails, the language
-//! changed — update CLAUDE.md and docs/AI_AGENT_GUIDE.md in the same PR,
-//! never let the agent-facing docs drift from the implementation again.
-//!
-//! Assertions use error codes (E002/E005/E006/E007), lint rule ids, and short
-//! stable fragments — never full message lines.
+//! These are not a snapshot of every current CLAUDE.md behavior. They only
+//! cover syntax rules we want to treat as stable language/agent contracts.
+//! If one fails, either the language changed intentionally and docs must be
+//! updated in the same PR, or we regressed a contract agents should rely on.
 
 use std::fs;
 use std::io::Write;
@@ -18,8 +15,7 @@ static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 fn unique_test_file(prefix: &str) -> String {
     let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
     let thread_id = format!("{:?}", std::thread::current().id());
-    let temp_dir = std::env::temp_dir();
-    temp_dir
+    std::env::temp_dir()
         .join(format!(
             "ntnt_{}_{}_{}_{}.tnt",
             prefix,
@@ -49,7 +45,7 @@ fn ntnt_binary() -> std::path::PathBuf {
 /// Run `ntnt <subcommand> <file>` on a code snippet.
 /// Returns (stdout, stderr, exit_code).
 fn run_ntnt(subcommand: &str, code: &str) -> (String, String, i32) {
-    let test_file = unique_test_file("doc_claim");
+    let test_file = unique_test_file("syntax_contract");
     let mut file = fs::File::create(&test_file).expect("Failed to create test file");
     writeln!(file, "{}", code).expect("Failed to write test file");
 
@@ -76,127 +72,55 @@ fn lint(code: &str) -> (String, String, i32) {
     run_ntnt("lint", code)
 }
 
-// ── Rule 1: maps require `map` keyword — bare `{}` is a block ──────────
-
 #[test]
-fn doc_rule01_bare_brace_map_is_parse_error() {
+fn map_literals_require_map_keyword() {
     let (_, stderr, exit_code) = run(r#"let user = { "name": "Alice" }
 print(user)"#);
     assert_ne!(exit_code, 0);
     assert!(
         stderr.contains("E002") && stderr.contains("Expected expression"),
-        "bare-brace map literal must be a loud parse error: {}",
+        "bare-brace map literals must be loud parse errors: {}",
         stderr
     );
 }
 
 #[test]
-fn doc_rule01_bare_brace_is_block_expression() {
-    let (stdout, _, exit_code) = run("let x = { 1 + 2 }\nprint(x)");
+fn string_interpolation_uses_hash_braces() {
+    let (stdout, _, exit_code) = run(r#"let name = "World"
+print("Hello, #{name}!")"#);
     assert_eq!(exit_code, 0);
+    assert!(stdout.contains("Hello, World!"), "stdout: {}", stdout);
+}
+
+#[test]
+fn javascript_style_interpolation_is_diagnosed() {
+    let (stdout, _, _) = lint(
+        r#"let name = "World"
+print("Hello, ${name}!")"#,
+    );
     assert!(
-        stdout.contains("3"),
-        "bare braces with an expression form a block: {}",
+        stdout.contains("javascript_style_interpolation") && stdout.contains("#{name}"),
+        "${{}} interpolation should be diagnosed with a #{{}} repair hint: {}",
         stdout
     );
 }
 
-// ── Rule 2: interpolation is `#{expr}`, not `${expr}` ──────────────────
-
 #[test]
-fn doc_rule02_dollar_interpolation_is_literal() {
-    let code = r#"let name = "World"
-print("Hello, ${name}!")
-print("Hello, #{name}!")"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0);
-    assert!(
-        stdout.contains("Hello, ${name}!"),
-        "${{}} must not interpolate: {}",
-        stdout
-    );
-    assert!(
-        stdout.contains("Hello, World!"),
-        "#{{}} must interpolate: {}",
-        stdout
-    );
-}
-
-// ── Rule 3: dot-call is UFCS sugar — x.f(a) calls f(x, a) ───────────────
-
-#[test]
-fn doc_rule03_ufcs_builtin() {
-    let (stdout, _, exit_code) = run(r#"print("abc".len())"#);
-    assert_eq!(exit_code, 0, "UFCS on builtins must work");
-    assert!(stdout.contains("3"), "stdout: {}", stdout);
-}
-
-#[test]
-fn doc_rule03_ufcs_user_function() {
-    let code = r#"fn double(x: Int) -> Int { return x * 2 }
+fn dot_call_ufcs_works_for_builtin_imported_and_user_functions() {
+    let code = r#"import { trim } from "std/string"
+fn double(x: Int) -> Int { return x * 2 }
+print("abc".len())
+print("  hi  ".trim())
 print(5.double())"#;
     let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0, "UFCS on user functions must work");
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("3"), "stdout: {}", stdout);
+    assert!(stdout.contains("hi"), "stdout: {}", stdout);
     assert!(stdout.contains("10"), "stdout: {}", stdout);
 }
 
 #[test]
-fn doc_rule03_ufcs_imported_function() {
-    let code = r#"import { trim } from "std/string"
-print("  hi  ".trim())"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0, "UFCS on imported functions must work");
-    assert!(stdout.contains("hi"), "stdout: {}", stdout);
-}
-
-#[test]
-fn doc_rule03_ufcs_stdlib_without_import() {
-    let code = r#"let m = map { "a": 1 }
-print(m.keys())"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0, "stdlib functions are globally registered");
-    assert!(stdout.contains("a"), "stdout: {}", stdout);
-}
-
-#[test]
-fn doc_rule03_parens_disambiguate_map_key_shadow() {
-    // `m.keys` (no parens) reads the map key; `m.keys()` always calls keys(m).
-    let code = r#"let m = map { "keys": 42, "a": 1 }
-print(m.keys)
-print(m.keys())"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0);
-    let lines: Vec<&str> = stdout.lines().collect();
-    assert!(
-        lines.first().map(|l| l.contains("42")).unwrap_or(false),
-        "m.keys must read the stored key value: {}",
-        stdout
-    );
-    assert!(
-        lines.get(1).map(|l| l.contains("a")).unwrap_or(false)
-            && lines.get(1).map(|l| l.contains("keys")).unwrap_or(false),
-        "m.keys() must call keys(m), ignoring the key: {}",
-        stdout
-    );
-}
-
-#[test]
-fn doc_rule03_map_closure_not_dot_callable() {
-    // Documented UFCS gap: closures stored in map values are not dot-callable.
-    let code = r#"let m = map { "f": fn(x) { x + 1 } }
-print(m.f(10))"#;
-    let (_, stderr, exit_code) = run(code);
-    assert_ne!(exit_code, 0);
-    assert!(
-        stderr.contains("E007") && stderr.contains("Undefined function: f"),
-        "map-stored closures must fail with E007 on dot-call: {}",
-        stderr
-    );
-}
-
-#[test]
-fn doc_rule03_lint_no_unused_import_for_ufcs() {
-    // An import used only via dot-call must count as used.
+fn imported_function_used_by_dot_call_is_not_unused() {
     let code = r#"import { trim } from "std/string"
 print("  hi  ".trim())"#;
     let (stdout, _, exit_code) = lint(code);
@@ -209,80 +133,14 @@ print("  hi  ".trim())"#;
 }
 
 #[test]
-fn doc_rule03_ufcs_typo_suggests_near_match() {
-    // A misspelled dot-call resolves like a free-function miss and gets a hint.
-    let code = r#"fn double(x: Int) -> Int { return x * 2 }
-print(5.doubl())"#;
-    let (_, stderr, exit_code) = run(code);
-    assert_ne!(exit_code, 0);
-    assert!(
-        stderr.contains("double"),
-        "a typo'd dot-call should suggest the near-match free function: {}",
-        stderr
-    );
-}
-
-#[test]
-fn doc_rule03_ufcs_suggestion_skips_non_callable_binding() {
-    // A variable named `doubl` is an exact match for the typo, but it is not
-    // callable — the suggestion must point at the callable `double` instead.
-    let code = r#"let doubl = 5
-fn double(x: Int) -> Int { return x * 2 }
-print(7.doubl())"#;
-    let (_, stderr, exit_code) = run(code);
-    assert_ne!(exit_code, 0);
-    assert!(
-        stderr.contains("double"),
-        "suggestion must name the callable function, not the variable: {}",
-        stderr
-    );
-}
-
-// ── Rule 4: route functions are global builtins — never import them ────
-
-#[test]
-fn doc_rule04_route_fns_not_importable() {
-    let code = r#"import { get, listen } from "std/http/server""#;
-    let (_, stderr, exit_code) = run(code);
-    assert_ne!(exit_code, 0);
-    assert!(
-        stderr.contains("is not exported from 'std/http/server'"),
-        "importing route builtins must fail loudly: {}",
-        stderr
-    );
-}
-
-// ── Rule 5: semicolons are unnecessary (lint warning, not corruption) ──
-
-#[test]
-fn doc_rule05_semicolons_execute_correctly() {
-    let (stdout, _, exit_code) = run("let x = 1; let y = 2; print(x + y);");
-    assert_eq!(exit_code, 0, "semicolons must not corrupt parsing");
-    assert!(stdout.contains("3"), "stdout: {}", stdout);
-}
-
-#[test]
-fn doc_rule05_semicolons_lint_warns() {
-    let (stdout, _, exit_code) = lint("let x = 1; print(x);");
-    assert_eq!(exit_code, 0, "semicolon warnings must not fail lint");
-    assert!(
-        stdout.contains("unnecessary_semicolon"),
-        "lint must flag semicolons: {}",
-        stdout
-    );
-}
-
-// ── Rule 6: `otherwise` blocks must diverge ────────────────────────────
-
-#[test]
-fn doc_rule06_otherwise_nondiverge_is_lint_error() {
+fn otherwise_recovery_blocks_must_diverge() {
     let code = r#"fn main() -> Int {
     let v = int("nope") otherwise { 0 }
     return v
 }
 print(main())"#;
     let (stdout, _, exit_code) = lint(code);
-    assert_eq!(exit_code, 1, "non-diverging otherwise must fail lint");
+    assert_eq!(exit_code, 1);
     assert!(
         stdout.contains("otherwise block does not diverge"),
         "lint output: {}",
@@ -291,186 +149,16 @@ print(main())"#;
 }
 
 #[test]
-fn doc_rule06_otherwise_nondiverge_runtime_error_on_error_path() {
-    let code = r#"fn parse() -> Int {
-    let v = int("notanum") otherwise { 0 }
-    return v
-}
-print(parse())"#;
-    let (_, stderr, exit_code) = run(code);
-    assert_ne!(exit_code, 0);
-    assert!(
-        stderr.contains("otherwise block must diverge"),
-        "runtime must reject non-diverging otherwise on the error path: {}",
-        stderr
-    );
-}
-
-#[test]
-fn doc_rule06_otherwise_diverging_recovers() {
-    let code = r#"fn parse() -> Int {
-    let v = int("notanum") otherwise { return 0 }
-    return v
-}
-print(parse())"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0);
-    assert!(stdout.contains("0"), "stdout: {}", stdout);
-}
-
-// ── Rule 7: ranges are `0..10` — range() doesn't exist ─────────────────
-
-#[test]
-fn doc_rule07_range_function_undefined() {
-    let (_, stderr, exit_code) = run("for i in range(3) { print(i) }");
-    assert_ne!(exit_code, 0);
-    assert!(
-        stderr.contains("E006") && stderr.contains("range"),
-        "range() must be a loud undefined error: {}",
-        stderr
-    );
-}
-
-#[test]
-fn doc_rule07_range_syntax_works() {
-    let (stdout, _, exit_code) = run("for i in 0..3 { print(i) }");
-    assert_eq!(exit_code, 0);
-    assert!(
-        stdout.contains("0") && stdout.contains("1") && stdout.contains("2"),
-        "stdout: {}",
-        stdout
-    );
-}
-
-// ── Rule 8: `mut` is enforced for indexed mutation only ────────────────
-
-#[test]
-fn doc_rule08_plain_reassign_without_mut_succeeds() {
-    // Locks ACTUAL current behavior: plain rebinding does not require `mut`.
-    // If the maintainer later decides to enforce `mut` for plain reassignment
-    // (a breaking change), INVERT this test in the same PR that changes it.
-    let (stdout, _, exit_code) = run("let x = 0\nx = x + 1\nprint(x)");
-    assert_eq!(
-        exit_code, 0,
-        "plain rebinding without mut currently succeeds"
-    );
-    assert!(stdout.contains("1"), "stdout: {}", stdout);
-}
-
-#[test]
-fn doc_rule08_index_assign_requires_mut() {
-    let (_, stderr, exit_code) = run("let arr = [1, 2, 3]\narr[0] = 99\nprint(arr)");
-    assert_ne!(exit_code, 0);
-    assert!(
-        stderr.contains("Cannot mutate 'arr'"),
-        "indexed mutation without mut must fail: {}",
-        stderr
-    );
-}
-
-#[test]
-fn doc_rule08_index_assign_with_mut_works() {
-    let (stdout, _, exit_code) = run("let mut arr = [1, 2, 3]\narr[0] = 99\nprint(arr)");
-    assert_eq!(exit_code, 0);
-    assert!(stdout.contains("99"), "stdout: {}", stdout);
-}
-
-// ── Rule 9: closures are `fn(x) { ... }` — pipe syntax doesn't exist ───
-
-#[test]
-fn doc_rule09_pipe_closure_is_parse_error() {
-    let (_, stderr, exit_code) = run("let f = |x| x * 2\nprint(f(3))");
-    assert_ne!(exit_code, 0);
-    assert!(
-        stderr.contains("E002"),
-        "pipe-style closures must be a parse error: {}",
-        stderr
-    );
-}
-
-#[test]
-fn doc_rule09_fn_closure_works() {
-    let (stdout, _, exit_code) = run("let f = fn(x) { x * 2 }\nprint(f(3))");
-    assert_eq!(exit_code, 0);
-    assert!(stdout.contains("6"), "stdout: {}", stdout);
-}
-
-// ── Rule 10 (replaced in docs): module-level `let` with `map {}` works ──
-
-#[test]
-fn doc_rule10_module_level_map_works() {
-    // Locks the un-stale behavior: the old rule claimed module-level `let`
-    // can't hold a map literal. It can.
-    let code = r#"let config = map { "k": "v" }
-print(config)"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0, "module-level map literals work");
-    assert!(
-        stdout.contains("k") && stdout.contains("v"),
-        "stdout: {}",
-        stdout
-    );
-}
-
-// ── Rule 11: for..in on a string skips with a warning — use chars() ────
-
-#[test]
-fn doc_rule11_for_in_string_zero_iterations_with_warning() {
-    let code = r#"for c in "ab" { print(c) }
-print("done")"#;
-    let (stdout, stderr, exit_code) = run(code);
-    assert_eq!(exit_code, 0);
-    assert_eq!(
-        stdout.trim(),
-        "done",
-        "for..in on a string must not iterate: {}",
-        stdout
-    );
-    assert!(
-        stderr.contains("for..in on String"),
-        "the skip must warn, not be silent: {}",
-        stderr
-    );
-}
-
-#[test]
-fn doc_rule11_chars_iterates_string() {
-    let code = r#"import { chars } from "std/string"
-for c in chars("ab") { print(c) }"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0);
-    assert!(
-        stdout.contains("a") && stdout.contains("b"),
-        "stdout: {}",
-        stdout
-    );
-}
-
-// ── Rule 12: template strings interpolate with {{expr}} ────────────────
-
-#[test]
-fn doc_rule12_template_double_braces() {
+fn template_strings_interpolate_double_braces() {
     let code = r#"let name = "World"
-print("""Hello {{name}}""")
-print("Hello {name}")"#;
+print("""Hello {{name}}""")"#;
     let (stdout, _, exit_code) = run(code);
     assert_eq!(exit_code, 0);
-    assert!(
-        stdout.contains("Hello World"),
-        "{{{{expr}}}} must interpolate in template strings: {}",
-        stdout
-    );
-    assert!(
-        stdout.contains("Hello {name}"),
-        "single braces stay literal in regular strings: {}",
-        stdout
-    );
+    assert!(stdout.contains("Hello World"), "stdout: {}", stdout);
 }
 
-// ── Rule 13: contracts go after return type, before body ───────────────
-
 #[test]
-fn doc_rule13_contract_placement_parses_and_runs() {
+fn contract_clauses_go_after_return_type_before_body() {
     let code = r#"fn divide(a: Int, b: Int) -> Int
     requires b != 0
     ensures result * b == a
@@ -481,80 +169,4 @@ print(divide(10, 2))"#;
     let (stdout, _, exit_code) = run(code);
     assert_eq!(exit_code, 0);
     assert!(stdout.contains("5"), "stdout: {}", stdout);
-}
-
-// ── Rule 14: 0 is truthy; falsy are false, "", None, [], map {} ────────
-
-#[test]
-fn doc_rule14_truthiness() {
-    let code = r#"if 0 { print("zero-truthy") } else { print("zero-falsy") }
-if "" { print("str-truthy") } else { print("str-falsy") }
-if [] { print("arr-truthy") } else { print("arr-falsy") }
-if map {} { print("map-truthy") } else { print("map-falsy") }"#;
-    let (stdout, stderr, exit_code) = run(code);
-    assert_eq!(exit_code, 0);
-    assert!(stdout.contains("zero-truthy"), "0 is truthy: {}", stdout);
-    assert!(stdout.contains("str-falsy"), "\"\" is falsy: {}", stdout);
-    assert!(stdout.contains("arr-falsy"), "[] is falsy: {}", stdout);
-    assert!(
-        stdout.contains("map-falsy"),
-        "map {{}} is falsy: {}",
-        stdout
-    );
-    assert!(
-        stderr.contains("Non-boolean condition"),
-        "non-boolean conditions warn: {}",
-        stderr
-    );
-}
-
-// ── Rule 15: missing map keys return None — use has_key() ──────────────
-
-#[test]
-fn doc_rule15_missing_map_key_returns_none() {
-    let code = r#"let m = map { "a": 1 }
-print(m["missing"])
-print(has_key(m, "missing"))
-print(m.missing)"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0);
-    let lines: Vec<&str> = stdout.lines().collect();
-    assert!(
-        lines.first().map(|l| l.contains("none")).unwrap_or(false),
-        "m[\"missing\"] is none: {}",
-        stdout
-    );
-    assert!(
-        lines.get(1).map(|l| l.contains("false")).unwrap_or(false),
-        "has_key is false: {}",
-        stdout
-    );
-    assert!(
-        lines.get(2).map(|l| l.contains("none")).unwrap_or(false),
-        "m.missing is none: {}",
-        stdout
-    );
-}
-
-// ── Rule 16: `for k in map` iterates keys — entries() for pairs ────────
-
-#[test]
-fn doc_rule16_for_map_iterates_keys() {
-    // Entry maps print with nondeterministic field order — always read
-    // e.key / e.value, never assert on a printed entry map.
-    let code = r#"let m = map { "a": 1, "b": 2 }
-for k in m { print("key:" + k) }
-for e in entries(m) { print(e.key + "=" + str(e.value)) }"#;
-    let (stdout, _, exit_code) = run(code);
-    assert_eq!(exit_code, 0);
-    assert!(
-        stdout.contains("key:a") && stdout.contains("key:b"),
-        "for..in map yields keys: {}",
-        stdout
-    );
-    assert!(
-        stdout.contains("a=1") && stdout.contains("b=2"),
-        "entries() yields key/value pairs: {}",
-        stdout
-    );
 }


### PR DESCRIPTION
## Summary

Implements a **narrowed DD-063 Rec 2** slice: truth-sync the stale agent-facing syntax docs, embrace UFCS dot-call as intentional sugar, and add tests only for syntax contracts we actually want to treat as stable.

After review, this PR deliberately does **not** lock every current CLAUDE.md behavior. Current-but-questionable behavior should remain available for language improvement, not be fossilized because a test happened to observe it.

## What this keeps

### Intentional syntax contract tests
- **`tests/doc_claims_tests.rs`** has **8 focused tests** instead of the earlier broad snapshot.
- Tests cover only the “yes, this is a real language/agent contract” items:
  - map literals require the `map` keyword
  - `#{expr}` interpolation works
  - JavaScript-style `${expr}` is diagnosed with a repair hint
  - UFCS dot-call works for builtin/imported/user functions
  - imports used via UFCS are not flagged unused
  - `otherwise` recovery blocks must diverge
  - template strings interpolate `{{expr}}`
  - contract clauses go after the return type and before the body

### Doc corrections
- `CLAUDE.md`, `CODEX.md`, and `.github/copilot-instructions.md` now describe actual behavior instead of stale rules:
  - dot-call is UFCS sugar; free functions remain canonical
  - semicolons parse but lint-warn; they do not corrupt parser state
  - `mut` is currently partial: indexed mutation requires it, plain reassignment does not
  - old module-level-map warning was stale
  - `for..in` on strings warns instead of failing silently
- `docs/AI_AGENT_GUIDE.md` and generated syntax docs document UFCS as first-class sugar.

### Small code/doc fixes required by review
- `collect_used_names` counts dot-call method names as function usage, so imports used only through UFCS (`"  hi  ".trim()`) are not incorrectly reported as `unused_import`.
- `IAL_REFERENCE.md` now includes a generated primitive status column so agent-facing docs do not present stubs as implemented:
  - `Sql`: `Not implemented`
  - `InvariantCheck`: `Resolver marker only; direct execution fails unless expanded`

## What was removed from this PR

Removed tests that locked behavior we may want to reconsider:

- partial `mut` semantics
- string iteration skipping with warning
- route functions being global-only / not importable
- semicolon permissiveness details
- `range()` absence
- pipe-closure absence
- module-level map behavior
- truthiness details
- missing map key behavior
- map iteration behavior
- UFCS edge gaps like map-stored closures not being dot-callable

Also removed the optional dot-call typo suggestion work. That belongs in a follow-up diagnostic PR, not this lighter syntax-doc slice.

## Test plan

- `cargo fmt --check`
- `cargo build --profile dev-release --locked`
- `cargo test --test doc_claims_tests`
- `./target/dev-release/ntnt docs --generate`
- `git diff --check`

## Notes

This PR’s invariant is now: **agent-facing docs must match implementation for intentional syntax contracts.** It is not: “every current behavior is forever.”