### PR TITLE
Polish std/net release boundary

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1193,7 +1193,7 @@ Added 17 stdlib functions across 3 modules plus 1 global builtin to enable build
 | `NTNT_SSRF_PROTECTION` | `true` | Block requests to private IPs and cloud metadata |
 | `NTNT_ALLOW_LOCALHOST` | dev: `true`, prod: `false` | Allow fetch() to localhost |
 | `NTNT_ALLOW_PRIVATE_IPS` | `false` | Allow `fetch()` to private IP ranges |
-| `NTNT_NET_ALLOW_PRIVATE` | `false` | Allow `std/net` probes to private/internal targets when each call also passes `allow_private: true` |
+| `NTNT_NET_ALLOW_PRIVATE` | unset | Allow `std/net` probes to private/internal targets when each call also passes `allow_private: true` |
 | `NTNT_BLOCKED_HOSTS` | `` | Comma-separated list of blocked hostnames |
 
 **Request Body Limits:**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1192,7 +1192,8 @@ Added 17 stdlib functions across 3 modules plus 1 global builtin to enable build
 | `NTNT_DETAILED_ERRORS` | dev: `true`, prod: `false` | Show detailed error messages |
 | `NTNT_SSRF_PROTECTION` | `true` | Block requests to private IPs and cloud metadata |
 | `NTNT_ALLOW_LOCALHOST` | dev: `true`, prod: `false` | Allow fetch() to localhost |
-| `NTNT_ALLOW_PRIVATE_IPS` | `false` | Allow fetch() to private IP ranges |
+| `NTNT_ALLOW_PRIVATE_IPS` | `false` | Allow `fetch()` to private IP ranges |
+| `NTNT_NET_ALLOW_PRIVATE` | `false` | Allow `std/net` probes to private/internal targets when each call also passes `allow_private: true` |
 | `NTNT_BLOCKED_HOSTS` | `` | Comma-separated list of blocked hostnames |
 
 **Request Body Limits:**

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -824,17 +824,22 @@ reachability remains explicit app/developer intent.
 
 ---
 
-## Phase 3 — Multi-Protocol Traceroute & mtr-style Diagnostics (in progress)
+## Phase 3 — Multi-Protocol Traceroute (release scope complete)
 
-Phase 2's `traceroute()` probes with ICMP echo. Phase 3 extends path discovery
-to UDP and TCP probes (shipped) and adds the continuous, per-hop statistics
-that make `mtr` useful (planned). None of this requires rethinking the substrate: the hard part of
-traceroute — receiving and matching the ICMP Time Exceeded messages that
-intermediate routers emit — is **independent of the probe protocol**, because a
-router whose TTL/hop-limit reaches zero sends Time Exceeded regardless of what
-the expiring packet contained. The receive side built in PR 7
-(`create_raw_icmp_socket`, the TTL-stepping driver, `probe_attempt_budget`,
-target policy, capability detection, per-hop result shaping) is reused as-is.
+Phase 2's `traceroute()` probes with ICMP echo. Phase 3 extended path discovery
+to UDP and TCP probes (shipped). Continuous MTR-style statistics, parallel hop
+sweeps, and per-hop enrichment are intentionally **not** part of the `std/net`
+release surface; they are monitoring-product behavior and should live in a
+future/private monitoring layer only if a concrete app proves the shape.
+
+The shipped multi-protocol traceroute does not require rethinking the substrate:
+the hard part of traceroute — receiving and matching the ICMP Time Exceeded
+messages that intermediate routers emit — is **independent of the probe
+protocol**, because a router whose TTL/hop-limit reaches zero sends Time
+Exceeded regardless of what the expiring packet contained. The receive side
+built in PR 7 (`create_raw_icmp_socket`, the TTL-stepping driver,
+`probe_attempt_budget`, target policy, capability detection, per-hop result
+shaping) is reused as-is.
 
 ### Core refactor: `ProbeMethod` abstraction
 
@@ -902,36 +907,29 @@ of packet construction, checksums, and the quoted/​reply matchers; the
 integration test asserts each method's outcome matches its capability flag.
 End-to-end validation is a manual run on a capable host.
 
-### Parallel hop probing (PR 10)
+### Deferred from `std/net`: MTR-style diagnostics and hop enrichment
 
-`mtr` sends all TTLs concurrently rather than waiting hop-by-hop, turning a
-30-hop trace from sum-of-per-hop-timeouts into roughly a single timeout. This
-is a driver-loop change: emit probes for TTL `1..max` up front, then collect
-replies and demultiplex by sequence→TTL. High value once traces are long or
-run in cycles.
+The closed/unmerged follow-up work should not be revived as `std/net` release
+scope. The primitives are useful, but the product shape is monitoring-specific:
+run repeated traces, aggregate per-hop stats, resolve/router-enrich hops, store
+history, and present trends. That belongs in a future/private monitoring layer
+or app, not in the default stdlib's low-level safe primitives.
 
-*Estimated effort: ~1–2 days.*
+If this resurfaces, keep these as separate design work rather than queued
+`std/net` PRs:
 
-### mtr-style continuous statistics (PR 11)
+- **Parallel hop probing** — concurrent TTL emission and demux by sequence→TTL.
+  Useful for MTR-like tools, but it complicates the driver and is not required
+  for one-shot diagnostics.
+- **MTR-style cycle statistics** — `cycles`/`probes_per_hop` with per-hop loss%
+  and last/avg/best/worst/stddev RTT. This is monitoring state, not a primitive.
+- **Per-hop reverse DNS** — annotate hop IPs via `dns_reverse()`. Off by default
+  if ever added, because it adds latency and drags enrichment concerns into the
+  probe result.
 
-`mtr` is traceroute in a loop with per-hop accumulation: sent, received,
-loss%, and last/avg/best/worst/stddev RTT per hop. Single-pass already emits
-per-hop latency; this adds a `cycles` (and `probes_per_hop`) option and an
-aggregation layer keyed by hop index. The synchronous stdlib model fits
-"run N cycles, return aggregated stats" (`traceroute(host, map { "cycles": 10 })`);
-a live/streaming TUI does not map to a `Result`-returning call and would need
-a channel/callback variant if ever wanted — out of scope here.
-
-*Estimated effort: ~1–2 days.*
-
-### Per-hop reverse DNS (PR 12, optional)
-
-`mtr` shows router hostnames. `std/net` already has `dns_reverse()`; add an
-opt-in `resolve_hops: true` that annotates each hop with its PTR name. Off by
-default because it adds latency. ASN/AS-name annotation is a separate data
-source and stays deferred.
-
-*Estimated effort: ~half day.*
+`std/net` should release with one-shot `traceroute(method: "icmp"|"udp"|"tcp")`
+and leave repeated/aggregated/enriched path monitoring to a layer that can own
+storage, polling cadence, and UI expectations.
 
 ### Capability & security continuity
 
@@ -943,13 +941,23 @@ plumbing from Phase 2 carry over unchanged. As methods land,
 policy (private/loopback/metadata denial with the two-level opt-in) applies to
 every method exactly as it does to ICMP traceroute.
 
-### Suggested sequencing
+### Release boundary and follow-up posture
 
-TCP first (PR 9 — highest real-world value, works through firewalls), then
-parallel hops (PR 10 — makes multi-cycle traces bearable), then mtr stats
-(PR 11), then UDP (PR 8) and reverse DNS (PR 12) to round out. Each is an
-independent, reviewable PR on the shared substrate; the `ProbeMethod` refactor
-lands with the first method that needs it.
+Release `std/net` once the shipped primitives are documented, bounded, and
+verified. Do not queue more stdlib features just because the probe substrate can
+technically support them; that is how a clean network primitive library becomes
+a suspiciously enthusiastic appliance firmware menu.
+
+For follow-up work:
+
+1. Fix correctness/safety issues in existing primitives immediately.
+2. Keep SNMP, interface telemetry, alerting, and composite checks in DD-047 / a
+   private monitoring layer.
+3. Keep repeated/aggregated/enriched traceroute behavior out of `std/net` until
+   a concrete monitoring app proves a minimal, reusable API.
+4. Any future raw-socket feature needs the same capability reporting,
+   policy-denied target checks, CI-safe tests, and deployment docs as the
+   current traceroute methods.
 
 ---
 
@@ -985,12 +993,11 @@ As of 2026-06-09:
 - [x] **PR 6 — Probe substrate + `net_capabilities()`**: typed `ProbeFailure` classification, `src/stdlib/net/` module split (`probe.rs`, `icmp.rs`), and capability detection — groundwork for traceroute.
 - [x] **PR 7 — `traceroute()`**: TTL-stepped echo probes on the shared substrate (raw ICMP only, graceful `Err` otherwise), `traceroute` capability flag, Docker `cap_add` deployment docs; see Phase 2 above.
 - [x] **PR 8/9 — UDP + TCP traceroute** (`method: "udp"`/`"tcp"`): shared `TraceProbe`/`HopProbe` abstraction, generalized quoted-transport matcher, UDP (Port Unreachable arrival) and raw TCP SYN (SYN-ACK/RST arrival, Linux), plus `traceroute_udp`/`traceroute_tcp` capability flags. See Phase 3.
-- [ ] **PR 10 — Parallel hop probing**: concurrent TTL emission, demux by sequence→TTL. See Phase 3.
-- [ ] **PR 11 — mtr-style cycle statistics**: `cycles`/`probes_per_hop` with per-hop loss% and last/avg/best/worst/stddev RTT. See Phase 3.
-- [ ] **PR 12 — Per-hop reverse DNS** (optional): opt-in `resolve_hops` via existing `dns_reverse()`. See Phase 3.
+- [x] **Release-readiness cleanup**: target policy moved into `net/policy.rs`, duplicate policy tests consolidated, private-target opt-in narrowed to `NTNT_NET_ALLOW_PRIVATE=1`, and TCP/port-scan attempts now spend one timeout budget across resolved addresses rather than multiplying timeout by address count.
+- [ ] **Deferred — MTR-style traceroute statistics / parallel hop sweeps / hop enrichment**: not release scope for `std/net`; keep in a future/private monitoring layer if real app pressure proves the API.
 - [x] **Superseded PRs**: [PR #116](https://github.com/ntntlang/ntnt/pull/116) was closed in favor of the cleaner PR #117 branch; [PR #118](https://github.com/ntntlang/ntnt/pull/118) was closed in favor of the cleaner PR #119 branch.
 
-The DD-046 initial scope is complete and Phase 2 is underway. The merged implementation includes runtime registration, typechecker signatures, generated stdlib docs, AI guide coverage, deterministic examples, CI-safe tests, public-network smoke tests gated behind environment variables, and review hardening for target policy, bounded scans, and TLS validation behavior.
+The DD-046 initial scope is complete, and the stdlib release boundary is now the shipped safe primitives plus one-shot multi-protocol traceroute. The merged implementation includes runtime registration, typechecker signatures, generated stdlib docs, AI guide coverage, deterministic examples, CI-safe tests, public-network smoke tests gated behind environment variables, and review hardening for target policy, bounded scans, TLS validation behavior, and raw-socket capability reporting. MTR-style aggregation and monitoring enrichment are explicitly deferred out of `std/net`.
 
 ### PR 1 — `std/net` shell + IPAM helpers + protocol-honest reachability
 

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -156,7 +156,7 @@ That option should only work when the process-level config also allows private t
 
 - Public IP/hostname target: allowed by default.
 - Loopback/private/link-local target: denied by default in all server/runtime modes.
-- Loopback/private/link-local target with `allow_private: true` but no process-level opt-in: `Err("Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1")`.
+- Loopback/private/link-local target with `allow_private: true` but no process-level opt-in: `Err("Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1 for std/net probes (NTNT_ALLOW_PRIVATE_IPS only applies to fetch())")`.
 - Loopback/private/link-local target with process-level opt-in and `allow_private: true`: allowed.
 - Cloud metadata, multicast, broadcast, unspecified, and documentation targets: never allowed, even with private-network opt-in.
 - User-controlled target strings in public web apps: still the app's responsibility to validate input, but stdlib policy blocks the worst SSRF targets by default.

--- a/design-docs/dd-046-std-net.md
+++ b/design-docs/dd-046-std-net.md
@@ -1,10 +1,10 @@
 # DD-046: `std/net` — Safe Network Primitives for ntnt
 
-**Status:** Complete — shipped across PRs [#113](https://github.com/ntntlang/ntnt/pull/113), [#114](https://github.com/ntntlang/ntnt/pull/114), [#115](https://github.com/ntntlang/ntnt/pull/115), and [#117](https://github.com/ntntlang/ntnt/pull/117)
+**Status:** Complete / release-ready — shipped across PRs [#113](https://github.com/ntntlang/ntnt/pull/113), [#114](https://github.com/ntntlang/ntnt/pull/114), [#115](https://github.com/ntntlang/ntnt/pull/115), [#117](https://github.com/ntntlang/ntnt/pull/117), [#119](https://github.com/ntntlang/ntnt/pull/119), plus follow-up traceroute/release-readiness PRs through [#127](https://github.com/ntntlang/ntnt/pull/127)
 **Author:** Larri
 **Created:** 2026-03-22
-**Updated:** 2026-06-07
-**Target baseline:** v0.4.10 (`std/net` track)
+**Updated:** 2026-06-18
+**Target baseline:** v0.4.11 (`std/net` track)
 
 ---
 
@@ -29,10 +29,13 @@ Initial scope:
 - `dns_reverse(ip, opts?)`
 - `port_scan(host, ports, opts?)` with strict bounds
 - `tls_info(host, opts?)`
+- `reachable(host, opts?)`
+- `net_capabilities()`
+- `traceroute(host, opts?)` with `method: "icmp" | "udp" | "tcp"`
 
 Explicitly deferred:
 
-- ~~`traceroute` and other raw packet path-discovery tools~~ — `traceroute()` shipped in Phase 2 (PR 7)
+- MTR-style continuous traceroute statistics, parallel hop sweeps, and per-hop enrichment — keep these out of `std/net` until a concrete monitoring app proves a minimal reusable API
 - SSH remote command execution
 - SNMP polling/walking
 - WHOIS
@@ -70,13 +73,13 @@ The important product idea: `std/net` should make ntnt good at **bounded, audita
 
 ## Implemented State
 
-As of the merged PR #117 baseline:
+As of the PR #127 release-readiness baseline:
 
-- `src/stdlib/net.rs` exists and registers safe `std/net` primitives.
+- `src/stdlib/net/` exists and registers safe `std/net` primitives, with IPAM/probe/policy/traceroute code split into focused modules.
 - `src/stdlib/mod.rs` exposes the `std/net` module.
 - `src/typechecker.rs` includes `std/net` signatures.
 - `docs/STDLIB_REFERENCE.md` is generated from the `// @ntnt` docs, and `docs/AI_AGENT_GUIDE.md` includes practical `std/net` examples.
-- `examples/std_net_ipam.tnt`, `examples/std_net_ping.tnt`, `examples/std_net_dns.tnt`, `examples/std_net_scan.tnt`, and `examples/std_net_tls.tnt` cover the shipped slices.
+- `examples/std_net_ipam.tnt`, `examples/std_net_ping.tnt`, `examples/std_net_dns.tnt`, `examples/std_net_scan.tnt`, `examples/std_net_tls.tnt`, and traceroute/probe docs cover the shipped slices.
 - `std/net` uses a dedicated outbound safety posture: public targets are easy, private/internal targets require process-level `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private: true`.
 - TLS inspection deliberately added `rustls`, `rustls-pki-types`, `webpki-roots`, and `x509-parser`; it does not depend on `reqwest`'s TLS stack.
 
@@ -221,7 +224,7 @@ Goal: create the module and safety foundation before exposing broad network beha
 
 Files:
 
-- Create: `src/stdlib/net.rs`
+- Create: `src/stdlib/net/` module directory
 - Modify: `src/stdlib/mod.rs`
 - Modify: `src/typechecker.rs`
 - Later generated: `docs/STDLIB_REFERENCE.md`
@@ -983,7 +986,7 @@ SNMP is a real network-monitoring need, but it is its own protocol family. It sh
 
 ### Status Dashboard
 
-As of 2026-06-09:
+As of 2026-06-18:
 
 - [x] **PR 1 — `std/net` shell + IPAM helpers + protocol-honest reachability**: merged in [PR #113](https://github.com/ntntlang/ntnt/pull/113).
 - [x] **PR 2 — DNS lookup types**: merged in [PR #114](https://github.com/ntntlang/ntnt/pull/114).
@@ -993,7 +996,7 @@ As of 2026-06-09:
 - [x] **PR 6 — Probe substrate + `net_capabilities()`**: typed `ProbeFailure` classification, `src/stdlib/net/` module split (`probe.rs`, `icmp.rs`), and capability detection — groundwork for traceroute.
 - [x] **PR 7 — `traceroute()`**: TTL-stepped echo probes on the shared substrate (raw ICMP only, graceful `Err` otherwise), `traceroute` capability flag, Docker `cap_add` deployment docs; see Phase 2 above.
 - [x] **PR 8/9 — UDP + TCP traceroute** (`method: "udp"`/`"tcp"`): shared `TraceProbe`/`HopProbe` abstraction, generalized quoted-transport matcher, UDP (Port Unreachable arrival) and raw TCP SYN (SYN-ACK/RST arrival, Linux), plus `traceroute_udp`/`traceroute_tcp` capability flags. See Phase 3.
-- [x] **Release-readiness cleanup**: target policy moved into `net/policy.rs`, duplicate policy tests consolidated, private-target opt-in narrowed to `NTNT_NET_ALLOW_PRIVATE=1`, and TCP/port-scan attempts now spend one timeout budget across resolved addresses rather than multiplying timeout by address count.
+- [x] **PR #127 — Release-readiness cleanup**: target policy moved into `net/policy.rs`, duplicate policy tests consolidated, private-target opt-in narrowed to `NTNT_NET_ALLOW_PRIVATE=1`, and TCP/port-scan attempts now spend one timeout budget across resolved addresses rather than multiplying timeout by address count.
 - [ ] **Deferred — MTR-style traceroute statistics / parallel hop sweeps / hop enrichment**: not release scope for `std/net`; keep in a future/private monitoring layer if real app pressure proves the API.
 - [x] **Superseded PRs**: [PR #116](https://github.com/ntntlang/ntnt/pull/116) was closed in favor of the cleaner PR #117 branch; [PR #118](https://github.com/ntntlang/ntnt/pull/118) was closed in favor of the cleaner PR #119 branch.
 
@@ -1005,7 +1008,7 @@ Status: **merged in PR #113.**
 
 Scope:
 
-- [x] `src/stdlib/net.rs`
+- [x] `src/stdlib/net/`
 - [x] `src/stdlib/mod.rs`
 - [x] `src/typechecker.rs`
 - [x] unit tests for helpers and IPv4/IPv6 IPAM behavior
@@ -1097,7 +1100,7 @@ Acceptance:
 Every public function must update all layers:
 
 1. Runtime module:
-   - `src/stdlib/net.rs`
+   - `src/stdlib/net/`
    - `Value::NativeFunction` arity/max_arity matching actual args
    - returns `Value::ok(...)` / `Value::err(...)` for documented `Result`
 
@@ -1167,14 +1170,16 @@ For network-specific PRs:
 
 ## Bottom Line
 
-The refined `std/net` path shipped as four reviewable PRs:
+The refined `std/net` release path is now complete/release-ready:
 
 1. deterministic IP helpers plus protocol-honest `ping()`
 2. dedicated TCP and high-level reachability probes with explicit safety policy
 3. DNS lookup/reverse lookup with CI-safe tests
 4. bounded port scan and TLS certificate inspection
+5. native ICMP, probe capability reporting, and one-shot multi-protocol traceroute
+6. release-readiness cleanup for target policy, timeout budgeting, and DD boundary clarity
 
-That gives ntnt real network-diagnostic capability without making users trip over `CAP_NET_RAW`, and without smuggling in traceroute, SSH, SNMP, broad scanners, public-network CI flakes, or SSRF footguns in one heroic PR. Heroic PRs are where bugs go to get tenure.
+That gives ntnt real network-diagnostic capability without making users trip over `CAP_NET_RAW` for the default paths, and without smuggling in SSH, SNMP, broad scanners, MTR-style monitoring state, public-network CI flakes, or SSRF footguns in one heroic PR. Heroic PRs are where bugs go to get tenure.
 
 ---
 

--- a/design-docs/dd-047-std-netmon.md
+++ b/design-docs/dd-047-std-netmon.md
@@ -23,11 +23,13 @@ DD-046 gives ntnt safe network primitives. DD-047 is where those primitives beco
 DD-046 owns the low-level, generally safe primitives:
 
 - IP/CIDR/IPAM helpers
-- `ping()` with first-shot fallback behavior
+- `ping()` with protocol-honest ICMP behavior
+- `reachable()` for explicit high-level reachability fallback
 - `tcp_connect()`
 - DNS lookup/reverse lookup
 - bounded port scanning
 - TLS certificate inspection
+- one-shot traceroute (`icmp`/`udp`/`tcp`)
 
 DD-047 owns higher-level monitoring concerns:
 
@@ -468,6 +470,7 @@ Retention, rollups, dashboards, and notification delivery should live in the ref
 - DNS lookup/reverse
 - bounded port scan
 - TLS inspection
+- one-shot traceroute
 
 ### `std/netmon` / DD-047
 
@@ -492,7 +495,7 @@ Retention, rollups, dashboards, and notification delivery should live in the ref
 
 ### Future raw/network toolbox, not initial `std/netmon`
 
-- traceroute/MTR
+- MTR-style repeated traceroute statistics / hop enrichment
 - ARP scan
 - packet capture
 - bandwidth testing

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -898,6 +898,7 @@ server 8080 {
 | `NTNT_ENV` | `production`, `prod` | Disables hot-reload for better performance |
 | `NTNT_STRICT` | `1`, `true` | Blocks execution on type errors (runs type checker before `ntnt run`) |
 | `NTNT_ALLOW_PRIVATE_IPS` | `true` | Allows `fetch()` to connect to private/internal IPs (see below) |
+| `NTNT_NET_ALLOW_PRIVATE` | `1`, `true`, `yes` | Process-level opt-in for `std/net` probes (`ping`, `tcp_connect`, `reachable`, `port_scan`, `tls_info`, `traceroute`) to private/internal targets; calls still need `allow_private: true` |
 | `NTNT_WORKERS` | `1` (dev) / CPU cores (prod) | Number of interpreter worker threads. Auto-scales in production. |
 
 ```bash
@@ -913,11 +914,11 @@ NTNT_WORKERS=4 ntnt run server.tnt
 
 **Hot-reload** watches your `.tnt` files and imported modules for changes, automatically reloading on the next request. Disable in production for zero filesystem overhead per request.
 
-### SSRF Protection (Private IP Blocking)
+### SSRF Protection (`fetch()` Private IP Blocking)
 
 By default, `fetch()` blocks requests to private/internal IP ranges (`10.x`, `172.16-31.x`, `192.168.x`, `127.x`, `localhost`). This prevents Server-Side Request Forgery attacks.
 
-**In Docker**, this blocks inter-container communication (e.g., calling a sidecar service at `172.19.0.1:8889`). Set `NTNT_ALLOW_PRIVATE_IPS=true` to allow it:
+**In Docker**, this blocks inter-container HTTP calls made with `fetch()` (e.g., calling a sidecar service at `172.19.0.1:8889`). Set `NTNT_ALLOW_PRIVATE_IPS=true` to allow `fetch()` to call those targets:
 
 ```yaml
 # docker-compose.yml
@@ -1069,7 +1070,7 @@ let reachability = reachable("example.com", map {
 })
 ```
 
-`tcp_connect()` and `reachable()` support optional `count` (1-10), `timeout_ms`, and `interval_ms`, returning per-attempt results plus `sent`, `received`, `failed`, and `loss_percent` summary fields.
+`tcp_connect()` and `reachable()` support optional `count` (1-10), `timeout_ms`, and `interval_ms`, returning per-attempt results plus `sent`, `received`, `failed`, and `loss_percent` summary fields. For `reachable()`, `timeout_ms` is a per-TCP-port budget across that port's resolved addresses, so a multi-port check can spend up to `timeout_ms × number_of_tcp_ports` before declaring all TCP fallbacks failed.
 
 `port_scan(host, ports, opts?)` scans an explicit `Array<Int>` of TCP ports. It rejects duplicate, invalid, or overly large port lists, clamps `concurrency`, applies the same private-target safety policy as `tcp_connect()`, and returns results sorted by port:
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1072,7 +1072,7 @@ let reachability = reachable("example.com", map {
 
 `tcp_connect()` and `reachable()` support optional `count` (1-10), `timeout_ms`, and `interval_ms`, returning per-attempt results plus `sent`, `received`, `failed`, and `loss_percent` summary fields. For `reachable()`, `timeout_ms` is a per-TCP-port budget across that port's resolved addresses, so a multi-port check can spend up to `timeout_ms × number_of_tcp_ports` before declaring all TCP fallbacks failed.
 
-`port_scan(host, ports, opts?)` scans an explicit `Array<Int>` of TCP ports. It rejects duplicate, invalid, or overly large port lists, clamps `concurrency`, applies the same private-target safety policy as `tcp_connect()`, and returns results sorted by port:
+`port_scan(host, ports, opts?)` scans an explicit `Array<Int>` of TCP ports. It rejects duplicate, invalid, or overly large port lists, clamps `concurrency`, applies the same private-target safety policy as `tcp_connect()`, and returns results sorted by port. Its `timeout_ms` is also a per-port budget across that port's resolved addresses; `concurrency` controls how many ports are probed at once, not how many resolved addresses get independent timeout budgets:
 
 ```ntnt
 let scan = port_scan("example.com", [22, 80, 443], map {

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -23,11 +23,12 @@ Environment variables that control NTNT runtime behavior
 
 | Variable | Values | Default | Description |
 |----------|--------|---------|-------------|
-| `NTNT_ALLOW_PRIVATE_IPS` | `true` | unset (disabled — private IPs blocked) | Allow `fetch()` to connect to private/internal IP ranges (10.x, 172.16-31.x, 192.168.x, 127.x). Required for Docker inter-container communication (e.g., calling a sidecar at 172.19.0.1). Disabled by default to prevent SSRF attacks. |
+| `NTNT_ALLOW_PRIVATE_IPS` | `true` | unset (disabled — private IPs blocked) | Allow `fetch()` to connect to private/internal IP ranges (10.x, 172.16-31.x, 192.168.x, 127.x). Required for Docker inter-container communication (e.g., calling a sidecar at 172.19.0.1). Disabled by default to prevent SSRF attacks. This does not enable `std/net` probes; use `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private: true` for those. |
 | `NTNT_DB_POOL_SIZE` | `any positive integer` | 5 | Maximum number of connections per database pool. Each worker creates its own pools, so total connections = num_workers × num_databases × pool_size. For multi-worker production deployments with multiple databases, keep this low (2-5) to avoid exhausting PostgreSQL max_connections. |
 | `NTNT_ENV` | `development`, `production`, `prod` | development (when unset) | Controls runtime mode. Production mode disables hot-reload for better performance. |
 | `NTNT_LINT_MODE` | `default`, `warn`, `strict` | default | Controls lint strictness for type annotations. `default`: only check annotated code. `warn`: also warn about missing annotations (non-fatal). `strict`: missing annotations are errors. CLI flags (`--strict`, `--warn-untyped`) override this. |
 | `NTNT_MAX_RECURSION` | integer | 256 | Maximum recursion depth for function calls. Prevents stack overflow from runaway recursion. |
+| `NTNT_NET_ALLOW_PRIVATE` | `1`, `true`, `yes` | unset (disabled — private targets blocked) | Process-level opt-in for `std/net` probes (`ping`, `tcp_connect`, `reachable`, `port_scan`, `tls_info`, `traceroute`) against private/internal targets. Each call must also pass `allow_private: true`. Special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges remain blocked. This is separate from `NTNT_ALLOW_PRIVATE_IPS`, which only applies to `fetch()`. |
 | `NTNT_STRICT` | `1`, `true` | unset (disabled) | **Deprecated — use `NTNT_LINT_MODE=strict` instead.** Enable strict type checking. Still works but emits a deprecation warning. |
 | `NTNT_TIMEOUT` | integer (seconds) | 30 | Request timeout for HTTP server in seconds. |
 | `NTNT_TYPE_MODE` | `strict`, `warn`, `forgiving` | warn | Controls runtime behavior for type mismatches. `strict`: type mismatches crash (fail-closed, recommended for auth/payments). `warn`: log `[WARN]` and continue (default). `forgiving`: silent degradation (pre-v0.4 behavior). See [Type Safety Modes](#type-safety-modes). |
@@ -49,6 +50,9 @@ NTNT_LINT_MODE=strict ntnt lint server.tnt
 
 # Maximum recursion depth for function calls
 NTNT_MAX_RECURSION=512 ntnt run server.tnt
+
+# Process-level opt-in for `std/net` probes (`ping`, `tcp_connect`, `reachable`, `port_scan`, `tls_info`, `traceroute`) against private/internal targets
+NTNT_NET_ALLOW_PRIVATE=1 ntnt run monitor.tnt
 
 # **Deprecated — use `NTNT_LINT_MODE=strict` instead.** Enable strict type checking
 NTNT_STRICT=1 ntnt run server.tnt

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -9855,7 +9855,7 @@ Performs a bounded TCP scan of explicit ports for one host. Only explicit port a
 
 - `host` — Hostname or IP address to resolve and scan
 - `ports` — Explicit array of TCP ports from 1 to 65535; duplicates are rejected
-- `opts` — Optional map with timeout_ms, concurrency, and allow_private
+- `opts` — Optional map with timeout_ms (per port across resolved addresses), concurrency, and allow_private
 
 **Returns:** Result containing one map per port with open, latency_ms, and reason fields
 
@@ -9880,7 +9880,7 @@ Performs a high-level reachability check using ICMP plus TCP ports 80 and 443 by
 **Parameters:**
 
 - `host` — Hostname or IP address to resolve and probe
-- `opts` — Optional map with extra tcp_ports, timeout_ms, count, interval_ms, and allow_private
+- `opts` — Optional map with extra tcp_ports, timeout_ms (per TCP port across resolved addresses), count, interval_ms, and allow_private
 
 **Returns:** Result containing reachability status, method used, fallback metadata, and attempt summary
 

--- a/docs/runtime.toml
+++ b/docs/runtime.toml
@@ -30,9 +30,16 @@ cli_override = "--timeout"
 [env_vars.NTNT_ALLOW_PRIVATE_IPS]
 values = ["true"]
 default = "unset (disabled — private IPs blocked)"
-description = "Allow `fetch()` to connect to private/internal IP ranges (10.x, 172.16-31.x, 192.168.x, 127.x). Required for Docker inter-container communication (e.g., calling a sidecar at 172.19.0.1). Disabled by default to prevent SSRF attacks."
+description = "Allow `fetch()` to connect to private/internal IP ranges (10.x, 172.16-31.x, 192.168.x, 127.x). Required for Docker inter-container communication (e.g., calling a sidecar at 172.19.0.1). Disabled by default to prevent SSRF attacks. This does not enable `std/net` probes; use `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private: true` for those."
 example = "NTNT_ALLOW_PRIVATE_IPS=true ntnt run server.tnt"
 affects = ["http-client", "security"]
+
+[env_vars.NTNT_NET_ALLOW_PRIVATE]
+values = ["1", "true", "yes"]
+default = "unset (disabled — private targets blocked)"
+description = "Process-level opt-in for `std/net` probes (`ping`, `tcp_connect`, `reachable`, `port_scan`, `tls_info`, `traceroute`) against private/internal targets. Each call must also pass `allow_private: true`. Special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges remain blocked. This is separate from `NTNT_ALLOW_PRIVATE_IPS`, which only applies to `fetch()`."
+example = "NTNT_NET_ALLOW_PRIVATE=1 ntnt run monitor.tnt"
+affects = ["std-net", "security"]
 
 [env_vars.NTNT_MAX_RECURSION]
 type = "integer"

--- a/src/stdlib/net/icmp.rs
+++ b/src/stdlib/net/icmp.rs
@@ -17,7 +17,7 @@ use super::probe::{
     internet_checksum, probe_attempt_budget, quoted_inner_v4, quoted_inner_v6,
     set_socket_hop_limit, transport_checksum, HopProbe, ProbeFailure, TraceProbe,
 };
-use super::{enforce_resolved_target_policy, ProbeOptions};
+use super::{policy::enforce_resolved_target_policy, ProbeOptions};
 use crate::interpreter::Value;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use std::collections::HashMap;

--- a/src/stdlib/net/mod.rs
+++ b/src/stdlib/net/mod.rs
@@ -1,6 +1,7 @@
 //! std/net module - IPAM-grade IP/CIDR helpers and reachability probes.
 
 mod icmp;
+mod policy;
 mod probe;
 mod traceroute;
 mod transport;
@@ -12,6 +13,7 @@ use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::error::{ResolveError, ResolveErrorKind};
 use hickory_resolver::proto::rr::RecordType;
 use hickory_resolver::Resolver;
+use policy::{classify_ip, enforce_resolved_target_policy};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::WebPkiServerVerifier;
 use rustls::{
@@ -1598,10 +1600,20 @@ fn scan_port_targets(port: u16, targets: Vec<SocketAddr>, timeout: Duration) -> 
         };
     }
 
+    let deadline = Instant::now() + timeout;
     let mut last_reason = "unreachable".to_string();
     for addr in targets {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            last_reason = "timeout".to_string();
+            break;
+        };
+        if remaining.is_zero() {
+            last_reason = "timeout".to_string();
+            break;
+        }
+
         let start = Instant::now();
-        match TcpStream::connect_timeout(&addr, timeout) {
+        match TcpStream::connect_timeout(&addr, remaining) {
             Ok(stream) => {
                 let remote_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
                 let local_addr = stream.local_addr().ok().map(|addr| addr.to_string());
@@ -1659,10 +1671,20 @@ fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> Tc
         };
     }
 
+    let deadline = Instant::now() + timeout;
     let mut last_reason = "unreachable".to_string();
     for (port, addr) in targets {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            last_reason = "timeout".to_string();
+            break;
+        };
+        if remaining.is_zero() {
+            last_reason = "timeout".to_string();
+            break;
+        }
+
         let start = Instant::now();
-        match TcpStream::connect_timeout(addr, timeout) {
+        match TcpStream::connect_timeout(addr, remaining) {
             Ok(stream) => {
                 let remote_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
                 let local_addr = stream.local_addr().ok().map(|addr| addr.to_string());
@@ -1726,16 +1748,6 @@ fn resolve_port_scan_targets(host: &str, ports: &[u16]) -> Result<Vec<(u16, Sock
         targets.extend(ips.iter().map(|ip| (*port, SocketAddr::new(*ip, *port))));
     }
     Ok(targets)
-}
-
-fn enforce_resolved_target_policy(
-    targets: &[(u16, SocketAddr)],
-    allow_private: bool,
-) -> Result<(), String> {
-    for (_, addr) in targets {
-        enforce_target_policy(addr.ip(), allow_private)?;
-    }
-    Ok(())
 }
 
 fn tcp_reachability_result_map(
@@ -2099,110 +2111,6 @@ fn add_common_classification(map: &mut HashMap<String, Value>, ip: IpAddr) {
     );
 }
 
-#[derive(Debug)]
-struct IpClassification {
-    is_private: bool,
-    is_loopback: bool,
-    is_link_local: bool,
-    is_multicast: bool,
-    is_unspecified: bool,
-    is_documentation: bool,
-    is_broadcast: bool,
-    is_metadata_endpoint: bool,
-    is_unique_local: bool,
-}
-
-fn classify_ip(ip: IpAddr) -> IpClassification {
-    match ip {
-        IpAddr::V4(ip) => IpClassification {
-            is_private: ip.is_private(),
-            is_loopback: ip.is_loopback(),
-            is_link_local: ip.is_link_local(),
-            is_multicast: ip.is_multicast(),
-            is_unspecified: ip.is_unspecified(),
-            is_documentation: is_ipv4_documentation(ip),
-            is_broadcast: ip.is_broadcast(),
-            is_metadata_endpoint: is_ipv4_metadata_endpoint(ip),
-            is_unique_local: false,
-        },
-        IpAddr::V6(ip) => {
-            if let Some(mapped) = ip.to_ipv4_mapped() {
-                return classify_ip(IpAddr::V4(mapped));
-            }
-            let first_segment = ip.segments()[0];
-            let is_unique_local = (first_segment & 0xfe00) == 0xfc00;
-            let is_link_local = (first_segment & 0xffc0) == 0xfe80;
-            let is_documentation = ip.segments()[0] == 0x2001 && ip.segments()[1] == 0x0db8;
-            IpClassification {
-                is_private: is_unique_local,
-                is_loopback: ip.is_loopback(),
-                is_link_local,
-                is_multicast: ip.is_multicast(),
-                is_unspecified: ip.is_unspecified(),
-                is_documentation,
-                is_broadcast: false,
-                is_metadata_endpoint: is_ipv6_metadata_endpoint(ip),
-                is_unique_local,
-            }
-        }
-    }
-}
-
-fn is_ipv4_documentation(ip: Ipv4Addr) -> bool {
-    let octets = ip.octets();
-    matches!(
-        octets,
-        [192, 0, 2, _] | [198, 51, 100, _] | [203, 0, 113, _]
-    )
-}
-
-fn is_ipv4_metadata_endpoint(ip: Ipv4Addr) -> bool {
-    matches!(ip.octets(), [169, 254, 169, 254] | [169, 254, 170, 2])
-}
-
-fn is_ipv6_metadata_endpoint(ip: Ipv6Addr) -> bool {
-    ip.segments() == [0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254]
-}
-
-fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> {
-    let classification = classify_ip(ip);
-    let never_allowed = classification.is_metadata_endpoint
-        || classification.is_unspecified
-        || classification.is_multicast
-        || classification.is_documentation
-        || classification.is_broadcast;
-    if never_allowed {
-        return Err(
-            "Network target denied by policy: special-purpose targets are not allowed".to_string(),
-        );
-    }
-
-    let private_target = classification.is_private
-        || classification.is_loopback
-        || classification.is_link_local
-        || classification.is_unique_local;
-    if !private_target {
-        return Ok(());
-    }
-    if !allow_private || !process_allows_private_targets() {
-        return Err(
-            "Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1"
-                .to_string(),
-        );
-    }
-    Ok(())
-}
-
-fn process_allows_private_targets() -> bool {
-    matches!(
-        std::env::var("NTNT_NET_ALLOW_PRIVATE").as_deref(),
-        Ok("1") | Ok("true") | Ok("yes")
-    ) || matches!(
-        std::env::var("NTNT_ALLOW_PRIVATE_IPS").as_deref(),
-        Ok("1") | Ok("true") | Ok("yes")
-    )
-}
-
 fn ensure_same_family(a: &Network, b: &Network) -> Result<(), String> {
     if a.family != b.family {
         return Err("mixed IPv4/IPv6 families are not comparable".to_string());
@@ -2544,62 +2452,6 @@ mod tests {
             }
             other => panic!("expected Result::Err, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn target_policy_classifies_ipv4_mapped_ipv6_by_embedded_address() {
-        let mapped_loopback = "[::ffff:127.0.0.1]:80".parse::<SocketAddr>().unwrap();
-        let mapped_metadata = "[::ffff:169.254.169.254]:80".parse::<SocketAddr>().unwrap();
-
-        assert!(enforce_resolved_target_policy(&[(80, mapped_loopback)], false).is_err());
-        assert!(enforce_resolved_target_policy(&[(80, mapped_metadata)], false).is_err());
-    }
-
-    #[test]
-    fn target_policy_rejects_special_ranges_by_default() {
-        let multicast = "224.0.0.1:80".parse::<SocketAddr>().unwrap();
-        let documentation = "192.0.2.1:80".parse::<SocketAddr>().unwrap();
-        let broadcast = "255.255.255.255:80".parse::<SocketAddr>().unwrap();
-        let mapped_broadcast = "[::ffff:255.255.255.255]:80".parse::<SocketAddr>().unwrap();
-
-        assert!(enforce_resolved_target_policy(&[(80, multicast)], false).is_err());
-        assert!(enforce_resolved_target_policy(&[(80, documentation)], false).is_err());
-        assert!(enforce_resolved_target_policy(&[(80, broadcast)], false).is_err());
-        assert!(enforce_resolved_target_policy(&[(80, mapped_broadcast)], false).is_err());
-    }
-
-    #[test]
-    fn target_policy_never_allows_metadata_or_special_ranges() {
-        let metadata = "169.254.169.254:80".parse::<SocketAddr>().unwrap();
-        let ecs_metadata = "169.254.170.2:80".parse::<SocketAddr>().unwrap();
-        let mapped_metadata = "[::ffff:169.254.169.254]:80".parse::<SocketAddr>().unwrap();
-        let mapped_ecs_metadata = "[::ffff:169.254.170.2]:80".parse::<SocketAddr>().unwrap();
-        let multicast = "224.0.0.1:80".parse::<SocketAddr>().unwrap();
-        let documentation = "192.0.2.1:80".parse::<SocketAddr>().unwrap();
-        let broadcast = "255.255.255.255:80".parse::<SocketAddr>().unwrap();
-
-        for target in [
-            metadata,
-            ecs_metadata,
-            mapped_metadata,
-            mapped_ecs_metadata,
-            multicast,
-            documentation,
-            broadcast,
-        ] {
-            let err = enforce_resolved_target_policy(&[(80, target)], true).unwrap_err();
-            assert!(err.contains("special-purpose targets are not allowed"));
-        }
-    }
-
-    #[test]
-    fn target_policy_checks_all_resolved_addresses_before_probe() {
-        let public = "93.184.216.34:443".parse::<SocketAddr>().unwrap();
-        let private = "127.0.0.1:443".parse::<SocketAddr>().unwrap();
-        let targets = [(443, public), (443, private)];
-
-        let err = enforce_resolved_target_policy(&targets, false).unwrap_err();
-        assert!(err.contains("Network target denied by policy"));
     }
 
     #[test]

--- a/src/stdlib/net/mod.rs
+++ b/src/stdlib/net/mod.rs
@@ -1596,26 +1596,6 @@ fn port_scan_for_host(
 }
 
 fn scan_port_targets(port: u16, targets: Vec<SocketAddr>, timeout: Duration) -> PortScanResult {
-    scan_port_targets_with(port, targets, timeout, |addr, remaining| {
-        let stream = TcpStream::connect_timeout(addr, remaining)?;
-        let info = TcpConnectInfo {
-            remote_addr: stream.peer_addr().ok().map(|addr| addr.to_string()),
-            local_addr: stream.local_addr().ok().map(|addr| addr.to_string()),
-        };
-        drop(stream);
-        Ok(info)
-    })
-}
-
-fn scan_port_targets_with<F>(
-    port: u16,
-    targets: Vec<SocketAddr>,
-    timeout: Duration,
-    mut connect: F,
-) -> PortScanResult
-where
-    F: FnMut(&SocketAddr, Duration) -> io::Result<TcpConnectInfo>,
-{
     if targets.is_empty() {
         return PortScanResult {
             port,
@@ -1630,20 +1610,23 @@ where
     let deadline = Instant::now() + timeout;
     let mut last_reason = "unreachable".to_string();
     for addr in targets {
-        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+        let start = Instant::now();
+        let Some(remaining) = deadline.checked_duration_since(start) else {
             last_reason = "timeout".to_string();
             break;
         };
 
-        let start = Instant::now();
-        match connect(&addr, remaining) {
-            Ok(info) => {
+        match TcpStream::connect_timeout(&addr, remaining) {
+            Ok(stream) => {
+                let remote_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
+                let local_addr = stream.local_addr().ok().map(|addr| addr.to_string());
+                drop(stream);
                 return PortScanResult {
                     port,
                     open: true,
                     latency_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
-                    remote_addr: info.remote_addr,
-                    local_addr: info.local_addr,
+                    remote_addr,
+                    local_addr,
                     reason: "connected".to_string(),
                 };
             }
@@ -1733,12 +1716,12 @@ where
             .expect("port_order is populated from targets_by_port; entry must exist");
         let deadline = Instant::now() + timeout;
         for addr in addrs {
-            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            let start = Instant::now();
+            let Some(remaining) = deadline.checked_duration_since(start) else {
                 last_reason = "timeout".to_string();
                 break;
             };
 
-            let start = Instant::now();
             match connect(&addr, remaining) {
                 Ok(info) => {
                     let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -2802,46 +2785,24 @@ mod tests {
     }
 
     #[test]
-    fn scan_port_targets_share_budget_across_resolved_addresses() {
-        let port = 80;
-        let first_addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let second_addr = SocketAddr::from(([127, 0, 0, 2], port));
-        let mut tried = Vec::new();
-
-        let result = scan_port_targets_with(
-            port,
-            vec![first_addr, second_addr],
-            Duration::from_millis(100),
-            |addr, remaining| {
-                tried.push(*addr);
-                thread::sleep(remaining + Duration::from_millis(5));
-                Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "simulated filtered address",
-                ))
-            },
-        );
-
-        assert!(!result.open);
-        assert_eq!(result.reason, "timeout");
-        assert_eq!(tried, vec![first_addr]);
-    }
-
-    #[test]
-    fn tcp_reachability_attempts_give_each_port_its_own_address_budget() {
+    fn tcp_reachability_attempts_later_ports_after_earlier_failures() {
         let first_port = 80;
         let second_port = 443;
-        let first = SocketAddr::from(([127, 0, 0, 1], first_port));
+        let first_a = SocketAddr::from(([127, 0, 0, 1], first_port));
+        let first_b = SocketAddr::from(([127, 0, 0, 2], first_port));
         let second = SocketAddr::from(([127, 0, 0, 1], second_port));
         let mut tried = Vec::new();
 
         let result = tcp_reachability_once_with(
-            &[(first_port, first), (second_port, second)],
+            &[
+                (first_port, first_a),
+                (first_port, first_b),
+                (second_port, second),
+            ],
             Duration::from_millis(100),
-            |addr, remaining| {
-                tried.push(addr.port());
+            |addr, _remaining| {
+                tried.push(*addr);
                 if addr.port() == first_port {
-                    thread::sleep(remaining + Duration::from_millis(5));
                     return Err(io::Error::new(
                         io::ErrorKind::TimedOut,
                         "simulated filtered port",
@@ -2856,32 +2817,6 @@ mod tests {
 
         assert!(result.reachable);
         assert_eq!(result.connected_port, Some(second_port));
-        assert_eq!(tried, vec![first_port, second_port]);
-    }
-
-    #[test]
-    fn tcp_reachability_attempts_share_budget_within_same_port() {
-        let port = 80;
-        let first_addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let second_addr = SocketAddr::from(([127, 0, 0, 2], port));
-        let mut tried = Vec::new();
-
-        let result = tcp_reachability_once_with(
-            &[(port, first_addr), (port, second_addr)],
-            Duration::from_millis(100),
-            |addr, remaining| {
-                tried.push(*addr);
-                thread::sleep(remaining + Duration::from_millis(5));
-                Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "simulated filtered address",
-                ))
-            },
-        );
-
-        assert!(!result.reachable);
-        assert_eq!(result.connected_port, None);
-        assert_eq!(result.reason, "timeout");
-        assert_eq!(tried, vec![first_addr]);
+        assert_eq!(tried, vec![first_a, first_b, second]);
     }
 }

--- a/src/stdlib/net/mod.rs
+++ b/src/stdlib/net/mod.rs
@@ -1596,6 +1596,26 @@ fn port_scan_for_host(
 }
 
 fn scan_port_targets(port: u16, targets: Vec<SocketAddr>, timeout: Duration) -> PortScanResult {
+    scan_port_targets_with(port, targets, timeout, |addr, remaining| {
+        let stream = TcpStream::connect_timeout(addr, remaining)?;
+        let info = TcpConnectInfo {
+            remote_addr: stream.peer_addr().ok().map(|addr| addr.to_string()),
+            local_addr: stream.local_addr().ok().map(|addr| addr.to_string()),
+        };
+        drop(stream);
+        Ok(info)
+    })
+}
+
+fn scan_port_targets_with<F>(
+    port: u16,
+    targets: Vec<SocketAddr>,
+    timeout: Duration,
+    mut connect: F,
+) -> PortScanResult
+where
+    F: FnMut(&SocketAddr, Duration) -> io::Result<TcpConnectInfo>,
+{
     if targets.is_empty() {
         return PortScanResult {
             port,
@@ -1616,22 +1636,19 @@ fn scan_port_targets(port: u16, targets: Vec<SocketAddr>, timeout: Duration) -> 
         };
 
         let start = Instant::now();
-        match TcpStream::connect_timeout(&addr, remaining) {
-            Ok(stream) => {
-                let remote_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
-                let local_addr = stream.local_addr().ok().map(|addr| addr.to_string());
-                drop(stream);
+        match connect(&addr, remaining) {
+            Ok(info) => {
                 return PortScanResult {
                     port,
                     open: true,
                     latency_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
-                    remote_addr,
-                    local_addr,
+                    remote_addr: info.remote_addr,
+                    local_addr: info.local_addr,
                     reason: "connected".to_string(),
                 };
             }
             Err(e) => {
-                last_reason = e.kind().to_string();
+                last_reason = tcp_probe_error_reason(e.kind());
             }
         }
     }
@@ -1643,6 +1660,13 @@ fn scan_port_targets(port: u16, targets: Vec<SocketAddr>, timeout: Duration) -> 
         remote_addr: None,
         local_addr: None,
         reason: last_reason,
+    }
+}
+
+fn tcp_probe_error_reason(kind: io::ErrorKind) -> String {
+    match kind {
+        io::ErrorKind::TimedOut => "timeout".to_string(),
+        _ => kind.to_string(),
     }
 }
 
@@ -1693,20 +1717,20 @@ where
         };
     }
 
-    let mut targets_by_port: Vec<(u16, Vec<SocketAddr>)> = Vec::new();
+    let mut port_order = Vec::new();
+    let mut targets_by_port: HashMap<u16, Vec<SocketAddr>> = HashMap::new();
     for (port, addr) in targets {
-        if let Some((_, addrs)) = targets_by_port
-            .iter_mut()
-            .find(|(existing_port, _)| existing_port == port)
-        {
-            addrs.push(*addr);
-        } else {
-            targets_by_port.push((*port, vec![*addr]));
+        if !targets_by_port.contains_key(port) {
+            port_order.push(*port);
         }
+        targets_by_port.entry(*port).or_default().push(*addr);
     }
 
     let mut last_reason = "unreachable".to_string();
-    for (port, addrs) in targets_by_port {
+    for port in port_order {
+        let addrs = targets_by_port
+            .remove(&port)
+            .expect("port_order is populated from targets_by_port; entry must exist");
         let deadline = Instant::now() + timeout;
         for addr in addrs {
             let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
@@ -1728,7 +1752,7 @@ where
                     };
                 }
                 Err(e) => {
-                    last_reason = e.kind().to_string();
+                    last_reason = tcp_probe_error_reason(e.kind());
                 }
             }
         }
@@ -2778,6 +2802,32 @@ mod tests {
     }
 
     #[test]
+    fn scan_port_targets_share_budget_across_resolved_addresses() {
+        let port = 80;
+        let first_addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let second_addr = SocketAddr::from(([127, 0, 0, 2], port));
+        let mut tried = Vec::new();
+
+        let result = scan_port_targets_with(
+            port,
+            vec![first_addr, second_addr],
+            Duration::from_millis(100),
+            |addr, remaining| {
+                tried.push(*addr);
+                thread::sleep(remaining + Duration::from_millis(5));
+                Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "simulated filtered address",
+                ))
+            },
+        );
+
+        assert!(!result.open);
+        assert_eq!(result.reason, "timeout");
+        assert_eq!(tried, vec![first_addr]);
+    }
+
+    #[test]
     fn tcp_reachability_attempts_give_each_port_its_own_address_budget() {
         let first_port = 80;
         let second_port = 443;
@@ -2787,7 +2837,7 @@ mod tests {
 
         let result = tcp_reachability_once_with(
             &[(first_port, first), (second_port, second)],
-            Duration::from_millis(1),
+            Duration::from_millis(100),
             |addr, remaining| {
                 tried.push(addr.port());
                 if addr.port() == first_port {
@@ -2807,5 +2857,31 @@ mod tests {
         assert!(result.reachable);
         assert_eq!(result.connected_port, Some(second_port));
         assert_eq!(tried, vec![first_port, second_port]);
+    }
+
+    #[test]
+    fn tcp_reachability_attempts_share_budget_within_same_port() {
+        let port = 80;
+        let first_addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let second_addr = SocketAddr::from(([127, 0, 0, 2], port));
+        let mut tried = Vec::new();
+
+        let result = tcp_reachability_once_with(
+            &[(port, first_addr), (port, second_addr)],
+            Duration::from_millis(100),
+            |addr, remaining| {
+                tried.push(*addr);
+                thread::sleep(remaining + Duration::from_millis(5));
+                Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "simulated filtered address",
+                ))
+            },
+        );
+
+        assert!(!result.reachable);
+        assert_eq!(result.connected_port, None);
+        assert_eq!(result.reason, "timeout");
+        assert_eq!(tried, vec![first_addr]);
     }
 }

--- a/src/stdlib/net/mod.rs
+++ b/src/stdlib/net/mod.rs
@@ -22,6 +22,7 @@ use rustls::{
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
+use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -472,7 +473,7 @@ pub fn init() -> HashMap<String, Value> {
     // by default. Caller-provided tcp_ports add extra explicit TCP ports.
     // The result records the method that established reachability without pretending TCP is ping.
     // @param host Hostname or IP address to resolve and probe
-    // @param opts Optional map with extra tcp_ports, timeout_ms, count, interval_ms, and allow_private
+    // @param opts Optional map with extra tcp_ports, timeout_ms (per TCP port across resolved addresses), count, interval_ms, and allow_private
     // @returns Result containing reachability status, method used, fallback metadata, and attempt summary
     // @since v0.4.10
     // @tags #network
@@ -495,7 +496,7 @@ pub fn init() -> HashMap<String, Value> {
     // are accepted; ranges are intentionally not expanded. Results are sorted by port.
     // @param host Hostname or IP address to resolve and scan
     // @param ports Explicit array of TCP ports from 1 to 65535; duplicates are rejected
-    // @param opts Optional map with timeout_ms, concurrency, and allow_private
+    // @param opts Optional map with timeout_ms (per port across resolved addresses), concurrency, and allow_private
     // @returns Result containing one map per port with open, latency_ms, and reason fields
     // @since v0.4.10
     // @tags #network
@@ -1525,6 +1526,12 @@ struct TcpProbeResult {
     reason: String,
 }
 
+#[derive(Debug)]
+struct TcpConnectInfo {
+    remote_addr: Option<String>,
+    local_addr: Option<String>,
+}
+
 fn tcp_reachability_attempts_for_host(
     host: &str,
     ports: &[u16],
@@ -1607,10 +1614,6 @@ fn scan_port_targets(port: u16, targets: Vec<SocketAddr>, timeout: Duration) -> 
             last_reason = "timeout".to_string();
             break;
         };
-        if remaining.is_zero() {
-            last_reason = "timeout".to_string();
-            break;
-        }
 
         let start = Instant::now();
         match TcpStream::connect_timeout(&addr, remaining) {
@@ -1660,6 +1663,25 @@ fn tcp_reachability_attempts(
 }
 
 fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> TcpProbeResult {
+    tcp_reachability_once_with(targets, timeout, |addr, remaining| {
+        let stream = TcpStream::connect_timeout(addr, remaining)?;
+        let info = TcpConnectInfo {
+            remote_addr: stream.peer_addr().ok().map(|addr| addr.to_string()),
+            local_addr: stream.local_addr().ok().map(|addr| addr.to_string()),
+        };
+        drop(stream);
+        Ok(info)
+    })
+}
+
+fn tcp_reachability_once_with<F>(
+    targets: &[(u16, SocketAddr)],
+    timeout: Duration,
+    mut connect: F,
+) -> TcpProbeResult
+where
+    F: FnMut(&SocketAddr, Duration) -> io::Result<TcpConnectInfo>,
+{
     if targets.is_empty() {
         return TcpProbeResult {
             reachable: false,
@@ -1671,35 +1693,43 @@ fn tcp_reachability_once(targets: &[(u16, SocketAddr)], timeout: Duration) -> Tc
         };
     }
 
-    let deadline = Instant::now() + timeout;
-    let mut last_reason = "unreachable".to_string();
+    let mut targets_by_port: Vec<(u16, Vec<SocketAddr>)> = Vec::new();
     for (port, addr) in targets {
-        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
-            last_reason = "timeout".to_string();
-            break;
-        };
-        if remaining.is_zero() {
-            last_reason = "timeout".to_string();
-            break;
+        if let Some((_, addrs)) = targets_by_port
+            .iter_mut()
+            .find(|(existing_port, _)| existing_port == port)
+        {
+            addrs.push(*addr);
+        } else {
+            targets_by_port.push((*port, vec![*addr]));
         }
+    }
 
-        let start = Instant::now();
-        match TcpStream::connect_timeout(addr, remaining) {
-            Ok(stream) => {
-                let remote_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
-                let local_addr = stream.local_addr().ok().map(|addr| addr.to_string());
-                drop(stream);
-                return TcpProbeResult {
-                    reachable: true,
-                    connected_port: Some(*port),
-                    latency_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
-                    remote_addr,
-                    local_addr,
-                    reason: "connected".to_string(),
-                };
-            }
-            Err(e) => {
-                last_reason = e.kind().to_string();
+    let mut last_reason = "unreachable".to_string();
+    for (port, addrs) in targets_by_port {
+        let deadline = Instant::now() + timeout;
+        for addr in addrs {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                last_reason = "timeout".to_string();
+                break;
+            };
+
+            let start = Instant::now();
+            match connect(&addr, remaining) {
+                Ok(info) => {
+                    let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                    return TcpProbeResult {
+                        reachable: true,
+                        connected_port: Some(port),
+                        latency_ms: Some(latency_ms),
+                        remote_addr: info.remote_addr,
+                        local_addr: info.local_addr,
+                        reason: "connected".to_string(),
+                    };
+                }
+                Err(e) => {
+                    last_reason = e.kind().to_string();
+                }
             }
         }
     }
@@ -2745,5 +2775,37 @@ mod tests {
         assert!(matches!(summary.get("failed"), Some(Value::Int(0))));
         assert!(matches!(summary.get("loss_percent"), Some(Value::Float(value)) if *value == 0.0));
         assert!(matches!(summary.get("attempts"), Some(Value::Array(values)) if values.len() == 3));
+    }
+
+    #[test]
+    fn tcp_reachability_attempts_give_each_port_its_own_address_budget() {
+        let first_port = 80;
+        let second_port = 443;
+        let first = SocketAddr::from(([127, 0, 0, 1], first_port));
+        let second = SocketAddr::from(([127, 0, 0, 1], second_port));
+        let mut tried = Vec::new();
+
+        let result = tcp_reachability_once_with(
+            &[(first_port, first), (second_port, second)],
+            Duration::from_millis(1),
+            |addr, remaining| {
+                tried.push(addr.port());
+                if addr.port() == first_port {
+                    thread::sleep(remaining + Duration::from_millis(5));
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "simulated filtered port",
+                    ));
+                }
+                Ok(TcpConnectInfo {
+                    remote_addr: Some(addr.to_string()),
+                    local_addr: Some("127.0.0.1:50000".to_string()),
+                })
+            },
+        );
+
+        assert!(result.reachable);
+        assert_eq!(result.connected_port, Some(second_port));
+        assert_eq!(tried, vec![first_port, second_port]);
     }
 }

--- a/src/stdlib/net/policy.rs
+++ b/src/stdlib/net/policy.rs
@@ -1,0 +1,160 @@
+//! Target classification and outbound safety policy for `std/net`.
+//!
+//! `std/net` can be used from public web apps, so hostname/IP-taking probes
+//! must not become SSRF/scanning shortcuts by default. Public targets are
+//! allowed; private/internal targets require both process-level deployment
+//! intent (`NTNT_NET_ALLOW_PRIVATE=1`) and per-call `allow_private: true`;
+//! cloud metadata and other special-purpose targets remain denied.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+#[derive(Debug)]
+pub(super) struct IpClassification {
+    pub(super) is_private: bool,
+    pub(super) is_loopback: bool,
+    pub(super) is_link_local: bool,
+    pub(super) is_multicast: bool,
+    pub(super) is_unspecified: bool,
+    pub(super) is_documentation: bool,
+    pub(super) is_broadcast: bool,
+    pub(super) is_metadata_endpoint: bool,
+    pub(super) is_unique_local: bool,
+}
+
+pub(super) fn classify_ip(ip: IpAddr) -> IpClassification {
+    match ip {
+        IpAddr::V4(ip) => IpClassification {
+            is_private: ip.is_private(),
+            is_loopback: ip.is_loopback(),
+            is_link_local: ip.is_link_local(),
+            is_multicast: ip.is_multicast(),
+            is_unspecified: ip.is_unspecified(),
+            is_documentation: is_ipv4_documentation(ip),
+            is_broadcast: ip.is_broadcast(),
+            is_metadata_endpoint: is_ipv4_metadata_endpoint(ip),
+            is_unique_local: false,
+        },
+        IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                return classify_ip(IpAddr::V4(mapped));
+            }
+            let first_segment = ip.segments()[0];
+            let is_unique_local = (first_segment & 0xfe00) == 0xfc00;
+            let is_link_local = (first_segment & 0xffc0) == 0xfe80;
+            let is_documentation = ip.segments()[0] == 0x2001 && ip.segments()[1] == 0x0db8;
+            IpClassification {
+                is_private: is_unique_local,
+                is_loopback: ip.is_loopback(),
+                is_link_local,
+                is_multicast: ip.is_multicast(),
+                is_unspecified: ip.is_unspecified(),
+                is_documentation,
+                is_broadcast: false,
+                is_metadata_endpoint: is_ipv6_metadata_endpoint(ip),
+                is_unique_local,
+            }
+        }
+    }
+}
+
+pub(in crate::stdlib::net) fn enforce_resolved_target_policy(
+    targets: &[(u16, SocketAddr)],
+    allow_private: bool,
+) -> Result<(), String> {
+    for (_, addr) in targets {
+        enforce_target_policy(addr.ip(), allow_private)?;
+    }
+    Ok(())
+}
+
+fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> {
+    let classification = classify_ip(ip);
+    let never_allowed = classification.is_metadata_endpoint
+        || classification.is_unspecified
+        || classification.is_multicast
+        || classification.is_documentation
+        || classification.is_broadcast;
+    if never_allowed {
+        return Err(
+            "Network target denied by policy: special-purpose targets are not allowed".to_string(),
+        );
+    }
+
+    let private_target = classification.is_private
+        || classification.is_loopback
+        || classification.is_link_local
+        || classification.is_unique_local;
+    if !private_target {
+        return Ok(());
+    }
+    if !allow_private || !process_allows_private_targets() {
+        return Err(
+            "Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn process_allows_private_targets() -> bool {
+    matches!(
+        std::env::var("NTNT_NET_ALLOW_PRIVATE").as_deref(),
+        Ok("1") | Ok("true") | Ok("yes")
+    )
+}
+
+fn is_ipv4_documentation(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    matches!(
+        octets,
+        [192, 0, 2, _] | [198, 51, 100, _] | [203, 0, 113, _]
+    )
+}
+
+fn is_ipv4_metadata_endpoint(ip: Ipv4Addr) -> bool {
+    matches!(ip.octets(), [169, 254, 169, 254] | [169, 254, 170, 2])
+}
+
+fn is_ipv6_metadata_endpoint(ip: Ipv6Addr) -> bool {
+    ip.segments() == [0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_ipv4_mapped_ipv6_by_embedded_address() {
+        let mapped_loopback = "::ffff:127.0.0.1".parse::<IpAddr>().unwrap();
+        let mapped_metadata = "::ffff:169.254.169.254".parse::<IpAddr>().unwrap();
+
+        assert!(classify_ip(mapped_loopback).is_loopback);
+        assert!(classify_ip(mapped_metadata).is_metadata_endpoint);
+    }
+
+    #[test]
+    fn policy_rejects_special_ranges_even_when_private_targets_are_allowed() {
+        for target in [
+            "169.254.169.254:80",
+            "169.254.170.2:80",
+            "[::ffff:169.254.169.254]:80",
+            "[::ffff:169.254.170.2]:80",
+            "224.0.0.1:80",
+            "192.0.2.1:80",
+            "255.255.255.255:80",
+        ] {
+            let addr = target.parse::<SocketAddr>().unwrap();
+            let err = enforce_resolved_target_policy(&[(80, addr)], true).unwrap_err();
+            assert!(err.contains("special-purpose targets are not allowed"));
+        }
+    }
+
+    #[test]
+    fn policy_checks_all_resolved_addresses_before_probe() {
+        let public = "93.184.216.34:443".parse::<SocketAddr>().unwrap();
+        let private = "127.0.0.1:443".parse::<SocketAddr>().unwrap();
+        let err =
+            enforce_resolved_target_policy(&[(443, public), (443, private)], false).unwrap_err();
+        assert!(err.contains("Network target denied by policy"));
+    }
+}

--- a/src/stdlib/net/policy.rs
+++ b/src/stdlib/net/policy.rs
@@ -200,12 +200,15 @@ mod tests {
 
     #[test]
     fn policy_rejects_private_and_mapped_loopback_without_opt_in() {
+        let _env_lock = ENV_MUTEX.lock().unwrap();
         for target in [
             "127.0.0.1:80",
             "[::1]:80",
             "[::ffff:127.0.0.1]:80",
             "10.0.0.1:80",
+            "169.254.1.1:80",
             "[fc00::1]:80",
+            "[fe80::1]:80",
         ] {
             let addr = target.parse::<SocketAddr>().unwrap();
             let err = enforce_resolved_target_policy(&[(80, addr)], false).unwrap_err();
@@ -228,9 +231,16 @@ mod tests {
     fn policy_allows_private_targets_with_call_and_process_opt_in() {
         let _env_lock = ENV_MUTEX.lock().unwrap();
         let _env_guard = PrivateOptInEnvGuard::std_net_allowed();
-        let private = "127.0.0.1:80".parse::<SocketAddr>().unwrap();
-
-        assert!(enforce_resolved_target_policy(&[(80, private)], true).is_ok());
+        for target in [
+            "127.0.0.1:80",
+            "10.0.0.1:80",
+            "169.254.1.1:80",
+            "[fc00::1]:80",
+            "[fe80::1]:80",
+        ] {
+            let private = target.parse::<SocketAddr>().unwrap();
+            assert!(enforce_resolved_target_policy(&[(80, private)], true).is_ok());
+        }
     }
 
     #[test]

--- a/src/stdlib/net/policy.rs
+++ b/src/stdlib/net/policy.rs
@@ -89,7 +89,7 @@ fn enforce_target_policy(ip: IpAddr, allow_private: bool) -> Result<(), String> 
     }
     if !allow_private || !process_allows_private_targets() {
         return Err(
-            "Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1"
+            "Network target denied by policy: private targets require NTNT_NET_ALLOW_PRIVATE=1 for std/net probes (NTNT_ALLOW_PRIVATE_IPS only applies to fetch())"
                 .to_string(),
         );
     }
@@ -122,6 +122,55 @@ fn is_ipv6_metadata_endpoint(ip: Ipv6Addr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct PrivateOptInEnvGuard {
+        previous_net: Option<String>,
+        previous_legacy_fetch: Option<String>,
+    }
+
+    impl PrivateOptInEnvGuard {
+        fn legacy_fetch_only() -> Self {
+            let guard = Self {
+                previous_net: std::env::var("NTNT_NET_ALLOW_PRIVATE").ok(),
+                previous_legacy_fetch: std::env::var("NTNT_ALLOW_PRIVATE_IPS").ok(),
+            };
+            unsafe {
+                std::env::remove_var("NTNT_NET_ALLOW_PRIVATE");
+                std::env::set_var("NTNT_ALLOW_PRIVATE_IPS", "true");
+            }
+            guard
+        }
+
+        fn std_net_allowed() -> Self {
+            let guard = Self {
+                previous_net: std::env::var("NTNT_NET_ALLOW_PRIVATE").ok(),
+                previous_legacy_fetch: std::env::var("NTNT_ALLOW_PRIVATE_IPS").ok(),
+            };
+            unsafe {
+                std::env::set_var("NTNT_NET_ALLOW_PRIVATE", "1");
+                std::env::remove_var("NTNT_ALLOW_PRIVATE_IPS");
+            }
+            guard
+        }
+    }
+
+    impl Drop for PrivateOptInEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous_net {
+                    Some(value) => std::env::set_var("NTNT_NET_ALLOW_PRIVATE", value),
+                    None => std::env::remove_var("NTNT_NET_ALLOW_PRIVATE"),
+                }
+                match &self.previous_legacy_fetch {
+                    Some(value) => std::env::set_var("NTNT_ALLOW_PRIVATE_IPS", value),
+                    None => std::env::remove_var("NTNT_ALLOW_PRIVATE_IPS"),
+                }
+            }
+        }
+    }
 
     #[test]
     fn classifies_ipv4_mapped_ipv6_by_embedded_address() {
@@ -147,6 +196,41 @@ mod tests {
             let err = enforce_resolved_target_policy(&[(80, addr)], true).unwrap_err();
             assert!(err.contains("special-purpose targets are not allowed"));
         }
+    }
+
+    #[test]
+    fn policy_rejects_private_and_mapped_loopback_without_opt_in() {
+        for target in [
+            "127.0.0.1:80",
+            "[::1]:80",
+            "[::ffff:127.0.0.1]:80",
+            "10.0.0.1:80",
+            "[fc00::1]:80",
+        ] {
+            let addr = target.parse::<SocketAddr>().unwrap();
+            let err = enforce_resolved_target_policy(&[(80, addr)], false).unwrap_err();
+            assert!(err.contains("private targets require NTNT_NET_ALLOW_PRIVATE=1"));
+        }
+    }
+
+    #[test]
+    fn policy_rejects_legacy_fetch_env_var_for_std_net_private_targets() {
+        let _env_lock = ENV_MUTEX.lock().unwrap();
+        let _env_guard = PrivateOptInEnvGuard::legacy_fetch_only();
+        let private = "127.0.0.1:80".parse::<SocketAddr>().unwrap();
+
+        let err = enforce_resolved_target_policy(&[(80, private)], true).unwrap_err();
+
+        assert!(err.contains("private targets require NTNT_NET_ALLOW_PRIVATE=1"));
+    }
+
+    #[test]
+    fn policy_allows_private_targets_with_call_and_process_opt_in() {
+        let _env_lock = ENV_MUTEX.lock().unwrap();
+        let _env_guard = PrivateOptInEnvGuard::std_net_allowed();
+        let private = "127.0.0.1:80".parse::<SocketAddr>().unwrap();
+
+        assert!(enforce_resolved_target_policy(&[(80, private)], true).is_ok());
     }
 
     #[test]

--- a/src/stdlib/net/traceroute.rs
+++ b/src/stdlib/net/traceroute.rs
@@ -11,8 +11,8 @@
 //! require CAP_NET_RAW; when it is unavailable the driver returns a clear
 //! backend error. Apps can check `net_capabilities()` first.
 
-use super::enforce_resolved_target_policy;
 use super::icmp::{open_icmp_trace_probe, resolve_probe_targets, unique_target_ips};
+use super::policy::enforce_resolved_target_policy;
 use super::probe::{probe_attempt_budget, HopProbe, ProbeFailure, TraceProbe};
 use super::transport::{open_tcp_trace_probe, open_udp_trace_probe};
 use crate::interpreter::Value;


### PR DESCRIPTION
## Summary
- move std/net target classification/policy into `net/policy.rs` and keep private probing gated only by `NTNT_NET_ALLOW_PRIVATE=1` plus per-call `allow_private`
- make TCP reachability and port scan attempts spend one caller-visible timeout budget across resolved addresses instead of multiplying timeout by address count
- update DD-046/DD-047 to mark one-shot multi-protocol traceroute as release scope and defer MTR-style aggregation, parallel hop sweeps, and hop enrichment out of `std/net`

## Verification
- `cargo fmt && git diff --check && cargo test --lib stdlib::net -- --test-threads=1`
- `cargo build --profile dev-release`
- `cargo test --test type_checker_tests std_net -- --nocapture`
- `./target/dev-release/ntnt docs --generate`
- `./target/dev-release/ntnt validate examples/` (passes; existing examples/collections_demo warnings only)
- `./target/dev-release/ntnt lint examples/` (passes; existing warnings/suggestions only)
- `cargo test`
