### PR TITLE
DD-061 PR1: Align template contract and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "ntnt"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntnt"
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 authors = ["NTNT Language Team"]
 description = "NTNT (Intent) - A programming language designed for AI-driven development"

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1616,7 +1616,7 @@ template("../views/page.html", data) // WRONG — don't use relative paths from 
 
 ### Template Strings vs template() — Key Difference
 
-Template strings in `.tnt` code (`"""...{{expr}}..."""`) **auto-escape HTML** in interpolated values. The `template()` function uses Mustache syntax where `{{var}}` escapes HTML and `{{{var}}}` outputs raw HTML.
+Template strings in `.tnt` code (`"""...{{expr}}..."""`) and external templates rendered with `template()` share the same NTNT template syntax: `{{expr}}` emits HTML-escaped output and `{{{expr}}}` emits trusted raw HTML.
 
 If you need to inject pre-rendered HTML (like from another template call), use `{{{var}}}` triple-braces in the template file:
 

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [ial.toml](ial.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.11
+> Last updated: v0.4.12
 
 IAL is a term rewriting engine that translates natural language assertions into executable tests
 

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [runtime.toml](runtime.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.11
+> Last updated: v0.4.12
 
 Runtime configuration, environment variables, and CLI commands for NTNT
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from source code doc comments** - Do not edit directly.
 >
-> Last updated: v0.4.11
+> Last updated: v0.4.12
 
 ## Table of Contents
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1551,9 +1551,9 @@ template(path: String, data: Map) -> String
 
 Load and render an external HTML template with data.
 
-Loads a `.html` template file and renders it using Mustache-style syntax. Templates use `{{var}}` for escaped output, `{{{var}}}` for raw/unescaped output, `{{#key}}...{{/key}}` for sections (conditionals and loops), and `{{> partial}}` for including other templates.
+Loads a `.html` template file and renders it using NTNT template syntax. Templates use `{{expr}}` for escaped output, `{{{expr}}}` for raw/unescaped output, explicit `{{#if cond}}...{{/if}}` conditionals, explicit `{{#for item in items}}...{{/for}}` loops, and `{{> partial}}` includes. Mustache-style ambiguous sections such as `{{#key}}...{{/key}}` are not supported; use `#if` or `#for` instead.
 
-Template paths are relative to the `.tnt` file's location. Partials are resolved from the same directory as the parent template.
+Template paths are relative to the `.tnt` file's location. Partials are resolved from the project/script directory in this order: `views/partials/{name}.html`, `views/partials/{name}`, `views/{name}.html`, `{name}.html`, then `{name}`.
 
 Typically used with `html()` from `std/http/server`: `return html(template("views/home.html", map { "title": "Home" }))`
 
@@ -1573,8 +1573,9 @@ template("views/user.html", map { "name": "Alice", "posts": [...] })  // => "<ht
 
 **Gotchas:**
 
-- Use {{var}} (double braces) for escaped output in templates — this is Mustache syntax, not NTNT string interpolation (#{var})
-- There is no escape syntax for literal {{ in templates. Workaround: pass the braces as a variable (e.g. map { "lb": "{{", "rb": "}}" }) and use {{lb}} in the template.
+- Use {{expr}} (double braces) for escaped output in external templates; use {{{expr}}} only for trusted raw HTML.
+- Use explicit {{#if cond}} and {{#for item in items}} blocks. Ambiguous Mustache-style {{#key}} sections are intentionally unsupported.
+- Use \{{ and \}} for literal template delimiters where supported.
 
 **See also:** `serve_static`, `html`, `get`
 

--- a/docs/SYNTAX_REFERENCE.md
+++ b/docs/SYNTAX_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [syntax.toml](syntax.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.11
+> Last updated: v0.4.12
 
 ## Table of Contents
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3691,13 +3691,17 @@ impl Interpreter {
         // @signature template(path: String, data: Map) -> String
         // Load and render an external HTML template with data.
         //
-        // Loads a `.html` template file and renders it using Mustache-style
-        // syntax. Templates use `{{var}}` for escaped output, `{{{var}}}` for
-        // raw/unescaped output, `{{#key}}...{{/key}}` for sections (conditionals
-        // and loops), and `{{> partial}}` for including other templates.
+        // Loads a `.html` template file and renders it using NTNT template
+        // syntax. Templates use `{{expr}}` for escaped output, `{{{expr}}}` for
+        // raw/unescaped output, explicit `{{#if cond}}...{{/if}}` conditionals,
+        // explicit `{{#for item in items}}...{{/for}}` loops, and `{{> partial}}`
+        // includes. Mustache-style ambiguous sections such as
+        // `{{#key}}...{{/key}}` are not supported; use `#if` or `#for` instead.
         //
         // Template paths are relative to the `.tnt` file's location.
-        // Partials are resolved from the same directory as the parent template.
+        // Partials are resolved from the project/script directory in this order:
+        // `views/partials/{name}.html`, `views/partials/{name}`,
+        // `views/{name}.html`, `{name}.html`, then `{name}`.
         //
         // Typically used with `html()` from `std/http/server`:
         // `return html(template("views/home.html", map { "title": "Home" }))`
@@ -3709,8 +3713,9 @@ impl Interpreter {
         // @since v0.2.0
         // @example template("views/home.html", map { "title": "Home" }) => "<html>..." ~ "Render a template"
         // @example template("views/user.html", map { "name": "Alice", "posts": [...] }) => "<html>..." ~ "Render with loop data"
-        // @gotcha Use {{var}} (double braces) for escaped output in templates — this is Mustache syntax, not NTNT string interpolation (#{var})
-        // @gotcha There is no escape syntax for literal {{ in templates. Workaround: pass the braces as a variable (e.g. map { "lb": "{{", "rb": "}}" }) and use {{lb}} in the template.
+        // @gotcha Use {{expr}} (double braces) for escaped output in external templates; use {{{expr}}} only for trusted raw HTML.
+        // @gotcha Use explicit {{#if cond}} and {{#for item in items}} blocks. Ambiguous Mustache-style {{#key}} sections are intentionally unsupported.
+        // @gotcha Use \{{ and \}} for literal template delimiters where supported.
         self.environment.borrow_mut().define(
             "template".to_string(),
             Value::NativeFunction {
@@ -7739,11 +7744,30 @@ impl Interpreter {
         }
     }
 
+    /// Evaluate a template condition expression.
+    /// Undefined variables are intentionally falsy for optional layout slots;
+    /// other errors flow through the normal template TypeMode boundary.
+    fn eval_template_condition(
+        &mut self,
+        condition: &crate::ast::Expression,
+        context: &str,
+        result: &mut String,
+    ) -> Result<bool> {
+        match self.eval_expression(condition) {
+            Ok(v) => Ok(v.is_truthy()),
+            Err(IntentError::UndefinedVariable { .. }) => Ok(false),
+            Err(e) => {
+                Self::handle_template_error(e, context, result)?;
+                Ok(false)
+            }
+        }
+    }
+
     /// Evaluate template string parts
     fn eval_template_parts(&mut self, parts: &[TemplatePart]) -> Result<Value> {
         let mut result = String::new();
 
-        for part in parts {
+        'parts: for part in parts {
             match part {
                 TemplatePart::Literal(s) => result.push_str(s),
                 TemplatePart::Expr(expr) => {
@@ -7756,7 +7780,7 @@ impl Interpreter {
                             let s = v.to_string();
                             result.push_str(&html_escape_string(&s));
                         }
-                        // Undefined variables render as empty string (standard Mustache behavior)
+                        // Undefined template variables render as empty string
                         Err(IntentError::UndefinedVariable { .. }) => {}
                         Err(e) => Self::handle_template_error(e, "expression", &mut result)?,
                     }
@@ -7767,7 +7791,7 @@ impl Interpreter {
                         Ok(v) => {
                             result.push_str(&v.to_string());
                         }
-                        // Undefined variables render as empty string (standard Mustache behavior)
+                        // Undefined template variables render as empty string
                         Err(IntentError::UndefinedVariable { .. }) => {}
                         Err(e) => Self::handle_template_error(e, "raw expression", &mut result)?,
                     }
@@ -7779,20 +7803,18 @@ impl Interpreter {
                     let mut value = match self.eval_expression(expr) {
                         Ok(v) => v,
                         Err(e) => {
-                            if has_default {
-                                // Log non-variable errors even with default filter
-                                if !matches!(e, IntentError::UndefinedVariable { .. })
-                                    && get_type_mode() == TypeMode::Warn
-                                {
-                                    eprintln!(
-                                        "[WARN] Template expression error (using default): {}",
-                                        e
-                                    );
-                                }
+                            if has_default && matches!(e, IntentError::UndefinedVariable { .. }) {
+                                Value::Unit
+                            } else if has_default {
+                                Self::handle_template_error(
+                                    e,
+                                    "filtered expression default source",
+                                    &mut result,
+                                )?;
                                 Value::Unit
                             } else {
                                 Self::handle_template_error(e, "filtered expression", &mut result)?;
-                                continue;
+                                continue 'parts;
                             }
                         }
                     };
@@ -7801,7 +7823,13 @@ impl Interpreter {
                         if filter.name == "safe" || filter.name == "raw" {
                             skip_escape = true;
                         }
-                        value = self.apply_template_filter(&value, filter)?;
+                        match self.apply_template_filter(&value, filter) {
+                            Ok(v) => value = v,
+                            Err(e) => {
+                                Self::handle_template_error(e, "filter", &mut result)?;
+                                continue 'parts;
+                            }
+                        }
                     }
                     let s = value.to_string();
                     if skip_escape {
@@ -7816,25 +7844,33 @@ impl Interpreter {
                     let mut value = match self.eval_expression(expr) {
                         Ok(v) => v,
                         Err(e) => {
-                            if has_default {
-                                // Log non-variable errors even with default filter
-                                if !matches!(e, IntentError::UndefinedVariable { .. })
-                                    && get_type_mode() == TypeMode::Warn
-                                {
-                                    eprintln!(
-                                        "[WARN] Template expression error (using default): {}",
-                                        e
-                                    );
-                                }
+                            if has_default && matches!(e, IntentError::UndefinedVariable { .. }) {
+                                Value::Unit
+                            } else if has_default {
+                                Self::handle_template_error(
+                                    e,
+                                    "raw filtered expression default source",
+                                    &mut result,
+                                )?;
                                 Value::Unit
                             } else {
-                                Self::handle_template_error(e, "filtered expression", &mut result)?;
-                                continue;
+                                Self::handle_template_error(
+                                    e,
+                                    "raw filtered expression",
+                                    &mut result,
+                                )?;
+                                continue 'parts;
                             }
                         }
                     };
                     for filter in filters {
-                        value = self.apply_template_filter(&value, filter)?;
+                        match self.apply_template_filter(&value, filter) {
+                            Ok(v) => value = v,
+                            Err(e) => {
+                                Self::handle_template_error(e, "raw filter", &mut result)?;
+                                continue 'parts;
+                            }
+                        }
                     }
                     result.push_str(&value.to_string());
                 }
@@ -7989,18 +8025,10 @@ impl Interpreter {
                     elif_chains,
                     else_parts,
                 } => {
-                    // Error boundary: any error in condition is treated as false
-                    let condition_value = match self.eval_expression(condition) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            if !matches!(&e, IntentError::UndefinedVariable { .. }) {
-                                eprintln!("[ERROR] Template if-condition failed: {}", e);
-                            }
-                            Value::Bool(false)
-                        }
-                    };
+                    let condition_truthy =
+                        self.eval_template_condition(condition, "if condition", &mut result)?;
 
-                    if condition_value.is_truthy() {
+                    if condition_truthy {
                         let then_result = self.eval_template_parts(then_parts)?;
                         if let Value::String(s) = then_result {
                             result.push_str(&s);
@@ -8009,16 +8037,12 @@ impl Interpreter {
                         // Check elif chains
                         let mut handled = false;
                         for (elif_condition, elif_body) in elif_chains {
-                            let elif_value = match self.eval_expression(elif_condition) {
-                                Ok(v) => v,
-                                Err(e) => {
-                                    if !matches!(&e, IntentError::UndefinedVariable { .. }) {
-                                        eprintln!("[ERROR] Template elif-condition failed: {}", e);
-                                    }
-                                    Value::Bool(false)
-                                }
-                            };
-                            if elif_value.is_truthy() {
+                            let elif_truthy = self.eval_template_condition(
+                                elif_condition,
+                                "elif condition",
+                                &mut result,
+                            )?;
+                            if elif_truthy {
                                 let elif_result = self.eval_template_parts(elif_body)?;
                                 if let Value::String(s) = elif_result {
                                     result.push_str(&s);

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -987,6 +987,142 @@ print(page)
     );
 }
 
+/// DD-061 PR1: Non-undefined template condition errors must honor TypeMode.
+#[test]
+fn test_template_if_condition_errors_honor_type_mode() {
+    let code = r#"
+let page = """{{#if 1 / 0}}YES{{#else}}NO{{/if}}"""
+print(page)
+"#;
+
+    let (_, strict_stderr, strict_exit) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_ne!(
+        strict_exit, 0,
+        "strict mode should fail closed for template condition errors: {}",
+        strict_stderr
+    );
+
+    let (warn_stdout, warn_stderr, warn_exit) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "warn")]);
+    assert_eq!(warn_exit, 0, "warn mode should continue: {}", warn_stderr);
+    assert!(
+        warn_stderr.contains("[WARN]") && warn_stderr.contains("Template if condition failed"),
+        "warn mode should log through the template warning path: {}",
+        warn_stderr
+    );
+    assert!(
+        warn_stdout.contains("NO"),
+        "warn mode should treat the failed condition as false: {}",
+        warn_stdout
+    );
+    assert!(
+        warn_stdout.contains("TEMPLATE ERROR"),
+        "warn mode should include the normal template error comment: {}",
+        warn_stdout
+    );
+
+    let (forgiving_stdout, forgiving_stderr, forgiving_exit) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "forgiving")]);
+    assert_eq!(
+        forgiving_exit, 0,
+        "forgiving mode should continue: {}",
+        forgiving_stderr
+    );
+    assert!(
+        forgiving_stdout.contains("NO"),
+        "forgiving mode should treat the failed condition as false: {}",
+        forgiving_stdout
+    );
+    assert!(
+        !forgiving_stderr.contains("[WARN]") && !forgiving_stdout.contains("TEMPLATE ERROR"),
+        "forgiving mode should stay silent; stdout={}, stderr={}",
+        forgiving_stdout,
+        forgiving_stderr
+    );
+}
+
+/// DD-061 PR1: Elif condition errors use the same TypeMode policy as if conditions.
+#[test]
+fn test_template_elif_condition_errors_honor_type_mode() {
+    let code = r#"
+let page = """{{#if false}}NO{{#elif 1 / 0}}ELIF{{#else}}ELSE{{/if}}"""
+print(page)
+"#;
+
+    let (_, strict_stderr, strict_exit) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_ne!(
+        strict_exit, 0,
+        "strict mode should fail closed for elif condition errors: {}",
+        strict_stderr
+    );
+
+    let (warn_stdout, warn_stderr, warn_exit) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "warn")]);
+    assert_eq!(warn_exit, 0, "warn mode should continue: {}", warn_stderr);
+    assert!(
+        warn_stderr.contains("[WARN]") && warn_stderr.contains("Template elif condition failed"),
+        "warn mode should log elif errors through the template warning path: {}",
+        warn_stderr
+    );
+    assert!(
+        warn_stdout.contains("ELSE"),
+        "warn mode should fall through after failed elif condition: {}",
+        warn_stdout
+    );
+}
+
+/// DD-061 PR1: Filter errors should use the same TypeMode boundary as expressions.
+#[test]
+fn test_template_filter_errors_honor_type_mode() {
+    let code = r#"
+let page = """before {{"abcdef" | truncate("bad")}} after"""
+print(page)
+"#;
+
+    let (_, strict_stderr, strict_exit) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_ne!(
+        strict_exit, 0,
+        "strict mode should fail closed for filter errors: {}",
+        strict_stderr
+    );
+
+    let (warn_stdout, warn_stderr, warn_exit) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "warn")]);
+    assert_eq!(warn_exit, 0, "warn mode should continue: {}", warn_stderr);
+    assert!(
+        warn_stderr.contains("[WARN]") && warn_stderr.contains("Template filter failed"),
+        "warn mode should report filter errors through template warning path: {}",
+        warn_stderr
+    );
+    assert!(
+        warn_stdout.contains("before") && warn_stdout.contains("after"),
+        "warn mode should preserve surrounding template output: {}",
+        warn_stdout
+    );
+
+    let (forgiving_stdout, forgiving_stderr, forgiving_exit) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "forgiving")]);
+    assert_eq!(
+        forgiving_exit, 0,
+        "forgiving mode should continue: {}",
+        forgiving_stderr
+    );
+    assert!(
+        forgiving_stdout.contains("before") && forgiving_stdout.contains("after"),
+        "forgiving mode should preserve surrounding template output: {}",
+        forgiving_stdout
+    );
+    assert!(
+        !forgiving_stderr.contains("[WARN]") && !forgiving_stdout.contains("TEMPLATE ERROR"),
+        "forgiving mode should stay silent; stdout={}, stderr={}",
+        forgiving_stdout,
+        forgiving_stderr
+    );
+}
+
 /// @since v0.3.16
 /// Finding #36: Shared layout pattern with optional slots
 #[test]


### PR DESCRIPTION
## Summary
- Route template expression/filter/condition failures through the existing TypeMode template boundary
- Keep undefined template variables falsy/empty for optional slots, but fail closed in strict mode for real errors
- Update generated and human docs to describe NTNT template syntax, explicit #if/#for blocks, partial resolution, and literal delimiter escapes

## Verification
- cargo fmt
- cargo build --profile dev-release
- cargo test --test language_features_tests honor_type_mode -- --nocapture
- ./target/dev-release/ntnt docs --generate
- cargo test
- git diff --check

## Notes
PR1 for DD-061: no caching or broad template redesign; this is the contract/docs cleanup slice.