### PR TITLE
perf: add DD-061 benchmark harness

### DIFF
--- a/design-docs/dd-061-interpreter-performance-roadmap.md
+++ b/design-docs/dd-061-interpreter-performance-roadmap.md
@@ -166,20 +166,20 @@ This should be a docs/tests/runtime-semantics cleanup PR, not a syntax redesign.
 
 Scope:
 
-- [ ] Update the canonical template docs/spec so implementation and docs agree:
-  - [ ] `{{expr}}` is escaped output.
-  - [ ] `{{{expr}}}` is raw/unescaped output.
-  - [ ] `{{#if cond}}`, `{{#elif cond}}`, `{{#else}}`, `{{/if}}` are explicit conditional forms.
-  - [ ] `{{#for item in items}}`, `{{#empty}}`, `{{/for}}` are explicit loop forms.
-  - [ ] `{{> partial}}` and `{{> partial data_expr}}` are partial forms.
-  - [ ] filters use parenthesized args as canonical, with space-separated args preserved as compatibility sugar.
-  - [ ] `\{{` and `\}}` produce literal braces where supported.
-- [ ] Remove or correct doc claims that Mustache `{{#key}}...{{/key}}` sections are supported.
-- [ ] Explicitly document that ambiguous Mustache sections are a non-goal for now; use `#if` or `#for` instead.
-- [ ] Document external `.html` templates as `{{expr}}`-first; keep `#{expr}` documented only for inline triple-quoted ntnt strings.
-- [ ] Document partial lookup order exactly as implemented, or adjust implementation/tests to match the chosen lookup order.
-- [ ] Normalize template error handling so interpolation, filters, loops, and `#if` / `#elif` conditions consistently honor strict/warn/forgiving mode.
-- [ ] Add regression tests for the chosen contract without changing existing app-visible syntax.
+- [x] Update the canonical template docs/spec so implementation and docs agree:
+  - [x] `{{expr}}` is escaped output.
+  - [x] `{{{expr}}}` is raw/unescaped output.
+  - [x] `{{#if cond}}`, `{{#elif cond}}`, `{{#else}}`, `{{/if}}` are explicit conditional forms.
+  - [x] `{{#for item in items}}`, `{{#empty}}`, `{{/for}}` are explicit loop forms.
+  - [x] `{{> partial}}` and `{{> partial data_expr}}` are partial forms.
+  - [x] filters use parenthesized args as canonical, with space-separated args preserved as compatibility sugar.
+  - [x] `\{{` and `\}}` produce literal braces where supported.
+- [x] Remove or correct doc claims that Mustache `{{#key}}...{{/key}}` sections are supported.
+- [x] Explicitly document that ambiguous Mustache sections are a non-goal for now; use `#if` or `#for` instead.
+- [x] Document external `.html` templates as `{{expr}}`-first; keep `#{expr}` documented only for inline triple-quoted ntnt strings.
+- [x] Document partial lookup order exactly as implemented, or adjust implementation/tests to match the chosen lookup order.
+- [x] Normalize template error handling so interpolation, filters, loops, and `#if` / `#elif` conditions consistently honor strict/warn/forgiving mode.
+- [x] Add regression tests for the chosen contract without changing existing app-visible syntax.
 
 Likely files:
 
@@ -211,11 +211,11 @@ git diff --check
 
 Acceptance criteria:
 
-- [ ] Existing app template syntax remains valid.
-- [ ] Docs no longer claim unsupported Mustache section behavior.
-- [ ] Partial lookup rules are precise enough for cache dependency tracking.
-- [ ] Template condition errors follow the same TypeMode policy as other template errors.
-- [ ] The follow-up cache PR has a stable semantic contract to preserve.
+- [x] Existing app template syntax remains valid.
+- [x] Docs no longer claim unsupported Mustache section behavior.
+- [x] Partial lookup rules are precise enough for cache dependency tracking.
+- [x] Template condition errors follow the same TypeMode policy as other template errors.
+- [x] The follow-up cache PR has a stable semantic contract to preserve.
 
 ### PR 2: Benchmark harness and current-use-case baseline
 
@@ -225,19 +225,19 @@ This should be a small PR that adds scripts/examples only. It should establish b
 
 Scope:
 
-- [ ] Add a benchmark script under `scripts/bench/` or `tools/bench/` that can build `dev-release`, start benchmark servers, run `wrk`, and write JSON/Markdown results.
-- [ ] Add representative ntnt benchmark apps under `examples/perf/` or `benchmarks/`:
-  - [ ] plaintext response
-  - [ ] small JSON response
-  - [ ] route param + map read
-  - [ ] compute loop (`for i in 0..N`) for interpreter-only cost
-  - [ ] external template render with layout + partial + loop
-  - [ ] template-heavy page with 100 row maps
-  - [ ] single PostgreSQL query handler, optional/gated by env
-  - [ ] multi-query handler, optional/gated by env
-- [ ] Capture interpreter-only CLI timings separately from HTTP throughput where practical.
-- [ ] Document how to run the suite locally and how to compare before/after.
-- [ ] Ensure benchmarks are opt-in and do not make normal CI flaky.
+- [x] Add a benchmark script under `scripts/bench/` or `tools/bench/` that can build `dev-release`, start benchmark servers, run `wrk`, and write JSON/Markdown results.
+- [x] Add representative ntnt benchmark apps under `examples/perf/` or `benchmarks/`:
+  - [x] plaintext response
+  - [x] small JSON response
+  - [x] route param + map read
+  - [x] compute loop (`for i in 0..N`) for interpreter-only cost
+  - [x] external template render with layout + partial + loop
+  - [x] template-heavy page with 100 row maps
+  - [x] single PostgreSQL query handler, optional/gated by env
+  - [x] multi-query handler, optional/gated by env
+- [x] Capture interpreter-only CLI timings separately from HTTP throughput where practical.
+- [x] Document how to run the suite locally and how to compare before/after.
+- [x] Ensure benchmarks are opt-in and do not make normal CI flaky.
 
 Likely files:
 
@@ -255,9 +255,9 @@ python3 scripts/bench/run-benchmarks.py --quick
 
 Acceptance criteria:
 
-- [ ] A future PR can run one command and produce comparable baseline/after numbers.
-- [ ] The suite includes at least one template-heavy route and one interpreter-only route.
-- [ ] DB benchmarks are skipped unless env config is present.
+- [x] A future PR can run one command and produce comparable baseline/after numbers.
+- [x] The suite includes at least one template-heavy route and one interpreter-only route.
+- [x] DB benchmarks are skipped unless env config is present.
 
 ### PR 3: Automatic path-keyed template AST cache for `template()`
 
@@ -499,8 +499,8 @@ Recommended local toolchain:
 
 ## Updated Definition of Done
 
-- [ ] PR 1 clarifies and tests the template contract without breaking existing apps.
-- [ ] PR 2 adds a repeatable benchmark harness and baseline results.
+- [x] PR 1 clarifies and tests the template contract without breaking existing apps.
+- [x] PR 2 adds a repeatable benchmark harness and baseline results.
 - [ ] PR 3 makes ordinary `template(path, data)` use a safe automatic AST/cache path.
 - [ ] PR 4 reduces template render/loop scope overhead without semantic drift.
 - [ ] PR 5 adds a safe direct native/global call fast path, or documents why profiling does not justify it.
@@ -513,9 +513,7 @@ Recommended local toolchain:
 
 ## Current Recommendation
 
-Start with **PR 1: template system contract cleanup**. It is the right first PR because it is low-risk, preserves existing app syntax, and makes the subsequent cache work target a clear, consistent template language.
-
-After PR 1 is merged, proceed with **PR 2: benchmark harness**, then **PR 3: automatic `template()` AST cache**.
+Start with **PR 3: automatic `template()` AST cache** now that PR 1 has locked the template contract and PR 2 has added the benchmark harness.
 
 The template cache remains the best first implementation performance target because it is:
 

--- a/examples/perf/README.md
+++ b/examples/perf/README.md
@@ -1,0 +1,53 @@
+# DD-061 performance benchmarks
+
+This directory contains the opt-in benchmark fixtures for DD-061. Normal CI does not run these benchmarks; they are for local before/after comparisons on performance PRs.
+
+## Run the quick suite
+
+```bash
+python3 scripts/bench/run-benchmarks.py --quick
+```
+
+The harness:
+
+1. builds `target/dev-release/ntnt`
+2. starts `examples/perf/server.tnt` on `127.0.0.1:18080`
+3. runs representative HTTP routes with `wrk` when installed, or a sequential `urllib` fallback when it is not
+4. runs an interpreter-only CLI compute fixture
+5. writes JSON and Markdown results under `target/perf-bench/`
+
+## Run a fuller local suite
+
+```bash
+python3 scripts/bench/run-benchmarks.py --duration 10s --runs 3 --connections 32 --threads 4
+```
+
+Durations use `s` or `m` suffixes so wrk and the fallback runner measure the same window.
+Use the same command on `main` and on the performance branch, then compare the generated Markdown summaries.
+
+## Optional PostgreSQL routes
+
+DB routes are skipped unless both of these are true:
+
+- `DATABASE_URL` is set
+- `--include-db` is passed
+
+Example:
+
+```bash
+DATABASE_URL=postgres://ntnt:password@localhost/ntnt \
+  python3 scripts/bench/run-benchmarks.py --quick --include-db
+```
+
+The DB fixtures use simple `SELECT` queries so they do not require schema setup. They intentionally measure the current full connect-query-close request path rather than pooled query-only latency. Keep DB numbers separate from the default HTTP/template/interpreter results; database latency can easily drown out interpreter changes, as databases enjoy making everything about themselves.
+
+## Benchmarked routes
+
+- `/` — plaintext response
+- `/json` — small JSON response
+- `/param/{id}` — route params and map reads
+- `/compute` — interpreter loop inside an HTTP request
+- `/template/layout` — external template render with layout, partial, and loop
+- `/template/rows` — template-heavy 100-row render
+- `/db/single` — optional single PostgreSQL query
+- `/db/multi` — optional small multi-query PostgreSQL handler

--- a/examples/perf/compute_cli.tnt
+++ b/examples/perf/compute_cli.tnt
@@ -1,0 +1,13 @@
+// Interpreter-only benchmark fixture for DD-061.
+// Run with: ./target/dev-release/ntnt run examples/perf/compute_cli.tnt
+
+fn compute(iterations: Int) -> Int {
+    let mut total = 0
+    for i in 0..iterations {
+        total = total + ((i * 3) % 17)
+    }
+    return total
+}
+
+let result = compute(200000)
+print("compute=" + str(result))

--- a/examples/perf/server.tnt
+++ b/examples/perf/server.tnt
@@ -8,6 +8,8 @@ import { get_env } from "std/env"
 fn make_rows(count: Int) -> Array {
     let mut rows = []
     for i in 0..count {
+        // ntnt array construction returns a new array today. Rows are built once
+        // at startup so this does not pollute per-request template timings.
         rows = rows + [map {
             "id": i,
             "name": "Widget " + str(i),

--- a/examples/perf/server.tnt
+++ b/examples/perf/server.tnt
@@ -1,0 +1,127 @@
+// DD-061 performance benchmark HTTP server.
+// Run with: ./target/dev-release/ntnt run examples/perf/server.tnt
+// The benchmark harness expects this server on localhost:18080.
+
+import { html, json, text } from "std/http/server"
+import { get_env } from "std/env"
+
+fn make_rows(count: Int) -> Array {
+    let mut rows = []
+    for i in 0..count {
+        rows = rows + [map {
+            "id": i,
+            "name": "Widget " + str(i),
+            "status": if i % 2 == 0 { "active" } else { "draft" },
+            "score": i * 7,
+            "summary": "Benchmark row " + str(i) + " with enough text to exercise escaping and template output."
+        }]
+    }
+    return rows
+}
+
+// Build row data once at startup so template routes mostly measure rendering work.
+let ROWS_10 = make_rows(10)
+let ROWS_100 = make_rows(100)
+
+fn plaintext(req: Map) -> Map {
+    return text("Hello, ntnt performance harness")
+}
+
+fn small_json(req: Map) -> Map {
+    return json(map {
+        "ok": true,
+        "message": "Hello, ntnt performance harness",
+        "items": [1, 2, 3, 4, 5]
+    })
+}
+
+fn route_param(req: Map) -> Map {
+    let id = req.params["id"] ?? "missing"
+    return json(map {
+        "id": id,
+        "label": "item-" + id,
+        "metadata": map { "source": "route", "active": true }
+    })
+}
+
+fn compute_loop(req: Map) -> Map {
+    let mut total = 0
+    for i in 0..5000 {
+        total = total + ((i * 3) % 17)
+    }
+    return json(map { "total": total })
+}
+
+fn template_layout(req: Map) -> Map {
+    let rendered = template("views/page.html", map {
+        "title": "Template layout benchmark",
+        "heading": "Layout + partial + loop",
+        "rows": ROWS_10
+    })
+    return html(rendered)
+}
+
+fn template_rows(req: Map) -> Map {
+    let rendered = template("views/page.html", map {
+        "title": "Template row benchmark",
+        "heading": "One hundred row render",
+        "rows": ROWS_100
+    })
+    return html(rendered)
+}
+
+// The optional DB routes intentionally measure ntnt's current full
+// connect-query-close request path. Keep these numbers separate from pooled
+// query-only benchmarks.
+fn db_single(req: Map) -> Map {
+    import { connect, query_one, close } from "std/db/postgres"
+
+    let db_url = get_env("DATABASE_URL") ?? ""
+    if db_url == "" {
+        return json(map { "skipped": true, "reason": "DATABASE_URL is not set" })
+    }
+
+    let db = connect(db_url) otherwise {
+        return json(map { "error": "connect_failed" })
+    }
+    let row = query_one(db, "SELECT 1 AS value", []) otherwise {
+        close(db)
+        return json(map { "error": "query_failed" })
+    }
+    close(db)
+    return json(map { "value": row["value"] ?? 1 })
+}
+
+fn db_multi(req: Map) -> Map {
+    import { connect, query_one, close } from "std/db/postgres"
+
+    let db_url = get_env("DATABASE_URL") ?? ""
+    if db_url == "" {
+        return json(map { "skipped": true, "reason": "DATABASE_URL is not set" })
+    }
+
+    let db = connect(db_url) otherwise {
+        return json(map { "error": "connect_failed" })
+    }
+    let mut total = 0
+    for i in 0..5 {
+        let row = query_one(db, "SELECT $1::int AS value", [i]) otherwise {
+            close(db)
+            return json(map { "error": "query_failed" })
+        }
+        total = total + (row["value"] ?? 0)
+    }
+    close(db)
+    return json(map { "total": total })
+}
+
+get("/", plaintext)
+get("/json", small_json)
+get("/param/{id}", route_param)
+get("/compute", compute_loop)
+get("/template/layout", template_layout)
+get("/template/rows", template_rows)
+get("/db/single", db_single)
+get("/db/multi", db_multi)
+
+listen(18080)

--- a/examples/perf/views/page.html
+++ b/examples/perf/views/page.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{title}}</title>
+</head>
+<body>
+  {{> nav}}
+  <main>
+    <h1>{{heading}}</h1>
+    <section class="rows">
+      {{#for row in rows}}
+        {{> row_card row}}
+      {{#empty}}
+        <p>No rows.</p>
+      {{/for}}
+    </section>
+  </main>
+</body>
+</html>

--- a/examples/perf/views/partials/nav.html
+++ b/examples/perf/views/partials/nav.html
@@ -1,0 +1,6 @@
+<nav class="perf-nav">
+  <a href="/">Plaintext</a>
+  <a href="/json">JSON</a>
+  <a href="/template/layout">Template layout</a>
+  <a href="/template/rows">Template rows</a>
+</nav>

--- a/examples/perf/views/partials/row_card.html
+++ b/examples/perf/views/partials/row_card.html
@@ -1,0 +1,6 @@
+<article class="row-card" data-id="{{id}}">
+  <h2>{{name}}</h2>
+  <p>Status: {{status | default("unknown")}}</p>
+  <p>Score: {{score}}</p>
+  <p>{{summary}}</p>
+</article>

--- a/scripts/bench/run-benchmarks.py
+++ b/scripts/bench/run-benchmarks.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""DD-061 performance benchmark harness for ntnt.
+
+The harness is intentionally opt-in. It builds the dev-release binary, starts the
+representative benchmark server, runs HTTP route benchmarks with `wrk` when
+available (or a deterministic sequential urllib fallback), records an
+interpreter-only CLI timing, and writes JSON plus Markdown summaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import urlopen
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SERVER = REPO_ROOT / "examples" / "perf" / "server.tnt"
+DEFAULT_CLI = REPO_ROOT / "examples" / "perf" / "compute_cli.tnt"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "target" / "perf-bench"
+HTTP_BENCHMARKS = [
+    {"name": "plaintext route", "path": "/"},
+    {"name": "small JSON route", "path": "/json"},
+    {"name": "route param + map read", "path": "/param/12345"},
+    {"name": "compute loop route", "path": "/compute"},
+    {"name": "template layout + partial", "path": "/template/layout"},
+    {"name": "template 100-row loop", "path": "/template/rows"},
+]
+DB_BENCHMARKS = [
+    {"name": "PostgreSQL single query", "path": "/db/single"},
+    {"name": "PostgreSQL multi query", "path": "/db/multi"},
+]
+
+
+@dataclass
+class CommandResult:
+    command: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed_ms: float
+
+
+def run_command(command: list[str], *, cwd: Path = REPO_ROOT, env: dict[str, str] | None = None) -> CommandResult:
+    started = time.perf_counter()
+    proc = subprocess.run(command, cwd=cwd, env=env, text=True, capture_output=True)
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    return CommandResult(command, proc.returncode, proc.stdout, proc.stderr, elapsed_ms)
+
+
+def require_success(result: CommandResult) -> None:
+    if result.returncode == 0:
+        return
+    command = " ".join(result.command)
+    sys.stderr.write(f"Command failed: {command}\n")
+    if result.stdout:
+        sys.stderr.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    raise SystemExit(result.returncode)
+
+
+def ntnt_binary(args: argparse.Namespace) -> Path:
+    if args.ntnt_bin:
+        return Path(args.ntnt_bin).resolve()
+    return REPO_ROOT / "target" / "dev-release" / "ntnt"
+
+
+def build_if_needed(args: argparse.Namespace) -> None:
+    if args.skip_build:
+        return
+    result = run_command(["cargo", "build", "--profile", "dev-release"])
+    require_success(result)
+
+
+def wait_for_server(base_url: str, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(base_url + "/", timeout=1) as response:
+                if 200 <= response.status < 500:
+                    return
+        except Exception as exc:  # noqa: BLE001 - readiness retry reports last error
+            last_error = exc
+        time.sleep(0.1)
+    raise RuntimeError(f"server did not become ready at {base_url}: {last_error}")
+
+
+def start_server(args: argparse.Namespace, env: dict[str, str]) -> tuple[subprocess.Popen[str], Any]:
+    command = [str(ntnt_binary(args)), "run", str(DEFAULT_SERVER)]
+    log_file = tempfile.TemporaryFile(mode="w+")
+    proc = subprocess.Popen(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        wait_for_server(args.base_url, args.startup_timeout)
+    except Exception:
+        stop_process(proc)
+        log_file.seek(0)
+        output = log_file.read()[-4000:]
+        log_file.close()
+        raise RuntimeError(f"failed to start benchmark server. Recent output:\n{output}")
+    return proc, log_file
+
+
+def stop_process(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+        proc.wait(timeout=5)
+    except Exception:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def parse_wrk_output(output: str) -> dict[str, Any]:
+    requests_match = re.search(r"Requests/sec:\s+([0-9.]+)", output)
+    transfer_match = re.search(r"Transfer/sec:\s+([^\n]+)", output)
+    latency_match = re.search(r"Latency\s+([0-9.]+)(us|ms|s)", output)
+    result: dict[str, Any] = {"raw": output}
+    warnings: list[str] = []
+    if requests_match:
+        result["requests_per_second"] = float(requests_match.group(1))
+    else:
+        warnings.append("wrk Requests/sec output did not match expected format")
+    if transfer_match:
+        result["transfer_per_second"] = transfer_match.group(1).strip()
+    if latency_match:
+        value = float(latency_match.group(1))
+        unit = latency_match.group(2)
+        multiplier = {"us": 0.001, "ms": 1.0, "s": 1000.0}[unit]
+        result["avg_latency_ms"] = value * multiplier
+    else:
+        warnings.append("wrk Latency output did not match expected format")
+    if warnings:
+        result["parse_warning"] = "; ".join(warnings)
+    return result
+
+
+def run_wrk(url: str, args: argparse.Namespace) -> dict[str, Any]:
+    command = [
+        "wrk",
+        "-t",
+        str(args.threads),
+        "-c",
+        str(args.connections),
+        "-d",
+        args.duration,
+        url,
+    ]
+    result = run_command(command)
+    if result.returncode != 0:
+        return {
+            "tool": "wrk",
+            "ok": False,
+            "command": command,
+            "error": result.stderr or result.stdout,
+            "elapsed_ms": result.elapsed_ms,
+        }
+    parsed = parse_wrk_output(result.stdout)
+    parsed.update({"tool": "wrk", "ok": True, "command": command, "elapsed_ms": result.elapsed_ms})
+    return parsed
+
+
+def run_urllib_loop(url: str, args: argparse.Namespace) -> dict[str, Any]:
+    duration_s = parse_duration_seconds(args.duration)
+    started_all = time.perf_counter()
+    deadline = started_all + duration_s
+    latencies_ms: list[float] = []
+    errors = 0
+    while time.perf_counter() < deadline:
+        started = time.perf_counter()
+        try:
+            with urlopen(url, timeout=args.request_timeout) as response:
+                response.read()
+        except (OSError, URLError):
+            errors += 1
+            continue
+        latencies_ms.append((time.perf_counter() - started) * 1000)
+    elapsed_s = max(time.perf_counter() - started_all, 0.001)
+    requests = len(latencies_ms)
+    return {
+        "tool": "urllib-sequential",
+        "ok": errors == 0,
+        "requests": requests,
+        "errors": errors,
+        "requests_per_second": requests / elapsed_s,
+        "avg_latency_ms": statistics.mean(latencies_ms) if latencies_ms else None,
+        "p95_latency_ms": percentile(latencies_ms, 95) if latencies_ms else None,
+    }
+
+
+def parse_duration_seconds(value: str) -> float:
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)(s|m)?", value)
+    if not match:
+        raise ValueError(f"unsupported duration: {value}; use seconds or minutes, e.g. 2s or 1m")
+    number = float(match.group(1))
+    unit = match.group(2) or "s"
+    return number * {"s": 1.0, "m": 60.0}[unit]
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((pct / 100.0) * (len(ordered) - 1))))
+    return ordered[index]
+
+
+def run_http_benchmark(bench: dict[str, str], args: argparse.Namespace, use_wrk: bool) -> dict[str, Any]:
+    url = args.base_url + bench["path"]
+    result = run_wrk(url, args) if use_wrk else run_urllib_loop(url, args)
+    return {"name": bench["name"], "path": bench["path"], "url": url, **result}
+
+
+def run_cli_benchmark(args: argparse.Namespace, env: dict[str, str]) -> dict[str, Any]:
+    command = [str(ntnt_binary(args)), "run", str(DEFAULT_CLI)]
+    timings: list[float] = []
+    outputs: list[str] = []
+    for _ in range(args.runs):
+        result = run_command(command, env=env)
+        if result.returncode != 0:
+            return {
+                "name": "interpreter compute CLI",
+                "ok": False,
+                "command": command,
+                "runs": len(timings),
+                "error": result.stderr or result.stdout or "CLI benchmark failed",
+            }
+        timings.append(result.elapsed_ms)
+        outputs.append(result.stdout.strip())
+    return {
+        "name": "interpreter compute CLI",
+        "ok": True,
+        "command": command,
+        "runs": args.runs,
+        "median_ms": statistics.median(timings),
+        "best_ms": min(timings),
+        "worst_ms": max(timings),
+        "outputs": outputs[-1:],
+    }
+
+
+def write_results(results: dict[str, Any], output_dir: Path) -> tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    json_path = output_dir / f"ntnt-perf-{stamp}.json"
+    md_path = output_dir / f"ntnt-perf-{stamp}.md"
+    json_path.write_text(json.dumps(results, indent=2) + "\n")
+    md_path.write_text(render_markdown(results))
+    return json_path, md_path
+
+
+def render_markdown(results: dict[str, Any]) -> str:
+    lines = [
+        "# ntnt DD-061 benchmark run",
+        "",
+        f"- timestamp: `{results['timestamp']}`",
+        f"- git: `{results['git']['short_sha']}` on `{results['git']['branch']}`",
+        f"- ntnt: `{results['ntnt_binary']}`",
+        f"- HTTP tool: `{results['http_tool']}`",
+        "",
+        "## HTTP benchmarks",
+        "",
+        "| Benchmark | Path | RPS | Avg latency ms | Notes |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for item in results["http"]:
+        rps = format_number(item.get("requests_per_second"))
+        latency = format_number(item.get("avg_latency_ms"))
+        notes = item.get("parse_warning") or ("ok" if item.get("ok") else item.get("error", "error"))
+        lines.append(f"| {item['name']} | `{item['path']}` | {rps} | {latency} | {notes} |")
+    cli = results["cli"]
+    lines.extend(["", "## CLI benchmark", ""])
+    if cli.get("ok", False):
+        lines.append(
+            f"- {cli['name']}: median `{cli['median_ms']:.2f}ms`, best `{cli['best_ms']:.2f}ms`, worst `{cli['worst_ms']:.2f}ms` over {cli['runs']} run(s)"
+        )
+    else:
+        lines.append(f"- {cli['name']}: failed after {cli['runs']} successful run(s): `{cli.get('error', 'unknown error')}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_number(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def git_context() -> dict[str, str]:
+    branch = git_output(["git", "branch", "--show-current"])
+    sha = git_output(["git", "rev-parse", "HEAD"])
+    short_sha = sha[:12] if sha != "unknown" else "unknown"
+    return {"branch": branch, "sha": sha, "short_sha": short_sha}
+
+
+def git_output(command: list[str]) -> str:
+    result = run_command(command)
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        return "unknown"
+    return value
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run ntnt DD-061 performance benchmarks.")
+    parser.add_argument("--quick", action="store_true", help="Use short durations and one CLI timing run.")
+    parser.add_argument("--skip-build", action="store_true", help="Do not run cargo build before benchmarks.")
+    parser.add_argument("--ntnt-bin", help="Path to ntnt binary. Defaults to target/dev-release/ntnt.")
+    parser.add_argument(
+        "--base-url",
+        default="http://127.0.0.1:18080",
+        help="Benchmark server base URL. Must match examples/perf/server.tnt's listen() port.",
+    )
+    parser.add_argument("--duration", default=None, help="HTTP benchmark duration per route, e.g. 3s or 10s.")
+    parser.add_argument("--threads", type=int, default=2, help="wrk thread count.")
+    parser.add_argument("--connections", type=int, default=16, help="wrk connection count.")
+    parser.add_argument("--runs", type=int, default=None, help="CLI benchmark repetitions.")
+    parser.add_argument("--include-db", action="store_true", help="Include PostgreSQL routes when DATABASE_URL is set.")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--startup-timeout", type=float, default=10.0)
+    parser.add_argument("--request-timeout", type=float, default=5.0)
+    args = parser.parse_args()
+    if args.quick:
+        args.duration = args.duration or "2s"
+        args.runs = args.runs or 1
+        args.connections = min(args.connections, 8)
+    else:
+        args.duration = args.duration or "10s"
+        args.runs = args.runs or 3
+    try:
+        parse_duration_seconds(args.duration)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if re.fullmatch(r"[0-9]+(?:\.[0-9]+)?", args.duration):
+        args.duration = f"{args.duration}s"
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    build_if_needed(args)
+
+    env = os.environ.copy()
+    env.setdefault("NTNT_ENV", "production")
+    env.setdefault("NTNT_TYPE_MODE", "strict")
+    env.setdefault("NTNT_LINT_MODE", "strict")
+
+    use_wrk = shutil.which("wrk") is not None
+    benches = list(HTTP_BENCHMARKS)
+    if args.include_db and env.get("DATABASE_URL"):
+        benches.extend(DB_BENCHMARKS)
+
+    server, server_log = start_server(args, env)
+    try:
+        http_results = [run_http_benchmark(bench, args, use_wrk) for bench in benches]
+    finally:
+        stop_process(server)
+        server_log.close()
+
+    cli_result = run_cli_benchmark(args, env)
+    results = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "git": git_context(),
+        "ntnt_binary": str(ntnt_binary(args)),
+        "http_tool": "wrk" if use_wrk else "urllib-sequential",
+        "quick": args.quick,
+        "http": http_results,
+        "cli": cli_result,
+        "db_included": args.include_db and bool(env.get("DATABASE_URL")),
+    }
+    json_path, md_path = write_results(results, args.output_dir)
+    print(f"Wrote {json_path}")
+    print(f"Wrote {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/run-benchmarks.py
+++ b/scripts/bench/run-benchmarks.py
@@ -114,12 +114,12 @@ def start_server(args: argparse.Namespace, env: dict[str, str]) -> tuple[subproc
     )
     try:
         wait_for_server(args.base_url, args.startup_timeout)
-    except Exception:
+    except Exception as exc:
         stop_process(proc)
         log_file.seek(0)
         output = log_file.read()[-4000:]
         log_file.close()
-        raise RuntimeError(f"failed to start benchmark server. Recent output:\n{output}")
+        raise RuntimeError(f"failed to start benchmark server. Recent output:\n{output}") from exc
     return proc, log_file
 
 
@@ -295,7 +295,14 @@ def render_markdown(results: dict[str, Any]) -> str:
     for item in results["http"]:
         rps = format_number(item.get("requests_per_second"))
         latency = format_number(item.get("avg_latency_ms"))
-        notes = item.get("parse_warning") or ("ok" if item.get("ok") else item.get("error", "error"))
+        if item.get("parse_warning"):
+            notes = item["parse_warning"]
+        elif item.get("ok"):
+            notes = "ok"
+        elif "errors" in item:
+            notes = f"{item['errors']} request error(s)"
+        else:
+            notes = item.get("error", "error")
         lines.append(f"| {item['name']} | `{item['path']}` | {rps} | {latency} | {notes} |")
     cli = results["cli"]
     lines.extend(["", "## CLI benchmark", ""])


### PR DESCRIPTION
## Summary
- Adds the DD-061 PR 2 benchmark harness at `scripts/bench/run-benchmarks.py`.
- Adds representative perf fixtures under `examples/perf/` for plaintext, JSON, route params, compute loop, templates/partials/loops, CLI compute, and optional PostgreSQL routes.
- Updates DD-061 to mark PR 1/2 complete and recommend the template AST cache as PR 3.

## Notes
- Default runs are database-free; DB routes are opt-in with `--include-db` and `DATABASE_URL`.
- Results are written to `target/perf-bench/` as JSON and Markdown.
- Greptile local review got several rounds of harness cleanup; final rerun timed out after dispatch, so this is pushed for the PR-side check rather than continuing the tiny robot treadmill.

## Verification
- `python3` AST parse for `scripts/bench/run-benchmarks.py`
- `./target/dev-release/ntnt validate examples/perf`
- `./target/dev-release/ntnt lint examples/perf --strict` (suggestions only: missing contracts in perf fixture functions)
- `python3 scripts/bench/run-benchmarks.py --quick --duration 1`
- `python3 scripts/bench/run-benchmarks.py --duration 500ms` rejects unsupported duration units
- `git diff --check`
