### PR TITLE
Warn on unclosed Postgres connects in functions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4402,15 +4402,30 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                 &mut closes,
             );
 
-            for (connect_name, handle_name, line) in connects {
-                let is_closed = handle_name.as_ref().is_some_and(|handle_name| {
-                    closes.iter().any(|closed| {
-                        closed.unconditional
-                            && closed.handle_name == *handle_name
-                            && closed.line > line
-                    })
-                });
-                if !is_closed {
+            let mut closed_connects = vec![false; connects.len()];
+            let mut unconditional_closes: Vec<&PostgresCloseCall> =
+                closes.iter().filter(|close| close.unconditional).collect();
+            unconditional_closes.sort_by_key(|close| close.line);
+
+            for close in unconditional_closes {
+                // A close consumes the most recent still-open binding with the same name.
+                // That keeps a later shadowed `let conn = ...; pg_close(conn)` from also
+                // satisfying an earlier `conn` binding that the program can no longer name.
+                if let Some((connect_index, _)) = connects.iter().enumerate().rev().find(
+                    |(connect_index, (_, handle_name, connect_line))| {
+                        !closed_connects[*connect_index]
+                            && handle_name.as_deref() == Some(close.handle_name.as_str())
+                            && *connect_line < close.line
+                    },
+                ) {
+                    closed_connects[connect_index] = true;
+                }
+            }
+
+            for (connect_index, (connect_name, _handle_name, line)) in
+                connects.into_iter().enumerate()
+            {
+                if !closed_connects[connect_index] {
                     issues.push(json!({
                         "severity": "warning",
                         "rule": "postgres_connect_in_function",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3842,80 +3842,569 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
     }
 
     if !postgres_connect_functions.is_empty() {
-        let mut in_template_string = false;
-        let mut function_depth: Option<i32> = None;
-        let mut function_connects: Vec<(String, usize)> = Vec::new();
-        let mut function_closes_connection = false;
-        let mut warned_lines = std::collections::HashSet::new();
+        fn located_line(stmt: &Statement) -> usize {
+            match stmt {
+                Statement::Located { line, .. } => *line,
+                _ => 0,
+            }
+        }
 
-        let mut emit_function_connect_warnings =
-            |issues: &mut Vec<serde_json::Value>,
-             function_connects: &[(String, usize)],
-             function_closes_connection: bool| {
-                if function_closes_connection {
-                    return;
+        fn collect_postgres_calls_in_expr(
+            expr: &Expression,
+            line: usize,
+            assigned_to: Option<&str>,
+            connect_names: &std::collections::HashSet<String>,
+            close_names: &std::collections::HashSet<String>,
+            connects: &mut Vec<(String, Option<String>, usize)>,
+            closes: &mut Vec<(String, usize)>,
+        ) {
+            match expr {
+                Expression::Call {
+                    function,
+                    arguments,
+                } => {
+                    if let Expression::Identifier(name) = function.as_ref() {
+                        if connect_names.contains(name) {
+                            connects.push((name.clone(), assigned_to.map(str::to_string), line));
+                        }
+                        if close_names.contains(name) {
+                            if let Some(Expression::Identifier(handle_name)) = arguments.first() {
+                                closes.push((handle_name.clone(), line));
+                            }
+                        }
+                    }
+                    collect_postgres_calls_in_expr(
+                        function,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    for arg in arguments {
+                        collect_postgres_calls_in_expr(
+                            arg,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
                 }
-                for (connect_name, line) in function_connects {
-                    if warned_lines.insert(*line) {
-                        issues.push(json!({
+                Expression::Binary { left, right, .. } => {
+                    collect_postgres_calls_in_expr(
+                        left,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    collect_postgres_calls_in_expr(
+                        right,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                }
+                Expression::Unary { operand, .. }
+                | Expression::Await(operand)
+                | Expression::Try(operand) => collect_postgres_calls_in_expr(
+                    operand,
+                    line,
+                    None,
+                    connect_names,
+                    close_names,
+                    connects,
+                    closes,
+                ),
+                Expression::Array(items) => {
+                    for item in items {
+                        collect_postgres_calls_in_expr(
+                            item,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
+                }
+                Expression::MapLiteral(pairs) => {
+                    for (key, value) in pairs {
+                        collect_postgres_calls_in_expr(
+                            key,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                        collect_postgres_calls_in_expr(
+                            value,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
+                }
+                Expression::MethodCall {
+                    object, arguments, ..
+                } => {
+                    collect_postgres_calls_in_expr(
+                        object,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    for arg in arguments {
+                        collect_postgres_calls_in_expr(
+                            arg,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
+                }
+                Expression::FieldAccess { object, .. } => collect_postgres_calls_in_expr(
+                    object,
+                    line,
+                    None,
+                    connect_names,
+                    close_names,
+                    connects,
+                    closes,
+                ),
+                Expression::Index { object, index } => {
+                    collect_postgres_calls_in_expr(
+                        object,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    collect_postgres_calls_in_expr(
+                        index,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                }
+                Expression::Range { start, end, .. } => {
+                    collect_postgres_calls_in_expr(
+                        start,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    collect_postgres_calls_in_expr(
+                        end,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                }
+                Expression::InterpolatedString(parts) => {
+                    for part in parts {
+                        if let ntnt::ast::StringPart::Expr(expr) = part {
+                            collect_postgres_calls_in_expr(
+                                expr,
+                                line,
+                                None,
+                                connect_names,
+                                close_names,
+                                connects,
+                                closes,
+                            );
+                        }
+                    }
+                }
+                Expression::StructLiteral { fields, .. } => {
+                    for (_, value) in fields {
+                        collect_postgres_calls_in_expr(
+                            value,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
+                }
+                Expression::EnumVariant { arguments, .. } => {
+                    for arg in arguments {
+                        collect_postgres_calls_in_expr(
+                            arg,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
+                }
+                Expression::Assign { target, value } => {
+                    collect_postgres_calls_in_expr(
+                        target,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    collect_postgres_calls_in_expr(
+                        value,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                }
+                Expression::IfExpr {
+                    condition,
+                    then_branch,
+                    else_branch,
+                } => {
+                    collect_postgres_calls_in_expr(
+                        condition,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    collect_postgres_calls_in_expr(
+                        then_branch,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    collect_postgres_calls_in_expr(
+                        else_branch,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                }
+                Expression::Match { scrutinee, arms } => {
+                    collect_postgres_calls_in_expr(
+                        scrutinee,
+                        line,
+                        None,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    );
+                    for arm in arms {
+                        if let Some(guard) = &arm.guard {
+                            collect_postgres_calls_in_expr(
+                                guard,
+                                line,
+                                None,
+                                connect_names,
+                                close_names,
+                                connects,
+                                closes,
+                            );
+                        }
+                        collect_postgres_calls_in_expr(
+                            &arm.body,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
+                }
+                Expression::Block(block)
+                | Expression::Lambda { body: block, .. }
+                | Expression::TryCatch { body: block } => collect_postgres_calls_in_block(
+                    block,
+                    connect_names,
+                    close_names,
+                    connects,
+                    closes,
+                ),
+                Expression::TemplateString(_)
+                | Expression::Integer(_)
+                | Expression::Float(_)
+                | Expression::String(_)
+                | Expression::Bool(_)
+                | Expression::Unit
+                | Expression::Identifier(_) => {}
+            }
+        }
+
+        fn collect_postgres_calls_in_block(
+            block: &ntnt::ast::Block,
+            connect_names: &std::collections::HashSet<String>,
+            close_names: &std::collections::HashSet<String>,
+            connects: &mut Vec<(String, Option<String>, usize)>,
+            closes: &mut Vec<(String, usize)>,
+        ) {
+            for stmt in &block.statements {
+                let line = located_line(stmt);
+                match unwrap_located(stmt) {
+                    Statement::Let {
+                        name,
+                        value,
+                        otherwise,
+                        ..
+                    } => {
+                        if let Some(expr) = value {
+                            collect_postgres_calls_in_expr(
+                                expr,
+                                line,
+                                Some(name),
+                                connect_names,
+                                close_names,
+                                connects,
+                                closes,
+                            );
+                        }
+                        if let Some(block) = otherwise {
+                            collect_postgres_calls_in_block(
+                                block,
+                                connect_names,
+                                close_names,
+                                connects,
+                                closes,
+                            );
+                        }
+                    }
+                    Statement::Expression(expr) | Statement::Defer(expr) => {
+                        collect_postgres_calls_in_expr(
+                            expr,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        )
+                    }
+                    Statement::Return { value, otherwise } => {
+                        if let Some(expr) = value {
+                            collect_postgres_calls_in_expr(
+                                expr,
+                                line,
+                                None,
+                                connect_names,
+                                close_names,
+                                connects,
+                                closes,
+                            );
+                        }
+                        if let Some(block) = otherwise {
+                            collect_postgres_calls_in_block(
+                                block,
+                                connect_names,
+                                close_names,
+                                connects,
+                                closes,
+                            );
+                        }
+                    }
+                    Statement::If {
+                        condition,
+                        then_branch,
+                        else_branch,
+                    } => {
+                        collect_postgres_calls_in_expr(
+                            condition,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                        collect_postgres_calls_in_block(
+                            then_branch,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                        if let Some(block) = else_branch {
+                            collect_postgres_calls_in_block(
+                                block,
+                                connect_names,
+                                close_names,
+                                connects,
+                                closes,
+                            );
+                        }
+                    }
+                    Statement::While { condition, body } => {
+                        collect_postgres_calls_in_expr(
+                            condition,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                        collect_postgres_calls_in_block(
+                            body,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
+                    Statement::ForIn { iterable, body, .. } => {
+                        collect_postgres_calls_in_expr(
+                            iterable,
+                            line,
+                            None,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                        collect_postgres_calls_in_block(
+                            body,
+                            connect_names,
+                            close_names,
+                            connects,
+                            closes,
+                        );
+                    }
+                    Statement::Loop { body } => collect_postgres_calls_in_block(
+                        body,
+                        connect_names,
+                        close_names,
+                        connects,
+                        closes,
+                    ),
+                    // Nested declarations are scanned independently by scan_postgres_connect_lint().
+                    Statement::Function { .. } => {}
+                    _ => {}
+                }
+            }
+        }
+
+        fn emit_postgres_connect_warnings_for_function(
+            function_body: &ntnt::ast::Block,
+            connect_names: &std::collections::HashSet<String>,
+            close_names: &std::collections::HashSet<String>,
+            issues: &mut Vec<serde_json::Value>,
+        ) {
+            let mut connects = Vec::new();
+            let mut closes = Vec::new();
+            collect_postgres_calls_in_block(
+                function_body,
+                connect_names,
+                close_names,
+                &mut connects,
+                &mut closes,
+            );
+
+            for (connect_name, handle_name, line) in connects {
+                let is_closed = handle_name.as_ref().is_some_and(|handle_name| {
+                    closes.iter().any(|(closed_name, close_line)| {
+                        closed_name == handle_name && *close_line > line
+                    })
+                });
+                if !is_closed {
+                    issues.push(json!({
                         "severity": "warning",
                         "rule": "postgres_connect_in_function",
-                        "message": format!("Postgres {}() is called inside a function without a matching close(). This can create a new connection pool on every request or repeated call; open the connection once at module scope or close it before returning.", connect_name),
+                        "message": format!("Postgres {}() is called inside a function without a matching close(). This can create a new connection pool on every request or repeated call; open the connection once at module scope or close the same handle before returning.", connect_name),
                         "line": line,
                         "fix": {
-                            "description": "Prefer a module-scope connection handle. If this code must connect per call, import close() from std/db/postgres and close the handle on every path after query/execute completes."
+                            "description": "Prefer a module-scope connection handle. If this code must connect per call, import close() from std/db/postgres and close the same handle on every path after query/execute completes."
                         }
                     }));
-                    }
-                }
-            };
-
-        for (line_num, line) in source_lines.iter().enumerate() {
-            let trimmed = line.trim();
-            if !trimmed.starts_with("//") {
-                let triple_count = line.matches("\"\"\"").count();
-                if triple_count % 2 == 1 {
-                    in_template_string = !in_template_string;
                 }
             }
-            if in_template_string || trimmed.starts_with("//") {
-                continue;
-            }
+        }
 
-            let starts_function = trimmed.starts_with("fn ");
-            if starts_function && trimmed.contains('{') {
-                function_depth = Some(0);
-                function_connects.clear();
-                function_closes_connection = false;
-            }
-
-            if function_depth.is_some() {
-                for connect_name in &postgres_connect_functions {
-                    if trimmed.contains(&format!("{}(", connect_name)) {
-                        function_connects.push((connect_name.clone(), line_num + 1));
+        fn scan_postgres_connect_lint(
+            stmt: &Statement,
+            connect_names: &std::collections::HashSet<String>,
+            close_names: &std::collections::HashSet<String>,
+            issues: &mut Vec<serde_json::Value>,
+        ) {
+            match unwrap_located(stmt) {
+                Statement::Function { body, .. } => emit_postgres_connect_warnings_for_function(
+                    body,
+                    connect_names,
+                    close_names,
+                    issues,
+                ),
+                Statement::Module { body, .. } => {
+                    for stmt in body {
+                        scan_postgres_connect_lint(stmt, connect_names, close_names, issues);
                     }
                 }
-                for close_name in &postgres_close_functions {
-                    if trimmed.contains(&format!("{}(", close_name)) {
-                        function_closes_connection = true;
+                Statement::Impl { methods, .. } => {
+                    for method in methods {
+                        scan_postgres_connect_lint(method, connect_names, close_names, issues);
                     }
                 }
-
-                let delta = line.matches('{').count() as i32 - line.matches('}').count() as i32;
-                if let Some(depth) = function_depth.as_mut() {
-                    *depth += delta;
-                    if *depth <= 0 {
-                        emit_function_connect_warnings(
-                            &mut issues,
-                            &function_connects,
-                            function_closes_connection,
-                        );
-                        function_depth = None;
-                        function_connects.clear();
-                        function_closes_connection = false;
+                Statement::Export { statement, .. } => {
+                    if let Some(stmt) = statement {
+                        scan_postgres_connect_lint(stmt, connect_names, close_names, issues);
                     }
                 }
+                _ => {}
             }
+        }
+
+        for stmt in &ast.statements {
+            scan_postgres_connect_lint(
+                stmt,
+                &postgres_connect_functions,
+                &postgres_close_functions,
+                &mut issues,
+            );
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3505,6 +3505,34 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
     let mut issues = Vec::new();
     let source_lines: Vec<&str> = source.lines().collect();
 
+    let mut postgres_connect_functions = std::collections::HashSet::new();
+    let mut postgres_close_functions = std::collections::HashSet::new();
+    for stmt in &ast.statements {
+        if let Statement::Import {
+            items,
+            source,
+            wildcard,
+            ..
+        } = unwrap_located(stmt)
+        {
+            if source == "std/db/postgres" {
+                if *wildcard {
+                    postgres_connect_functions.insert("connect".to_string());
+                    postgres_close_functions.insert("close".to_string());
+                }
+                for item in items {
+                    if item.name == "connect" {
+                        postgres_connect_functions
+                            .insert(item.alias.clone().unwrap_or_else(|| item.name.clone()));
+                    } else if item.name == "close" {
+                        postgres_close_functions
+                            .insert(item.alias.clone().unwrap_or_else(|| item.name.clone()));
+                    }
+                }
+            }
+        }
+    }
+
     // Track context
     let mut http_route_functions = std::collections::HashSet::new();
     http_route_functions.insert("get");
@@ -3808,6 +3836,84 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         }
                     }
                     imported_names.insert(local_name.clone(), (source.clone(), current_line));
+                }
+            }
+        }
+    }
+
+    if !postgres_connect_functions.is_empty() {
+        let mut in_template_string = false;
+        let mut function_depth: Option<i32> = None;
+        let mut function_connects: Vec<(String, usize)> = Vec::new();
+        let mut function_closes_connection = false;
+        let mut warned_lines = std::collections::HashSet::new();
+
+        let mut emit_function_connect_warnings =
+            |issues: &mut Vec<serde_json::Value>,
+             function_connects: &[(String, usize)],
+             function_closes_connection: bool| {
+                if function_closes_connection {
+                    return;
+                }
+                for (connect_name, line) in function_connects {
+                    if warned_lines.insert(*line) {
+                        issues.push(json!({
+                        "severity": "warning",
+                        "rule": "postgres_connect_in_function",
+                        "message": format!("Postgres {}() is called inside a function without a matching close(). This can create a new connection pool on every request or repeated call; open the connection once at module scope or close it before returning.", connect_name),
+                        "line": line,
+                        "fix": {
+                            "description": "Prefer a module-scope connection handle. If this code must connect per call, import close() from std/db/postgres and close the handle on every path after query/execute completes."
+                        }
+                    }));
+                    }
+                }
+            };
+
+        for (line_num, line) in source_lines.iter().enumerate() {
+            let trimmed = line.trim();
+            if !trimmed.starts_with("//") {
+                let triple_count = line.matches("\"\"\"").count();
+                if triple_count % 2 == 1 {
+                    in_template_string = !in_template_string;
+                }
+            }
+            if in_template_string || trimmed.starts_with("//") {
+                continue;
+            }
+
+            let starts_function = trimmed.starts_with("fn ");
+            if starts_function && trimmed.contains('{') {
+                function_depth = Some(0);
+                function_connects.clear();
+                function_closes_connection = false;
+            }
+
+            if function_depth.is_some() {
+                for connect_name in &postgres_connect_functions {
+                    if trimmed.contains(&format!("{}(", connect_name)) {
+                        function_connects.push((connect_name.clone(), line_num + 1));
+                    }
+                }
+                for close_name in &postgres_close_functions {
+                    if trimmed.contains(&format!("{}(", close_name)) {
+                        function_closes_connection = true;
+                    }
+                }
+
+                let delta = line.matches('{').count() as i32 - line.matches('}').count() as i32;
+                if let Some(depth) = function_depth.as_mut() {
+                    *depth += delta;
+                    if *depth <= 0 {
+                        emit_function_connect_warnings(
+                            &mut issues,
+                            &function_connects,
+                            function_closes_connection,
+                        );
+                        function_depth = None;
+                        function_connects.clear();
+                        function_closes_connection = false;
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3849,14 +3849,24 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
             }
         }
 
+        struct PostgresCloseCall {
+            handle_name: String,
+            line: usize,
+            // Only closes reached by normal sequential execution suppress the warning.
+            // Branch/loop/otherwise/lambda closes are still recorded, but conservatively
+            // treated as conditional so one path cannot hide a leaked connection on another.
+            unconditional: bool,
+        }
+
         fn collect_postgres_calls_in_expr(
             expr: &Expression,
             line: usize,
             assigned_to: Option<&str>,
+            unconditional_closes: bool,
             connect_names: &std::collections::HashSet<String>,
             close_names: &std::collections::HashSet<String>,
             connects: &mut Vec<(String, Option<String>, usize)>,
-            closes: &mut Vec<(String, usize)>,
+            closes: &mut Vec<PostgresCloseCall>,
         ) {
             match expr {
                 Expression::Call {
@@ -3869,7 +3879,11 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         }
                         if close_names.contains(name) {
                             if let Some(Expression::Identifier(handle_name)) = arguments.first() {
-                                closes.push((handle_name.clone(), line));
+                                closes.push(PostgresCloseCall {
+                                    handle_name: handle_name.clone(),
+                                    line,
+                                    unconditional: unconditional_closes,
+                                });
                             }
                         }
                     }
@@ -3877,6 +3891,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         function,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -3887,6 +3902,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             arg,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -3899,6 +3915,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         left,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -3908,6 +3925,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         right,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -3920,6 +3938,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                     operand,
                     line,
                     None,
+                    unconditional_closes,
                     connect_names,
                     close_names,
                     connects,
@@ -3931,6 +3950,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             item,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -3944,6 +3964,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             key,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -3953,6 +3974,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             value,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -3967,6 +3989,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         object,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -3977,6 +4000,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             arg,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -3988,6 +4012,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                     object,
                     line,
                     None,
+                    unconditional_closes,
                     connect_names,
                     close_names,
                     connects,
@@ -3998,6 +4023,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         object,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -4007,6 +4033,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         index,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -4018,6 +4045,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         start,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -4027,6 +4055,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         end,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -4040,6 +4069,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                                 expr,
                                 line,
                                 None,
+                                unconditional_closes,
                                 connect_names,
                                 close_names,
                                 connects,
@@ -4054,6 +4084,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             value,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -4067,6 +4098,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             arg,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -4079,6 +4111,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         target,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -4088,6 +4121,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         value,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -4103,6 +4137,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         condition,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -4112,6 +4147,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         then_branch,
                         line,
                         None,
+                        false,
                         connect_names,
                         close_names,
                         connects,
@@ -4121,6 +4157,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         else_branch,
                         line,
                         None,
+                        false,
                         connect_names,
                         close_names,
                         connects,
@@ -4132,6 +4169,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         scrutinee,
                         line,
                         None,
+                        unconditional_closes,
                         connect_names,
                         close_names,
                         connects,
@@ -4143,6 +4181,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                                 guard,
                                 line,
                                 None,
+                                false,
                                 connect_names,
                                 close_names,
                                 connects,
@@ -4153,6 +4192,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             &arm.body,
                             line,
                             None,
+                            false,
                             connect_names,
                             close_names,
                             connects,
@@ -4164,6 +4204,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                 | Expression::Lambda { body: block, .. }
                 | Expression::TryCatch { body: block } => collect_postgres_calls_in_block(
                     block,
+                    false,
                     connect_names,
                     close_names,
                     connects,
@@ -4181,10 +4222,11 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
 
         fn collect_postgres_calls_in_block(
             block: &ntnt::ast::Block,
+            unconditional_closes: bool,
             connect_names: &std::collections::HashSet<String>,
             close_names: &std::collections::HashSet<String>,
             connects: &mut Vec<(String, Option<String>, usize)>,
-            closes: &mut Vec<(String, usize)>,
+            closes: &mut Vec<PostgresCloseCall>,
         ) {
             for stmt in &block.statements {
                 let line = located_line(stmt);
@@ -4200,6 +4242,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                                 expr,
                                 line,
                                 Some(name),
+                                unconditional_closes,
                                 connect_names,
                                 close_names,
                                 connects,
@@ -4209,6 +4252,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         if let Some(block) = otherwise {
                             collect_postgres_calls_in_block(
                                 block,
+                                false,
                                 connect_names,
                                 close_names,
                                 connects,
@@ -4221,6 +4265,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             expr,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -4233,6 +4278,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                                 expr,
                                 line,
                                 None,
+                                unconditional_closes,
                                 connect_names,
                                 close_names,
                                 connects,
@@ -4242,6 +4288,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         if let Some(block) = otherwise {
                             collect_postgres_calls_in_block(
                                 block,
+                                false,
                                 connect_names,
                                 close_names,
                                 connects,
@@ -4258,6 +4305,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             condition,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -4265,6 +4313,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         );
                         collect_postgres_calls_in_block(
                             then_branch,
+                            false,
                             connect_names,
                             close_names,
                             connects,
@@ -4273,6 +4322,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         if let Some(block) = else_branch {
                             collect_postgres_calls_in_block(
                                 block,
+                                false,
                                 connect_names,
                                 close_names,
                                 connects,
@@ -4285,6 +4335,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             condition,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -4292,6 +4343,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         );
                         collect_postgres_calls_in_block(
                             body,
+                            false,
                             connect_names,
                             close_names,
                             connects,
@@ -4303,6 +4355,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                             iterable,
                             line,
                             None,
+                            unconditional_closes,
                             connect_names,
                             close_names,
                             connects,
@@ -4310,6 +4363,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                         );
                         collect_postgres_calls_in_block(
                             body,
+                            false,
                             connect_names,
                             close_names,
                             connects,
@@ -4318,6 +4372,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
                     }
                     Statement::Loop { body } => collect_postgres_calls_in_block(
                         body,
+                        false,
                         connect_names,
                         close_names,
                         connects,
@@ -4340,6 +4395,7 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
             let mut closes = Vec::new();
             collect_postgres_calls_in_block(
                 function_body,
+                true,
                 connect_names,
                 close_names,
                 &mut connects,
@@ -4348,8 +4404,10 @@ fn lint_ast(ast: &ntnt::ast::Program, source: &str, _filename: &str) -> Vec<serd
 
             for (connect_name, handle_name, line) in connects {
                 let is_closed = handle_name.as_ref().is_some_and(|handle_name| {
-                    closes.iter().any(|(closed_name, close_line)| {
-                        closed_name == handle_name && *close_line > line
+                    closes.iter().any(|closed| {
+                        closed.unconditional
+                            && closed.handle_name == *handle_name
+                            && closed.line > line
                     })
                 });
                 if !is_closed {

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -276,6 +276,34 @@ fn load_count() {
 }
 
 #[test]
+fn test_lint_warns_when_postgres_close_is_conditional() {
+    let code = r#"import { connect as pg_connect, close as pg_close } from "std/db/postgres"
+
+fn load_count(should_close: Bool) {
+    let conn = pg_connect("postgres://example/app") otherwise { return None }
+    if should_close {
+        let _closed = pg_close(conn)
+    }
+    return conn
+}
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let warnings = json["files"][0]["issues"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|issue| issue["rule"].as_str() == Some("postgres_connect_in_function"))
+        .count();
+    assert_eq!(
+        warnings, 1,
+        "a branch-local close must not suppress the leak warning: {stdout}"
+    );
+}
+
+#[test]
 fn test_lint_catches_arg_type_mismatch() {
     let code = r#"fn add(a: Int, b: Int) -> Int {
     return a + b

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -304,6 +304,39 @@ fn load_count(should_close: Bool) {
 }
 
 #[test]
+fn test_lint_warns_when_shadowed_postgres_handle_leaks() {
+    let code = r#"import { connect as pg_connect, close as pg_close } from "std/db/postgres"
+
+fn load_count() {
+    let conn = pg_connect("postgres://example/first") otherwise { return None }
+    let conn = pg_connect("postgres://example/second") otherwise { return None }
+    let _closed = pg_close(conn)
+    return conn
+}
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let warnings: Vec<&serde_json::Value> = json["files"][0]["issues"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|issue| issue["rule"].as_str() == Some("postgres_connect_in_function"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "one close cannot satisfy both shadowed handles: {stdout}"
+    );
+    assert_eq!(
+        warnings[0]["line"].as_i64(),
+        Some(4),
+        "the first shadowed handle is the leaked connect: {stdout}"
+    );
+}
+
+#[test]
 fn test_lint_catches_arg_type_mismatch() {
     let code = r#"fn add(a: Int, b: Int) -> Int {
     return a + b

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -196,6 +196,86 @@ let pg = match pg_connect("postgres://example/app") {
 }
 
 #[test]
+fn test_lint_warns_when_only_unrelated_postgres_handle_is_closed() {
+    let code = r#"import { connect as pg_connect, close as pg_close } from "std/db/postgres"
+
+fn load_count() {
+    let old = pg_connect("postgres://example/app") otherwise { return None }
+    let _closed = pg_close(old)
+    let conn = pg_connect("postgres://example/app") otherwise { return None }
+    return conn
+}
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let warnings = json["files"][0]["issues"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|issue| issue["rule"].as_str() == Some("postgres_connect_in_function"))
+        .count();
+    assert_eq!(
+        warnings, 1,
+        "only the second, unclosed Postgres handle should warn: {stdout}"
+    );
+}
+
+#[test]
+fn test_lint_warns_after_string_brace_inside_function() {
+    let code = r#"import { connect as pg_connect } from "std/db/postgres"
+
+fn load_count() {
+    let label = "}"
+    let conn = pg_connect("postgres://example/app") otherwise { return None }
+    return conn
+}
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let has_warning = json["files"][0]["issues"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|issue| issue["rule"].as_str() == Some("postgres_connect_in_function"));
+    assert!(
+        has_warning,
+        "string braces must not hide a later Postgres connect: {stdout}"
+    );
+}
+
+#[test]
+fn test_lint_does_not_match_suffix_identifiers_as_postgres_connect() {
+    let code = r#"import * from "std/db/postgres"
+
+fn reconnect(url: String) -> String {
+    return url
+}
+
+fn load_count() {
+    let conn = reconnect("postgres://example/app")
+    return conn
+}
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let has_warning = json["files"][0]["issues"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|issue| issue["rule"].as_str() == Some("postgres_connect_in_function"));
+    assert!(
+        !has_warning,
+        "reconnect() is not the imported Postgres connect(): {stdout}"
+    );
+}
+
+#[test]
 fn test_lint_catches_arg_type_mismatch() {
     let code = r#"fn add(a: Int, b: Int) -> Int {
     return a + b

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -108,6 +108,94 @@ fn validate_code(code: &str) -> (String, String, i32) {
 // ============================================================================
 
 #[test]
+fn test_lint_warns_on_function_local_postgres_connect() {
+    let code = r#"import { connect as pg_connect } from "std/db/postgres"
+
+fn load_count() {
+    let conn = pg_connect("postgres://example/app") otherwise { return None }
+    return conn
+}
+"#;
+
+    let (stdout, _stderr, code) = lint_code(code);
+    assert_eq!(code, 0, "warning-only lint should exit zero");
+
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let files = json["files"].as_array().unwrap();
+    let has_warning = files.iter().any(|file| {
+        file["issues"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .any(|issue| {
+                issue["rule"].as_str() == Some("postgres_connect_in_function")
+                    && issue["severity"].as_str() == Some("warning")
+                    && issue["line"].as_i64() == Some(4)
+            })
+    });
+    assert!(
+        has_warning,
+        "expected postgres_connect_in_function warning: {stdout}"
+    );
+}
+
+#[test]
+fn test_lint_allows_closed_function_local_postgres_connect() {
+    let code = r#"import { connect as pg_connect, close as pg_close } from "std/db/postgres"
+
+fn load_count() {
+    let conn = pg_connect("postgres://example/app") otherwise { return None }
+    let _closed = pg_close(conn)
+    return conn
+}
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let files = json["files"].as_array().unwrap();
+    let has_warning = files.iter().any(|file| {
+        file["issues"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .any(|issue| issue["rule"].as_str() == Some("postgres_connect_in_function"))
+    });
+    assert!(
+        !has_warning,
+        "closed function-local Postgres connect should not warn: {stdout}"
+    );
+}
+
+#[test]
+fn test_lint_allows_module_scope_postgres_connect() {
+    let code = r#"import { connect as pg_connect } from "std/db/postgres"
+
+let pg = match pg_connect("postgres://example/app") {
+    Ok(conn) => conn,
+    Err(_) => None
+}
+"#;
+
+    let (stdout, _stderr, _code) = lint_code(code);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint should output valid JSON");
+    let files = json["files"].as_array().unwrap();
+    let has_warning = files.iter().any(|file| {
+        file["issues"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .any(|issue| issue["rule"].as_str() == Some("postgres_connect_in_function"))
+    });
+    assert!(
+        !has_warning,
+        "module-scope Postgres connect should not warn: {stdout}"
+    );
+}
+
+#[test]
 fn test_lint_catches_arg_type_mismatch() {
     let code = r#"fn add(a: Int, b: Int) -> Int {
     return a + b


### PR DESCRIPTION
## Summary
- add an ntnt lint warning for function-local std/db/postgres connect() calls that do not also close the handle
- support aliased connect/close imports and wildcard postgres imports
- add CLI lint regressions for unclosed, explicitly closed, and module-scope connects

## Verification
- cargo fmt
- cargo build --profile dev-release
- cargo test postgres_connect -- --nocapture
- cargo test