### PR TITLE
feat(diagnostics): parser error recovery and enriched contract violations (DD-063 PR-3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -802,7 +802,8 @@ Error[E012]: Type mismatch in function call
 - [x] Runtime error line numbers via AST location tracking
 - [x] "Did you mean?" suggestions for wrong imports — both wrong module names and wrong export names get Levenshtein suggestions with available exports list
 - [x] Contract violation messages show the contract expression (`"Precondition failed in 'fn': b != 0"`)
-- [ ] Contract violation messages show actual values (e.g., "b was 0") — expression is shown but runtime values are not
+- [x] Contract violation messages show actual values (`where: b = 0`), the failing clause's line with a source frame, and the call site (DD-063 Rec 4a)
+- [x] Parser error recovery: `ntnt lint`/`validate` report up to 5 syntax errors per file in one pass (DD-063 Rec 4a); `run` still stops at the first
 - [x] `ntnt lint --fix` outputs JSON patch suggestions for auto-fixes
 - [ ] `ntnt lint --format=json` explicit structured output mode for full agent consumption
 

--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -129,7 +129,7 @@ Scoping also surfaced **two additional doc drifts** beyond the v2 findings: CLAU
 
 - [x] **PR-1** — `${}` interpolation detection (Rec 1) — S
 - [x] **PR-2** — Intentional syntax contract tests, CLAUDE.md truth, UFCS embrace (Rec 2) — S
-- [ ] **PR-3** — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M
+- [x] **PR-3** — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M
 - [ ] **PR-4** — Diagnostics II: method bridge hints, unknown-method lint, IAL suggestions, `ntnt intent lint` (Rec 4b) — M
 - [ ] **PR-5** — Index out-of-bounds loudness (Rec 3) — M — **blocked on decisions**
 - [ ] Recs 5–10 — unscheduled, see end of section
@@ -164,13 +164,13 @@ Maintainer decision applied after review: PR-2 should not lock every current CLA
 
 New opt-in `Parser::parse_with_recovery() -> (Program, Vec<Error>)` with statement-level panic-mode synchronization (cap 5 errors/file, same-line dedup + token-gap cascade suppression); existing `parse()` keeps its exact signature and single-error behavior so all 18 call sites (run path, module imports, REPL, intent) are untouched — only `lint_project`/`validate_project` consume the multi-error path. E004 gains what every other error class has: per-clause line capture (`ast::ContractCondition { expression, line }`), a struct `ContractViolation { message, line, call_line, values }`, and parameter values read from the function environment *before* restore (`where: b = 0`), rendered with a real source frame. Display text stays byte-identical for existing consumers.
 
-- [ ] `parse_with_recovery` + private `recover` flag + `synchronize()` with guaranteed token advance
-- [ ] `lint_project`/`validate_project` report all recovered errors; semantic checks skipped on parse-error files
-- [ ] `ast::ContractCondition` + line capture in `parse_contract()`
-- [ ] `ContractViolation` struct variant; identifier-walking value capture (env lookups only — never expression re-evaluation, which could fire side effects during error construction); capture **before** env restore
-- [ ] `rich_display` source frame for E004; `error.rs` wiring
-- [ ] `tests/diagnostics_tests.rs`: multi-error lint, token-soup termination, run-path regression (run still aborts on first error), multi-param `where:` values
-- [ ] Lint all `examples/*.tnt` before/after as a recovery-regression sweep
+- [x] `parse_with_recovery` + private `recover` flag + `synchronize()` with guaranteed token advance
+- [x] `lint_project`/`validate_project` report all recovered errors; semantic checks skipped on parse-error files
+- [x] `ast::ContractCondition` + line capture in `parse_contract()`
+- [x] `ContractViolation` struct variant; identifier-walking value capture (env lookups only — never expression re-evaluation, which could fire side effects during error construction); capture **before** env restore
+- [x] `rich_display` source frame for E004; `error.rs` wiring
+- [x] `tests/diagnostics_tests.rs`: multi-error lint, token-soup termination, run-path regression (run still aborts on first error), multi-param `where:` values
+- [x] Lint all `examples/*.tnt` before/after as a recovery-regression sweep
 
 Defaults applied: run path stays first-error-only (lint is the multi-error surface); MAX_PARSE_ERRORS = 5; struct invariants get values but not clause lines in v1. Maintainer decision: `ntnt parse --json` contract-clause shape changes to `{expression, line}` objects — acceptable, or add a compatibility serializer?
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -128,10 +128,11 @@ ntnt test server.tnt --get /health --post /users --body 'name=Alice'
 
 **Multi-error lint:** `ntnt lint` recovers at statement boundaries and reports
 up to 5 syntax errors per file in one pass (rule `parse_error`, each with its
-own line), so fix them as a batch instead of re-linting after each one. When a
-file has parse errors, lint/type findings for that file are suppressed until
-it parses — re-lint after fixing. `ntnt run` still stops at the first syntax
-error.
+own line), so fix them as a batch instead of re-linting after each one. Each
+parse error counts individually in the JSON `summary.errors` total, matching
+how semantic errors are counted. When a file has parse errors, lint/type
+findings for that file are suppressed until it parses — re-lint after fixing.
+`ntnt run` still stops at the first syntax error.
 
 ---
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -126,6 +126,13 @@ ntnt run myfile.tnt         # Only after lint passes
 ntnt test server.tnt --get /health --post /users --body 'name=Alice'
 ```
 
+**Multi-error lint:** `ntnt lint` recovers at statement boundaries and reports
+up to 5 syntax errors per file in one pass (rule `parse_error`, each with its
+own line), so fix them as a batch instead of re-linting after each one. When a
+file has parse errors, lint/type findings for that file are suppressed until
+it parses — re-lint after fixing. `ntnt run` still stops at the first syntax
+error.
+
 ---
 
 ## Type Safety Modes (v0.4.0+)
@@ -1200,6 +1207,29 @@ fn create_user(req)
 - In `ensures`, `result` is typed to the function's return type
 - `old(expr)` returns the same type as `expr`
 - Struct invariants are checked with field types in scope
+
+**Contract violation diagnostics (E004):** when a contract fails at runtime,
+the error points at the failing clause and shows the actual values it saw —
+use them to fix the caller or the contract without re-running with prints:
+
+```text
+error[E004]
+  --> server.tnt:2
+  = Contract violation: Precondition failed in 'divide': b != 0
+  --> Source context
+   |
+   1 | fn divide(a: Int, b: Int) -> Int
+   2 |     requires b != 0
+   3 |     ensures result * b == a
+   |
+  where: b = 0
+  note: contract checked for call at line 7
+```
+
+- `-->` names the file and the line of the failing `requires`/`ensures` clause
+- `where:` lists the current values of the variables the clause references
+  (parameters, and `result` for `ensures`)
+- `note:` gives the call site that triggered the check
 
 ---
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -542,8 +542,19 @@ pub enum TypeExpr {
 /// Contract specification
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Contract {
-    pub requires: Vec<Expression>,
-    pub ensures: Vec<Expression>,
+    pub requires: Vec<ContractCondition>,
+    pub ensures: Vec<ContractCondition>,
+}
+
+/// A single `requires` or `ensures` clause with its source position.
+///
+/// Named ContractCondition (not ContractClause) to avoid colliding with
+/// `contracts::ContractClause`, which the interpreter also imports.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractCondition {
+    pub expression: Expression,
+    /// 1-based line of the `requires`/`ensures` keyword; 0 = unknown
+    pub line: usize,
 }
 
 /// Block of statements

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -218,7 +218,7 @@ impl ContractChecker {
             let msg = message
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| format!("Precondition failed: {}", condition));
-            return Err(IntentError::ContractViolation(msg));
+            return Err(IntentError::contract_violation(msg));
         }
 
         Ok(())
@@ -242,7 +242,7 @@ impl ContractChecker {
             let msg = message
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| format!("Postcondition failed: {}", condition));
-            return Err(IntentError::ContractViolation(msg));
+            return Err(IntentError::contract_violation(msg));
         }
 
         Ok(())
@@ -266,7 +266,7 @@ impl ContractChecker {
             let msg = message
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| format!("Invariant violated: {}", condition));
-            return Err(IntentError::ContractViolation(msg));
+            return Err(IntentError::contract_violation(msg));
         }
 
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -214,24 +214,6 @@ impl IntentError {
                 out
             }
             None => {
-                if let IntentError::ContractViolation {
-                    values, call_line, ..
-                } = self
-                {
-                    let mut out = base;
-                    if !values.is_empty() {
-                        let rendered = values
-                            .iter()
-                            .map(|(name, value)| format!("{} = {}", name, value))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        out.push_str(&format!("\n  │ where: {}", rendered));
-                    }
-                    if *call_line > 0 {
-                        out.push_str(&format!("\n  │ called from line {}", call_line));
-                    }
-                    return out;
-                }
                 // Add suggestion for known error types
                 if let Some(suggestion) = self.suggestion() {
                     format!("{}\n  └─ did you mean: {}?", base, suggestion)
@@ -458,10 +440,6 @@ mod tests {
 
         assert_eq!(err.error_code(), "E004");
         assert_eq!(err.line(), Some(2));
-
-        let rendered = err.rich_display();
-        assert!(rendered.contains("where: b = 0"), "{rendered}");
-        assert!(rendered.contains("called from line 7"), "{rendered}");
 
         // at_line backfills only when the clause line is unknown
         let backfilled = IntentError::contract_violation("msg").at_line(9);

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,8 +69,16 @@ pub enum IntentError {
         line: usize,
     },
 
-    #[error("Contract violation: {0}")]
-    ContractViolation(String),
+    #[error("Contract violation: {message}")]
+    ContractViolation {
+        message: String,
+        /// 1-based line of the failing requires/ensures clause; 0 = unknown
+        line: usize,
+        /// 1-based line of the call site that triggered the check; 0 = unknown
+        call_line: usize,
+        /// Variable name/value pairs referenced by the failing clause
+        values: Vec<(String, String)>,
+    },
 
     #[error("Runtime error: {message}")]
     RuntimeError {
@@ -137,6 +145,16 @@ impl IntentError {
         }
     }
 
+    /// Create a ContractViolation with just a message (no location or values)
+    pub fn contract_violation(message: impl Into<String>) -> Self {
+        IntentError::ContractViolation {
+            message: message.into(),
+            line: 0,
+            call_line: 0,
+            values: Vec::new(),
+        }
+    }
+
     /// Create a RuntimeError with just a message (backward compatible)
     pub fn runtime_error(message: impl Into<String>) -> Self {
         IntentError::RuntimeError {
@@ -165,6 +183,9 @@ impl IntentError {
             IntentError::UndefinedFunction { line: l, .. } => *l = line,
             IntentError::ArityMismatch { line: l, .. } => *l = line,
             IntentError::DivisionByZero { line: l } => *l = line,
+            // Backfill the call-site line from Located statement tracking,
+            // but never overwrite a clause line already captured.
+            IntentError::ContractViolation { line: l, .. } if *l == 0 => *l = line,
             _ => {}
         }
         self
@@ -193,6 +214,24 @@ impl IntentError {
                 out
             }
             None => {
+                if let IntentError::ContractViolation {
+                    values, call_line, ..
+                } = self
+                {
+                    let mut out = base;
+                    if !values.is_empty() {
+                        let rendered = values
+                            .iter()
+                            .map(|(name, value)| format!("{} = {}", name, value))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        out.push_str(&format!("\n  │ where: {}", rendered));
+                    }
+                    if *call_line > 0 {
+                        out.push_str(&format!("\n  │ called from line {}", call_line));
+                    }
+                    return out;
+                }
                 // Add suggestion for known error types
                 if let Some(suggestion) = self.suggestion() {
                     format!("{}\n  └─ did you mean: {}?", base, suggestion)
@@ -209,7 +248,7 @@ impl IntentError {
             IntentError::LexerError { .. } => "E001",
             IntentError::ParserError { .. } => "E002",
             IntentError::TypeError { .. } => "E003",
-            IntentError::ContractViolation(_) => "E004",
+            IntentError::ContractViolation { .. } => "E004",
             IntentError::RuntimeError { .. } => "E005",
             IntentError::UndefinedVariable { .. } => "E006",
             IntentError::UndefinedFunction { .. } => "E007",
@@ -232,6 +271,7 @@ impl IntentError {
             IntentError::UndefinedFunction { line, .. } if *line > 0 => Some(*line),
             IntentError::ArityMismatch { line, .. } if *line > 0 => Some(*line),
             IntentError::DivisionByZero { line } if *line > 0 => Some(*line),
+            IntentError::ContractViolation { line, .. } if *line > 0 => Some(*line),
             _ => None,
         }
     }
@@ -408,6 +448,29 @@ mod tests {
     }
 
     #[test]
+    fn contract_violation_carries_location_and_values() {
+        let err = IntentError::ContractViolation {
+            message: "Precondition failed in 'divide': b != 0".to_string(),
+            line: 2,
+            call_line: 7,
+            values: vec![("b".to_string(), "0".to_string())],
+        };
+
+        assert_eq!(err.error_code(), "E004");
+        assert_eq!(err.line(), Some(2));
+
+        let rendered = err.rich_display();
+        assert!(rendered.contains("where: b = 0"), "{rendered}");
+        assert!(rendered.contains("called from line 7"), "{rendered}");
+
+        // at_line backfills only when the clause line is unknown
+        let backfilled = IntentError::contract_violation("msg").at_line(9);
+        assert_eq!(backfilled.line(), Some(9));
+        let kept = err.at_line(99);
+        assert_eq!(kept.line(), Some(2));
+    }
+
+    #[test]
     fn test_error_codes_unique() {
         let errors: Vec<IntentError> = vec![
             IntentError::LexerError {
@@ -421,7 +484,7 @@ mod tests {
                 message: String::new(),
             },
             IntentError::type_error(""),
-            IntentError::ContractViolation(String::new()),
+            IntentError::contract_violation(String::new()),
             IntentError::runtime_error(""),
             IntentError::UndefinedVariable {
                 name: String::new(),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -10369,6 +10369,37 @@ impl Interpreter {
             Expression::FieldAccess { object, .. } => {
                 Self::collect_identifiers(object, out);
             }
+            // UFCS dot-call: `s.len()` — the receiver is a data variable,
+            // the method name is not
+            Expression::MethodCall {
+                object, arguments, ..
+            } => {
+                Self::collect_identifiers(object, out);
+                for arg in arguments {
+                    Self::collect_identifiers(arg, out);
+                }
+            }
+            Expression::IfExpr {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                Self::collect_identifiers(condition, out);
+                Self::collect_identifiers(then_branch, out);
+                Self::collect_identifiers(else_branch, out);
+            }
+            Expression::Range { start, end, .. } => {
+                Self::collect_identifiers(start, out);
+                Self::collect_identifiers(end, out);
+            }
+            Expression::Array(elements) => {
+                for element in elements {
+                    Self::collect_identifiers(element, out);
+                }
+            }
+            Expression::Try(inner) | Expression::Await(inner) => {
+                Self::collect_identifiers(inner, out);
+            }
             _ => {}
         }
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -145,13 +145,14 @@ pub enum Value {
     Continue,
 }
 
-/// Function contract with parsed expressions for runtime evaluation
+/// Function contract with parsed clauses (expression + source line) for
+/// runtime evaluation
 #[derive(Debug, Clone)]
 pub struct FunctionContract {
-    /// Precondition expressions
-    pub requires: Vec<Expression>,
-    /// Postcondition expressions
-    pub ensures: Vec<Expression>,
+    /// Precondition clauses
+    pub requires: Vec<crate::ast::ContractCondition>,
+    /// Postcondition clauses
+    pub ensures: Vec<crate::ast::ContractCondition>,
 }
 
 impl Value {
@@ -2596,9 +2597,7 @@ impl Interpreter {
                     if args[0].is_truthy() {
                         Ok(Value::Unit)
                     } else {
-                        Err(IntentError::ContractViolation(
-                            "Assertion failed".to_string(),
-                        ))
+                        Err(IntentError::contract_violation("Assertion failed"))
                     }
                 },
             },
@@ -5977,14 +5976,19 @@ impl Interpreter {
     ) -> Result<Value> {
         // Check preconditions
         if let Some(c) = contract {
-            for req_expr in &c.requires {
-                let condition_str = Self::format_expression(req_expr);
-                let check = self.eval_expression(req_expr)?;
+            for clause in &c.requires {
+                let condition_str = Self::format_expression(&clause.expression);
+                let check = self.eval_expression(&clause.expression)?;
                 if !check.is_truthy() {
-                    return Err(IntentError::ContractViolation(format!(
-                        "Precondition failed in '{}': {}",
-                        job_name, condition_str
-                    )));
+                    return Err(IntentError::ContractViolation {
+                        message: format!(
+                            "Precondition failed in '{}': {}",
+                            job_name, condition_str
+                        ),
+                        line: clause.line,
+                        call_line: 0,
+                        values: self.collect_clause_values(&clause.expression),
+                    });
                 }
                 self.contracts
                     .check_precondition(&condition_str, true, None)?;
@@ -6035,14 +6039,19 @@ impl Interpreter {
 
         // Check postconditions
         if let Some(c) = contract {
-            for ens_expr in &c.ensures {
-                let condition_str = Self::format_expression(ens_expr);
-                let check = self.eval_expression(ens_expr)?;
+            for clause in &c.ensures {
+                let condition_str = Self::format_expression(&clause.expression);
+                let check = self.eval_expression(&clause.expression)?;
                 if !check.is_truthy() {
-                    return Err(IntentError::ContractViolation(format!(
-                        "Postcondition failed in '{}': {}",
-                        job_name, condition_str
-                    )));
+                    return Err(IntentError::ContractViolation {
+                        message: format!(
+                            "Postcondition failed in '{}': {}",
+                            job_name, condition_str
+                        ),
+                        line: clause.line,
+                        call_line: 0,
+                        values: self.collect_clause_values(&clause.expression),
+                    });
                 }
                 self.contracts
                     .check_postcondition(&condition_str, true, None)?;
@@ -9224,20 +9233,31 @@ impl Interpreter {
 
         // Environment is already set to func_env for contract checking and body execution
 
+        // The caller's Located statement line — current_line still points at
+        // the call site here; after the body runs it points at the last body
+        // statement, so capture it before execution.
+        let call_site_line = self.current_line;
+
         // Track deferred statements for this function call
         let deferred_count_before = self.deferred_statements.len();
 
         // Check preconditions BEFORE execution
         if let Some(ref func_contract) = contract {
-            for req_expr in &func_contract.requires {
-                let condition_str = Self::format_expression(req_expr);
-                let result = self.eval_expression(req_expr)?;
+            for clause in &func_contract.requires {
+                let condition_str = Self::format_expression(&clause.expression);
+                let result = self.eval_expression(&clause.expression)?;
                 if !result.is_truthy() {
+                    // Read parameter values while func_env is still active —
+                    // after the restore below, lookups would hit the caller's
+                    // scope and silently produce wrong or missing values.
+                    let values = self.collect_clause_values(&clause.expression);
                     self.environment = previous;
-                    return Err(IntentError::ContractViolation(format!(
-                        "Precondition failed in '{}': {}",
-                        name, condition_str
-                    )));
+                    return Err(IntentError::ContractViolation {
+                        message: format!("Precondition failed in '{}': {}", name, condition_str),
+                        line: clause.line,
+                        call_line: call_site_line,
+                        values,
+                    });
                 }
                 self.contracts
                     .check_precondition(&condition_str, true, None)?;
@@ -9278,18 +9298,23 @@ impl Interpreter {
 
         // Check postconditions AFTER execution
         if let Some(ref func_contract) = contract {
-            for ens_expr in &func_contract.ensures {
-                let condition_str = Self::format_expression(ens_expr);
-                let postcond_result = self.eval_expression(ens_expr)?;
+            for clause in &func_contract.ensures {
+                let condition_str = Self::format_expression(&clause.expression);
+                let postcond_result = self.eval_expression(&clause.expression)?;
                 if !postcond_result.is_truthy() {
+                    // Values first: `result` and the parameters live in
+                    // func_env, which the restore below replaces.
+                    let values = self.collect_clause_values(&clause.expression);
                     // Clear state before returning error
                     self.current_old_values = None;
                     self.current_result = None;
                     self.environment = previous;
-                    return Err(IntentError::ContractViolation(format!(
-                        "Postcondition failed in '{}': {}",
-                        name, condition_str
-                    )));
+                    return Err(IntentError::ContractViolation {
+                        message: format!("Postcondition failed in '{}': {}", name, condition_str),
+                        line: clause.line,
+                        call_line: call_site_line,
+                        values,
+                    });
                 }
                 self.contracts
                     .check_postcondition(&condition_str, true, None)?;
@@ -9615,7 +9640,10 @@ impl Interpreter {
                                     } else {
                                         let method_path = format!("{} {}", method, path);
                                         // Check for contract violations and return appropriate HTTP status
-                                        if let IntentError::ContractViolation(msg) = &e {
+                                        if let IntentError::ContractViolation {
+                                            message: msg, ..
+                                        } = &e
+                                        {
                                             if msg.contains("Precondition failed") {
                                                 http_server::create_error_response_with_context(
                                                     400,
@@ -10284,14 +10312,105 @@ impl Interpreter {
     }
 
     /// Capture old values from expressions in postconditions
-    fn capture_old_values(&mut self, ensures: &[Expression]) -> Result<OldValues> {
+    fn capture_old_values(
+        &mut self,
+        ensures: &[crate::ast::ContractCondition],
+    ) -> Result<OldValues> {
         let mut old_values = OldValues::new();
 
-        for expr in ensures {
-            self.extract_old_calls(expr, &mut old_values)?;
+        for clause in ensures {
+            self.extract_old_calls(&clause.expression, &mut old_values)?;
         }
 
         Ok(old_values)
+    }
+
+    /// Recursively collect identifier names referenced by a contract clause,
+    /// skipping call-position names (`len` in `len(x)`) so only data
+    /// variables are reported in `where:` diagnostics.
+    fn collect_identifiers(expr: &Expression, out: &mut Vec<String>) {
+        match expr {
+            Expression::Identifier(name) => {
+                if !out.iter().any(|n| n == name) {
+                    out.push(name.clone());
+                }
+            }
+            Expression::Binary { left, right, .. } => {
+                Self::collect_identifiers(left, out);
+                Self::collect_identifiers(right, out);
+            }
+            Expression::Unary { operand, .. } => {
+                Self::collect_identifiers(operand, out);
+            }
+            Expression::Call {
+                function,
+                arguments,
+            } => {
+                // A bare identifier in function position is a function name,
+                // not a data variable — but old(x) exposes x.
+                match function.as_ref() {
+                    Expression::Identifier(name) if name == "old" => {
+                        for arg in arguments {
+                            Self::collect_identifiers(arg, out);
+                        }
+                        return;
+                    }
+                    Expression::Identifier(_) => {}
+                    other => Self::collect_identifiers(other, out),
+                }
+                for arg in arguments {
+                    Self::collect_identifiers(arg, out);
+                }
+            }
+            Expression::Index { object, index } => {
+                Self::collect_identifiers(object, out);
+                Self::collect_identifiers(index, out);
+            }
+            Expression::FieldAccess { object, .. } => {
+                Self::collect_identifiers(object, out);
+            }
+            _ => {}
+        }
+    }
+
+    /// Read the current values of the variables a failing contract clause
+    /// references, for `where: b = 0` diagnostics. Pure environment lookups
+    /// only — expressions are never re-evaluated here, so error construction
+    /// cannot trigger side effects.
+    fn collect_clause_values(&self, expr: &Expression) -> Vec<(String, String)> {
+        const MAX_VALUES: usize = 8;
+        const MAX_RENDERED_LEN: usize = 60;
+
+        let mut names = Vec::new();
+        Self::collect_identifiers(expr, &mut names);
+
+        let env = self.environment.borrow();
+        let mut values = Vec::new();
+        for name in names {
+            if values.len() >= MAX_VALUES {
+                break;
+            }
+            let Some(value) = env.get(&name) else {
+                continue;
+            };
+            let rendered = match &value {
+                Value::Function { .. } | Value::NativeFunction { .. } => continue,
+                Value::String(s) => format!("{:?}", s),
+                other => other.to_string(),
+            };
+            let mut rendered = rendered;
+            if rendered.len() > MAX_RENDERED_LEN {
+                // Truncate at a char boundary — String::truncate panics mid-char
+                let cut = (0..=MAX_RENDERED_LEN)
+                    .rev()
+                    .find(|i| rendered.is_char_boundary(*i))
+                    .unwrap_or(0);
+                rendered.truncate(cut);
+                rendered.push('…');
+            }
+            values.push((name, rendered));
+        }
+        values
     }
 
     /// Recursively find old() calls in an expression and capture their values
@@ -10530,11 +10649,19 @@ impl Interpreter {
             let result = self.eval_expression(inv_expr)?;
 
             if !result.is_truthy() {
+                // Field values are read from inv_env before the restore
+                let values = self.collect_clause_values(inv_expr);
                 self.environment = previous;
-                return Err(IntentError::ContractViolation(format!(
-                    "Invariant violated for '{}': {}",
-                    struct_name, condition_str
-                )));
+                return Err(IntentError::ContractViolation {
+                    message: format!(
+                        "Invariant violated for '{}': {}",
+                        struct_name, condition_str
+                    ),
+                    // Invariant expressions don't carry parsed lines yet
+                    line: 0,
+                    call_line: self.current_line,
+                    values,
+                });
             }
             self.contracts.check_invariant(&condition_str, true, None)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -800,6 +800,28 @@ fn format_error(error: &anyhow::Error, file_path: Option<&PathBuf>) {
             }
         }
 
+        // Contract violation context: runtime values + call site
+        if let IntentError::ContractViolation {
+            values, call_line, ..
+        } = intent_err
+        {
+            if !values.is_empty() {
+                let rendered = values
+                    .iter()
+                    .map(|(name, value)| format!("{} = {}", name, value))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                eprintln!("  {} {}", "where:".cyan().bold(), rendered);
+            }
+            if *call_line > 0 && Some(*call_line) != line_info {
+                eprintln!(
+                    "  {} contract checked for call at line {}",
+                    "note:".cyan().bold(),
+                    call_line
+                );
+            }
+        }
+
         // Suggestion ("Did you mean?")
         if let Some(suggestion) = intent_err.suggestion() {
             eprintln!(
@@ -2646,7 +2668,17 @@ fn check_file(path: &PathBuf) -> anyhow::Result<()> {
     let tokens: Vec<_> = lexer.collect();
 
     let mut parser = IntentParser::new(tokens);
-    let _ast = parser.parse()?;
+    let (_ast, parse_errors) = parser.parse_with_recovery();
+
+    if !parse_errors.is_empty() {
+        for e in &parse_errors {
+            match e.line() {
+                Some(line) => eprintln!("error[E002] line {}: {}", line, e),
+                None => eprintln!("error[E002]: {}", e),
+            }
+        }
+        anyhow::bail!("{} parse error(s) found", parse_errors.len());
+    }
 
     println!("{} No errors found in {}", "✓".green(), path.display());
     Ok(())
@@ -3175,8 +3207,10 @@ fn validate_project(path: &PathBuf) -> anyhow::Result<()> {
         let tokens: Vec<_> = lexer.collect();
         let mut parser = IntentParser::new(tokens);
 
-        match parser.parse() {
-            Ok(ast) => {
+        let (ast, parse_errors) = parser.parse_with_recovery();
+
+        match parse_errors.as_slice() {
+            [] => {
                 // Check for potential issues
                 let mut warnings = analyze_ast_warnings(&ast, &source);
 
@@ -3234,18 +3268,25 @@ fn validate_project(path: &PathBuf) -> anyhow::Result<()> {
                     );
                 }
             }
-            Err(e) => {
-                let error_msg = e.to_string();
-                // Try to extract line number from error
-                let line = extract_line_from_error(&error_msg);
+            errors => {
+                // One entry per recovered parse error; semantic checks are
+                // skipped because the AST is partial.
+                let error_entries: Vec<JsonValue> = errors
+                    .iter()
+                    .map(|e| {
+                        let error_msg = e.to_string();
+                        let line = e.line().or_else(|| extract_line_from_error(&error_msg));
+                        json!({"message": error_msg, "line": line})
+                    })
+                    .collect();
+                error_count += errors.len();
 
                 results.push(json!({
                     "file": relative_path,
                     "valid": false,
-                    "errors": [{"message": error_msg, "line": line}],
+                    "errors": error_entries,
                     "warnings": [],
                 }));
-                error_count += 1;
 
                 eprintln!("{} {}", "✗".red(), relative_path);
             }
@@ -3340,8 +3381,10 @@ fn lint_project(
         let tokens: Vec<_> = lexer.collect();
         let mut parser = IntentParser::new(tokens);
 
-        match parser.parse() {
-            Ok(ast) => {
+        let (ast, parse_errors) = parser.parse_with_recovery();
+
+        match parse_errors.as_slice() {
+            [] => {
                 // Run comprehensive lint checks
                 let mut issues = lint_ast(&ast, &source, &relative_path);
 
@@ -3429,20 +3472,37 @@ fn lint_project(
                     eprintln!("{} {}", "✓".green(), relative_path);
                 }
             }
-            Err(e) => {
-                let error_msg = e.to_string();
-                let line = extract_line_from_error(&error_msg);
+            errors => {
+                // Report every recovered parse error, then skip lint/type
+                // checks: semantic results on a partial AST are misleading.
+                let mut issues: Vec<JsonValue> = errors
+                    .iter()
+                    .map(|e| {
+                        let error_msg = e.to_string();
+                        let line = e.line().or_else(|| extract_line_from_error(&error_msg));
+                        json!({
+                            "severity": "error",
+                            "rule": "parse_error",
+                            "message": error_msg,
+                            "line": line,
+                            "column": e.column(),
+                        })
+                    })
+                    .collect();
+                if errors.len() >= ntnt::parser::MAX_PARSE_ERRORS {
+                    issues.push(json!({
+                        "severity": "suggestion",
+                        "rule": "parse_error",
+                        "message": "additional parse errors may be suppressed; re-lint after fixing the reported ones",
+                        "line": JsonValue::Null,
+                    }));
+                }
+                error_count += errors.len();
 
                 results.push(json!({
                     "file": relative_path,
-                    "issues": [{
-                        "severity": "error",
-                        "rule": "parse_error",
-                        "message": error_msg,
-                        "line": line
-                    }],
+                    "issues": issues,
                 }));
-                error_count += 1;
 
                 eprintln!("{} {}", "✗".red(), relative_path);
             }
@@ -4848,8 +4908,8 @@ fn contract_to_json(contract: &Option<ntnt::ast::Contract>) -> serde_json::Value
     use serde_json::json;
     match contract {
         Some(c) => json!({
-            "requires": c.requires.iter().map(|e| expr_to_string(e)).collect::<Vec<_>>(),
-            "ensures": c.ensures.iter().map(|e| expr_to_string(e)).collect::<Vec<_>>(),
+            "requires": c.requires.iter().map(|cond| expr_to_string(&cond.expression)).collect::<Vec<_>>(),
+            "ensures": c.ensures.iter().map(|cond| expr_to_string(&cond.expression)).collect::<Vec<_>>(),
         }),
         None => json!(null),
     }
@@ -5252,10 +5312,10 @@ fn collect_used_names(stmt: &ntnt::ast::Statement, names: &mut std::collections:
             // Collect from contracts too
             if let Some(c) = contract {
                 for req in &c.requires {
-                    collect_from_expr(req, names);
+                    collect_from_expr(&req.expression, names);
                 }
                 for ens in &c.ensures {
-                    collect_from_expr(ens, names);
+                    collect_from_expr(&ens.expression, names);
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3276,7 +3276,7 @@ fn validate_project(path: &PathBuf) -> anyhow::Result<()> {
                     .map(|e| {
                         let error_msg = e.to_string();
                         let line = e.line().or_else(|| extract_line_from_error(&error_msg));
-                        json!({"message": error_msg, "line": line})
+                        json!({"message": error_msg, "line": line, "column": e.column()})
                     })
                     .collect();
                 error_count += errors.len();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,12 +8,26 @@ use crate::lexer::{
     StringPart as LexerStringPart, TemplatePart as LexerTemplatePart, Token, TokenKind,
 };
 
+/// Maximum parse errors collected per file in recovery mode
+pub const MAX_PARSE_ERRORS: usize = 5;
+/// Minimum token distance between recorded errors (cascade suppression)
+const MIN_ERROR_TOKEN_GAP: usize = 2;
+
 /// Parser for Intent source code
 pub struct Parser {
     tokens: Vec<Token>,
     current: usize,
     /// Track if we're inside a map literal context (for nested map inference)
     in_map_context: bool,
+    /// When true, statement-level errors are recorded and parsing resumes at
+    /// the next statement boundary instead of aborting (lint/validate only)
+    recover: bool,
+    /// Errors collected while recovering
+    errors: Vec<IntentError>,
+    /// Line of the last recorded error (same-line dedup)
+    last_error_line: usize,
+    /// Token position of the last recorded error (cascade suppression)
+    last_error_pos: usize,
 }
 
 impl Parser {
@@ -22,6 +36,10 @@ impl Parser {
             tokens,
             current: 0,
             in_map_context: false,
+            recover: false,
+            errors: Vec::new(),
+            last_error_line: 0,
+            last_error_pos: 0,
         }
     }
 
@@ -34,6 +52,107 @@ impl Parser {
         }
 
         Ok(Program { statements })
+    }
+
+    /// Parse a complete program, recovering at statement boundaries after
+    /// errors so multiple syntax errors can be reported in a single pass.
+    ///
+    /// Returns the statements that parsed successfully alongside every
+    /// collected error (capped at [`MAX_PARSE_ERRORS`]). Intended for lint,
+    /// validate, and check paths only — the run/import pipeline uses
+    /// [`Parser::parse`], which still aborts on the first error and never
+    /// executes a partial AST.
+    pub fn parse_with_recovery(&mut self) -> (Program, Vec<IntentError>) {
+        self.recover = true;
+
+        let mut statements = Vec::new();
+        while !self.is_at_end() {
+            match self.declaration() {
+                Ok(stmt) => statements.push(stmt),
+                Err(e) => {
+                    self.record_error(e);
+                    if self.errors.len() >= MAX_PARSE_ERRORS {
+                        break;
+                    }
+                    self.synchronize();
+                    // A bare `}` is never a valid top-level declaration; any
+                    // we see here are leftovers from a broken construct.
+                    while self.check(&TokenKind::RightBrace) {
+                        self.advance();
+                    }
+                }
+            }
+        }
+
+        self.recover = false;
+        (Program { statements }, std::mem::take(&mut self.errors))
+    }
+
+    /// Record an error during recovery, suppressing cascades: errors on the
+    /// same line as the previous one, or within a couple of tokens of it,
+    /// are usually artifacts of the first failure rather than new problems.
+    fn record_error(&mut self, e: IntentError) {
+        let line = e.line().unwrap_or(0);
+        let same_line = line != 0 && line == self.last_error_line;
+        let too_close =
+            !self.errors.is_empty() && self.current < self.last_error_pos + MIN_ERROR_TOKEN_GAP;
+        if same_line || too_close {
+            return;
+        }
+        self.last_error_line = line;
+        self.last_error_pos = self.current;
+        self.errors.push(e);
+    }
+
+    /// Skip tokens until a likely statement boundary: either a token that
+    /// starts a new line and looks like a statement keyword, or a `}` that
+    /// lets an enclosing block close. Always advances at least one token so
+    /// recovery cannot loop forever.
+    fn synchronize(&mut self) {
+        self.advance();
+
+        while let Some(tok) = self.peek() {
+            if tok.kind == TokenKind::RightBrace {
+                return;
+            }
+            // The lexer swallows newlines (no Newline token is emitted), so
+            // line starts are detected by comparing Token.line values.
+            let starts_line = self.previous().is_none_or(|p| p.line < tok.line);
+            if starts_line && Self::is_statement_start(&tok.kind) {
+                return;
+            }
+            self.advance();
+        }
+    }
+
+    /// Tokens that can begin a top-level or block statement — used as
+    /// synchronization points for error recovery.
+    fn is_statement_start(kind: &TokenKind) -> bool {
+        matches!(
+            kind,
+            TokenKind::Let
+                | TokenKind::Fn
+                | TokenKind::Type
+                | TokenKind::Struct
+                | TokenKind::Enum
+                | TokenKind::Trait
+                | TokenKind::Impl
+                | TokenKind::Mod
+                | TokenKind::Use
+                | TokenKind::Import
+                | TokenKind::Export
+                | TokenKind::Pub
+                | TokenKind::Server
+                | TokenKind::If
+                | TokenKind::While
+                | TokenKind::Loop
+                | TokenKind::For
+                | TokenKind::Defer
+                | TokenKind::Break
+                | TokenKind::Continue
+                | TokenKind::Return
+                | TokenKind::Hash
+        )
     }
 
     // Helper methods
@@ -369,11 +488,19 @@ impl Parser {
         let mut ensures = Vec::new();
 
         while self.match_token(&[TokenKind::Requires]) {
-            requires.push(self.expression()?);
+            let line = self.previous().map(|t| t.line).unwrap_or(0);
+            requires.push(ContractCondition {
+                expression: self.expression()?,
+                line,
+            });
         }
 
         while self.match_token(&[TokenKind::Ensures]) {
-            ensures.push(self.expression()?);
+            let line = self.previous().map(|t| t.line).unwrap_or(0);
+            ensures.push(ContractCondition {
+                expression: self.expression()?,
+                line,
+            });
         }
 
         if requires.is_empty() && ensures.is_empty() {
@@ -1436,7 +1563,17 @@ impl Parser {
         let mut statements = Vec::new();
 
         while !self.check(&TokenKind::RightBrace) && !self.is_at_end() {
-            statements.push(self.declaration()?);
+            match self.declaration() {
+                Ok(stmt) => statements.push(stmt),
+                // In recovery mode, record the error and resync so the rest
+                // of the block (and file) can still be checked. synchronize()
+                // stops at `}` so the block closes normally.
+                Err(e) if self.recover && self.errors.len() < MAX_PARSE_ERRORS => {
+                    self.record_error(e);
+                    self.synchronize();
+                }
+                Err(e) => return Err(e),
+            }
         }
 
         self.consume(&TokenKind::RightBrace, "Expected '}' after block")?;
@@ -2939,6 +3076,77 @@ mod tests {
             Statement::Located { stmt, .. } => stmt,
             other => other,
         }
+    }
+
+    fn parse_recover(source: &str) -> (Program, Vec<IntentError>) {
+        let lexer = Lexer::new(source);
+        let tokens: Vec<_> = lexer.collect();
+        let mut parser = Parser::new(tokens);
+        parser.parse_with_recovery()
+    }
+
+    #[test]
+    fn recovery_reports_multiple_top_level_errors_and_keeps_valid_statements() {
+        let source = "let a = 1\nlet 2 = 3\nlet b = 4\nlet 5 = 6\nlet c = 7";
+        let (program, errors) = parse_recover(source);
+
+        assert_eq!(errors.len(), 2, "expected two errors, got: {errors:?}");
+        assert_eq!(errors[0].line(), Some(2));
+        assert_eq!(errors[1].line(), Some(4));
+        // The three valid lets survive recovery
+        assert_eq!(program.statements.len(), 3);
+    }
+
+    #[test]
+    fn recovery_reports_errors_across_function_bodies() {
+        let source = "fn one() {\n    let 1 = 2\n}\nfn two() {\n    let 3 = 4\n}\nfn three() {\n    let x = 5\n}";
+        let (program, errors) = parse_recover(source);
+
+        assert_eq!(errors.len(), 2, "expected two errors, got: {errors:?}");
+        assert_eq!(errors[0].line(), Some(2));
+        assert_eq!(errors[1].line(), Some(5));
+        // All three functions still parse (bodies recovered)
+        assert_eq!(program.statements.len(), 3);
+    }
+
+    #[test]
+    fn recovery_caps_errors_at_maximum() {
+        let mut source = String::new();
+        for i in 0..8 {
+            source.push_str(&format!("let {} = {}\n", i * 2, i * 2 + 1));
+        }
+        let (_, errors) = parse_recover(&source);
+        assert_eq!(errors.len(), MAX_PARSE_ERRORS);
+    }
+
+    #[test]
+    fn recovery_suppresses_cascade_from_single_error() {
+        let source = "let x = 1 +\nlet y = 2\nlet z = 3";
+        let (_, errors) = parse_recover(source);
+        // One broken expression should not produce a pile of follow-on errors
+        assert!(
+            errors.len() <= 2,
+            "cascading errors from one break: {errors:?}"
+        );
+        assert!(!errors.is_empty());
+    }
+
+    #[test]
+    fn recovery_terminates_on_token_soup() {
+        let source = ") ) ( ] } @ } ) ( ] fn ) let }";
+        let (_, errors) = parse_recover(source);
+        assert!(!errors.is_empty());
+        assert!(errors.len() <= MAX_PARSE_ERRORS);
+    }
+
+    #[test]
+    fn plain_parse_still_aborts_on_first_error() {
+        let source = "let a = 1\nlet 2 = 3\nlet 5 = 6";
+        let err = parse(source).unwrap_err();
+        assert_eq!(err.line(), Some(2));
+
+        let (_, recovered) = parse_recover(source);
+        assert_eq!(recovered[0].to_string(), err.to_string());
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,6 +92,12 @@ impl Parser {
     /// same line as the previous one, or within a couple of tokens of it,
     /// are usually artifacts of the first failure rather than new problems.
     fn record_error(&mut self, e: IntentError) {
+        // Enforce the cap here, not just in the loops: a block-level error at
+        // the cap propagates out of block() and reaches the top-level loop's
+        // record_error, which would otherwise push a 6th error.
+        if self.errors.len() >= MAX_PARSE_ERRORS {
+            return;
+        }
         let line = e.line().unwrap_or(0);
         let same_line = line != 0 && line == self.last_error_line;
         let too_close =
@@ -3117,6 +3123,19 @@ mod tests {
         }
         let (_, errors) = parse_recover(&source);
         assert_eq!(errors.len(), MAX_PARSE_ERRORS);
+    }
+
+    #[test]
+    fn recovery_cap_holds_when_block_error_propagates_to_top_level() {
+        // Errors inside fn bodies are recorded by block(); once the cap is
+        // reached the block guard stops catching and the error propagates to
+        // the top-level loop, which must not record past the cap either.
+        let mut source = String::new();
+        for i in 0..7 {
+            source.push_str(&format!("fn f{}() {{\n    let {} = 1\n}}\n", i, i * 2));
+        }
+        let (_, errors) = parse_recover(&source);
+        assert_eq!(errors.len(), MAX_PARSE_ERRORS, "cap breached: {errors:?}");
     }
 
     #[test]

--- a/src/stdlib/concurrent.rs
+++ b/src/stdlib/concurrent.rs
@@ -1310,11 +1310,11 @@ fn collect_free_vars(
                 bind_parameter_defaults_and_names(params, referenced, &mut fn_bound);
 
                 if let Some(contract) = contract {
-                    for expr in &contract.requires {
-                        collect_free_vars_expr(expr, referenced, &fn_bound);
+                    for clause in &contract.requires {
+                        collect_free_vars_expr(&clause.expression, referenced, &fn_bound);
                     }
-                    for expr in &contract.ensures {
-                        collect_free_vars_expr(expr, referenced, &fn_bound);
+                    for clause in &contract.ensures {
+                        collect_free_vars_expr(&clause.expression, referenced, &fn_bound);
                     }
                 }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1223,12 +1223,16 @@ impl TypeContext {
                     let fn_line = self.find_line_near(&format!("fn {}", name));
 
                     // requires: check each expression evaluates to Bool
-                    for req_expr in &contract.requires {
-                        let req_type = self.infer_expression(req_expr);
+                    for req_clause in &contract.requires {
+                        let req_type = self.infer_expression(&req_clause.expression);
                         if !self.compatible(&req_type, &Type::Bool)
                             && !matches!(req_type, Type::Any)
                         {
-                            let line = self.find_line_near_from("requires", fn_line);
+                            let line = if req_clause.line > 0 {
+                                req_clause.line
+                            } else {
+                                self.find_line_near_from("requires", fn_line)
+                            };
                             self.error(
                                 format!(
                                     "Contract 'requires' in '{}' should be Bool, got {}",
@@ -1246,12 +1250,16 @@ impl TypeContext {
                         let result_type = resolved_return.clone().unwrap_or(Type::Any);
                         self.bind("result", result_type);
 
-                        for ens_expr in &contract.ensures {
-                            let ens_type = self.infer_expression(ens_expr);
+                        for ens_clause in &contract.ensures {
+                            let ens_type = self.infer_expression(&ens_clause.expression);
                             if !self.compatible(&ens_type, &Type::Bool)
                                 && !matches!(ens_type, Type::Any)
                             {
-                                let line = self.find_line_near_from("ensures", fn_line);
+                                let line = if ens_clause.line > 0 {
+                                    ens_clause.line
+                                } else {
+                                    self.find_line_near_from("ensures", fn_line)
+                                };
                                 self.error(
                                     format!(
                                         "Contract 'ensures' in '{}' should be Bool, got {}",

--- a/tests/diagnostics_tests.rs
+++ b/tests/diagnostics_tests.rs
@@ -209,6 +209,19 @@ fn e004_multi_param_clause_lists_all_values_in_order() {
 }
 
 #[test]
+fn e004_ufcs_receiver_appears_in_where_values() {
+    // `s.len()` is a MethodCall — the receiver must still be collected
+    let code = "fn shout(s: String) -> String\n    requires s.len() > 0\n{\n    return s\n}\n\nlet x = shout(\"\")";
+    let (_stdout, stderr, exit_code) = run(code);
+
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("where: s = \"\""),
+        "UFCS receiver missing from where values: {stderr}"
+    );
+}
+
+#[test]
 fn e004_message_text_is_unchanged_for_existing_consumers() {
     // HTTP mapping and user tests match on this exact Display prefix
     let code = "fn divide(a: Int, b: Int) -> Int\n    requires b != 0\n{\n    return a / b\n}\n\nlet boom = divide(10, 0)";

--- a/tests/diagnostics_tests.rs
+++ b/tests/diagnostics_tests.rs
@@ -1,0 +1,221 @@
+//! Integration tests for DD-063 Rec 4a diagnostics:
+//! multi-error parser recovery in lint/validate, and enriched E004 contract
+//! violations (clause line, source frame, call site, runtime values).
+
+use std::fs;
+use std::io::Write;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a unique test file path
+fn unique_test_file(prefix: &str) -> String {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let thread_id = format!("{:?}", std::thread::current().id());
+    let temp_dir = std::env::temp_dir();
+    temp_dir
+        .join(format!(
+            "ntnt_{}_{}_{}_{}.tnt",
+            prefix,
+            std::process::id(),
+            thread_id.replace(|c: char| !c.is_alphanumeric(), "_"),
+            counter
+        ))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn ntnt_binary() -> std::path::PathBuf {
+    let exe = std::env::consts::EXE_SUFFIX;
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let debug_path = manifest.join(format!("target/debug/ntnt{}", exe));
+    let dev_release_path = manifest.join(format!("target/dev-release/ntnt{}", exe));
+    let release_path = manifest.join(format!("target/release/ntnt{}", exe));
+
+    if debug_path.exists() {
+        debug_path
+    } else if dev_release_path.exists() {
+        dev_release_path
+    } else if release_path.exists() {
+        release_path
+    } else {
+        panic!("No ntnt binary found. Run 'cargo build' first.");
+    }
+}
+
+/// Run the ntnt binary with the given subcommand args on a code snippet.
+/// Returns (stdout, stderr, exit_code).
+fn run_ntnt(args: &[&str], code: &str) -> (String, String, i32) {
+    let test_file = unique_test_file("diagnostics");
+    let mut file = fs::File::create(&test_file).expect("Failed to create test file");
+    writeln!(file, "{}", code).expect("Failed to write test file");
+
+    let mut cmd = Command::new(ntnt_binary());
+    cmd.args(args)
+        .arg(&test_file)
+        .current_dir(env!("CARGO_MANIFEST_DIR"));
+
+    let output = cmd.output().expect("Failed to execute ntnt");
+    let _ = fs::remove_file(&test_file);
+
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+fn lint(code: &str) -> (String, String, i32) {
+    run_ntnt(&["lint"], code)
+}
+
+fn run(code: &str) -> (String, String, i32) {
+    run_ntnt(&["run"], code)
+}
+
+fn count_parse_errors(lint_stdout: &str) -> usize {
+    lint_stdout.matches("\"rule\": \"parse_error\"").count()
+}
+
+// ── Parser error recovery (lint) ───────────────────────────────────────
+
+#[test]
+fn lint_reports_multiple_parse_errors_with_distinct_lines() {
+    let code = "fn one() {\n    let 1 = 2\n}\n\nfn two() {\n    let 3 = 4\n}\n\nfn three() {\n    let 5 = 6\n}";
+    let (stdout, _stderr, _) = lint(code);
+
+    // Three errors, one per broken function, each with a severity of error
+    assert_eq!(
+        count_parse_errors(&stdout),
+        3,
+        "expected 3 parse_error issues in: {stdout}"
+    );
+    assert!(stdout.contains("\"line\": 2"), "missing line 2: {stdout}");
+    assert!(stdout.contains("\"line\": 6"), "missing line 6: {stdout}");
+    assert!(stdout.contains("\"line\": 10"), "missing line 10: {stdout}");
+}
+
+#[test]
+fn lint_caps_parse_errors_and_notes_suppression() {
+    let mut code = String::new();
+    for i in 0..8 {
+        code.push_str(&format!("let {} = {}\n", i * 2, i * 2 + 1));
+    }
+    let (stdout, _stderr, _) = lint(&code);
+
+    assert_eq!(
+        count_parse_errors(&stdout),
+        // 5 real errors + 1 informational cap notice (same rule id)
+        6,
+        "expected capped errors plus notice in: {stdout}"
+    );
+    assert!(
+        stdout.contains("additional parse errors may be suppressed"),
+        "missing cap notice: {stdout}"
+    );
+}
+
+#[test]
+fn lint_does_not_cascade_from_a_single_broken_expression() {
+    let code = "let x = 1 +\nlet y = 2\nlet z = 3";
+    let (stdout, _stderr, _) = lint(code);
+
+    let count = count_parse_errors(&stdout);
+    assert!(
+        (1..=2).contains(&count),
+        "one broken expression should yield 1-2 errors, got {count}: {stdout}"
+    );
+}
+
+#[test]
+fn lint_skips_semantic_checks_when_parse_errors_exist() {
+    // The undefined variable would normally produce a type_check issue;
+    // with a parse error present, semantic checks must be suppressed.
+    let code = "let 1 = 2\nprint(definitely_undefined_variable)";
+    let (stdout, _stderr, _) = lint(code);
+
+    assert!(count_parse_errors(&stdout) >= 1);
+    assert!(
+        !stdout.contains("\"rule\": \"type_check\""),
+        "semantic issues reported on a partial AST: {stdout}"
+    );
+}
+
+#[test]
+fn run_still_aborts_on_first_parse_error_only() {
+    let code = "fn one() {\n    let 1 = 2\n}\n\nfn two() {\n    let 3 = 4\n}";
+    let (_stdout, stderr, exit_code) = run(code);
+
+    assert_ne!(exit_code, 0);
+    assert!(stderr.contains("error[E002]"), "stderr: {stderr}");
+    assert!(stderr.contains("line 2"), "stderr: {stderr}");
+    // The second error is never reached on the run path
+    assert!(
+        !stderr.contains("line 6"),
+        "run path reported more than the first error: {stderr}"
+    );
+}
+
+// ── Enriched E004 contract violations ──────────────────────────────────
+
+#[test]
+fn e004_precondition_shows_clause_line_frame_and_values() {
+    let code = "fn divide(a: Int, b: Int) -> Int\n    requires b != 0\n{\n    return a / b\n}\n\nlet boom = divide(10, 0)";
+    let (_stdout, stderr, exit_code) = run(code);
+
+    assert_ne!(exit_code, 0);
+    assert!(stderr.contains("error[E004]"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("Precondition failed in 'divide': b != 0"),
+        "stderr: {stderr}"
+    );
+    // Clause line (the `requires` on line 2) drives the location + frame
+    assert!(stderr.contains(":2"), "missing clause line: {stderr}");
+    assert!(
+        stderr.contains("requires b != 0"),
+        "missing source frame: {stderr}"
+    );
+    assert!(stderr.contains("where: b = 0"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("call at line 7"),
+        "missing call-site note: {stderr}"
+    );
+}
+
+#[test]
+fn e004_postcondition_shows_result_value() {
+    let code = "fn buggy_add(a: Int, b: Int) -> Int\n    ensures result == a + b\n{\n    return a + b + 1\n}\n\nlet x = buggy_add(2, 3)";
+    let (_stdout, stderr, exit_code) = run(code);
+
+    assert_ne!(exit_code, 0);
+    assert!(stderr.contains("error[E004]"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("where: result = 6, a = 2, b = 3"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn e004_multi_param_clause_lists_all_values_in_order() {
+    let code = "fn withdraw(from_balance: Int, amount: Int) -> Int\n    requires from_balance >= amount\n{\n    return from_balance - amount\n}\n\nlet x = withdraw(50, 100)";
+    let (_stdout, stderr, exit_code) = run(code);
+
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("where: from_balance = 50, amount = 100"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn e004_message_text_is_unchanged_for_existing_consumers() {
+    // HTTP mapping and user tests match on this exact Display prefix
+    let code = "fn divide(a: Int, b: Int) -> Int\n    requires b != 0\n{\n    return a / b\n}\n\nlet boom = divide(10, 0)";
+    let (_stdout, stderr, _) = run(code);
+
+    assert!(
+        stderr.contains("Contract violation: Precondition failed in 'divide': b != 0"),
+        "Display text drifted: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

DD-063 Rec 4a — the first of the two diagnostics PRs upgrading the agent edit-lint-run loop to match the error infrastructure.

### Parser error recovery (lint/validate/check only)

- New `Parser::parse_with_recovery() -> (Program, Vec<IntentError>)` with statement-level panic-mode synchronization: cap of 5 errors per file, same-line dedup plus minimum-token-gap cascade suppression, and an unconditional token advance in `synchronize()` so recovery can never loop.
- `parse()` is byte-for-byte unchanged — recovery is gated behind a private flag, so all 18 existing call sites (run path, module imports, REPL, intent) keep single-error behavior and never execute a partial AST.
- `ntnt lint` / `ntnt validate` now report every recovered error (one `parse_error` issue each, with line and column) and skip lint/type checks on files with parse errors, since semantic findings on a partial AST are misleading. A notice is appended when the 5-error cap is hit. `ntnt check` reports all errors and exits nonzero.

Three syntax errors that previously cost three lint round trips are now reported in one pass:

```
✗ multi_err.tnt
2  Parser error at line 2, column 9: Expected variable name
6  Parser error at line 6, column 9: Expected variable name
12 Parser error at line 12, column 9: Expected variable name
```

### Enriched E004 contract violations

- `ast::ContractCondition { expression, line }` threads each `requires`/`ensures` clause's source line from `parse_contract()` through to the interpreter.
- `IntentError::ContractViolation` becomes a struct variant `{ message, line, call_line, values }`. Clause variable values are read from the function environment **before** it is restored (pure `Environment::get` lookups only — expressions are never re-evaluated during error construction, so no side effects). Value rendering truncates at char boundaries.
- The typechecker's contract Bool-check diagnostics now use the exact clause line instead of a string-search heuristic.

Before: `error[E004] Contract violation: Precondition failed in 'divide': b != 0` (no line, no frame, no values). After:

```
error[E004]
  --> contract_test.tnt:2
  = Contract violation: Precondition failed in 'divide': b != 0
  --> Source context
   |
   1 | fn divide(a: Int, b: Int) -> Int
   2 |     requires b != 0
   3 |     ensures result * b == a
   |
  where: b = 0
  note: contract checked for call at line 10
```

Display text is unchanged, preserving the HTTP status mapping (400 precondition / 500 postcondition) and all existing string-match consumers.

## Defaults applied (per DD-063 scoping)

- Run path stays first-error-only; lint is the multi-error surface
- MAX_PARSE_ERRORS = 5
- Struct invariants get `where:` values but no clause line in v1 (invariant expressions don't flow through `parse_contract`)
- Lint exit code semantics untouched (still 0; JSON is the contract)
- JSON counting change: a file with N parse errors now contributes N to `summary.errors` (previously 1), matching how semantic errors are counted; per-file counts remain available as `files[].issues`. Documented in the agent guide.

## Maintainer decision to confirm

`ntnt parse --json` output for functions with contracts now serializes clauses as `{expression, line}` objects instead of bare expressions (`ntnt inspect` output is unchanged — still plain strings). Flagging per the DD: acceptable, or should a compatibility serializer flatten them back?

## Test plan

- 6 new parser unit tests: multi-error recovery, block-level recovery, 5-error cap, cascade suppression, token-soup termination, `parse()` regression guard
- 1 new error unit test: E004 line/code/at_line backfill/rich_display
- 9 new integration tests (`tests/diagnostics_tests.rs`): multi-error lint with distinct lines, cap notice, no-cascade, partial-AST semantic suppression, run-path first-error regression, E004 pre/post/multi-param with `where:` values and source frames, Display-text stability
- Full suite: 1697 tests, 0 failures
- Regression sweep: `ntnt lint` output byte-identical across all 45 `examples/` files (before/after diff)

Part of DD-063 (dd-063-language-assessment.md). PR-4 (method bridge hints, unknown-method lint, IAL suggestions, `ntnt intent lint`) follows separately.
