### PR TITLE
feat(diagnostics): bridge hints, unknown-method lint, IAL suggestions, ntnt intent lint (DD-063 PR-4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ fn divide(a: Int, b: Int) -> Int
 4. **Verify** with `ntnt intent check` or `ntnt intent studio`
 
 ```bash
+ntnt intent lint server.intent     # Static glossary/scenario check — run after editing .intent
 ntnt intent check server.tnt       # Verify code matches intent
 ntnt intent studio server.intent   # Visual studio with live tests
 ntnt intent coverage server.tnt    # Feature coverage report
@@ -194,6 +195,7 @@ ntnt run <file>              # Run (hot-reload in dev)
 ntnt lint <file>             # Check for errors
 ntnt lint --strict <file>    # Strict type warnings
 ntnt test <file> --get /     # Test HTTP endpoints
+ntnt intent lint <intent>    # Static glossary/scenario validation
 ntnt intent check <file>     # Verify intent specs
 ntnt intent studio <intent>  # Visual studio
 ntnt docs [query]            # Search stdlib docs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1421,14 +1421,18 @@ $ ntnt intent validate server.intent
 
 **Implementation plan:**
 
-- [ ] `ntnt intent validate <file.intent>` — parse and validate without server
-- [ ] Check all glossary terms resolve to primitives (no dangling references)
-- [ ] Warn on unused glossary terms
+> Shipped as **`ntnt intent lint`** (DD-063 Rec 4b) — same feature, named to
+> match `ntnt lint`. Remaining items below extend it.
+
+- [x] `ntnt intent lint <file.intent>` — parse and validate without server (also accepts a `.tnt` path with a paired `.intent`)
+- [x] Check all scenario when-clauses and outcomes resolve (mirrors the execution fallback chain)
+- [x] Detect glossary definition cycles, including in entries no scenario uses
+- [x] Warn on unused glossary terms
 - [ ] Warn on features with no scenarios
 - [ ] Warn on duplicate feature IDs
 - [ ] Validate `@implements` annotations reference existing feature IDs (cross-check with `.tnt` file)
-- [ ] Suggest corrections for unresolved terms (Levenshtein distance against glossary + standard terms)
-- [ ] JSON output mode for agent consumption
+- [x] Suggest corrections for unresolved terms (Levenshtein distance against glossary + standard terms)
+- [x] JSON output mode for agent consumption (`--json`, exit 1 on errors for CI)
 
 ### 8.3 Glossary Inspector (`ntnt intent glossary`)
 

--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -130,7 +130,7 @@ Scoping also surfaced **two additional doc drifts** beyond the v2 findings: CLAU
 - [x] **PR-1** — `${}` interpolation detection (Rec 1) — S
 - [x] **PR-2** — Intentional syntax contract tests, CLAUDE.md truth, UFCS embrace (Rec 2) — S
 - [x] **PR-3** — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M
-- [ ] **PR-4** — Diagnostics II: method bridge hints, unknown-method lint, IAL suggestions, `ntnt intent lint` (Rec 4b) — M
+- [x] **PR-4** — Diagnostics II: method bridge hints, unknown-method lint, IAL suggestions, `ntnt intent lint` (Rec 4b) — M
 - [ ] **PR-5** — Index out-of-bounds loudness (Rec 3) — M — **blocked on decisions**
 - [ ] Recs 5–10 — unscheduled, see end of section
 
@@ -178,12 +178,12 @@ Defaults applied: run path stays first-error-only (lint is the multi-error surfa
 
 Four self-contained commits in one PR: (1) method-call misses get Levenshtein suggestions over `Environment::keys()` plus a small alias table (`length→len`, …) and a UFCS bridge hint ("methods resolve to free functions: try `len(s)`"); (2) the typechecker warns on method names found in neither the function registry, builtin sigs, nor scope (gated to non-`Any` receivers; warning in default lint mode, error in strict); (3) `ResolveError` gains `kind` + `suggestions` computed over normalized vocabulary patterns, flowing to intent-check output automatically; (4) `ntnt intent lint` statically resolves every scenario assertion against glossary+standard vocabulary without executing primitives — reports unresolved terms (with suggestions), cycles, orphan glossary entries; exit 1 on unresolved/cycles, `--json` for CI.
 
-- [ ] Method-miss suggestions + alias table + `hint` field on `IntentError::UndefinedFunction` (`src/interpreter.rs` ~7044)
-- [ ] Typechecker unknown-method diagnostic + register the five runtime-global option/result helpers (`is_some`/`is_none`/`is_ok`/`is_err`/`unwrap_or`) in `builtin_sigs` (note: introduces arity checking on previously-unchecked calls — release-note item)
-- [ ] IAL `ResolveError.suggestions` via vocabulary-key Levenshtein with `normalize_term_for_cycle` normalization
-- [ ] `intent::lint_intent_file()` + clap subcommand + `--json`; orphan entries stay warnings (never exit-1 — legacy direct-pattern fallback makes orphan detection imperfect)
+- [x] Method-miss suggestions + alias table + `hint` field on `IntentError::UndefinedFunction` (`src/interpreter.rs` ~7044)
+- [x] Typechecker unknown-method diagnostic + register the five runtime-global option/result helpers (`is_some`/`is_none`/`is_ok`/`is_err`/`unwrap_or`) in `builtin_sigs` (note: introduces arity checking on previously-unchecked calls — release-note item)
+- [x] IAL `ResolveError.suggestions` via vocabulary-key Levenshtein with `normalize_term_for_cycle` normalization
+- [x] `intent::lint_intent_file()` + clap subcommand + `--json`; orphan entries stay warnings (never exit-1 — legacy direct-pattern fallback makes orphan detection imperfect)
 - [ ] Visual check of Intent Studio error rendering (trace.error string changes)
-- [ ] Lint-run real .tnt projects to confirm unknown-method noise level before merging
+- [x] Lint-run real .tnt projects to confirm unknown-method noise level before merging
 
 Defaults applied: unknown-method fires in default lint mode (that's the DD-063 complaint — `lint` passed clean on `s.length()`); `intent lint` accepts a `.tnt` path and auto-locates the paired `.intent`. Maintainer decision: approve/trim the alias table (`length→len, size→len, count→len, map→transform, to_string→str, to_str→str, append→push, upper→to_upper, lower→to_lower`).
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -315,10 +315,17 @@ For the complete list, see [IAL_REFERENCE.md](IAL_REFERENCE.md).
 
 ```bash
 ntnt intent check server.tnt       # Verify code matches intent
+ntnt intent lint server.intent     # Static glossary/scenario validation (no server)
 ntnt intent studio server.intent   # Live visual feedback (opens :3001)
 ntnt intent coverage server.tnt    # Feature coverage report
 ntnt intent init server.intent     # Generate scaffolding from intent
 ```
+
+Run `ntnt intent lint` after editing a `.intent` file and before
+`intent check`: it catches unresolved terms (with did-you-mean
+suggestions), glossary cycles, and unused glossary entries in
+milliseconds, without starting a server. Exit 1 means at least one
+scenario cannot execute as written.
 
 ---
 
@@ -448,6 +455,22 @@ Two rules to know:
 - **Closures stored in map values are not dot-callable.** `m.f(10)` fails with
   E007 `Undefined function: f` because the parens make it a UFCS lookup for a
   function named `f`. Bind first: `let f = m.f` then `f(10)`.
+
+**Unknown methods are caught early with a bridge back to the real function.**
+`ntnt lint` warns (rule `unknown_method`; error in strict mode) when a
+dot-call names a method that no defined or imported function backs, and the
+runtime E007 shows the closest match plus the free-function form:
+
+```text
+error[E007]
+  = Undefined function: length
+  help: Did you mean 'len'?
+  hint: NTNT methods resolve to free functions — try len(s)
+```
+
+Common method names from other languages are mapped directly: `length`,
+`size`, `count` → `len`; `to_string`/`to_str` → `str`; `append` → `push`;
+`upper`/`lower` → `to_upper`/`to_lower`.
 
 **When to use dot vs brackets on maps:**
 - **Dot notation** for static keys known at write time: `req.params.id`

--- a/docs/ial.toml
+++ b/docs/ial.toml
@@ -583,6 +583,11 @@ command = "ntnt intent check <file>"
 description = "Run tests defined in intent file against implementation"
 example = "ntnt intent check server.tnt"
 
+[commands.lint]
+command = "ntnt intent lint <file>"
+description = "Statically validate glossary and scenarios without running tests: unresolved terms and when-clauses (with did-you-mean suggestions), definition cycles, and orphan glossary entries. Exit 1 on unresolved terms or cycles; orphans are warnings only. --json for CI"
+example = "ntnt intent lint server.intent"
+
 [commands.coverage]
 command = "ntnt intent coverage <file>"
 description = "Show which features have implementations"

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,6 +100,8 @@ pub enum IntentError {
     UndefinedFunction {
         name: String,
         suggestion: Option<String>,
+        /// Extra guidance beyond did-you-mean (e.g. the UFCS bridge hint)
+        hint: Option<String>,
 
         line: usize,
     },
@@ -275,7 +277,31 @@ impl IntentError {
             _ => None,
         }
     }
+
+    /// Return the extra hint if this error has one
+    pub fn hint(&self) -> Option<&str> {
+        match self {
+            IntentError::UndefinedFunction { hint, .. } => hint.as_deref(),
+            _ => None,
+        }
+    }
 }
+
+/// Method names agents commonly reach for, mapped to the NTNT function that
+/// actually exists. Consulted before Levenshtein by both the runtime
+/// method-miss error and the typechecker's unknown-method lint.
+pub const METHOD_ALIAS_HINTS: &[(&str, &str)] = &[
+    ("length", "len"),
+    ("size", "len"),
+    ("count", "len"),
+    // no "map" entry: `map` is a keyword, so `.map(` is a parse error and
+    // never reaches method dispatch
+    ("to_string", "str"),
+    ("to_str", "str"),
+    ("append", "push"),
+    ("upper", "to_upper"),
+    ("lower", "to_lower"),
+];
 
 /// Compute the Levenshtein edit distance between two strings
 pub fn levenshtein_distance(a: &str, b: &str) -> usize {
@@ -472,6 +498,7 @@ mod tests {
             IntentError::UndefinedFunction {
                 name: String::new(),
                 suggestion: None,
+                hint: None,
                 line: 0,
             },
             IntentError::ArityMismatch {

--- a/src/ial/mod.rs
+++ b/src/ial/mod.rs
@@ -44,6 +44,7 @@ pub use execute::{execute, execute_all, Context, ExecuteResult};
 pub use primitives::{CheckOp, Primitive, Value};
 pub use resolve::{
     resolve, resolve_all, resolve_with_trace, ResolutionStep, ResolutionTrace, ResolveError,
+    ResolveErrorKind,
 };
 pub use standard::{parse_glossary, standard_vocabulary};
 pub use vocabulary::{Definition, Pattern, Term, Vocabulary};

--- a/src/ial/resolve.rs
+++ b/src/ial/resolve.rs
@@ -51,20 +51,68 @@ pub struct ResolutionTrace {
     pub error: Option<String>,
 }
 
+/// What kind of resolution failure occurred
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveErrorKind {
+    /// The term matched nothing in the vocabulary
+    UnknownTerm,
+    /// The term's definitions form a cycle
+    Cycle,
+    /// Resolution exceeded MAX_DEPTH
+    MaxDepth,
+}
+
 /// Error during resolution
 #[derive(Debug, Clone)]
 pub struct ResolveError {
     pub term: String,
     pub message: String,
+    pub kind: ResolveErrorKind,
+    /// Near-miss vocabulary patterns for unknown terms (best first)
+    pub suggestions: Vec<String>,
 }
 
 impl std::fmt::Display for ResolveError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Failed to resolve '{}': {}", self.term, self.message)
+        write!(f, "Failed to resolve '{}': {}", self.term, self.message)?;
+        if !self.suggestions.is_empty() {
+            let quoted: Vec<String> = self
+                .suggestions
+                .iter()
+                .map(|s| format!("'{}'", s))
+                .collect();
+            write!(f, "\n  did you mean: {}?", quoted.join(", "))?;
+        }
+        Ok(())
     }
 }
 
 impl std::error::Error for ResolveError {}
+
+/// Find vocabulary patterns similar to an unknown term. Both sides are
+/// normalized with the cycle normalizer (quoted args and `{param}` become
+/// placeholders) so `body containz "x"` can match `body contains {text}`.
+/// Returns up to 3 original pattern texts, closest first.
+fn suggest_similar_terms(text: &str, vocab: &Vocabulary) -> Vec<String> {
+    let normalized = normalize_term_for_cycle(text);
+    // Identifier-tuned thresholds in find_suggestion are too tight for
+    // multi-word phrases; allow roughly a quarter of the phrase to differ.
+    let max_distance = std::cmp::max(2, normalized.len() / 4);
+
+    let mut scored: Vec<(usize, String)> = vocab
+        .pattern_texts()
+        .into_iter()
+        .filter_map(|pattern| {
+            let dist = crate::error::levenshtein_distance(
+                &normalized,
+                &normalize_term_for_cycle(&pattern),
+            );
+            (dist > 0 && dist <= max_distance).then_some((dist, pattern))
+        })
+        .collect();
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    scored.into_iter().take(3).map(|(_, p)| p).collect()
+}
 
 /// Resolve a term to primitives by recursive rewriting.
 ///
@@ -119,7 +167,8 @@ pub fn resolve_with_trace(
             Err(_) => vec![],
         },
         success: result.is_ok(),
-        error: result.as_ref().err().map(|e| e.message.clone()),
+        // to_string() rather than .message so traces carry the suggestions
+        error: result.as_ref().err().map(|e| e.to_string()),
     };
 
     (result, trace)
@@ -212,6 +261,8 @@ fn resolve_with_cycle_detection(
                 MAX_DEPTH,
                 path.join("\n  → ")
             ),
+            kind: ResolveErrorKind::MaxDepth,
+            suggestions: Vec::new(),
         });
     }
 
@@ -239,6 +290,8 @@ fn resolve_with_cycle_detection(
                  Check your glossary for circular references.",
                 cycle_path
             ),
+            kind: ResolveErrorKind::Cycle,
+            suggestions: Vec::new(),
         });
     }
 
@@ -326,6 +379,8 @@ fn resolve_with_cycle_detection(
         None => Err(ResolveError {
             term: term.text.clone(),
             message: "Unknown term - not found in vocabulary".to_string(),
+            kind: ResolveErrorKind::UnknownTerm,
+            suggestions: suggest_similar_terms(&term.text, vocab),
         }),
     }
 }
@@ -728,5 +783,72 @@ mod tests {
         assert!(!trace.success);
         assert!(trace.error.is_some());
         assert!(trace.final_primitives.is_empty());
+    }
+
+    #[test]
+    fn unknown_term_gets_suggestions_for_near_miss() {
+        let vocab = test_vocab();
+        let err = resolve(&Term::new("success respones"), &vocab).unwrap_err();
+
+        assert_eq!(err.kind, ResolveErrorKind::UnknownTerm);
+        assert_eq!(
+            err.suggestions.first().map(String::as_str),
+            Some("success response"),
+            "suggestions: {:?}",
+            err.suggestions
+        );
+        assert!(err.to_string().contains("did you mean"), "{err}");
+    }
+
+    #[test]
+    fn suggestions_normalize_params_and_quoted_args() {
+        let vocab = test_vocab();
+        // Typo'd verb with a quoted arg — normalizer maps "x" and {text}
+        // to the same placeholder so the patterns are comparable
+        let err = resolve(&Term::new("body containz \"x\""), &vocab).unwrap_err();
+
+        assert!(
+            err.suggestions.iter().any(|s| s == "body contains {text}"),
+            "suggestions: {:?}",
+            err.suggestions
+        );
+    }
+
+    #[test]
+    fn cycle_error_has_cycle_kind_and_no_suggestions() {
+        let mut vocab = Vocabulary::new();
+        vocab.add_terms("term a", vec![Term::new("term b")]);
+        vocab.add_terms("term b", vec![Term::new("term a")]);
+
+        let err = resolve(&Term::new("term a"), &vocab).unwrap_err();
+        assert_eq!(err.kind, ResolveErrorKind::Cycle);
+        assert!(err.suggestions.is_empty());
+        assert!(!err.to_string().contains("did you mean"));
+    }
+
+    #[test]
+    fn distant_unknown_term_gets_no_suggestions() {
+        let vocab = test_vocab();
+        let err = resolve(&Term::new("completely unrelated phrase here"), &vocab).unwrap_err();
+
+        assert_eq!(err.kind, ResolveErrorKind::UnknownTerm);
+        assert!(
+            err.suggestions.is_empty(),
+            "distant phrases should not suggest: {:?}",
+            err.suggestions
+        );
+    }
+
+    #[test]
+    fn trace_error_includes_suggestions() {
+        let vocab = test_vocab();
+        let (result, trace) = resolve_with_trace(&Term::new("success respones"), &vocab);
+
+        assert!(result.is_err());
+        let error_text = trace.error.unwrap();
+        assert!(
+            error_text.contains("did you mean"),
+            "trace error should carry suggestions: {error_text}"
+        );
     }
 }

--- a/src/ial/resolve.rs
+++ b/src/ial/resolve.rs
@@ -93,7 +93,7 @@ impl std::error::Error for ResolveError {}
 /// normalized with the cycle normalizer (quoted args and `{param}` become
 /// placeholders) so `body containz "x"` can match `body contains {text}`.
 /// Returns up to 3 original pattern texts, closest first.
-fn suggest_similar_terms(text: &str, vocab: &Vocabulary) -> Vec<String> {
+pub(crate) fn suggest_similar_terms(text: &str, vocab: &Vocabulary) -> Vec<String> {
     let normalized = normalize_term_for_cycle(text);
     // Identifier-tuned thresholds in find_suggestion are too tight for
     // multi-word phrases; allow roughly a quarter of the phrase to differ.

--- a/src/ial/vocabulary.rs
+++ b/src/ial/vocabulary.rs
@@ -230,6 +230,12 @@ impl Vocabulary {
         self.patterns.push((pattern, def));
     }
 
+    /// All pattern texts in insertion order (with `{param}` placeholders
+    /// visible) — used for did-you-mean suggestions and glossary lint scans
+    pub fn pattern_texts(&self) -> Vec<String> {
+        self.patterns.iter().map(|(p, _)| p.text.clone()).collect()
+    }
+
     /// Look up a term by exact text (fast path)
     pub fn lookup_exact(&self, text: &str) -> Option<&Definition> {
         self.terms.get(text).map(|(_, def)| def)

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -5832,8 +5832,7 @@ pub struct IntentLintFinding {
     pub scenario: String,
     /// The offending text (outcome, when-clause, or glossary term)
     pub text: String,
-    /// Near-miss vocabulary patterns, best first
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    /// Near-miss vocabulary patterns, best first (empty array when none)
     pub suggestions: Vec<String>,
     /// Human-readable explanation
     pub detail: String,

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -5947,14 +5947,37 @@ pub fn lint_intent_file(intent: &IntentFile) -> IntentLintReport {
 
     // Glossary-wide cycle scan: catches cycles in entries no scenario touches.
     // Substitute dummy values for {param} placeholders so patterns resolve.
-    let mut seen_cycles = HashSet::new();
+    // Dedup on the set of participating terms, not the path message —
+    // scanning "a" and "b" yields "a → b → a" and "b → a → b" for the SAME
+    // cycle, so message keys would report each cycle once per participant.
+    fn cycle_identity(message: &str) -> String {
+        let mut nodes: Vec<String> = message
+            .lines()
+            .find(|l| l.contains(" → "))
+            .map(|l| {
+                l.split(" → ")
+                    .map(|n| Glossary::normalize_for_cycle(n.trim()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        nodes.sort();
+        nodes.dedup();
+        nodes.join(" | ")
+    }
+
+    // Cycles already reported through a scenario outcome count as seen
+    let mut seen_cycles: HashSet<String> = errors
+        .iter()
+        .filter(|f| f.kind == "cycle")
+        .map(|f| cycle_identity(&f.detail))
+        .collect();
     let param_re = regex::Regex::new(r"\{[^}]+\}").unwrap();
     for term in glossary.terms.values() {
         let ial_term = Glossary::convert_params_to_ial(&term.term);
         let dummy = param_re.replace_all(&ial_term, "\"x\"").to_string();
         if let Err(e) = crate::ial::resolve(&Term::new(&dummy), &vocab) {
             if e.kind == crate::ial::ResolveErrorKind::Cycle
-                && seen_cycles.insert(e.message.clone())
+                && seen_cycles.insert(cycle_identity(&e.message))
             {
                 errors.push(IntentLintFinding {
                     kind: "cycle".to_string(),

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -5817,6 +5817,222 @@ pub fn find_intent_file(ntnt_path: &Path) -> Option<std::path::PathBuf> {
     None
 }
 
+// ============================================================================
+// INTENT LINT (static glossary/scenario validation, DD-063 Rec 4b)
+// ============================================================================
+
+/// A single finding from `ntnt intent lint`
+#[derive(Debug, Clone, Serialize)]
+pub struct IntentLintFinding {
+    /// One of: unresolved_term, unresolved_when, cycle, orphan_term
+    pub kind: String,
+    /// Feature the finding belongs to (empty for glossary-wide findings)
+    pub feature: String,
+    /// Scenario the finding belongs to (empty for glossary-wide findings)
+    pub scenario: String,
+    /// The offending text (outcome, when-clause, or glossary term)
+    pub text: String,
+    /// Near-miss vocabulary patterns, best first
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub suggestions: Vec<String>,
+    /// Human-readable explanation
+    pub detail: String,
+}
+
+/// Report from statically validating an intent file's glossary and scenarios
+#[derive(Debug, Serialize)]
+pub struct IntentLintReport {
+    /// Unresolved terms/when-clauses and cycles — these make `intent check`
+    /// unable to execute the affected scenarios
+    pub errors: Vec<IntentLintFinding>,
+    /// Orphan glossary entries and other non-blocking findings
+    pub warnings: Vec<IntentLintFinding>,
+    pub terms_checked: usize,
+    pub scenarios_checked: usize,
+}
+
+/// Statically resolve every scenario when-clause and outcome against the
+/// glossary + standard vocabulary without executing any primitives, scan the
+/// glossary for definition cycles, and report unused glossary entries.
+///
+/// Outcome resolution deliberately mirrors the execution fallback chain in
+/// `resolve_scenario_with_base_dir` (component reference → IAL vocabulary →
+/// direct pattern) — if that chain changes, update this to match, or lint
+/// will drift from what `intent check` actually executes.
+pub fn lint_intent_file(intent: &IntentFile) -> IntentLintReport {
+    let glossary = intent.glossary.clone().unwrap_or_default();
+    let vocab = glossary.to_ial_vocabulary_full(&intent.components, &intent.invariants);
+
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+    let mut scenarios_checked = 0;
+
+    for feature in &intent.features {
+        for scenario in &feature.scenarios {
+            scenarios_checked += 1;
+
+            if glossary
+                .resolve_when_clause(&scenario.when_clause)
+                .is_none()
+            {
+                errors.push(IntentLintFinding {
+                    kind: "unresolved_when".to_string(),
+                    feature: feature.name.clone(),
+                    scenario: scenario.name.clone(),
+                    text: scenario.when_clause.clone(),
+                    suggestions: crate::ial::resolve::suggest_similar_terms(
+                        &Glossary::convert_params_to_ial(&scenario.when_clause),
+                        &vocab,
+                    ),
+                    detail: "when-clause matches no known action pattern".to_string(),
+                });
+            }
+
+            // Given-clauses are skipped: execution treats them as descriptive
+
+            for outcome in &scenario.outcomes {
+                // Mirror the execution fallback chain
+                if glossary
+                    .resolve_component_reference(outcome, &intent.components)
+                    .is_some()
+                {
+                    continue;
+                }
+                if !glossary
+                    .resolve_outcomes_with_context(outcome, &intent.components, &intent.invariants)
+                    .is_empty()
+                {
+                    continue;
+                }
+
+                // Unresolvable at execution time — classify via the IAL
+                // resolver (cycle vs unknown term, with suggestions)
+                let ial_outcome = Glossary::convert_params_to_ial(outcome);
+                let err = match crate::ial::resolve(&Term::new(&ial_outcome), &vocab) {
+                    Err(e) => e,
+                    // Resolvable as raw IAL but not through the execution
+                    // chain — still report, without classification detail
+                    Ok(_) => {
+                        errors.push(IntentLintFinding {
+                            kind: "unresolved_term".to_string(),
+                            feature: feature.name.clone(),
+                            scenario: scenario.name.clone(),
+                            text: outcome.clone(),
+                            suggestions: Vec::new(),
+                            detail: "outcome does not resolve to executable assertions".to_string(),
+                        });
+                        continue;
+                    }
+                };
+                match err.kind {
+                    crate::ial::ResolveErrorKind::Cycle => errors.push(IntentLintFinding {
+                        kind: "cycle".to_string(),
+                        feature: feature.name.clone(),
+                        scenario: scenario.name.clone(),
+                        text: outcome.clone(),
+                        suggestions: Vec::new(),
+                        detail: err.message,
+                    }),
+                    _ => errors.push(IntentLintFinding {
+                        kind: "unresolved_term".to_string(),
+                        feature: feature.name.clone(),
+                        scenario: scenario.name.clone(),
+                        text: outcome.clone(),
+                        suggestions: err.suggestions,
+                        detail: "term not found in glossary or standard vocabulary".to_string(),
+                    }),
+                }
+            }
+        }
+    }
+
+    // Glossary-wide cycle scan: catches cycles in entries no scenario touches.
+    // Substitute dummy values for {param} placeholders so patterns resolve.
+    let mut seen_cycles = HashSet::new();
+    let param_re = regex::Regex::new(r"\{[^}]+\}").unwrap();
+    for term in glossary.terms.values() {
+        let ial_term = Glossary::convert_params_to_ial(&term.term);
+        let dummy = param_re.replace_all(&ial_term, "\"x\"").to_string();
+        if let Err(e) = crate::ial::resolve(&Term::new(&dummy), &vocab) {
+            if e.kind == crate::ial::ResolveErrorKind::Cycle
+                && seen_cycles.insert(e.message.clone())
+            {
+                errors.push(IntentLintFinding {
+                    kind: "cycle".to_string(),
+                    feature: String::new(),
+                    scenario: String::new(),
+                    text: term.term.clone(),
+                    suggestions: Vec::new(),
+                    detail: e.message,
+                });
+            }
+        }
+    }
+
+    // Orphan detection: a glossary term is used if any scenario clause,
+    // other term's meaning part, component behavior, or invariant assertion
+    // matches its pattern (via the same matcher execution uses) or contains
+    // it as a phrase.
+    let mut usage_corpus: Vec<String> = Vec::new();
+    for feature in &intent.features {
+        for scenario in &feature.scenarios {
+            usage_corpus.push(scenario.when_clause.clone());
+            if let Some(given) = &scenario.given_clause {
+                usage_corpus.push(given.clone());
+            }
+            for outcome in &scenario.outcomes {
+                usage_corpus.push(outcome.clone());
+            }
+        }
+    }
+    for component in &intent.components {
+        usage_corpus.extend(component.inherent_behavior.iter().cloned());
+    }
+    for invariant in &intent.invariants {
+        usage_corpus.extend(invariant.assertions.iter().cloned());
+    }
+
+    for (key, term) in &glossary.terms {
+        // Meaning parts of OTHER terms also count as usage
+        let other_meanings: Vec<String> = glossary
+            .terms
+            .iter()
+            .filter(|(k, _)| *k != key)
+            .flat_map(|(_, t)| t.meaning.split(','))
+            .map(|part| part.trim().to_string())
+            .collect();
+
+        let term_lower = term.term.to_lowercase();
+        let used = usage_corpus
+            .iter()
+            .chain(other_meanings.iter())
+            .any(|usage| {
+                glossary.match_term_pattern(usage, &term.term).is_some()
+                    || usage.to_lowercase().contains(&term_lower)
+            });
+
+        if !used {
+            warnings.push(IntentLintFinding {
+                kind: "orphan_term".to_string(),
+                feature: String::new(),
+                scenario: String::new(),
+                text: term.term.clone(),
+                suggestions: Vec::new(),
+                detail:
+                    "glossary term is never used by a scenario, component, invariant, or other term"
+                        .to_string(),
+            });
+        }
+    }
+
+    IntentLintReport {
+        errors,
+        warnings,
+        terms_checked: glossary.terms.len(),
+        scenarios_checked,
+    }
+}
+
 /// Resolve both .intent and .tnt paths from either extension
 ///
 /// This function accepts either a .tnt or .intent file and resolves both paths.

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -7462,10 +7462,13 @@ impl Interpreter {
                                 .strip_prefix("module:")
                                 .or_else(|| name.strip_prefix("lib:"))
                                 .unwrap_or(name);
-                            return Err(IntentError::runtime_error(format!(
-                                "Module '{}' has no function '{}'",
-                                module_name, method
-                            )));
+                            let exports: Vec<String> = fields.keys().cloned().collect();
+                            let mut msg =
+                                format!("Module '{}' has no function '{}'", module_name, method);
+                            if let Some(sugg) = crate::error::find_suggestion(method, &exports) {
+                                msg.push_str(&format!(". Did you mean '{}'?", sugg));
+                            }
+                            return Err(IntentError::runtime_error(msg));
                         }
                     }
                 }
@@ -7496,10 +7499,37 @@ impl Interpreter {
 
                     Ok(result)
                 } else {
+                    // Suggest the closest real function: alias table first
+                    // (length→len etc.), then Levenshtein over everything in
+                    // scope (builtins, imports, user functions)
+                    let candidates = self.environment.borrow().keys();
+                    let alias = crate::error::METHOD_ALIAS_HINTS
+                        .iter()
+                        .find(|(from, to)| from == method && candidates.iter().any(|c| c == to))
+                        .map(|(_, to)| to.to_string());
+                    let suggestion =
+                        alias.or_else(|| crate::error::find_suggestion(method, &candidates));
+
+                    let receiver = Self::format_expression(object);
+                    let hint = match &suggestion {
+                        Some(sugg) => {
+                            let rest = if arguments.is_empty() { "" } else { ", ..." };
+                            format!(
+                                "NTNT methods resolve to free functions — try {}({}{})",
+                                sugg, receiver, rest
+                            )
+                        }
+                        None => format!(
+                            "NTNT methods resolve to free functions — call name({}, ...) or define fn {}({}, ...)",
+                            receiver, method, receiver
+                        ),
+                    };
+
                     Err(IntentError::UndefinedFunction {
                         name: method.clone(),
-                        suggestion: None,
-                        line: 0,
+                        suggestion,
+                        hint: Some(hint),
+                        line: self.current_line,
                     })
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -830,6 +830,11 @@ fn format_error(error: &anyhow::Error, file_path: Option<&PathBuf>) {
                 suggestion.green()
             );
         }
+
+        // Extra guidance (e.g. the UFCS free-function bridge for method misses)
+        if let Some(hint) = intent_err.hint() {
+            eprintln!("  {} {}", "hint:".cyan().bold(), hint);
+        }
     } else {
         // Non-IntentError: fall back to simple display
         eprintln!("{}: {}", "Error".red().bold(), error);

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,6 +427,30 @@ enum IntentCommands {
         #[arg(long = "intent", short = 'i')]
         intent_file: Option<PathBuf>,
     },
+    /// Statically validate an intent file's glossary and scenarios
+    ///
+    /// Resolves every scenario when-clause and outcome against the glossary
+    /// and standard vocabulary WITHOUT starting a server or executing tests.
+    /// Reports unresolved terms (with did-you-mean suggestions), glossary
+    /// definition cycles, and unused glossary entries.
+    ///
+    /// Exit code 1 when unresolved terms or cycles are found (orphan
+    /// warnings never fail the run), so it can gate CI before the slower
+    /// `ntnt intent check`.
+    ///
+    /// Examples:
+    ///   ntnt intent lint server.intent
+    ///   ntnt intent lint server.tnt          (locates the paired .intent)
+    ///   ntnt intent lint server.intent --json
+    Lint {
+        /// The .intent file to validate (or a .tnt file with a paired .intent)
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Output the report as JSON (for CI)
+        #[arg(long)]
+        json: bool,
+    },
     /// Generate code scaffolding from an intent file
     ///
     /// Creates a new .tnt file with function stubs and route
@@ -4022,6 +4046,7 @@ fn run_intent_command(cmd: IntentCommands) -> anyhow::Result<()> {
         IntentCommands::Coverage { file, intent_file } => {
             run_intent_coverage_command(&file, intent_file.as_ref())
         }
+        IntentCommands::Lint { file, json } => run_intent_lint_command(&file, json),
         IntentCommands::Init {
             intent_file,
             output,
@@ -4033,6 +4058,94 @@ fn run_intent_command(cmd: IntentCommands) -> anyhow::Result<()> {
             no_open,
         } => run_intent_studio_command(&intent_file, port, app_port, no_open),
     }
+}
+
+/// Run the intent lint command: static glossary/scenario validation with
+/// no server startup and no primitive execution
+fn run_intent_lint_command(input_path: &PathBuf, json_output: bool) -> anyhow::Result<()> {
+    // Accept either a .intent file or a .tnt file with a paired .intent
+    let intent_path = if input_path.extension().and_then(|e| e.to_str()) == Some("intent") {
+        input_path.clone()
+    } else {
+        let (intent, _tnt) = ntnt::intent::resolve_intent_tnt_pair(input_path);
+        match intent.filter(|p| p.exists()) {
+            Some(p) => p,
+            None => anyhow::bail!(
+                "No .intent file found for {} — pass the .intent file directly",
+                input_path.display()
+            ),
+        }
+    };
+
+    if !intent_path.exists() {
+        anyhow::bail!("Intent file not found: {}", intent_path.display());
+    }
+
+    let intent = ntnt::intent::IntentFile::parse(&intent_path)
+        .map_err(|e| anyhow::anyhow!("Failed to parse {}: {}", intent_path.display(), e))?;
+
+    let report = ntnt::intent::lint_intent_file(&intent);
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("{}", "=== NTNT Intent Lint ===".cyan().bold());
+        println!("  File: {}", intent_path.display());
+        println!();
+
+        for finding in &report.errors {
+            let location = if finding.feature.is_empty() {
+                "glossary".to_string()
+            } else {
+                format!("{} › {}", finding.feature, finding.scenario)
+            };
+            println!(
+                "{} [{}] {}: \"{}\"",
+                "✗".red(),
+                finding.kind.red(),
+                location,
+                finding.text
+            );
+            println!("    {}", finding.detail);
+            if !finding.suggestions.is_empty() {
+                let quoted: Vec<String> = finding
+                    .suggestions
+                    .iter()
+                    .map(|s| format!("'{}'", s))
+                    .collect();
+                println!("    {} {}", "did you mean:".cyan(), quoted.join(", "));
+            }
+        }
+
+        for finding in &report.warnings {
+            println!(
+                "{} [{}] \"{}\" — {}",
+                "⚠".yellow(),
+                finding.kind.yellow(),
+                finding.text,
+                finding.detail
+            );
+        }
+
+        println!();
+        if report.errors.is_empty() && report.warnings.is_empty() {
+            println!("{}", "No issues found!".green().bold());
+        }
+        println!(
+            "{} scenarios and {} glossary terms checked: {} error(s), {} warning(s)",
+            report.scenarios_checked,
+            report.terms_checked,
+            report.errors.len(),
+            report.warnings.len()
+        );
+    }
+
+    // Orphans are warnings and never fail the run (legacy direct-pattern
+    // fallback makes orphan detection imperfect)
+    if !report.errors.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
 }
 
 /// Run the intent check command

--- a/src/main.rs
+++ b/src/main.rs
@@ -3229,6 +3229,7 @@ fn validate_project(path: &PathBuf) -> anyhow::Result<()> {
                         ntnt::typechecker::DiagnosticKind::JsStyleInterpolation => {
                             "javascript_style_interpolation"
                         }
+                        ntnt::typechecker::DiagnosticKind::UnknownMethod => "unknown_method",
                         _ => "type_check",
                     };
                     let entry = json!({
@@ -3410,6 +3411,7 @@ fn lint_project(
                         ntnt::typechecker::DiagnosticKind::JsStyleInterpolation => {
                             "javascript_style_interpolation"
                         }
+                        ntnt::typechecker::DiagnosticKind::UnknownMethod => "unknown_method",
                         _ => "type_check",
                     };
                     issues.push(json!({

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -555,17 +555,24 @@ impl TypeContext {
     }
 
     /// Warn on `x.method()` when `method` is not a defined function,
-    /// builtin, or in-scope binding — UFCS means the call can only fail at
-    /// runtime (E007). Skipped for `Any` receivers (module aliases, untyped
-    /// params) and whenever an import could not be resolved, since both make
-    /// the check unreliable.
+    /// builtin, or callable in-scope binding — UFCS means the call can only
+    /// fail at runtime (E007). Skipped for `Any` receivers (module aliases,
+    /// untyped params) and whenever an import could not be resolved, since
+    /// both make the check unreliable.
     fn check_unknown_method(&mut self, object: &Expression, method: &str, obj_type: &Type) {
         if matches!(obj_type, Type::Any) || self.has_unresolved_import {
             return;
         }
+        // Scope bindings only count when callable: `let double = fn(x){..}`
+        // suppresses, `let length = 42` does not (that call fails at runtime).
+        // Any-typed bindings suppress because we can't tell.
+        let callable_binding = matches!(
+            self.lookup(method),
+            Some(Type::Function { .. }) | Some(Type::Any)
+        );
         if self.functions.contains_key(method)
             || self.builtin_sigs.contains_key(method)
-            || self.lookup(method).is_some()
+            || callable_binding
         {
             return;
         }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -31,6 +31,9 @@ pub enum DiagnosticKind {
     /// JavaScript-style `${ident}` interpolation in a string literal where
     /// `ident` is a variable in scope (NTNT interpolation is `#{expr}`)
     JsStyleInterpolation,
+    /// Dot-call on a method name that is not a defined or imported function
+    /// (UFCS means `x.f()` needs a reachable function `f`)
+    UnknownMethod,
     /// General type error (mismatch, undefined, etc.)
     General,
 }
@@ -97,6 +100,9 @@ pub struct TypeContext {
     search_after: usize,
     /// When true, warn about untyped function parameters and missing return types
     strict_lint: bool,
+    /// True when an import could not be resolved — unknown-method warnings
+    /// are suppressed because unseen imports make the check unreliable
+    has_unresolved_import: bool,
     /// File path of the current file being checked (for resolving relative imports)
     current_file: Option<String>,
     /// Cache of already-parsed module exports (to avoid re-parsing)
@@ -213,6 +219,7 @@ pub fn check_program_with_lint_mode(
                         | DiagnosticKind::MissingReturnAnnotation
                         | DiagnosticKind::MissingLambdaParamAnnotation
                         | DiagnosticKind::JsStyleInterpolation
+                        | DiagnosticKind::UnknownMethod
                 )
             {
                 d.severity = Severity::Error;
@@ -468,6 +475,7 @@ impl TypeContext {
             source_lines: source.lines().map(|l| l.to_string()).collect(),
             search_after: 0,
             strict_lint: false,
+            has_unresolved_import: false,
             current_file: None,
             module_cache: HashMap::new(),
             resolving_files: Vec::new(),
@@ -544,6 +552,55 @@ impl TypeContext {
 
     fn warning(&mut self, message: String, line: usize, hint: Option<String>) {
         self.emit(Severity::Warning, message, line, hint);
+    }
+
+    /// Warn on `x.method()` when `method` is not a defined function,
+    /// builtin, or in-scope binding — UFCS means the call can only fail at
+    /// runtime (E007). Skipped for `Any` receivers (module aliases, untyped
+    /// params) and whenever an import could not be resolved, since both make
+    /// the check unreliable.
+    fn check_unknown_method(&mut self, object: &Expression, method: &str, obj_type: &Type) {
+        if matches!(obj_type, Type::Any) || self.has_unresolved_import {
+            return;
+        }
+        if self.functions.contains_key(method)
+            || self.builtin_sigs.contains_key(method)
+            || self.lookup(method).is_some()
+        {
+            return;
+        }
+
+        let mut candidates: Vec<String> = self.functions.keys().cloned().collect();
+        candidates.extend(self.builtin_sigs.keys().cloned());
+        let alias = crate::error::METHOD_ALIAS_HINTS
+            .iter()
+            .find(|(from, to)| *from == method && candidates.iter().any(|c| c == *to))
+            .map(|(_, to)| to.to_string());
+        let suggestion = alias.or_else(|| crate::error::find_suggestion(method, &candidates));
+
+        let receiver = expr_search_hint(object);
+        let hint = match &suggestion {
+            Some(target) => format!(
+                "NTNT methods resolve to free functions — try {}({})",
+                target, receiver
+            ),
+            None => format!(
+                "NTNT methods resolve to free functions — call name({}, ...) or define fn {}(...)",
+                receiver, method
+            ),
+        };
+
+        let line = self.find_line_near(&format!(".{}(", method));
+        self.emit_with_kind(
+            Severity::Warning,
+            DiagnosticKind::UnknownMethod,
+            format!(
+                "Unknown method '{}' — no function with this name is defined or imported",
+                method
+            ),
+            line,
+            Some(hint),
+        );
     }
 
     /// Warn when a string literal contains JavaScript-style `${ident}` and
@@ -1945,6 +2002,7 @@ impl TypeContext {
                 arguments,
             } => {
                 let obj_type = self.infer_expression(object);
+                self.check_unknown_method(object, method, &obj_type);
                 let method_arg_types: Vec<Type> =
                     arguments.iter().map(|a| self.infer_expression(a)).collect();
                 // Method calls: infer return type from known methods
@@ -3428,22 +3486,27 @@ impl TypeContext {
                 return;
             }
 
-            if let Some(file_path) = self.resolve_import_path(source) {
-                let exports = self.extract_file_exports(&file_path);
-                for (name, sig) in exports.functions {
-                    self.builtin_sigs.insert(name, sig);
+            match self.resolve_import_path(source) {
+                Some(file_path) if file_path.exists() => {
+                    let exports = self.extract_file_exports(&file_path);
+                    for (name, sig) in exports.functions {
+                        self.builtin_sigs.insert(name, sig);
+                    }
+                    for (name, fields) in exports.structs {
+                        self.structs.insert(name.clone(), fields);
+                        self.bind(&name, Type::Named(name.clone()));
+                    }
+                    for (name, variants) in exports.enums {
+                        self.enums.insert(name.clone(), variants);
+                        self.bind(&name, Type::Named(name.clone()));
+                    }
+                    for (name, typ) in exports.type_aliases {
+                        self.type_aliases.insert(name, typ);
+                    }
                 }
-                for (name, fields) in exports.structs {
-                    self.structs.insert(name.clone(), fields);
-                    self.bind(&name, Type::Named(name.clone()));
-                }
-                for (name, variants) in exports.enums {
-                    self.enums.insert(name.clone(), variants);
-                    self.bind(&name, Type::Named(name.clone()));
-                }
-                for (name, typ) in exports.type_aliases {
-                    self.type_aliases.insert(name, typ);
-                }
+                // Wildcard import of something we can't see — any method
+                // name might exist in it
+                _ => self.has_unresolved_import = true,
             }
             return;
         }
@@ -3463,7 +3526,7 @@ impl TypeContext {
         }
 
         // Try user file import
-        if let Some(file_path) = self.resolve_import_path(source) {
+        if let Some(file_path) = self.resolve_import_path(source).filter(|p| p.exists()) {
             let exports = self.extract_file_exports(&file_path);
             for item in items {
                 let local_name = item.alias.as_ref().unwrap_or(&item.name);
@@ -3489,6 +3552,7 @@ impl TypeContext {
         }
 
         // Unknown module — bind all as Any
+        self.has_unresolved_import = true;
         for item in items {
             let local_name = item.alias.as_ref().unwrap_or(&item.name);
             self.bind(local_name, Type::Any);
@@ -3620,6 +3684,13 @@ impl TypeContext {
 
         // Utility
         sig!("unwrap", ["value" => Type::Any], Type::Any);
+        // Runtime-global Option/Result helpers (interpreter globals; keeping
+        // builtin_sigs the single source of truth for the unknown-method check)
+        sig!("is_some", ["value" => Type::Any], Type::Bool);
+        sig!("is_none", ["value" => Type::Any], Type::Bool);
+        sig!("is_ok", ["value" => Type::Any], Type::Bool);
+        sig!("is_err", ["value" => Type::Any], Type::Bool);
+        sig!("unwrap_or", ["value" => Type::Any, "default" => Type::Any], Type::Any);
 
         // Register synthetic struct types for HTTP
         let map_string_string = Type::Map {

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -889,6 +889,43 @@ fn intent_lint_json_output_shape() {
 }
 
 #[test]
+fn intent_lint_reports_each_cycle_exactly_once() {
+    // A two-term cycle must yield ONE finding, not one per participant —
+    // and not once more via the scenario that references it
+    let content = r#"## Glossary
+
+| Term | Means |
+|------|-------|
+| a user visits {path} | GET {path} |
+| the homepage | / |
+| term alpha | term beta |
+| term beta | term alpha |
+
+---
+
+Feature: Home Page
+  id: feature.home
+
+  Scenario: First visit
+    When a user visits the homepage
+    → term alpha
+"#;
+    let (stdout, _stderr, exit_code) = run_intent_lint(content, &["--json"]);
+    assert_eq!(exit_code, 1);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let cycle_count = json["errors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|e| e["kind"] == "cycle")
+        .count();
+    assert_eq!(
+        cycle_count, 1,
+        "cycle reported {cycle_count} times: {stdout}"
+    );
+}
+
+#[test]
 fn intent_lint_json_suggestions_is_empty_array_when_no_near_miss() {
     // Cycle findings carry no suggestions — the key must still be present
     let content = r#"## Glossary

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -889,6 +889,41 @@ fn intent_lint_json_output_shape() {
 }
 
 #[test]
+fn intent_lint_json_suggestions_is_empty_array_when_no_near_miss() {
+    // Cycle findings carry no suggestions — the key must still be present
+    let content = r#"## Glossary
+
+| Term | Means |
+|------|-------|
+| a user visits {path} | GET {path} |
+| the homepage | / |
+| term alpha | term beta |
+| term beta | term alpha |
+
+---
+
+Feature: Home Page
+  id: feature.home
+
+  Scenario: First visit
+    When a user visits the homepage
+    → term alpha
+"#;
+    let (stdout, _stderr, _exit) = run_intent_lint(content, &["--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let cycle = json["errors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["kind"] == "cycle")
+        .expect("cycle finding present");
+    assert!(
+        cycle["suggestions"].is_array() && cycle["suggestions"].as_array().unwrap().is_empty(),
+        "suggestions must serialize as an empty array: {stdout}"
+    );
+}
+
+#[test]
 fn intent_lint_accepts_tnt_path_with_paired_intent() {
     use std::io::Write as _;
     let dir = std::env::temp_dir().join(format!("ntnt_lint_pair_{}", std::process::id()));

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -758,3 +758,159 @@ fn test_intent_coverage_command() {
         );
     }
 }
+
+// ============================================================================
+// ntnt intent lint (DD-063 Rec 4b)
+// ============================================================================
+
+/// Write an intent file to a unique temp path, run `ntnt intent lint` on it
+/// (plus extra args), clean up, and return (stdout, stderr, exit_code).
+fn run_intent_lint(content: &str, extra_args: &[&str]) -> (String, String, i32) {
+    use std::io::Write as _;
+    static LINT_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let counter = LINT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "ntnt_intent_lint_{}_{}.intent",
+        std::process::id(),
+        counter
+    ));
+    let mut file = std::fs::File::create(&path).expect("create intent file");
+    write!(file, "{}", content).expect("write intent file");
+    drop(file);
+
+    let path_str = path.to_string_lossy().to_string();
+    let mut args = vec!["intent", "lint", path_str.as_str()];
+    args.extend_from_slice(extra_args);
+    let result = run_ntnt(&args);
+
+    std::fs::remove_file(&path).ok();
+    result
+}
+
+const CLEAN_INTENT: &str = r#"## Glossary
+
+| Term | Means |
+|------|-------|
+| a user visits {path} | GET {path} |
+| the homepage | / |
+| they see {text} | body contains {text} |
+| success response | status 200 |
+
+---
+
+Feature: Home Page
+  id: feature.home
+
+  Scenario: First visit
+    When a user visits the homepage
+    → success response
+    → they see "Welcome"
+"#;
+
+#[test]
+fn intent_lint_clean_file_exits_zero() {
+    let (stdout, _stderr, exit_code) = run_intent_lint(CLEAN_INTENT, &[]);
+    assert_eq!(exit_code, 0, "clean intent should pass: {stdout}");
+    assert!(stdout.contains("No issues found"), "{stdout}");
+}
+
+#[test]
+fn intent_lint_unknown_term_exits_one_with_suggestion() {
+    let content = CLEAN_INTENT.replace("→ success response", "→ succes response");
+    let (stdout, _stderr, exit_code) = run_intent_lint(&content, &[]);
+    assert_eq!(exit_code, 1, "unresolved term should fail: {stdout}");
+    assert!(stdout.contains("unresolved_term"), "{stdout}");
+    assert!(
+        stdout.contains("did you mean") && stdout.contains("success response"),
+        "should suggest the near-miss glossary term: {stdout}"
+    );
+}
+
+#[test]
+fn intent_lint_unresolved_when_clause_exits_one() {
+    let content = CLEAN_INTENT.replace(
+        "When a user visits the homepage",
+        "When a user creates a task",
+    );
+    let (stdout, _stderr, exit_code) = run_intent_lint(&content, &[]);
+    assert_eq!(exit_code, 1, "{stdout}");
+    assert!(stdout.contains("unresolved_when"), "{stdout}");
+}
+
+#[test]
+fn intent_lint_detects_glossary_cycle() {
+    let content = r#"## Glossary
+
+| Term | Means |
+|------|-------|
+| a user visits {path} | GET {path} |
+| the homepage | / |
+| term alpha | term beta |
+| term beta | term alpha |
+
+---
+
+Feature: Home Page
+  id: feature.home
+
+  Scenario: First visit
+    When a user visits the homepage
+    → term alpha
+"#;
+    let (stdout, _stderr, exit_code) = run_intent_lint(content, &[]);
+    assert_eq!(exit_code, 1, "{stdout}");
+    assert!(stdout.contains("cycle"), "{stdout}");
+    assert!(stdout.contains("term alpha"), "{stdout}");
+}
+
+#[test]
+fn intent_lint_orphan_term_warns_but_exits_zero() {
+    let content = CLEAN_INTENT.replace(
+        "| success response | status 200 |",
+        "| success response | status 200 |\n| never used term | status 418 |",
+    );
+    let (stdout, _stderr, exit_code) = run_intent_lint(&content, &[]);
+    assert_eq!(exit_code, 0, "orphans are warnings only: {stdout}");
+    assert!(stdout.contains("orphan_term"), "{stdout}");
+    assert!(stdout.contains("never used term"), "{stdout}");
+}
+
+#[test]
+fn intent_lint_json_output_shape() {
+    let content = CLEAN_INTENT.replace("→ success response", "→ succes response");
+    let (stdout, _stderr, exit_code) = run_intent_lint(&content, &["--json"]);
+    assert_eq!(exit_code, 1);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert!(json["errors"].is_array());
+    assert!(json["warnings"].is_array());
+    assert_eq!(json["errors"][0]["kind"], "unresolved_term");
+    assert!(json["errors"][0]["suggestions"].is_array());
+    assert!(json["scenarios_checked"].is_number());
+}
+
+#[test]
+fn intent_lint_accepts_tnt_path_with_paired_intent() {
+    use std::io::Write as _;
+    let dir = std::env::temp_dir().join(format!("ntnt_lint_pair_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let intent_path = dir.join("app.intent");
+    let tnt_path = dir.join("app.tnt");
+    write!(
+        std::fs::File::create(&intent_path).unwrap(),
+        "{}",
+        CLEAN_INTENT
+    )
+    .unwrap();
+    write!(
+        std::fs::File::create(&tnt_path).unwrap(),
+        "get(\"/\", fn(req) {{ \"Welcome\" }})\nlisten(8080)\n"
+    )
+    .unwrap();
+
+    let tnt_str = tnt_path.to_string_lossy().to_string();
+    let (stdout, _stderr, exit_code) = run_ntnt(&["intent", "lint", &tnt_str]);
+
+    std::fs::remove_dir_all(&dir).ok();
+    assert_eq!(exit_code, 0, "should locate paired .intent: {stdout}");
+    assert!(stdout.contains("app.intent"), "{stdout}");
+}

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -2951,6 +2951,97 @@ print(completely_wrong_name)
 }
 
 // ===========================================================================
+// Method-miss bridge hints (DD-063 Rec 4b)
+// ===========================================================================
+
+#[test]
+fn test_unknown_method_gets_alias_suggestion_and_bridge_hint() {
+    let code = r#"
+let s = "hi"
+print(s.length())
+"#;
+    let (_, stderr, exit_code) = run_ntnt_code(code);
+    assert_ne!(exit_code, 0);
+    assert!(stderr.contains("error[E007]"), "stderr: {}", stderr);
+    assert!(stderr.contains("Did you mean 'len'"), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("free functions") && stderr.contains("len(s)"),
+        "missing bridge hint: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_unknown_method_suggests_user_function() {
+    let code = r#"
+fn greet(u) {
+    return "hello " + u
+}
+let u = "world"
+print(u.greeet())
+"#;
+    let (_, stderr, exit_code) = run_ntnt_code(code);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("Did you mean 'greet'"),
+        "user functions should be suggestion candidates: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_size_alias_hints_len() {
+    let code = r#"
+let nums = [1, 2, 3]
+print(nums.size())
+"#;
+    let (_, stderr, exit_code) = run_ntnt_code(code);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("Did you mean 'len'"),
+        "alias table should map size->len: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("len(nums)"),
+        "hint should show receiver: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_ufcs_dispatch_still_works() {
+    let code = r#"
+let s = "hi"
+let arr = [1, 2]
+print(s.len())
+print(len(arr.push(3)))
+"#;
+    let (_, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0, "UFCS positive control failed: {}", stderr);
+}
+
+#[test]
+fn test_module_method_miss_suggests_export() {
+    let code = r#"
+import "std/string" as strutil
+print(strutil.trimm("  x  "))
+"#;
+    let (_, stderr, exit_code) = run_ntnt_code(code);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("has no function 'trimm'"),
+        "module miss message changed: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("Did you mean 'trim'"),
+        "module miss should suggest nearest export: {}",
+        stderr
+    );
+}
+
+// ===========================================================================
 // ? operator tests
 // ===========================================================================
 

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1233,6 +1233,21 @@ fn test_unknown_method_suppressed_for_untyped_receiver() {
 }
 
 #[test]
+fn test_unknown_method_warns_for_non_callable_binding() {
+    // A plain value binding named like the method must not silence the
+    // lint — UFCS dispatch on it fails at runtime
+    let source = r#"let length = 42
+let s = "hi"
+print(s.length())
+"#;
+    let (stdout, _stderr, _exit) = lint_code(source);
+    assert!(
+        stdout.contains("unknown_method"),
+        "non-callable bindings must not suppress: {stdout}"
+    );
+}
+
+#[test]
 fn test_unknown_method_suppressed_for_let_bound_lambda() {
     let source = r#"let double = fn(x) { x * 2 }
 let n = 5

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1176,3 +1176,114 @@ let cert = tls_info(443)
         "type errors should mention expected argument types: {stdout}"
     );
 }
+
+// ===========================================================================
+// Unknown-method lint (DD-063 Rec 4b)
+// ===========================================================================
+
+#[test]
+fn test_unknown_method_warns_in_default_mode() {
+    let source = r#"let s = "hi"
+print(s.length())
+"#;
+    let (stdout, _stderr, exit_code) = lint_code(source);
+    assert!(
+        stdout.contains("\"rule\": \"unknown_method\""),
+        "default-mode lint should flag s.length(): {stdout}"
+    );
+    assert!(
+        stdout.contains("try len(s)"),
+        "hint should bridge to the free function: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"severity\": \"warning\""),
+        "should be a warning in default mode: {stdout}"
+    );
+    assert_eq!(exit_code, 0, "warnings must not fail default lint");
+}
+
+#[test]
+fn test_unknown_method_errors_in_strict_mode() {
+    let source = r#"let s = "hi"
+print(s.length())
+"#;
+    let (stdout, _stderr, _exit_code) = lint_strict_code(source);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let found = json["files"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|f| f["issues"].as_array().cloned().unwrap_or_default())
+        .any(|i| i["rule"] == "unknown_method" && i["severity"] == "error");
+    assert!(found, "strict mode should promote to error: {stdout}");
+}
+
+#[test]
+fn test_unknown_method_suppressed_for_untyped_receiver() {
+    // Untyped param -> receiver is Any -> no warning (runtime hint catches it)
+    let source = r#"fn shout(s) {
+    return s.length()
+}
+"#;
+    let (stdout, _stderr, _exit) = lint_code(source);
+    assert!(
+        !stdout.contains("unknown_method"),
+        "Any receivers must not warn: {stdout}"
+    );
+}
+
+#[test]
+fn test_unknown_method_suppressed_for_let_bound_lambda() {
+    let source = r#"let double = fn(x) { x * 2 }
+let n = 5
+print(n.double())
+"#;
+    let (stdout, _stderr, _exit) = lint_code(source);
+    assert!(
+        !stdout.contains("unknown_method"),
+        "let-bound lambdas are UFCS-callable: {stdout}"
+    );
+}
+
+#[test]
+fn test_unknown_method_suppressed_with_unresolved_import() {
+    let source = r#"import { mystery } from "./does_not_exist_anywhere.tnt"
+let s = "hi"
+print(s.definitely_not_real())
+"#;
+    let (stdout, _stderr, _exit) = lint_code(source);
+    assert!(
+        !stdout.contains("unknown_method"),
+        "unresolved imports must suppress the check: {stdout}"
+    );
+}
+
+#[test]
+fn test_ufcs_known_functions_do_not_warn() {
+    let source = r#"let s = "hi"
+let arr = [1, 2, 3]
+let x = Some(1)
+print(s.len())
+print(arr.push(4))
+print(x.is_some())
+print(x.unwrap_or(0))
+"#;
+    let (stdout, _stderr, _exit) = lint_code(source);
+    assert!(
+        !stdout.contains("unknown_method"),
+        "real builtins/runtime globals must not warn: {stdout}"
+    );
+}
+
+#[test]
+fn test_option_helper_free_call_arity_checked() {
+    // is_some is now in builtin_sigs, so wrong arity is caught statically
+    let source = r#"let x = Some(1)
+print(is_some(x, 99))
+"#;
+    let (stdout, _stderr, _exit) = lint_code(source);
+    assert!(
+        stdout.contains("is_some") && stdout.contains("argument"),
+        "arity mismatch on is_some should be reported: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

DD-063 Rec 4b — the second diagnostics PR, closing out the repair-loop work. Four self-contained commits:

### 1. Runtime method-miss bridge hints (E007)

`s.length()` now produces a did-you-mean (alias table first: `length`/`size`/`count`→`len`, `to_string`/`to_str`→`str`, `append`→`push`, `upper`/`lower`→`to_upper`/`to_lower`; then Levenshtein over everything in scope) plus a UFCS bridge hint with the actual receiver, and a line number for the source frame:

```text
error[E007]
  --> method_miss.tnt:2
  = Undefined function: length
  help: Did you mean 'len'?
  hint: NTNT methods resolve to free functions — try len(s)
```

Module namespace misses (`strutil.trimm(...)`) suggest the nearest export. No `map`→`transform` alias: `map` is a keyword, so `.map(` is a parse error that never reaches dispatch.

### 2. Typechecker unknown-method lint

The DD-063 complaint was that default-mode `ntnt lint` passes clean on `s.length()`. New rule `unknown_method` warns in **all** lint modes (error in strict) when a dot-call names a method backed by no defined function, builtin, or in-scope binding, with the same alias/Levenshtein hints. Guards against false positives: `Any` receivers skipped (module aliases, untyped params — the runtime hint still catches those), and any unresolvable import (unknown module, missing file, unreadable wildcard) suppresses the check file-wide. **Zero new findings across all 45 `examples/` files**, and full lint output is byte-identical to main across the sweep.

`is_some`/`is_none`/`is_ok`/`is_err`/`unwrap_or` are now registered in `builtin_sigs` (they are runtime globals) — this also introduces arity checking on free calls to them that previously passed silently. **Release-note item.**

### 3. IAL did-you-mean

`ResolveError` gains `kind` (UnknownTerm/Cycle/MaxDepth) and `suggestions`: unknown terms get up to 3 near-miss vocabulary patterns, compared after param/quote normalization so `body containz "x"` finds `body contains {text}`. Flows to `intent check` output and Studio traces automatically via Display.

### 4. `ntnt intent lint`

New subcommand: static glossary/scenario validation with no server and no primitive execution. Reports unresolved when-clauses and outcomes (with suggestions), glossary definition cycles (including entries no scenario touches), and orphan glossary entries. Exit 1 on errors; orphans are warnings only. `--json` for CI. Accepts either a `.intent` path or a `.tnt` path with a paired `.intent`.

Outcome resolution deliberately mirrors the execution fallback chain (`resolve_scenario_with_base_dir`: component reference → IAL vocabulary → direct pattern), and orphan detection uses the same `match_term_pattern` matcher as when-clause resolution — so lint findings match what `intent check` can actually execute.

This ships ROADMAP 8.2 (Offline Intent Validation, planned as `intent validate`) under the `intent lint` name; the ROADMAP section is updated with the remaining extension items.

Sweep over the repo's 7 `.intent` files: 3 errors, all true positives — two are deliberate demo fixtures (`this_term_is_not_in_glossary`), and `examples/crypto_chart/crypto.intent` has a `body matches r"…"` outcome that resolves to zero executable assertions at execution time (pre-existing latent gap, surfaced by the new tool; left for follow-up).

## Maintainer decisions applied (flag if you disagree)

- Unknown-method warning fires in **Default** lint mode (that was the DD complaint), promoted to error in Strict
- Alias table contents as listed above — trim if too aggressive
- Orphan glossary entries never fail CI (no strict flag yet)
- `intent lint` accepts `.tnt` paths via `resolve_intent_tnt_pair`

## Not done

- Intent Studio visual check of the new trace error strings (they now include suggestion lines) — worth a quick manual look in the Studio UI; no tests assert on the old text

## Test plan

- 5 runtime integration tests (bridge hints, alias, user-fn suggestion, UFCS positive control, module miss)
- 7 typechecker lint tests (default warn, strict error, three suppression cases, UFCS control, arity on option helpers)
- 5 IAL unit tests (suggestion kinds, normalization, cycle kind, distance cutoff, trace propagation)
- 7 `intent lint` CLI tests (clean exit 0, unknown term exit 1 + suggestion, unresolved when, cycle, orphan warning exit 0, `--json` shape, `.tnt` pairing)
- Full suite: 1724 tests, 0 failures
- Regression sweeps vs origin/main baseline: `ntnt lint` byte-identical across all 45 examples; `intent lint` run over all 7 repo `.intent` files

Part of DD-063 (dd-063-language-assessment.md). Completes Rec 4; remaining DD-063 items are PR-5 (index OOB loudness, blocked on decisions) and Recs 5–10.