### PR TITLE
feat(runtime): array/string out-of-bounds reads are loud by type mode (DD-063 PR-5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,8 @@ fn divide(a: Int, b: Int) -> Int
 
 ### 15. Map access returns `None` for missing keys — use `has_key()` to check existence, not `is_some()`
 
+Array/string out-of-bounds is different: it warns in warn mode and errors (E010) in strict mode. `arr[i] ?? default` and `otherwise` suppress both — guard any index that can legitimately miss.
+
 ### 16. `for k in map` iterates keys — use `entries()` for key-value pairs
 
 ---

--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -131,7 +131,7 @@ Scoping also surfaced **two additional doc drifts** beyond the v2 findings: CLAU
 - [x] **PR-2** — Intentional syntax contract tests, CLAUDE.md truth, UFCS embrace (Rec 2) — S
 - [x] **PR-3** — Diagnostics I: parser error recovery + contract violation context (Rec 4a) — M
 - [x] **PR-4** — Diagnostics II: method bridge hints, unknown-method lint, IAL suggestions, `ntnt intent lint` (Rec 4b) — M
-- [ ] **PR-5** — Index out-of-bounds loudness (Rec 3) — M — **blocked on decisions**
+- [x] **PR-5** — Index out-of-bounds loudness (Rec 3) — M
 - [ ] Recs 5–10 — unscheduled, see end of section
 
 ### PR-1 — `${}` interpolation detection (Rec 1) — S, ~150 impl + ~280 tests
@@ -192,16 +192,16 @@ Defaults applied: unknown-method fires in default lint mode (that's the DD-063 c
 Scoping analysis recommends **staging**: ship runtime loudness for out-of-bounds **array/string read** access now (strict → E010 error; warn → deduped `[WARN]` + `None`; forgiving → silent), exactly mirroring the existing TypeMode gates in the same `Expression::Index` arm; **map missing-key stays silent-`None`** (documented intentional DX, 127 of 150 index usages in examples/ are map-key access, `has_key()` exists). `arr[i] ?? default` / `arr[i]?` / `otherwise` suppress both warn and strict error. Typechecker honesty (inferring `Option<T>`) is **deferred with cause**: the runtime's index result is a nullable union (`T | None`), not enum `Option<T>` — annotating `Option<T>` would be a new lie that crashes checker-blessed code on `unwrap`/`match`; unifying that representation needs its own DD first.
 
 Decisions required before this PR starts:
-- [ ] Confirm map missing-key (and `map.field`) stays silent in all modes
-- [ ] Confirm `??` / `?` / `otherwise` suppress the strict-mode error too (recommended: yes — `??` is the documented universal safety net)
-- [ ] Confirm `String[i]` OOB included alongside arrays (recommended: yes)
-- [ ] Confirm a strict-mode runtime behavior change is acceptable within 0.4.x (or needs 0.5 / a breaking-change release note)
-- [ ] Acknowledge the deferred-option-(a) constraint: any future `Option<T>` inference for index expressions requires the runtime-representation DD first
+- [x] Confirm map missing-key (and `map.field`) stays silent in all modes — **confirmed 2026-07-08**
+- [x] Confirm `??` / `?` / `otherwise` suppress the strict-mode error too — **confirmed: suppress both warn and error**
+- [x] Confirm `String[i]` OOB included alongside arrays — **confirmed: included**
+- [x] Confirm a strict-mode runtime behavior change is acceptable within 0.4.x — **confirmed: ship in 0.4.x with a release-note callout**
+- [x] Acknowledge the deferred-option-(a) constraint: any future `Option<T>` inference for index expressions requires the runtime-representation DD first — **acknowledged; recorded in the typechecker comment**
 
 Implementation (after decisions):
-- [ ] TypeMode-gated OOB handling in `Expression::Index` read path + suppression for guarded parents
-- [ ] Resolve the read/write asymmetry note (index *assignment* OOB already errors unconditionally)
-- [ ] Tests across all three modes + guarded-access suppression; update CLAUDE.md rule 15 area and AI_AGENT_GUIDE error-handling docs
+- [x] TypeMode-gated OOB handling in `Expression::Index` read path + suppression for guarded parents
+- [x] Resolve the read/write asymmetry note (index *assignment* OOB already errors unconditionally) — reads are now gated; writes keep erroring unconditionally, which is strictly louder and consistent
+- [x] Tests across all three modes + guarded-access suppression; update CLAUDE.md rule 15 area and AI_AGENT_GUIDE error-handling docs
 
 ### Recs 5–10 — assessed, not yet scheduled
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1310,6 +1310,27 @@ fn get_user(id) {
 }
 ```
 
+### Indexing Semantics (out-of-bounds is loud)
+
+Array and string indexing past the end is almost always a bug (off-by-one,
+short `split()` result, missing regex group), so it is loud by type mode:
+
+| Access | warn (default) | strict | forgiving |
+|--------|----------------|--------|-----------|
+| `arr[99]` / `"hi"[99]` out of bounds | `[WARN]` + `None` | error `E010` | silent `None` |
+| `m["missing"]` map key absent | silent `None` | silent `None` | silent `None` |
+
+Map missing-key stays silent by design — "optional key" is a legitimate idiom
+(`req.params`, config maps); use `has_key()` to check existence.
+
+Guarded access never warns or errors — the guard says None is expected:
+
+```ntnt
+let third = arr[2] ?? 0                       // suppressed: ?? is the safety net
+let item = arr[i] otherwise { return None }   // suppressed: otherwise handles it
+if len(arr) > 2 { print(arr[2]) }             // in bounds: nothing to report
+```
+
 **Behavior:**
 - `Some(v) ?? default` → `v` (unwrapped)
 - `None ?? default` → `default`

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -6916,6 +6916,11 @@ impl Interpreter {
             }
 
             Expression::Index { object, index } => {
+                // Guard suppression applies to THIS index only: consume the
+                // flag before evaluating sub-expressions so a nested OOB
+                // (`arr[brr[99]] ?? d`) still gets its own clear diagnostic
+                // instead of a confusing downstream type mismatch.
+                let oob_suppressed = self.suppress_index_warn.replace(false);
                 let obj = self.eval_expression(object)?;
                 let idx = self.eval_expression(index)?;
 
@@ -6925,14 +6930,16 @@ impl Interpreter {
                         let index = if i < 0 {
                             match (len as i64).checked_add(i) {
                                 Some(idx) if idx >= 0 => idx as usize,
-                                _ => return self.index_oob_outcome("Array", i, len),
+                                _ => {
+                                    return self.index_oob_outcome(oob_suppressed, "Array", i, len)
+                                }
                             }
                         } else {
                             i as usize
                         };
                         match arr.get(index) {
                             Some(value) => Ok(value.clone()),
-                            None => self.index_oob_outcome("Array", i, len),
+                            None => self.index_oob_outcome(oob_suppressed, "Array", i, len),
                         }
                     }
                     (Value::String(s), Value::Int(i)) => {
@@ -6940,14 +6947,21 @@ impl Interpreter {
                         let index = if i < 0 {
                             match (char_count as i64).checked_add(i) {
                                 Some(idx) if idx >= 0 => idx as usize,
-                                _ => return self.index_oob_outcome("String", i, char_count),
+                                _ => {
+                                    return self.index_oob_outcome(
+                                        oob_suppressed,
+                                        "String",
+                                        i,
+                                        char_count,
+                                    )
+                                }
                             }
                         } else {
                             i as usize
                         };
                         match s.chars().nth(index) {
                             Some(c) => Ok(Value::String(c.to_string())),
-                            None => self.index_oob_outcome("String", i, char_count),
+                            None => self.index_oob_outcome(oob_suppressed, "String", i, char_count),
                         }
                     }
                     // Map access with string key: map["key"]
@@ -10370,11 +10384,18 @@ impl Interpreter {
 
     /// TypeMode-gated outcome for an out-of-bounds array/string read
     /// (DD-063 Rec 3): strict → E010 error; warn → deduped [WARN] + None;
-    /// forgiving → silent None. Suppressed entirely under `??`/`?`/`otherwise`
-    /// guards. Map missing-key access never routes here — None-for-missing
-    /// is documented intentional DX there.
-    fn index_oob_outcome(&self, kind: &str, requested: i64, length: usize) -> Result<Value> {
-        if self.suppress_index_warn.get() {
+    /// forgiving → silent None. `suppressed` is the guard flag consumed by
+    /// the Index arm (`??`/`?`/`otherwise` on the direct index). Map
+    /// missing-key access never routes here — None-for-missing is documented
+    /// intentional DX there.
+    fn index_oob_outcome(
+        &self,
+        suppressed: bool,
+        kind: &str,
+        requested: i64,
+        length: usize,
+    ) -> Result<Value> {
+        if suppressed {
             return Ok(Value::none());
         }
         match get_type_mode() {
@@ -10383,12 +10404,20 @@ impl Interpreter {
                 length,
             }),
             TypeMode::Warn => {
+                // current_line scopes dedup to the statement, so two
+                // different arrays with the same OOB signature still warn
+                let line = self.current_line;
+                let location = if line > 0 {
+                    format!(" (line {})", line)
+                } else {
+                    String::new()
+                };
                 crate::config::type_warn_dedup(
-                    &format!("index_oob:{}:{}:{}", kind, requested, length),
+                    &format!("index_oob:{}:{}:{}:{}", kind, requested, length, line),
                     &format!(
-                        "{} index {} out of bounds (length {}) — returning None. \
+                        "{} index {} out of bounds (length {}){} — returning None. \
                          Guard with `value[i] ?? default` or a len() check.",
-                        kind, requested, length
+                        kind, requested, length, location
                     ),
                 );
                 Ok(Value::none())

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -751,6 +751,10 @@ pub struct Interpreter {
     call_depth: usize,
     /// Maximum allowed recursion depth
     max_recursion_depth: usize,
+    /// True while evaluating an index expression guarded by `??`, `?`, or
+    /// `otherwise` — out-of-bounds stays silent-None under a guard, in every
+    /// type mode (the guard is the documented safety net)
+    suppress_index_warn: std::cell::Cell<bool>,
 }
 
 /// Information about a trait definition
@@ -937,6 +941,7 @@ impl Interpreter {
             current_line: 0,
             current_col: 0,
             call_depth: 0,
+            suppress_index_warn: std::cell::Cell::new(false),
             max_recursion_depth: std::env::var("NTNT_MAX_RECURSION")
                 .ok()
                 .and_then(|v| v.parse::<usize>().ok())
@@ -4999,8 +5004,15 @@ impl Interpreter {
             } => {
                 let val = if let Some(expr) = value {
                     if otherwise.is_some() {
-                        // With otherwise block: catch runtime errors too
-                        match self.eval_expression(expr) {
+                        // With otherwise block: catch runtime errors too.
+                        // A guarded index stays silent-None so the otherwise
+                        // path is taken cleanly instead of via a caught error.
+                        let evaluated = if matches!(expr, Expression::Index { .. }) {
+                            self.eval_with_index_warn_suppressed(expr)
+                        } else {
+                            self.eval_expression(expr)
+                        };
+                        match evaluated {
                             Ok(v) => v,
                             Err(e) => {
                                 if !is_production_mode() {
@@ -5225,7 +5237,13 @@ impl Interpreter {
             Statement::Return { value, otherwise } => {
                 let value = if let Some(expr) = value {
                     if otherwise.is_some() {
-                        match self.eval_expression(expr) {
+                        // Guarded index stays silent-None (see let-otherwise)
+                        let evaluated = if matches!(expr, Expression::Index { .. }) {
+                            self.eval_with_index_warn_suppressed(expr)
+                        } else {
+                            self.eval_expression(expr)
+                        };
+                        match evaluated {
                             Ok(v) => v,
                             Err(e) => {
                                 if !is_production_mode() {
@@ -6113,7 +6131,15 @@ impl Interpreter {
                 operator,
                 right,
             } => {
-                let lhs = self.eval_expression(left)?;
+                // `arr[i] ?? default` is the documented safety net for
+                // optional access — don't warn/error on the guarded index
+                let lhs = if matches!(operator, BinaryOp::NullCoalesce)
+                    && matches!(left.as_ref(), Expression::Index { .. })
+                {
+                    self.eval_with_index_warn_suppressed(left)?
+                } else {
+                    self.eval_expression(left)?
+                };
 
                 // Short-circuit evaluation for logical operators
                 // TypeMode gate (DD-009 Phase 4): Strict requires Bool operands for && and ||.
@@ -6895,32 +6921,34 @@ impl Interpreter {
 
                 match (obj, idx) {
                     (Value::Array(arr), Value::Int(i)) => {
+                        let len = arr.len();
                         let index = if i < 0 {
-                            match (arr.len() as i64).checked_add(i) {
+                            match (len as i64).checked_add(i) {
                                 Some(idx) if idx >= 0 => idx as usize,
-                                _ => return Ok(Value::none()),
+                                _ => return self.index_oob_outcome("Array", i, len),
                             }
                         } else {
                             i as usize
                         };
-                        // Out-of-bounds returns None instead of crashing
-                        Ok(arr.get(index).cloned().unwrap_or_else(|| Value::none()))
+                        match arr.get(index) {
+                            Some(value) => Ok(value.clone()),
+                            None => self.index_oob_outcome("Array", i, len),
+                        }
                     }
                     (Value::String(s), Value::Int(i)) => {
+                        let char_count = s.chars().count();
                         let index = if i < 0 {
-                            let char_count = s.chars().count();
                             match (char_count as i64).checked_add(i) {
                                 Some(idx) if idx >= 0 => idx as usize,
-                                _ => return Ok(Value::none()),
+                                _ => return self.index_oob_outcome("String", i, char_count),
                             }
                         } else {
                             i as usize
                         };
-                        // Out-of-bounds returns None instead of crashing
-                        Ok(s.chars()
-                            .nth(index)
-                            .map(|c| Value::String(c.to_string()))
-                            .unwrap_or_else(|| Value::none()))
+                        match s.chars().nth(index) {
+                            Some(c) => Ok(Value::String(c.to_string())),
+                            None => self.index_oob_outcome("String", i, char_count),
+                        }
                     }
                     // Map access with string key: map["key"]
                     // Returns None for missing keys instead of throwing (DX improvement)
@@ -7618,7 +7646,11 @@ impl Interpreter {
             }
 
             Expression::Try(inner) => {
-                let value = self.eval_expression(inner)?;
+                let value = if matches!(inner.as_ref(), Expression::Index { .. }) {
+                    self.eval_with_index_warn_suppressed(inner)?
+                } else {
+                    self.eval_expression(inner)?
+                };
                 match &value {
                     Value::EnumValue {
                         enum_name,
@@ -10334,6 +10366,45 @@ impl Interpreter {
                 Err(_) => break, // Channel closed, server shutting down
             }
         }
+    }
+
+    /// TypeMode-gated outcome for an out-of-bounds array/string read
+    /// (DD-063 Rec 3): strict → E010 error; warn → deduped [WARN] + None;
+    /// forgiving → silent None. Suppressed entirely under `??`/`?`/`otherwise`
+    /// guards. Map missing-key access never routes here — None-for-missing
+    /// is documented intentional DX there.
+    fn index_oob_outcome(&self, kind: &str, requested: i64, length: usize) -> Result<Value> {
+        if self.suppress_index_warn.get() {
+            return Ok(Value::none());
+        }
+        match get_type_mode() {
+            TypeMode::Strict => Err(IntentError::IndexOutOfBounds {
+                index: requested,
+                length,
+            }),
+            TypeMode::Warn => {
+                crate::config::type_warn_dedup(
+                    &format!("index_oob:{}:{}:{}", kind, requested, length),
+                    &format!(
+                        "{} index {} out of bounds (length {}) — returning None. \
+                         Guard with `value[i] ?? default` or a len() check.",
+                        kind, requested, length
+                    ),
+                );
+                Ok(Value::none())
+            }
+            TypeMode::Forgiving => Ok(Value::none()),
+        }
+    }
+
+    /// Evaluate an expression with OOB index loudness suppressed — used for
+    /// the direct Index operand of `??`, `?`, and `otherwise`, which are the
+    /// documented safety nets for optional access.
+    fn eval_with_index_warn_suppressed(&mut self, expr: &Expression) -> Result<Value> {
+        let prev = self.suppress_index_warn.replace(true);
+        let result = self.eval_expression(expr);
+        self.suppress_index_warn.set(prev);
+        result
     }
 
     /// Capture old values from expressions in postconditions
@@ -15770,6 +15841,78 @@ c")
                 ref variant,
                 ..
             } if variant == "None"
+        ));
+    }
+
+    #[test]
+    fn index_oob_warn_mode_still_returns_none() {
+        let _lock = TYPE_MODE_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::config::set_test_type_mode(crate::config::TypeMode::Warn);
+        let result = eval(r#"[1, 2, 3][99]"#).unwrap();
+        assert!(matches!(
+            result,
+            Value::EnumValue { ref variant, .. } if variant == "None"
+        ));
+    }
+
+    #[test]
+    fn index_oob_strict_mode_errors_with_e010() {
+        let _lock = TYPE_MODE_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::config::set_test_type_mode(crate::config::TypeMode::Strict);
+        let err = eval(r#"[1, 2, 3][99]"#).unwrap_err();
+        assert!(matches!(
+            err,
+            IntentError::IndexOutOfBounds {
+                index: 99,
+                length: 3
+            }
+        ));
+
+        let err = eval(r#""hi"[99]"#).unwrap_err();
+        assert!(matches!(
+            err,
+            IntentError::IndexOutOfBounds {
+                index: 99,
+                length: 2
+            }
+        ));
+
+        let err = eval(r#"[1, 2, 3][-99]"#).unwrap_err();
+        assert!(matches!(
+            err,
+            IntentError::IndexOutOfBounds {
+                index: -99,
+                length: 3
+            }
+        ));
+    }
+
+    #[test]
+    fn index_oob_strict_mode_in_bounds_still_works() {
+        let _lock = TYPE_MODE_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::config::set_test_type_mode(crate::config::TypeMode::Strict);
+        assert!(matches!(eval(r#"[1, 2, 3][0]"#).unwrap(), Value::Int(1)));
+        assert!(matches!(eval(r#"[1, 2, 3][-1]"#).unwrap(), Value::Int(3)));
+    }
+
+    #[test]
+    fn index_oob_strict_mode_suppressed_by_null_coalesce() {
+        let _lock = TYPE_MODE_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::config::set_test_type_mode(crate::config::TypeMode::Strict);
+        assert!(matches!(
+            eval(r#"[1, 2, 3][99] ?? 42"#).unwrap(),
+            Value::Int(42)
+        ));
+    }
+
+    #[test]
+    fn index_oob_strict_mode_map_missing_key_stays_silent() {
+        let _lock = TYPE_MODE_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::config::set_test_type_mode(crate::config::TypeMode::Strict);
+        let result = eval(r#"map { "a": 1 }["missing"]"#).unwrap();
+        assert!(matches!(
+            result,
+            Value::EnumValue { ref variant, .. } if variant == "None"
         ));
     }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2126,11 +2126,16 @@ impl TypeContext {
                 }
             }
 
-            // TODO: arr[i] and map[k] return Option at runtime (None for out-of-bounds
-            // or missing keys), but the typechecker currently infers the unwrapped element
-            // type. A full fix would return Option<T> here and require ?? or ? at usage
-            // sites, but that's a breaking change requiring broader migration. For now,
-            // the mismatch is documented and the runtime handles it gracefully.
+            // Index expressions can yield None at runtime (out-of-bounds or
+            // missing key), but the checker infers the unwrapped element type.
+            // Resolved per DD-063 Rec 3 direction (b): the RUNTIME is now loud
+            // on array/string out-of-bounds (E010 in strict, [WARN] in warn;
+            // map missing-key stays silent by design). Inferring Option<T>
+            // here is deferred: the runtime returns bare elements in-bounds,
+            // so an Option<T> annotation would bless unwrap()/match-Some/
+            // is_some() code that crashes on valid values — any future change
+            // needs a nullable-union vs enum-Option unification DD first (see
+            // plans/dd-063-scoping-notes.md PR-5 options analysis).
             Expression::Index { object, index } => {
                 let obj_type = self.infer_expression(object);
                 let _idx_type = self.infer_expression(index);

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -6445,3 +6445,78 @@ print(arr[-1])
     assert!(stdout.contains("1") && stdout.contains("3"));
     assert!(!stderr.contains("out of bounds"));
 }
+
+#[test]
+fn test_oob_suppressed_by_otherwise_in_strict_mode() {
+    let code = r#"
+fn pick(arr) {
+    let x = arr[10] otherwise { return 0 }
+    return x
+}
+print(pick([1, 2]))
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_eq!(
+        exit_code, 0,
+        "otherwise must suppress strict E010: {stderr}"
+    );
+    assert!(stdout.contains("0"), "stdout: {stdout}");
+    assert!(!stderr.contains("E010"), "stderr: {stderr}");
+}
+
+#[test]
+fn test_oob_suppressed_by_try_operator() {
+    // arr[99]? unwraps None into an early return of None
+    let code = r#"
+fn pick(arr) {
+    let x = arr[99]?
+    return Some(x)
+}
+print(pick([1, 2]))
+"#;
+    for mode in ["warn", "strict"] {
+        let (stdout, stderr, exit_code) = run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", mode)]);
+        assert_eq!(exit_code, 0, "? must suppress OOB in {mode} mode: {stderr}");
+        assert!(stdout.contains("none"), "mode {mode}: {stdout}");
+        assert!(
+            !stderr.contains("out of bounds") && !stderr.contains("E010"),
+            "mode {mode}: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn test_nested_index_oob_keeps_clear_diagnostic_under_guard() {
+    // The guard covers the OUTER index only: the inner brr[99] OOB gets its
+    // own diagnostic instead of silently becoming a None-index mismatch
+    let code = r#"
+let arr = [1, 2]
+let brr = [1]
+print(arr[brr[99]] ?? 0)
+"#;
+    let (_stdout, stderr, exit_code) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("Index out of bounds: index 99, length 1"),
+        "inner OOB should surface its own E010: {stderr}"
+    );
+}
+
+#[test]
+fn test_oob_warns_per_call_site() {
+    // Same OOB signature on different lines: dedup is per statement line
+    let code = r#"
+let a = [1, 2]
+let b = [3, 4]
+print(a[10])
+print(b[10])
+"#;
+    let (_stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        stderr.matches("out of bounds").count(),
+        2,
+        "distinct call sites should each warn: {stderr}"
+    );
+}

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -6294,3 +6294,154 @@ print(x)
     assert_eq!(exit_code, 0);
     assert_eq!(stdout.trim(), "()", "Empty branch should return Unit");
 }
+
+// ===========================================================================
+// Index out-of-bounds loudness (DD-063 Rec 3, PR-5)
+// ===========================================================================
+
+#[test]
+fn test_array_oob_warns_in_default_mode() {
+    let code = r#"
+let arr = [1, 2]
+print(arr[10])
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("none"), "stdout: {stdout}");
+    assert!(
+        stderr.contains("[WARN]") && stderr.contains("out of bounds"),
+        "warn mode should warn on OOB: {stderr}"
+    );
+}
+
+#[test]
+fn test_array_oob_errors_in_strict_mode() {
+    let code = r#"
+let arr = [1, 2]
+print(arr[10])
+"#;
+    let (_stdout, stderr, exit_code) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("error[E010]") && stderr.contains("Index out of bounds"),
+        "strict mode should error: {stderr}"
+    );
+}
+
+#[test]
+fn test_array_oob_silent_in_forgiving_mode() {
+    let code = r#"
+let arr = [1, 2]
+print(arr[10])
+"#;
+    let (stdout, stderr, exit_code) =
+        run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "forgiving")]);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("none"));
+    assert!(
+        !stderr.contains("out of bounds"),
+        "forgiving mode must stay silent: {stderr}"
+    );
+}
+
+#[test]
+fn test_oob_suppressed_by_null_coalesce_in_warn_and_strict() {
+    let code = r#"
+let arr = [1, 2]
+print(arr[10] ?? 0)
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("0"), "stdout: {stdout}");
+    assert!(
+        !stderr.contains("out of bounds"),
+        "?? must suppress the warn: {stderr}"
+    );
+
+    let (stdout, stderr, exit_code) = run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_eq!(exit_code, 0, "?? must suppress the strict error: {stderr}");
+    assert!(stdout.contains("0"));
+}
+
+#[test]
+fn test_oob_suppressed_by_otherwise() {
+    let code = r#"
+fn pick(arr) {
+    let x = arr[10] otherwise { return 0 }
+    return x
+}
+print(pick([1, 2]))
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("0"), "stdout: {stdout}");
+    assert!(
+        !stderr.contains("out of bounds"),
+        "otherwise must suppress the warn: {stderr}"
+    );
+}
+
+#[test]
+fn test_map_missing_key_stays_silent_in_all_modes() {
+    let code = r#"
+let m = map { "a": 1 }
+print(m["missing"])
+"#;
+    for mode in ["warn", "strict", "forgiving"] {
+        let (stdout, stderr, exit_code) = run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", mode)]);
+        assert_eq!(exit_code, 0, "mode {mode}: {stderr}");
+        assert!(stdout.contains("none"), "mode {mode}: {stdout}");
+        assert!(
+            !stderr.contains("out of bounds") && !stderr.contains("[WARN]"),
+            "map missing key must stay silent in {mode} mode: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn test_string_and_negative_oob_warn() {
+    let code = r#"
+let s = "hi"
+print(s[99])
+let arr = [1, 2]
+print(arr[-99])
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0);
+    assert_eq!(stdout.matches("none").count(), 2, "stdout: {stdout}");
+    assert!(
+        stderr.contains("String index 99") && stderr.contains("Array index -99"),
+        "both OOB kinds should warn: {stderr}"
+    );
+}
+
+#[test]
+fn test_oob_warn_is_deduped_in_loops() {
+    let code = r#"
+let arr = [1, 2]
+for i in 0..5 {
+    print(arr[10])
+}
+"#;
+    let (_stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        stderr.matches("out of bounds").count(),
+        1,
+        "identical OOB should warn once: {stderr}"
+    );
+}
+
+#[test]
+fn test_in_bounds_access_no_warning_strict() {
+    let code = r#"
+let arr = [1, 2, 3]
+print(arr[0])
+print(arr[-1])
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code_with_env(code, &[("NTNT_TYPE_MODE", "strict")]);
+    assert_eq!(exit_code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("1") && stdout.contains("3"));
+    assert!(!stderr.contains("out of bounds"));
+}


### PR DESCRIPTION
## Summary

DD-063 PR-5 (Rec 3) — resolves the index/Option type-reality mismatch, the last verified silent failure from the language assessment. Out-of-bounds array/string reads previously returned silent `None` in every mode while the typechecker inferred the element type.

Direction (b) from the scoping analysis, with all five maintainer decisions confirmed:

| Access | warn (default) | strict | forgiving |
|--------|----------------|--------|-----------|
| `arr[99]` / `"hi"[99]` OOB | deduped `[WARN]` + `None` | error `E010` | silent `None` |
| `m["missing"]` | silent `None` | silent `None` | silent `None` |

- **Gate** follows the existing TypeMode template already used by Option/Result indexing in the same `Expression::Index` arm; both positive-miss and negative-overflow paths route through one helper, reusing the existing E010 `IndexOutOfBounds` variant (index *assignment* OOB already used it — reads were the only silent path).
- **Map missing-key stays silent by design** in all modes: 127 of 150 index usages in `examples/` are map-key access, "optional key" is a legitimate idiom (`req.params`, config), and `has_key()` is the existence check.
- **Guards suppress everything**: `arr[i] ?? default`, `arr[i]?`, and let/return `otherwise` suppress both the warning and the strict error — the guard is the documented universal safety net. Implemented as a `Cell` flag set around the direct Index operand at the four guard sites.
- **Typechecker `Option<T>` inference stays deferred with cause**: in-bounds reads return bare elements, so an `Option<T>` annotation would bless `unwrap(arr[i])` / `match Some(v)` code that crashes on valid values. The old TODO now records the constraint and points at the PR-5 options analysis; any future change needs a nullable-union vs enum-Option unification DD first.

## Release-note callout (breaking for strict mode)

`NTNT_TYPE_MODE=strict` gains a new runtime error: OOB reads that previously produced `None` now stop with `E010`. Confirmed acceptable for 0.4.x as an opt-in mode whose purpose is exactly this strictness. Warn-mode programs keep identical values and exit codes (one deduped stderr line per distinct OOB signature).

## Decisions applied (confirmed by maintainer 2026-07-08)

1. Map missing-key (and `map.field`) stays silent in all modes
2. `??` / `?` / `otherwise` suppress the strict-mode error too
3. `String[i]` OOB included alongside arrays
4. Ship in 0.4.x with this release-note callout
5. Deferred-option constraint acknowledged and recorded in the typechecker comment

## Test plan

- 5 unit tests: warn→None, strict→E010 (positive/negative/string), strict in-bounds control, `??` suppression under strict, map-key silence under strict
- 9 integration tests: full mode matrix, `??`/`otherwise` suppression, map silence across all three modes, string+negative OOB, warn dedup in loops (exactly one warning), in-bounds strict control
- Full suite: 1741 tests, 0 failures — including the pre-existing forgiving-mode OOB regression locks, unmodified
- Example runtime spot-check: no new warnings in `environment`, `contracts_full`, `collections_demo`, `error_handling`
- Docs: AI_AGENT_GUIDE indexing-semantics section, CLAUDE.md rule 15 amendment

Closes out DD-063 Rec 3. With PRs 1–4 merged, the tracked implementation plan is complete; remaining DD-063 items are the unscheduled Recs 5–10.