### PR TITLE
feat(stdlib): std/email — SMTP sending with a dev log transport (DD-058 item 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ import { log_info, log_warn, log_error, set_log_level } from "std/log"
 import { channel, send, recv, sleep_ms, spawn, await_task, parallel, race } from "std/concurrent"
 import { enqueue, enqueue_in, configure_queue, work_async, work_jobs } from "std/jobs"
 import { schema, validate, required, optional, email, min_value, max_length, one_of, matches, default } from "std/validate"
+import { configure_email, send_email, send_email_batch } from "std/email"
 // In schema rules, use the GLOBAL int/float/bool/str (and std/string trim) directly for coercion — do not look for them in std/validate
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -788,7 +788,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -848,6 +848,22 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64 0.22.1",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "encoding_rs"
@@ -1640,6 +1656,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lettre"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+dependencies = [
+ "base64 0.22.1",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-util",
+ "httpdate",
+ "idna 1.1.0",
+ "mime",
+ "nom 8.0.0",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2 0.6.1",
+ "tokio",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +1883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ntnt"
 version = "0.4.12"
 dependencies = [
@@ -1868,6 +1917,7 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "lazy_static",
+ "lettre",
  "libc",
  "num_cpus",
  "postgres",
@@ -2313,6 +2363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,7 +2665,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -2631,6 +2687,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3660,6 +3717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,7 +4115,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ reqwest = { version = "0.11", features = ["blocking", "json", "multipart", "cook
 # TLS certificate inspection
 rustls = { version = "0.23", default-features = false, features = ["std", "ring", "tls12"] }
 rustls-pki-types = "1"
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "builder", "pool", "rustls-tls"] }
 webpki-root-certs = "1"
 x509-parser = "0.18"
 

--- a/design-docs/dd-058-stdlib-gaps.md
+++ b/design-docs/dd-058-stdlib-gaps.md
@@ -1,6 +1,6 @@
 # DD-058: Stdlib Gap Analysis — Eliminating Common Package Dependencies
 
-**Status:** Draft — item 1 (`std/validate`) shipped 2026-07-08
+**Status:** Draft — items 1 (`std/validate`) and 2 (`std/email`) shipped 2026-07-08
 **Author:** Larri + Josh
 **Created:** 2026-03-31
 **App:** ntnt
@@ -115,7 +115,13 @@ let result = validate(user_schema, parse_form(req))
 
 **Scope:** ~500-800 lines of Rust. No new dependencies (regex already in use).
 
-#### 2. Email Sending (`std/email`)
+#### 2. Email Sending (`std/email`) — ✅ SHIPPED (v0.4.12)
+
+> Implemented as proposed (`lettre` with rustls, matching the repo's TLS
+> stack), plus a `"transport": "log"` mode (and `NTNT_EMAIL_MODE=log` env
+> override) that prints emails to stderr and reports them as sent — so dev
+> environments and CI run without an SMTP server. TLS defaults from the
+> port (465 implicit, otherwise STARTTLS) with an explicit `"tls"` override.
 
 **The gap:** Every web app with users eventually sends email — signup confirmations, password resets, notifications, contact forms. Currently requires `fetch()` to an external API (Resend, SendGrid) or shelling out.
 
@@ -479,7 +485,7 @@ Based on impact, effort, and dependencies:
 | Order | Module | Effort | Impact | Notes |
 |-------|--------|--------|--------|-------|
 | 1 | `std/validate` | Medium (500-800 LOC) | Very High | ✅ Shipped v0.4.12. Every app needs it. No new deps. |
-| 2 | `std/email` | Medium (400-600 LOC) | High | `lettre` crate. Every app with users. |
+| 2 | `std/email` | Medium (400-600 LOC) | High | ✅ Shipped v0.4.12. `lettre` crate. Every app with users. |
 | 3 | Rate limiting | Medium (300-500 LOC) | High | Covered in DD-051. Middleware-level. |
 | 4 | Multipart uploads | Medium (400-600 LOC) | High | `multer` crate. File upload forms. |
 | 5 | `from_now()` / `slugify()` / `paginate()` | Small (200 LOC total) | Medium | Quick wins, extend existing modules. |

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -2413,6 +2413,44 @@ let name = get_str(kv, "user:name", "Anonymous")     // String, default "Anonymo
 
 ---
 
+## Email (`std/email`)
+
+SMTP email for signup confirmations, password resets, and notifications.
+Configure once at startup; `send_email()` returns
+`Ok(map { "message_id", "transport" })` or `Err(message)` — bad addresses
+and SMTP failures are `Err` values, never crashes.
+
+```ntnt
+import { configure_email, send_email, send_email_batch } from "std/email"
+import { get_env } from "std/env"
+
+configure_email(map {
+    "host": get_env("SMTP_HOST") ?? "smtp.example.com",
+    "port": 587,                    // 587 STARTTLS (default), 465 implicit TLS
+    "username": get_env("SMTP_USER") ?? "",
+    "password": get_env("SMTP_PASS") ?? "",
+    "from": "hello@myapp.com",
+    "from_name": "My App"
+})
+
+let result = send_email(map {
+    "to": "user@example.com",       // string or array of strings
+    "subject": "Welcome!",
+    "html": template("emails/welcome.html", map { "name": name }),
+    "text": "Welcome, #{name}!"     // both = multipart with plain-text fallback
+}) otherwise { return status(500, "Email failed: #{err}") }
+```
+
+- **Development/CI**: `configure_email(map { "transport": "log", "from": "dev@localhost" })`
+  prints emails to stderr and reports them as sent — no SMTP server needed.
+  `NTNT_EMAIL_MODE=log` forces log mode over any config.
+- Options: `to` (required), `subject` (required), `text` and/or `html`,
+  `cc`, `bcc`, `reply_to`, per-message `from`/`from_name` overrides.
+- `send_email_batch([...])` reuses one connection and returns
+  `Ok(array of per-email results)` — one bad email doesn't stop the rest.
+
+---
+
 ## Logging (`std/log`)
 
 Structured logging with configurable levels.

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -12,6 +12,7 @@
 - [std/concurrent](#stdconcurrent)
 - [std/crypto](#stdcrypto)
 - [std/csv](#stdcsv)
+- [std/email](#stdemail)
 - [std/env](#stdenv)
 - [std/fs](#stdfs)
 - [std/http](#stdhttp)
@@ -5570,6 +5571,120 @@ stringify_with_headers([map { "name": "Alice" }], ["name"])  // => "name\nAlice"
 **See also:** `stringify`, `parse_with_headers`
 
 *Since v0.2.0*
+
+---
+
+## std/email
+
+SMTP email sending with a log transport for development
+
+```ntnt
+import { configure_email, send_email, send_email_batch } from "std/email"
+```
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| [`configure_email`](#configureemail) | Configure the SMTP transport. Call once at startup, before send_email(). |
+| [`send_email`](#sendemail) | Send a single email through the configured transport. |
+| [`send_email_batch`](#sendemailbatch) | Send multiple emails, reusing one SMTP connection. |
+
+#### `configure_email`
+
+```ntnt
+configure_email(config: Map<String, Any>) -> Unit
+```
+
+Configure the SMTP transport. Call once at startup, before send_email().
+
+Config keys: "host" (required for smtp), "port" (default 587), "username", "password", "from" (required), "from_name", "tls" ("starttls" | "implicit" | "none"; defaults from the port — 465 is implicit, others STARTTLS), and "transport" ("smtp" | "log"). The log transport prints emails to stderr and reports them as sent — use it in development and tests. The NTNT_EMAIL_MODE env var ("log" or "smtp") overrides the configured transport.
+
+**Parameters:**
+
+- `config` — SMTP configuration map.
+
+**Returns:** Unit
+
+**Examples:**
+
+```ntnt
+configure_email(map { "host": "smtp.example.com", "from": "hello@myapp.com", "username": "u", "password": "p" })  // Production SMTP
+configure_email(map { "transport": "log", "from": "dev@localhost" })  // Development: log emails instead of sending
+```
+
+**Errors:**
+
+- **TypeError**: requires a \ — *Fix: Add \"from\": \"hello@myapp.com\" to the config*
+
+**See also:** `send_email`, `send_email_batch`, `get_env`
+
+*Since v0.4.12*
+
+---
+
+#### `send_email`
+
+```ntnt
+send_email(opts: Map<String, Any>) -> Result<Map<String, String>, String>
+```
+
+Send a single email through the configured transport.
+
+Options: "to" (string or array, required), "subject" (required), "text" and/or "html" (at least one required — both sends a multipart message with a plain-text fallback), "cc", "bcc", "reply_to", and per-message "from" / "from_name" overrides. Returns Ok(map { "message_id", "transport" }) or Err(message). Invalid options and SMTP failures are Err values (use `otherwise` or match), not runtime errors.
+
+**Parameters:**
+
+- `opts` — The email to send.
+
+**Returns:** Ok with the generated message id, or Err with the failure reason.
+
+**Examples:**
+
+```ntnt
+send_email(map { "to": "user@example.com", "subject": "Welcome!", "text": "Hello!" })  // Plain text email
+send_email(map { "to": "user@example.com", "subject": "Welcome!", "html": template("emails/welcome.html", map { "name": name }), "text": "Welcome!" })  // HTML with text fallback
+```
+
+**Errors:**
+
+- **RuntimeError**: configure_email() has not been called — *Fix: Call configure_email() at startup before sending*
+
+**Gotchas:**
+
+- Returns Err for bad addresses or SMTP failures instead of crashing — always handle the Result.
+
+**See also:** `configure_email`, `send_email_batch`, `template`
+
+*Since v0.4.12*
+
+---
+
+#### `send_email_batch`
+
+```ntnt
+send_email_batch(emails: Array<Map<String, Any>>) -> Result<Array<Any>, String>
+```
+
+Send multiple emails, reusing one SMTP connection.
+
+Each entry takes the same options as send_email(). Returns Ok with an array of per-email results (each Ok(map) or Err(message), in input order); a hard Err is returned only when the transport itself cannot be set up. One bad email does not stop the rest.
+
+**Parameters:**
+
+- `emails` — Array of email option maps.
+
+**Returns:** Ok(array of per-email results), or Err for transport setup failure.
+
+**Examples:**
+
+```ntnt
+send_email_batch([map { "to": "a@x.co", "subject": "Hi", "text": "..." }, map { "to": "b@x.co", "subject": "Hi", "text": "..." }])  // Two emails, one connection
+```
+
+**See also:** `send_email`, `configure_email`
+
+*Since v0.4.12*
 
 ---
 

--- a/examples/email_demo.tnt
+++ b/examples/email_demo.tnt
@@ -1,0 +1,55 @@
+// std/email demo — SMTP email with a log transport for development
+//
+// Run: ntnt run examples/email_demo.tnt
+// (uses the log transport: emails print to stderr, nothing is sent)
+
+import { configure_email, send_email, send_email_batch } from "std/email"
+
+// Development setup: log emails instead of sending.
+// Production swaps transport for real SMTP config:
+//   configure_email(map {
+//       "host": get_env("SMTP_HOST") ?? "smtp.example.com",
+//       "port": 587,                       // 587 STARTTLS (default), 465 implicit TLS
+//       "username": get_env("SMTP_USER") ?? "",
+//       "password": get_env("SMTP_PASS") ?? "",
+//       "from": "hello@myapp.com",
+//       "from_name": "My App"
+//   })
+// NTNT_EMAIL_MODE=log also forces log mode without code changes.
+configure_email(map {
+    "transport": "log",
+    "from": "hello@myapp.com",
+    "from_name": "My App"
+})
+
+// Single email — text and/or html (both = multipart with text fallback)
+match send_email(map {
+    "to": "user@example.com",
+    "subject": "Welcome!",
+    "html": "<h1>Welcome!</h1><p>Glad you're here.</p>",
+    "text": "Welcome! Glad you're here."
+}) {
+    Ok(result) => print("Sent #{result["message_id"]} via #{result["transport"]}"),
+    Err(e) => print("Send failed: #{e}")
+}
+
+// Batch — one connection, per-email results; a bad address doesn't
+// stop the rest
+match send_email_batch([
+    map { "to": "a@example.com", "subject": "Digest", "text": "Your weekly digest" },
+    map { "to": "not-an-address", "subject": "Digest", "text": "Your weekly digest" },
+    map { "to": "b@example.com", "subject": "Digest", "text": "Your weekly digest" }
+]) {
+    Ok(results) => {
+        let mut sent = 0
+        let mut failed = 0
+        for r in results {
+            match r {
+                Ok(_) => { sent = sent + 1 },
+                Err(_) => { failed = failed + 1 }
+            }
+        }
+        print("Batch: #{sent} sent, #{failed} failed")
+    },
+    Err(e) => print("Batch transport failure: #{e}")
+}

--- a/src/stdlib/email.rs
+++ b/src/stdlib/email.rs
@@ -1,0 +1,601 @@
+//! Email Sending Module (std/email)
+//!
+//! SMTP email via the `lettre` crate (DD-058 item 2): signup confirmations,
+//! password resets, notifications, contact forms. Configure once at startup
+//! with `configure_email()`, then `send_email()` returns
+//! `Ok(map { "message_id": ... })` or `Err(message)`.
+//!
+//! For development and CI there is a log transport
+//! (`"transport": "log"` in the config, or `NTNT_EMAIL_MODE=log`): emails
+//! are printed to stderr and reported as sent, so app code and tests run
+//! without an SMTP server.
+
+use crate::error::{IntentError, Result};
+use crate::interpreter::Value;
+use lettre::message::{header::ContentType, Mailbox, MultiPart, SinglePart};
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{Message, SmtpTransport, Transport};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// SMTP configuration set by configure_email()
+#[derive(Debug, Clone)]
+struct EmailConfig {
+    host: String,
+    port: u16,
+    username: Option<String>,
+    password: Option<String>,
+    from: String,
+    from_name: Option<String>,
+    /// "starttls" | "implicit" | "none" (defaulted from the port)
+    tls: String,
+    /// "smtp" | "log"
+    transport: String,
+}
+
+/// Global config + cached pooled transport (rebuilt on configure_email).
+/// Process-wide like std/log's level; the pool makes send_email_batch and
+/// hot request paths reuse connections.
+#[allow(clippy::type_complexity)]
+static EMAIL_STATE: Mutex<Option<(EmailConfig, Option<SmtpTransport>)>> = Mutex::new(None);
+
+fn get_string(map: &HashMap<String, Value>, key: &str) -> Option<String> {
+    match map.get(key) {
+        Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Effective transport mode: NTNT_EMAIL_MODE env var overrides config,
+/// so tests and dev environments can force log mode without code changes
+fn transport_mode(config: &EmailConfig) -> String {
+    std::env::var("NTNT_EMAIL_MODE")
+        .ok()
+        .filter(|m| m == "log" || m == "smtp")
+        .unwrap_or_else(|| config.transport.clone())
+}
+
+fn parse_config(map: &HashMap<String, Value>) -> Result<EmailConfig> {
+    let transport = get_string(map, "transport").unwrap_or_else(|| "smtp".to_string());
+    if transport != "smtp" && transport != "log" {
+        return Err(IntentError::type_error(format!(
+            "configure_email(): transport must be \"smtp\" or \"log\", got \"{}\"",
+            transport
+        )));
+    }
+
+    let from = get_string(map, "from").ok_or_else(|| {
+        IntentError::type_error("configure_email() requires a \"from\" address".to_string())
+    })?;
+
+    let host = get_string(map, "host").unwrap_or_default();
+    if transport == "smtp" && host.is_empty() {
+        return Err(IntentError::type_error(
+            "configure_email() requires a \"host\" (or use \"transport\": \"log\" for development)"
+                .to_string(),
+        ));
+    }
+
+    let port = match map.get("port") {
+        Some(Value::Int(p)) if *p > 0 && *p <= 65535 => *p as u16,
+        Some(Value::String(s)) => s.parse::<u16>().map_err(|_| {
+            IntentError::type_error(format!("configure_email(): invalid port \"{}\"", s))
+        })?,
+        None => 587,
+        Some(other) => {
+            return Err(IntentError::type_error(format!(
+                "configure_email(): port must be an Int, got {}",
+                other.type_name()
+            )))
+        }
+    };
+
+    // TLS mode defaults from the port: 465 implicit, 587/25 STARTTLS
+    let tls = match get_string(map, "tls") {
+        Some(mode) if ["starttls", "implicit", "none"].contains(&mode.as_str()) => mode,
+        Some(mode) => return Err(IntentError::type_error(format!(
+            "configure_email(): tls must be \"starttls\", \"implicit\", or \"none\", got \"{}\"",
+            mode
+        ))),
+        None => {
+            if port == 465 {
+                "implicit".to_string()
+            } else {
+                "starttls".to_string()
+            }
+        }
+    };
+
+    Ok(EmailConfig {
+        host,
+        port,
+        username: get_string(map, "username"),
+        password: get_string(map, "password"),
+        from,
+        from_name: get_string(map, "from_name"),
+        tls,
+        transport,
+    })
+}
+
+fn build_transport(config: &EmailConfig) -> Result<SmtpTransport> {
+    let builder = match config.tls.as_str() {
+        "implicit" => SmtpTransport::relay(&config.host),
+        "starttls" => SmtpTransport::starttls_relay(&config.host),
+        _ => Ok(SmtpTransport::builder_dangerous(&config.host)),
+    }
+    .map_err(|e| IntentError::runtime_error(format!("Email transport setup failed: {}", e)))?;
+
+    let mut builder = builder.port(config.port);
+    if let (Some(user), Some(pass)) = (&config.username, &config.password) {
+        builder = builder.credentials(Credentials::new(user.clone(), pass.clone()));
+    }
+    Ok(builder.build())
+}
+
+/// Parse a mailbox as "Name <addr>" or bare "addr"
+fn parse_mailbox(addr: &str, name: Option<&str>) -> Result<Mailbox> {
+    let rendered = match name {
+        Some(n) => format!("{} <{}>", n, addr),
+        None => addr.to_string(),
+    };
+    rendered
+        .parse::<Mailbox>()
+        .map_err(|e| IntentError::type_error(format!("Invalid email address \"{}\": {}", addr, e)))
+}
+
+/// Addresses for to/cc/bcc: a single string or an array of strings
+fn parse_address_list(value: &Value, field: &str) -> Result<Vec<Mailbox>> {
+    let raw: Vec<String> = match value {
+        Value::String(s) => vec![s.clone()],
+        Value::Array(items) => items
+            .iter()
+            .map(|item| match item {
+                Value::String(s) => Ok(s.clone()),
+                other => Err(IntentError::type_error(format!(
+                    "send_email(): \"{}\" entries must be strings, got {}",
+                    field,
+                    other.type_name()
+                ))),
+            })
+            .collect::<Result<Vec<String>>>()?,
+        other => {
+            return Err(IntentError::type_error(format!(
+                "send_email(): \"{}\" must be a string or array of strings, got {}",
+                field,
+                other.type_name()
+            )))
+        }
+    };
+    raw.iter().map(|addr| parse_mailbox(addr, None)).collect()
+}
+
+/// Build a lettre Message from send_email() options, returning the message
+/// and its generated message id
+fn build_message(config: &EmailConfig, opts: &HashMap<String, Value>) -> Result<(Message, String)> {
+    let to_value = opts.get("to").ok_or_else(|| {
+        IntentError::type_error("send_email() requires a \"to\" address".to_string())
+    })?;
+    let to_boxes = parse_address_list(to_value, "to")?;
+    if to_boxes.is_empty() {
+        return Err(IntentError::type_error(
+            "send_email(): \"to\" must contain at least one address".to_string(),
+        ));
+    }
+
+    let subject = get_string(opts, "subject").ok_or_else(|| {
+        IntentError::type_error("send_email() requires a \"subject\"".to_string())
+    })?;
+
+    let text = get_string(opts, "text");
+    let html = get_string(opts, "html");
+    if text.is_none() && html.is_none() {
+        return Err(IntentError::type_error(
+            "send_email() requires \"text\" and/or \"html\" content".to_string(),
+        ));
+    }
+
+    // Per-message from override falls back to the configured sender
+    let from_addr = get_string(opts, "from").unwrap_or_else(|| config.from.clone());
+    let from_name = get_string(opts, "from_name").or_else(|| config.from_name.clone());
+    let from_box = parse_mailbox(&from_addr, from_name.as_deref())?;
+
+    let message_id = format!(
+        "<{}@{}>",
+        uuid::Uuid::new_v4(),
+        config
+            .host
+            .split(':')
+            .next()
+            .filter(|h| !h.is_empty())
+            .unwrap_or("ntnt.local")
+    );
+
+    let mut builder = Message::builder()
+        .from(from_box)
+        .subject(&subject)
+        .message_id(Some(message_id.clone()));
+
+    for mailbox in to_boxes {
+        builder = builder.to(mailbox);
+    }
+    if let Some(cc) = opts.get("cc") {
+        for mailbox in parse_address_list(cc, "cc")? {
+            builder = builder.cc(mailbox);
+        }
+    }
+    if let Some(bcc) = opts.get("bcc") {
+        for mailbox in parse_address_list(bcc, "bcc")? {
+            builder = builder.bcc(mailbox);
+        }
+    }
+    if let Some(reply_to) = get_string(opts, "reply_to") {
+        builder = builder.reply_to(parse_mailbox(&reply_to, None)?);
+    }
+
+    let message = match (text, html) {
+        (Some(text), Some(html)) => {
+            builder.multipart(MultiPart::alternative_plain_html(text, html))
+        }
+        (Some(text), None) => builder.singlepart(
+            SinglePart::builder()
+                .header(ContentType::TEXT_PLAIN)
+                .body(text),
+        ),
+        (None, Some(html)) => builder.singlepart(
+            SinglePart::builder()
+                .header(ContentType::TEXT_HTML)
+                .body(html),
+        ),
+        (None, None) => unreachable!("checked above"),
+    }
+    .map_err(|e| IntentError::type_error(format!("send_email(): invalid message: {}", e)))?;
+
+    Ok((message, message_id))
+}
+
+/// Render a sent-result map: map { "message_id": ..., "transport": ... }
+fn sent_result(message_id: String, transport: &str) -> Value {
+    let mut result = HashMap::new();
+    result.insert("message_id".to_string(), Value::String(message_id));
+    result.insert(
+        "transport".to_string(),
+        Value::String(transport.to_string()),
+    );
+    Value::ok(Value::Map(result))
+}
+
+fn log_email(opts: &HashMap<String, Value>, message_id: &str) {
+    let to = match opts.get("to") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+        _ => String::new(),
+    };
+    let subject = get_string(opts, "subject").unwrap_or_default();
+    eprintln!(
+        "[EMAIL:log] to: {} | subject: {} | id: {}",
+        to, subject, message_id
+    );
+}
+
+/// Send one already-parsed message through the given mode, sharing the
+/// cached transport for smtp
+fn dispatch(
+    config: &EmailConfig,
+    transport_slot: &mut Option<SmtpTransport>,
+    opts: &HashMap<String, Value>,
+) -> Result<Value> {
+    let mode = transport_mode(config);
+    let (message, message_id) = match build_message(config, opts) {
+        Ok(built) => built,
+        // Bad options are a per-email Err value, not a hard error, so
+        // batch sends can report per-item failures
+        Err(e) => return Ok(Value::err(Value::String(e.to_string()))),
+    };
+
+    if mode == "log" {
+        log_email(opts, &message_id);
+        return Ok(sent_result(message_id, "log"));
+    }
+
+    if transport_slot.is_none() {
+        *transport_slot = Some(build_transport(config)?);
+    }
+    let transport = transport_slot.as_ref().expect("just built");
+
+    match transport.send(&message) {
+        Ok(_) => Ok(sent_result(message_id, "smtp")),
+        Err(e) => Ok(Value::err(Value::String(format!(
+            "Failed to send email: {}",
+            e
+        )))),
+    }
+}
+
+fn with_state<T>(f: impl FnOnce(&mut Option<(EmailConfig, Option<SmtpTransport>)>) -> T) -> T {
+    let mut guard = EMAIL_STATE.lock().unwrap_or_else(|e| e.into_inner());
+    f(&mut guard)
+}
+
+fn require_config_map(value: &Value, function: &str) -> Result<HashMap<String, Value>> {
+    match value {
+        Value::Map(m) => Ok(m.clone()),
+        other => Err(IntentError::type_error(format!(
+            "{}() requires a map, got {}",
+            function,
+            other.type_name()
+        ))),
+    }
+}
+
+/// Initialize the std/email module
+pub fn init() -> HashMap<String, Value> {
+    let mut module: HashMap<String, Value> = HashMap::new();
+
+    // @ntnt configure_email
+    // @module std/email
+    // @module_description SMTP email sending with a log transport for development
+    // @signature configure_email(config: Map<String, Any>) -> Unit
+    // Configure the SMTP transport. Call once at startup, before send_email().
+    //
+    // Config keys: "host" (required for smtp), "port" (default 587), "username",
+    // "password", "from" (required), "from_name", "tls" ("starttls" | "implicit" |
+    // "none"; defaults from the port — 465 is implicit, others STARTTLS), and
+    // "transport" ("smtp" | "log"). The log transport prints emails to stderr and
+    // reports them as sent — use it in development and tests. The NTNT_EMAIL_MODE
+    // env var ("log" or "smtp") overrides the configured transport.
+    // @param config SMTP configuration map.
+    // @returns Unit
+    // @see_also send_email, send_email_batch, get_env
+    // @since v0.4.12
+    // @tags #email, #smtp
+    // @error TypeError ~ "requires a \"from\" address" fix: "Add \"from\": \"hello@myapp.com\" to the config"
+    // @example configure_email(map { "host": "smtp.example.com", "from": "hello@myapp.com", "username": "u", "password": "p" }) ~ "Production SMTP"
+    // @example configure_email(map { "transport": "log", "from": "dev@localhost" }) ~ "Development: log emails instead of sending"
+    module.insert(
+        "configure_email".to_string(),
+        Value::NativeFunction {
+            name: "configure_email".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| {
+                let map = require_config_map(&args[0], "configure_email")?;
+                let config = parse_config(&map)?;
+                with_state(|state| *state = Some((config, None)));
+                Ok(Value::Unit)
+            },
+        },
+    );
+
+    // @ntnt send_email
+    // @module std/email
+    // @signature send_email(opts: Map<String, Any>) -> Result<Map<String, String>, String>
+    // Send a single email through the configured transport.
+    //
+    // Options: "to" (string or array, required), "subject" (required), "text"
+    // and/or "html" (at least one required — both sends a multipart message with
+    // a plain-text fallback), "cc", "bcc", "reply_to", and per-message "from" /
+    // "from_name" overrides. Returns Ok(map { "message_id", "transport" }) or
+    // Err(message). Invalid options and SMTP failures are Err values (use
+    // `otherwise` or match), not runtime errors.
+    // @param opts The email to send.
+    // @returns Ok with the generated message id, or Err with the failure reason.
+    // @see_also configure_email, send_email_batch, template
+    // @since v0.4.12
+    // @tags #email, #smtp
+    // @error RuntimeError ~ "configure_email() has not been called" fix: "Call configure_email() at startup before sending"
+    // @example send_email(map { "to": "user@example.com", "subject": "Welcome!", "text": "Hello!" }) ~ "Plain text email"
+    // @example send_email(map { "to": "user@example.com", "subject": "Welcome!", "html": template("emails/welcome.html", map { "name": name }), "text": "Welcome!" }) ~ "HTML with text fallback"
+    // @gotcha Returns Err for bad addresses or SMTP failures instead of crashing — always handle the Result.
+    module.insert(
+        "send_email".to_string(),
+        Value::NativeFunction {
+            name: "send_email".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| {
+                let opts = require_config_map(&args[0], "send_email")?;
+                with_state(|state| {
+                    let Some((config, transport_slot)) = state.as_mut() else {
+                        return Err(IntentError::runtime_error(
+                            "configure_email() has not been called — configure SMTP (or \"transport\": \"log\") at startup"
+                                .to_string(),
+                        ));
+                    };
+                    let config = config.clone();
+                    dispatch(&config, transport_slot, &opts)
+                })
+            },
+        },
+    );
+
+    // @ntnt send_email_batch
+    // @module std/email
+    // @signature send_email_batch(emails: Array<Map<String, Any>>) -> Result<Array<Any>, String>
+    // Send multiple emails, reusing one SMTP connection.
+    //
+    // Each entry takes the same options as send_email(). Returns Ok with an
+    // array of per-email results (each Ok(map) or Err(message), in input
+    // order); a hard Err is returned only when the transport itself cannot be
+    // set up. One bad email does not stop the rest.
+    // @param emails Array of email option maps.
+    // @returns Ok(array of per-email results), or Err for transport setup failure.
+    // @see_also send_email, configure_email
+    // @since v0.4.12
+    // @tags #email, #smtp
+    // @example send_email_batch([map { "to": "a@x.co", "subject": "Hi", "text": "..." }, map { "to": "b@x.co", "subject": "Hi", "text": "..." }]) ~ "Two emails, one connection"
+    module.insert(
+        "send_email_batch".to_string(),
+        Value::NativeFunction {
+            name: "send_email_batch".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| {
+                let emails = match &args[0] {
+                    Value::Array(items) => items.clone(),
+                    other => {
+                        return Err(IntentError::type_error(format!(
+                            "send_email_batch() requires an array of email maps, got {}",
+                            other.type_name()
+                        )))
+                    }
+                };
+                with_state(|state| {
+                    let Some((config, transport_slot)) = state.as_mut() else {
+                        return Err(IntentError::runtime_error(
+                            "configure_email() has not been called — configure SMTP (or \"transport\": \"log\") at startup"
+                                .to_string(),
+                        ));
+                    };
+                    let config = config.clone();
+                    let mut results = Vec::with_capacity(emails.len());
+                    for email in &emails {
+                        let opts = require_config_map(email, "send_email_batch")?;
+                        results.push(dispatch(&config, transport_slot, &opts)?);
+                    }
+                    Ok(Value::ok(Value::Array(results)))
+                })
+            },
+        },
+    );
+
+    module
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(entries: Vec<(&str, Value)>) -> HashMap<String, Value> {
+        entries
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
+    }
+
+    fn s(text: &str) -> Value {
+        Value::String(text.to_string())
+    }
+
+    fn log_config() -> EmailConfig {
+        parse_config(&map(vec![
+            ("transport", s("log")),
+            ("from", s("dev@localhost")),
+        ]))
+        .unwrap()
+    }
+
+    #[test]
+    fn config_requires_from() {
+        let err = parse_config(&map(vec![("host", s("smtp.example.com"))])).unwrap_err();
+        assert!(err.to_string().contains("from"));
+    }
+
+    #[test]
+    fn config_requires_host_for_smtp_but_not_log() {
+        let err = parse_config(&map(vec![("from", s("a@b.co"))])).unwrap_err();
+        assert!(err.to_string().contains("host"));
+        assert!(parse_config(&map(vec![("transport", s("log")), ("from", s("a@b.co"))])).is_ok());
+    }
+
+    #[test]
+    fn tls_defaults_from_port() {
+        let implicit = parse_config(&map(vec![
+            ("host", s("smtp.example.com")),
+            ("port", Value::Int(465)),
+            ("from", s("a@b.co")),
+        ]))
+        .unwrap();
+        assert_eq!(implicit.tls, "implicit");
+
+        let starttls = parse_config(&map(vec![
+            ("host", s("smtp.example.com")),
+            ("from", s("a@b.co")),
+        ]))
+        .unwrap();
+        assert_eq!(starttls.tls, "starttls");
+        assert_eq!(starttls.port, 587);
+    }
+
+    #[test]
+    fn message_requires_to_subject_and_content() {
+        let config = log_config();
+        let missing_to = build_message(&config, &map(vec![("subject", s("Hi"))])).unwrap_err();
+        assert!(missing_to.to_string().contains("to"));
+
+        let missing_subject = build_message(&config, &map(vec![("to", s("a@b.co"))])).unwrap_err();
+        assert!(missing_subject.to_string().contains("subject"));
+
+        let missing_body = build_message(
+            &config,
+            &map(vec![("to", s("a@b.co")), ("subject", s("Hi"))]),
+        )
+        .unwrap_err();
+        assert!(missing_body.to_string().contains("text"));
+    }
+
+    #[test]
+    fn message_builds_with_multiple_recipients_and_html() {
+        let config = log_config();
+        let (message, id) = build_message(
+            &config,
+            &map(vec![
+                ("to", Value::Array(vec![s("a@b.co"), s("c@d.co")])),
+                ("cc", s("cc@b.co")),
+                ("reply_to", s("reply@b.co")),
+                ("subject", s("Hello")),
+                ("text", s("plain")),
+                ("html", s("<b>rich</b>")),
+            ]),
+        )
+        .unwrap();
+        assert!(id.starts_with('<') && id.ends_with('>'));
+        let rendered = String::from_utf8(message.formatted()).unwrap();
+        assert!(rendered.contains("a@b.co"));
+        assert!(rendered.contains("multipart/alternative"));
+    }
+
+    #[test]
+    fn invalid_address_is_rejected() {
+        let config = log_config();
+        let err = build_message(
+            &config,
+            &map(vec![
+                ("to", s("not an address")),
+                ("subject", s("Hi")),
+                ("text", s("x")),
+            ]),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Invalid email address"));
+    }
+
+    #[test]
+    fn per_message_from_overrides_config() {
+        let config = log_config();
+        let (message, _) = build_message(
+            &config,
+            &map(vec![
+                ("to", s("a@b.co")),
+                ("from", s("other@sender.co")),
+                ("from_name", s("Other")),
+                ("subject", s("Hi")),
+                ("text", s("x")),
+            ]),
+        )
+        .unwrap();
+        let rendered = String::from_utf8(message.formatted()).unwrap();
+        assert!(rendered.contains("other@sender.co"));
+        assert!(rendered.contains("Other"));
+    }
+}

--- a/src/stdlib/email.rs
+++ b/src/stdlib/email.rs
@@ -78,6 +78,12 @@ fn parse_config(map: &HashMap<String, Value>) -> Result<EmailConfig> {
 
     let port = match map.get("port") {
         Some(Value::Int(p)) if *p > 0 && *p <= 65535 => *p as u16,
+        Some(Value::Int(p)) => {
+            return Err(IntentError::type_error(format!(
+                "configure_email(): port {} is out of range (1-65535)",
+                p
+            )))
+        }
         Some(Value::String(s)) => s.parse::<u16>().map_err(|_| {
             IntentError::type_error(format!("configure_email(): invalid port \"{}\"", s))
         })?,
@@ -93,10 +99,12 @@ fn parse_config(map: &HashMap<String, Value>) -> Result<EmailConfig> {
     // TLS mode defaults from the port: 465 implicit, 587/25 STARTTLS
     let tls = match get_string(map, "tls") {
         Some(mode) if ["starttls", "implicit", "none"].contains(&mode.as_str()) => mode,
-        Some(mode) => return Err(IntentError::type_error(format!(
+        Some(mode) => {
+            return Err(IntentError::type_error(format!(
             "configure_email(): tls must be \"starttls\", \"implicit\", or \"none\", got \"{}\"",
             mode
-        ))),
+        )))
+        }
         None => {
             if port == 465 {
                 "implicit".to_string()
@@ -285,14 +293,38 @@ fn log_email(opts: &HashMap<String, Value>, message_id: &str) {
     );
 }
 
-/// Send one already-parsed message through the given mode, sharing the
-/// cached transport for smtp
+/// Check out the config and (for smtp mode) the shared pooled transport.
+/// The global lock is held only for this lookup — never across network
+/// I/O — so concurrent senders (spawned tasks, job workers) don't
+/// serialize behind one SMTP round-trip. SmtpTransport clones share the
+/// underlying connection pool.
+fn checkout() -> Result<(EmailConfig, Option<SmtpTransport>)> {
+    let mut guard = EMAIL_STATE.lock().unwrap_or_else(|e| e.into_inner());
+    let Some((config, transport_slot)) = guard.as_mut() else {
+        return Err(IntentError::runtime_error(
+            "configure_email() has not been called — configure SMTP (or \"transport\": \"log\") at startup"
+                .to_string(),
+        ));
+    };
+    let config = config.clone();
+    let transport = if transport_mode(&config) == "smtp" {
+        if transport_slot.is_none() {
+            *transport_slot = Some(build_transport(&config)?);
+        }
+        transport_slot.clone()
+    } else {
+        None
+    };
+    Ok((config, transport))
+}
+
+/// Send one email through the checked-out transport (None = log mode).
+/// Runs entirely outside the global lock.
 fn dispatch(
     config: &EmailConfig,
-    transport_slot: &mut Option<SmtpTransport>,
+    transport: Option<&SmtpTransport>,
     opts: &HashMap<String, Value>,
 ) -> Result<Value> {
-    let mode = transport_mode(config);
     let (message, message_id) = match build_message(config, opts) {
         Ok(built) => built,
         // Bad options are a per-email Err value, not a hard error, so
@@ -300,15 +332,10 @@ fn dispatch(
         Err(e) => return Ok(Value::err(Value::String(e.to_string()))),
     };
 
-    if mode == "log" {
+    let Some(transport) = transport else {
         log_email(opts, &message_id);
         return Ok(sent_result(message_id, "log"));
-    }
-
-    if transport_slot.is_none() {
-        *transport_slot = Some(build_transport(config)?);
-    }
-    let transport = transport_slot.as_ref().expect("just built");
+    };
 
     match transport.send(&message) {
         Ok(_) => Ok(sent_result(message_id, "smtp")),
@@ -317,11 +344,6 @@ fn dispatch(
             e
         )))),
     }
-}
-
-fn with_state<T>(f: impl FnOnce(&mut Option<(EmailConfig, Option<SmtpTransport>)>) -> T) -> T {
-    let mut guard = EMAIL_STATE.lock().unwrap_or_else(|e| e.into_inner());
-    f(&mut guard)
 }
 
 fn require_config_map(value: &Value, function: &str) -> Result<HashMap<String, Value>> {
@@ -369,7 +391,8 @@ pub fn init() -> HashMap<String, Value> {
             func: |args| {
                 let map = require_config_map(&args[0], "configure_email")?;
                 let config = parse_config(&map)?;
-                with_state(|state| *state = Some((config, None)));
+                let mut guard = EMAIL_STATE.lock().unwrap_or_else(|e| e.into_inner());
+                *guard = Some((config, None));
                 Ok(Value::Unit)
             },
         },
@@ -404,16 +427,8 @@ pub fn init() -> HashMap<String, Value> {
             requires: None,
             func: |args| {
                 let opts = require_config_map(&args[0], "send_email")?;
-                with_state(|state| {
-                    let Some((config, transport_slot)) = state.as_mut() else {
-                        return Err(IntentError::runtime_error(
-                            "configure_email() has not been called — configure SMTP (or \"transport\": \"log\") at startup"
-                                .to_string(),
-                        ));
-                    };
-                    let config = config.clone();
-                    dispatch(&config, transport_slot, &opts)
-                })
+                let (config, transport) = checkout()?;
+                dispatch(&config, transport.as_ref(), &opts)
             },
         },
     );
@@ -450,21 +465,13 @@ pub fn init() -> HashMap<String, Value> {
                         )))
                     }
                 };
-                with_state(|state| {
-                    let Some((config, transport_slot)) = state.as_mut() else {
-                        return Err(IntentError::runtime_error(
-                            "configure_email() has not been called — configure SMTP (or \"transport\": \"log\") at startup"
-                                .to_string(),
-                        ));
-                    };
-                    let config = config.clone();
-                    let mut results = Vec::with_capacity(emails.len());
-                    for email in &emails {
-                        let opts = require_config_map(email, "send_email_batch")?;
-                        results.push(dispatch(&config, transport_slot, &opts)?);
-                    }
-                    Ok(Value::ok(Value::Array(results)))
-                })
+                let (config, transport) = checkout()?;
+                let mut results = Vec::with_capacity(emails.len());
+                for email in &emails {
+                    let opts = require_config_map(email, "send_email_batch")?;
+                    results.push(dispatch(&config, transport.as_ref(), &opts)?);
+                }
+                Ok(Value::ok(Value::Array(results)))
             },
         },
     );
@@ -506,6 +513,17 @@ mod tests {
         let err = parse_config(&map(vec![("from", s("a@b.co"))])).unwrap_err();
         assert!(err.to_string().contains("host"));
         assert!(parse_config(&map(vec![("transport", s("log")), ("from", s("a@b.co"))])).is_ok());
+    }
+
+    #[test]
+    fn out_of_range_port_gets_clear_message() {
+        let err = parse_config(&map(vec![
+            ("host", s("smtp.example.com")),
+            ("from", s("a@b.co")),
+            ("port", Value::Int(70000)),
+        ]))
+        .unwrap_err();
+        assert!(err.to_string().contains("out of range"), "got: {}", err);
     }
 
     #[test]

--- a/src/stdlib/email.rs
+++ b/src/stdlib/email.rs
@@ -468,8 +468,13 @@ pub fn init() -> HashMap<String, Value> {
                 let (config, transport) = checkout()?;
                 let mut results = Vec::with_capacity(emails.len());
                 for email in &emails {
-                    let opts = require_config_map(email, "send_email_batch")?;
-                    results.push(dispatch(&config, transport.as_ref(), &opts)?);
+                    // A non-map entry is a per-email Err too — the documented
+                    // contract is that one bad email never stops the rest
+                    let result = match require_config_map(email, "send_email_batch") {
+                        Ok(opts) => dispatch(&config, transport.as_ref(), &opts)?,
+                        Err(e) => Value::err(Value::String(e.to_string())),
+                    };
+                    results.push(result);
                 }
                 Ok(Value::ok(Value::Array(results)))
             },

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -11,6 +11,7 @@ pub mod collections;
 pub mod concurrent;
 pub mod crypto;
 pub mod csv;
+pub mod email;
 pub mod env;
 pub mod fs;
 pub mod http;
@@ -67,6 +68,7 @@ pub fn init_all_modules() -> HashMap<String, StdlibModule> {
     modules.insert("std/jobs".to_string(), jobs::init());
     modules.insert("std/auth".to_string(), auth::init());
     modules.insert("std/validate".to_string(), validate::init());
+    modules.insert("std/email".to_string(), email::init());
 
     modules
 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3981,6 +3981,32 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("transaction", ["conn" => Type::Any, "callback" => Type::Any], Type::Any);
             sig!("close", ["conn" => Type::Any], Type::Unit);
         }
+        "std/email" => {
+            let opts_map = Type::Map {
+                key_type: Box::new(Type::String),
+                value_type: Box::new(Type::Any),
+            };
+            let send_result = Type::Generic {
+                name: "Result".to_string(),
+                args: vec![
+                    Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::String),
+                    },
+                    Type::String,
+                ],
+            };
+            sig!("configure_email", ["config" => opts_map.clone()], Type::Unit);
+            sig!("send_email", ["opts" => opts_map.clone()], send_result);
+            sig!(
+                "send_email_batch",
+                ["emails" => Type::Array(Box::new(opts_map))],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![Type::Array(Box::new(Type::Any)), Type::String],
+                }
+            );
+        }
         "std/validate" => {
             let validator = Type::Named("Validator".to_string());
             let string_map = Type::Map {

--- a/tests/email_tests.rs
+++ b/tests/email_tests.rs
@@ -164,6 +164,36 @@ match send_email_batch([
 }
 
 #[test]
+fn batch_records_non_map_entries_as_per_email_errors() {
+    let code = r#"
+import { configure_email, send_email_batch } from "std/email"
+
+configure_email(map { "transport": "log", "from": "dev@localhost" })
+
+match send_email_batch([
+    map { "to": "a@b.co", "subject": "One", "text": "x" },
+    "not a map",
+    map { "to": "c@d.co", "subject": "Three", "text": "x" }
+]) {
+    Ok(results) => {
+        print("count: " + str(len(results)))
+        match results[1] { Ok(_) => print("1 ok"), Err(e) => print("1 err: " + e) }
+        match results[2] { Ok(_) => print("2 ok"), Err(_) => print("2 err") }
+    },
+    Err(e) => print("unexpected hard failure: " + e)
+}
+"#;
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("count: 3"), "{stdout}");
+    assert!(
+        stdout.contains("1 err") && stdout.contains("requires a map"),
+        "non-map entry is a per-email Err: {stdout}"
+    );
+    assert!(stdout.contains("2 ok"), "later emails still send: {stdout}");
+}
+
+#[test]
 fn env_var_forces_log_mode_over_smtp_config() {
     // SMTP config pointing nowhere, but NTNT_EMAIL_MODE=log short-circuits
     // before any connection attempt

--- a/tests/email_tests.rs
+++ b/tests/email_tests.rs
@@ -1,0 +1,183 @@
+//! Integration tests for std/email (DD-058 item 2)
+//!
+//! Uses the log transport throughout — no SMTP server is contacted.
+
+use std::fs;
+use std::io::Write;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_test_file(prefix: &str) -> String {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let thread_id = format!("{:?}", std::thread::current().id());
+    std::env::temp_dir()
+        .join(format!(
+            "ntnt_{}_{}_{}_{}.tnt",
+            prefix,
+            std::process::id(),
+            thread_id.replace(|c: char| !c.is_alphanumeric(), "_"),
+            counter
+        ))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn ntnt_binary() -> std::path::PathBuf {
+    let exe = std::env::consts::EXE_SUFFIX;
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let debug_path = manifest.join(format!("target/debug/ntnt{}", exe));
+    let dev_release_path = manifest.join(format!("target/dev-release/ntnt{}", exe));
+    let release_path = manifest.join(format!("target/release/ntnt{}", exe));
+
+    if debug_path.exists() {
+        debug_path
+    } else if dev_release_path.exists() {
+        dev_release_path
+    } else if release_path.exists() {
+        release_path
+    } else {
+        panic!("No ntnt binary found. Run 'cargo build' first.");
+    }
+}
+
+fn run(code: &str, env_vars: &[(&str, &str)]) -> (String, String, i32) {
+    let test_file = unique_test_file("email");
+    let mut file = fs::File::create(&test_file).expect("create test file");
+    writeln!(file, "{}", code).expect("write test file");
+    drop(file);
+
+    let mut cmd = Command::new(ntnt_binary());
+    cmd.args(["run", &test_file])
+        .current_dir(env!("CARGO_MANIFEST_DIR"));
+    for (k, v) in env_vars {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("execute ntnt");
+    let _ = fs::remove_file(&test_file);
+
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn send_email_with_log_transport() {
+    let code = r#"
+import { configure_email, send_email } from "std/email"
+
+configure_email(map { "transport": "log", "from": "dev@localhost" })
+
+match send_email(map { "to": "user@example.com", "subject": "Welcome!", "text": "Hello!" }) {
+    Ok(result) => {
+        print("sent via " + result["transport"])
+        print(len(result["message_id"]) > 0)
+    },
+    Err(e) => print("unexpected err: " + e)
+}
+"#;
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("sent via log"), "{stdout}");
+    assert!(stdout.contains("true"), "message id present: {stdout}");
+    assert!(
+        stderr.contains("[EMAIL:log]") && stderr.contains("user@example.com"),
+        "log transport should print the email: {stderr}"
+    );
+}
+
+#[test]
+fn send_email_requires_configuration() {
+    let code = r#"
+import { send_email } from "std/email"
+
+let r = send_email(map { "to": "a@b.co", "subject": "Hi", "text": "x" })
+    otherwise { print("caught: #{err}") return }
+print("unexpected: " + str(r))
+"#;
+    let (stdout, _stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains("configure_email() has not been called"),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn bad_options_are_err_values_not_crashes() {
+    let code = r#"
+import { configure_email, send_email } from "std/email"
+
+configure_email(map { "transport": "log", "from": "dev@localhost" })
+
+match send_email(map { "to": "not an address", "subject": "Hi", "text": "x" }) {
+    Ok(_) => print("unexpected ok"),
+    Err(e) => print("err: " + e)
+}
+match send_email(map { "to": "a@b.co", "subject": "Hi" }) {
+    Ok(_) => print("unexpected ok"),
+    Err(e) => print("err: " + e)
+}
+"#;
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("Invalid email address"), "{stdout}");
+    assert!(
+        stdout.contains("\"text\" and/or \"html\""),
+        "missing body message: {stdout}"
+    );
+}
+
+#[test]
+fn batch_reports_per_email_results() {
+    let code = r#"
+import { configure_email, send_email_batch } from "std/email"
+
+configure_email(map { "transport": "log", "from": "dev@localhost" })
+
+match send_email_batch([
+    map { "to": "a@b.co", "subject": "One", "text": "x" },
+    map { "to": "broken", "subject": "Two", "text": "x" },
+    map { "to": "c@d.co", "subject": "Three", "text": "x" }
+]) {
+    Ok(results) => {
+        print("count: " + str(len(results)))
+        match results[0] { Ok(_) => print("0 ok"), Err(_) => print("0 err") }
+        match results[1] { Ok(_) => print("1 ok"), Err(_) => print("1 err") }
+        match results[2] { Ok(_) => print("2 ok"), Err(_) => print("2 err") }
+    },
+    Err(e) => print("unexpected: " + e)
+}
+"#;
+    let (stdout, stderr, exit_code) = run(code, &[]);
+    assert_eq!(exit_code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("count: 3"), "{stdout}");
+    assert!(stdout.contains("0 ok"), "{stdout}");
+    assert!(
+        stdout.contains("1 err"),
+        "one bad email doesn't stop the rest: {stdout}"
+    );
+    assert!(stdout.contains("2 ok"), "{stdout}");
+}
+
+#[test]
+fn env_var_forces_log_mode_over_smtp_config() {
+    // SMTP config pointing nowhere, but NTNT_EMAIL_MODE=log short-circuits
+    // before any connection attempt
+    let code = r#"
+import { configure_email, send_email } from "std/email"
+
+configure_email(map { "host": "smtp.invalid.example", "from": "a@b.co" })
+
+match send_email(map { "to": "user@example.com", "subject": "Hi", "text": "x" }) {
+    Ok(result) => print("via " + result["transport"]),
+    Err(e) => print("unexpected err: " + e)
+}
+"#;
+    let (stdout, stderr, exit_code) = run(code, &[("NTNT_EMAIL_MODE", "log")]);
+    assert_eq!(exit_code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("via log"), "{stdout}");
+}


### PR DESCRIPTION
## Summary

Ships DD-058 item 2: SMTP email via `lettre`. Every app with users sends email eventually — signup confirmations, password resets, notifications — and until now that meant `fetch()` to a third-party API.

```ntnt
import { configure_email, send_email } from "std/email"

configure_email(map {
    "host": get_env("SMTP_HOST") ?? "smtp.example.com",
    "port": 587,                    // 587 STARTTLS (default), 465 implicit TLS
    "username": get_env("SMTP_USER") ?? "",
    "password": get_env("SMTP_PASS") ?? "",
    "from": "hello@myapp.com",
    "from_name": "My App"
})

let result = send_email(map {
    "to": "user@example.com",
    "subject": "Welcome!",
    "html": template("emails/welcome.html", map { "name": name }),
    "text": "Welcome, #{name}!"     // both = multipart with plain-text fallback
}) otherwise { return status(500, "Email failed: #{err}") }
```

- `send_email` returns `Ok(map { "message_id", "transport" })` or `Err(message)` — bad addresses and SMTP failures are Err values (handle with `match`/`otherwise`), never crashes
- `send_email_batch([...])` reuses one pooled connection, returns per-email results in input order; one bad email doesn't stop the rest
- Options: `to` (string or array), `subject`, `text`/`html`, `cc`, `bcc`, `reply_to`, per-message `from`/`from_name` overrides
- TLS defaults from the port (465 → implicit, others → STARTTLS) with an explicit `"tls"` override

## Beyond the DD proposal: log transport

`configure_email(map { "transport": "log", "from": "dev@localhost" })` — or `NTNT_EMAIL_MODE=log` overriding any config — prints emails to stderr and reports them as sent. Development and CI run the full email code path with no SMTP server; that's also how this PR's own integration tests work (CI contacts nothing).

## New dependency

`lettre 0.11` (`smtp-transport`, `builder`, `pool`) with **rustls-tls**, matching the repo's existing rustls 0.23 stack — no openssl/native-tls added. The connection pool means repeated sends and batches reuse connections; the transport is cached and rebuilt on `configure_email()`.

## Test plan

- 7 Rust unit tests: config validation (from/host requirements, port/TLS defaulting), message building (required fields, multipart, multiple recipients, address rejection, from overrides)
- 5 `.tnt` integration tests via the log transport: happy path with message id, unconfigured error, Err-values-not-crashes, batch per-email results, env-var override forcing log mode over SMTP config
- `examples/email_demo.tnt` lints clean and runs
- Full suite: 1777 tests, 0 failures; clippy clean on the new module

DD-058 items 1–2 are now shipped; next per the DD sequence is item 3 (rate limiting, covered by DD-051) / item 4 (multipart upload streaming).