### PR TITLE
fix(intent): invariant execution — parser state leak made invariants vacuous (DD-063 Rec 5)

### DIFF
--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -205,7 +205,7 @@ Implementation (after decisions):
 
 ### Recs 5–10 — assessed, not yet scheduled
 
-- [ ] **Rec 5** — IAL stub completion: implement invariant execution (expansion already works); decide `Sql` primitive fate (PR-2 makes docs honest in the interim)
+- [x] **Rec 5** — IAL stub completion — shipped 2026-07-08. Root cause was better-defined than the assessment knew: invariant execution via expansion already worked, but the intent parser's `Feature:`/`Component:` handlers never finalized a pending invariant, so any file declaring invariants before features had the stale invariant swallow the feature's `id:` and scenario `→` outcomes — corrupting both and passing scenarios vacuously (verified: a broken slugify passed intent check with 0 assertions). Fixed the state leak; removed the never-constructed `InvariantCheck` and `Sql` primitives (docs now describe expansion instead of phantom primitives); `intent lint` warns on vacuous scenarios (zero outcomes) so this class can't hide again.
 - [ ] **Rec 6** — lint for silent block-binding (`let x = { 5 }` / `let e = {}`)
 - [ ] **Rec 7** — strict type mode in verification contexts (`intent check`, `ntnt test`)
 - [ ] **Rec 8** — whitepaper restructure: shipped vs aspirational

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -27,11 +27,9 @@ IAL primitives are the leaf nodes of term resolution - they execute directly
 | **Http** | Execute an HTTP request and capture response in context | `response.status`, `response.body`, `response.headers.*`, `response.time_ms` | Implemented |
 | **Cli** | Execute a CLI command and capture output | `cli.exit_code`, `cli.stdout`, `cli.stderr` | Implemented |
 | **CodeQuality** | Run lint/validation checks on source files | `code.quality.passed`, `code.quality.error_count`, `code.quality.warning_count`, `code.quality.errors` | Implemented |
-| **Sql** | Execute a SQL query with parameters | `sql.result`, `sql.rows` | Not implemented |
 | **ReadFile** | Read file contents into context | `file.content`, `file.exists` | Implemented |
 | **FunctionCall** | Call an NTNT function for unit testing | `result` | Implemented |
 | **PropertyCheck** | Verify a function property (deterministic, idempotent, round-trips) | `property.passed`, `property.failures` | Implemented |
-| **InvariantCheck** | Verify a named invariant holds for a value | `invariant.passed`, `invariant.failures` | Resolver marker only; direct execution fails unless expanded |
 | **Check** | Universal assertion - compare context value against expected |  | Implemented |
 
 ---

--- a/docs/ial.toml
+++ b/docs/ial.toml
@@ -55,22 +55,6 @@ parameters = ["function_name", "property_type", "test_inputs"]
 context_sets = ["property.passed", "property.failures"]
 example = "PropertyCheck(hash, Deterministic, [\"test\", \"data\"])"
 
-[primitives.sql]
-name = "Sql"
-description = "Execute a SQL query with parameters"
-status = "Not implemented"
-parameters = ["query", "params"]
-context_sets = ["sql.result", "sql.rows"]
-example = "Sql(SELECT * FROM users WHERE id = $1, [42])"
-
-[primitives.invariant_check]
-name = "InvariantCheck"
-description = "Verify a named invariant holds for a value"
-status = "Resolver marker only; direct execution fails unless expanded"
-parameters = ["invariant_id", "value"]
-context_sets = ["invariant.passed", "invariant.failures"]
-example = "InvariantCheck(invariant.url_slug, \"hello-world\")"
-
 [primitives.check]
 name = "Check"
 description = "Universal assertion - compare context value against expected"
@@ -81,6 +65,11 @@ example = "Check(Equals, response.status, 200)"
 # =============================================================================
 # CHECK OPERATIONS - Comparison types for Check primitive
 # =============================================================================
+
+[primitives.invariant_expansion]
+name = "Invariant expansion (not a primitive)"
+description = "Invariants have no primitive of their own: during term resolution, a reference to `invariant.id` (e.g. via a glossary meaning `check: invariant.url_slug`) expands to the invariant's assertion terms, each of which resolves to Check primitives (typically against the `result` path for unit-test scenarios). Parameterized invariants substitute `{param}` values during expansion."
+example = "glossary: `slug is URL-safe | check: invariant.url_slug` -> assertions `uses only [a-z0-9-]`, `is lowercase`, ... -> Check primitives"
 
 [check_operations]
 description = "Operations available for the Check primitive"

--- a/src/ial/execute.rs
+++ b/src/ial/execute.rs
@@ -132,7 +132,7 @@ impl ExecuteResult {
 
 /// Execute a single primitive against the context.
 ///
-/// Actions (Http, Cli, Sql, ReadFile) populate the context.
+/// Actions (Http, Cli, ReadFile) populate the context.
 /// Checks verify values in the context.
 pub fn execute(primitive: &Primitive, ctx: &mut Context, port: u16) -> ExecuteResult {
     match primitive {
@@ -151,14 +151,6 @@ pub fn execute(primitive: &Primitive, ctx: &mut Context, port: u16) -> ExecuteRe
             validate,
         } => execute_code_quality(file.as_deref(), *lint, *validate, ctx),
 
-        Primitive::Sql { query, params: _ } => {
-            // SQL execution not yet implemented
-            ExecuteResult::fail(
-                format!("SQL: {}", query),
-                "SQL execution not yet implemented",
-            )
-        }
-
         Primitive::ReadFile { path } => execute_read_file(path, ctx),
 
         Primitive::FunctionCall {
@@ -173,11 +165,6 @@ pub fn execute(primitive: &Primitive, ctx: &mut Context, port: u16) -> ExecuteRe
             function_name,
             input,
         } => execute_property_check(property, source_file, function_name, input, ctx),
-
-        Primitive::InvariantCheck {
-            invariant_id,
-            value,
-        } => execute_invariant_check(invariant_id, value, ctx),
 
         Primitive::Check { op, path, expected } => do_execute_check(op, path, expected, ctx),
     }
@@ -1105,22 +1092,6 @@ fn execute_property_check(
 /// Invariants are bundles of assertions that are expanded and checked.
 /// For now, this is a placeholder - invariant expansion happens during
 /// glossary resolution, not at execution time.
-fn execute_invariant_check(invariant_id: &str, value: &Value, ctx: &mut Context) -> ExecuteResult {
-    // Store the value being checked in context for assertion expansion
-    ctx.set("invariant.value", value.clone());
-
-    // Invariant expansion is handled during term resolution, not execution.
-    // This primitive is a marker that triggers the expansion.
-    // If we reach here, it means the invariant wasn't found/expanded.
-    ExecuteResult::fail(
-        format!("check: {}", invariant_id),
-        format!(
-            "Invariant '{}' not found or not expanded. Value: {}",
-            invariant_id, value
-        ),
-    )
-}
-
 /// Execute multiple primitives and collect results
 pub fn execute_all(primitives: &[Primitive], ctx: &mut Context, port: u16) -> Vec<ExecuteResult> {
     primitives.iter().map(|p| execute(p, ctx, port)).collect()

--- a/src/ial/execute.rs
+++ b/src/ial/execute.rs
@@ -1087,11 +1087,6 @@ fn execute_property_check(
     }
 }
 
-/// Execute an invariant check
-///
-/// Invariants are bundles of assertions that are expanded and checked.
-/// For now, this is a placeholder - invariant expansion happens during
-/// glossary resolution, not at execution time.
 /// Execute multiple primitives and collect results
 pub fn execute_all(primitives: &[Primitive], ctx: &mut Context, port: u16) -> Vec<ExecuteResult> {
     primitives.iter().map(|p| execute(p, ctx, port)).collect()

--- a/src/ial/primitives.rs
+++ b/src/ial/primitives.rs
@@ -33,9 +33,6 @@ pub enum Primitive {
         validate: bool,
     },
 
-    /// SQL query execution
-    Sql { query: String, params: Vec<Value> },
-
     /// Read file contents
     ReadFile { path: String },
 
@@ -63,13 +60,12 @@ pub enum Primitive {
         input: Value,
     },
 
-    /// Invariant check: expand and verify an invariant
-    InvariantCheck {
-        /// Invariant ID (e.g., "invariant.url_slug")
-        invariant_id: String,
-        /// Value to check against the invariant
-        value: Value,
-    },
+    // Note: invariants are handled by EXPANSION during term resolution —
+    // `invariant.id` resolves to its assertion terms, which become Check
+    // primitives. There is deliberately no InvariantCheck primitive (and no
+    // Sql primitive): neither had a construction path, and phantom
+    // primitives invite docs promising unimplemented capabilities
+    // (DD-063 Rec 5).
 
     // === Checks (verify values in Context) ===
     /// Universal check: operation on a path with expected value

--- a/src/ial/resolve.rs
+++ b/src/ial/resolve.rs
@@ -186,9 +186,6 @@ fn primitive_to_string(primitive: &Primitive) -> String {
         Primitive::Cli { command, args } => {
             format!("cli: {} {}", command, args.join(" "))
         }
-        Primitive::Sql { query, .. } => {
-            format!("sql: {}", query)
-        }
         Primitive::ReadFile { path } => {
             format!("read_file: {}", path)
         }
@@ -207,9 +204,6 @@ fn primitive_to_string(primitive: &Primitive) -> String {
         }
         Primitive::PropertyCheck { property, .. } => {
             format!("property_check: {:?}", property)
-        }
-        Primitive::InvariantCheck { invariant_id, .. } => {
-            format!("invariant_check: {}", invariant_id)
         }
     }
 }
@@ -406,14 +400,6 @@ fn substitute_primitive(primitive: &Primitive, params: &HashMap<String, Value>) 
             args: args.iter().map(|a| substitute_string(a, params)).collect(),
         },
 
-        Primitive::Sql {
-            query,
-            params: sql_params,
-        } => Primitive::Sql {
-            query: substitute_string(query, params),
-            params: sql_params.clone(),
-        },
-
         Primitive::ReadFile { path } => Primitive::ReadFile {
             path: substitute_string(path, params),
         },
@@ -454,14 +440,6 @@ fn substitute_primitive(primitive: &Primitive, params: &HashMap<String, Value>) 
             source_file: substitute_string(source_file, params),
             function_name: substitute_string(function_name, params),
             input: substitute_value(input, params),
-        },
-
-        Primitive::InvariantCheck {
-            invariant_id,
-            value,
-        } => Primitive::InvariantCheck {
-            invariant_id: substitute_string(invariant_id, params),
-            value: substitute_value(value, params),
         },
     }
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -5971,6 +5971,24 @@ pub fn lint_intent_file(intent: &IntentFile) -> IntentLintReport {
         }
     }
 
+    // Component scenarios pass vacuously without outcomes for the same
+    // reason feature scenarios do — warn symmetrically
+    for component in &intent.components {
+        for scenario in &component.scenarios {
+            scenarios_checked += 1;
+            if scenario.outcomes.is_empty() {
+                warnings.push(IntentLintFinding {
+                    kind: "vacuous_scenario".to_string(),
+                    feature: component.name.clone(),
+                    scenario: scenario.name.clone(),
+                    text: scenario.when_clause.clone(),
+                    suggestions: Vec::new(),
+                    detail: "scenario has no outcome (→) lines — it verifies nothing and will pass vacuously".to_string(),
+                });
+            }
+        }
+    }
+
     // Glossary-wide cycle scan: catches cycles in entries no scenario touches.
     // Substitute dummy values for {param} placeholders so patterns resolve.
     // Dedup on the set of participating terms, not the path message —
@@ -6035,6 +6053,14 @@ pub fn lint_intent_file(intent: &IntentFile) -> IntentLintReport {
     }
     for component in &intent.components {
         usage_corpus.extend(component.inherent_behavior.iter().cloned());
+        // Component scenarios use glossary terms exactly like feature ones
+        for scenario in &component.scenarios {
+            usage_corpus.push(scenario.when_clause.clone());
+            if let Some(given) = &scenario.given_clause {
+                usage_corpus.push(given.clone());
+            }
+            usage_corpus.extend(scenario.outcomes.iter().cloned());
+        }
     }
     for invariant in &intent.invariants {
         usage_corpus.extend(invariant.assertions.iter().cloned());

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -3114,6 +3114,12 @@ impl IntentFile {
                     }
                     features.push(feat);
                 }
+                // Save previous invariant — a stale one would otherwise
+                // swallow this feature's `id:` and `→` outcome lines,
+                // corrupting both and leaving scenarios vacuously green
+                if let Some(inv) = current_invariant.take() {
+                    invariants.push(inv);
+                }
 
                 let name = trimmed.trim_start_matches("Feature:").trim().to_string();
                 current_feature = Some(Feature {
@@ -3129,6 +3135,7 @@ impl IntentFile {
                 in_assertions = false;
                 in_glossary = false;
                 in_component_inherent = false;
+                in_invariant_assertions = false;
                 _in_glossary_bindings = false;
                 continue;
             }
@@ -3153,6 +3160,11 @@ impl IntentFile {
                     features.push(feat);
                 }
 
+                // Save (not drop) a pending invariant
+                if let Some(inv) = current_invariant.take() {
+                    invariants.push(inv);
+                }
+
                 let name = trimmed.trim_start_matches("Component:").trim().to_string();
                 current_component = Some(Component {
                     id: String::new(),
@@ -3165,7 +3177,6 @@ impl IntentFile {
                 current_test = None;
                 current_scenario = None;
                 current_feature = None;
-                current_invariant = None;
                 current_test_data = None;
                 in_assertions = false;
                 in_glossary = false;
@@ -5870,6 +5881,21 @@ pub fn lint_intent_file(intent: &IntentFile) -> IntentLintReport {
         for scenario in &feature.scenarios {
             scenarios_checked += 1;
 
+            // A scenario with no outcomes asserts nothing and passes
+            // vacuously in intent check — usually a parse or authoring
+            // mistake (this exact shape was how the invariant state-leak
+            // bug hid: swallowed outcome lines left green scenarios)
+            if scenario.outcomes.is_empty() {
+                warnings.push(IntentLintFinding {
+                    kind: "vacuous_scenario".to_string(),
+                    feature: feature.name.clone(),
+                    scenario: scenario.name.clone(),
+                    text: scenario.when_clause.clone(),
+                    suggestions: Vec::new(),
+                    detail: "scenario has no outcome (→) lines — it verifies nothing and will pass vacuously".to_string(),
+                });
+            }
+
             if glossary
                 .resolve_when_clause(&scenario.when_clause)
                 .is_none()
@@ -6555,6 +6581,113 @@ fn generate_function_name(path: &str, method: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invariants_before_features_do_not_swallow_feature_lines() {
+        // Regression: a pending invariant used to stay active across a
+        // Feature: declaration, eating the feature's `id:` and the
+        // scenarios' `→` outcomes — corrupting both and making scenarios
+        // pass vacuously (DD-063 Rec 5)
+        let content = r#"
+## Glossary
+
+| Term | Means |
+|------|-------|
+| a user visits {path} | GET {path} |
+| the slug is url-safe | check: invariant.url_slug |
+
+---
+
+Invariant: URL Slug
+  id: invariant.url_slug
+
+  Assertions:
+    → uses only [a-z0-9-]
+    → is lowercase
+
+---
+
+Feature: Slugs
+  id: feature.slugs
+
+  Scenario: Simple title
+    When a user visits /posts
+    → the slug is url-safe
+"#;
+        let intent = IntentFile::parse_content(content, "test.intent".to_string()).unwrap();
+
+        // The invariant is intact: right id, exactly its own assertions
+        assert_eq!(intent.invariants.len(), 1);
+        assert_eq!(intent.invariants[0].id, "invariant.url_slug");
+        assert_eq!(
+            intent.invariants[0].assertions,
+            vec![
+                "uses only [a-z0-9-]".to_string(),
+                "is lowercase".to_string()
+            ]
+        );
+
+        // The feature keeps its id and the scenario keeps its outcome
+        assert_eq!(intent.features.len(), 1);
+        assert_eq!(intent.features[0].id.as_deref(), Some("feature.slugs"));
+        let scenario = &intent.features[0].scenarios[0];
+        assert_eq!(scenario.outcomes, vec!["the slug is url-safe".to_string()]);
+    }
+
+    #[test]
+    fn invariant_before_component_is_saved_not_dropped() {
+        let content = r#"
+Invariant: URL Slug
+  id: invariant.url_slug
+
+  Assertions:
+    → is lowercase
+
+Component: Error Popup
+  id: component.error_popup
+  Inherent Behavior:
+    → status 200
+"#;
+        let intent = IntentFile::parse_content(content, "test.intent".to_string()).unwrap();
+        assert_eq!(intent.invariants.len(), 1);
+        assert_eq!(intent.invariants[0].id, "invariant.url_slug");
+        assert_eq!(intent.components.len(), 1);
+    }
+
+    #[test]
+    fn invariant_outcomes_resolve_to_executable_assertions() {
+        // End-to-end resolution: check: invariant.id expands through the
+        // vocabulary into concrete unit-test assertions
+        let content = r#"
+## Glossary
+
+| Term | Means |
+|------|-------|
+| the slug is url-safe | check: invariant.url_slug |
+
+---
+
+Invariant: URL Slug
+  id: invariant.url_slug
+
+  Assertions:
+    → uses only [a-z0-9-]
+    → is lowercase
+    → is non-empty
+"#;
+        let intent = IntentFile::parse_content(content, "test.intent".to_string()).unwrap();
+        let glossary = intent.glossary.clone().unwrap();
+        let assertions = glossary.resolve_outcomes_with_context(
+            "the slug is url-safe",
+            &intent.components,
+            &intent.invariants,
+        );
+        assert_eq!(
+            assertions.len(),
+            3,
+            "all three invariant assertions should resolve: {assertions:?}"
+        );
+    }
 
     #[test]
     fn test_parse_simple_intent() {

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -961,6 +961,33 @@ Feature: Home Page
 }
 
 #[test]
+fn intent_lint_warns_on_vacuous_scenario() {
+    // A scenario with no outcome lines verifies nothing — warn, don't fail
+    let content = r#"## Glossary
+
+| Term | Means |
+|------|-------|
+| a user visits {path} | GET {path} |
+| the homepage | / |
+
+---
+
+Feature: Home Page
+  id: feature.home
+
+  Scenario: First visit
+    When a user visits the homepage
+"#;
+    let (stdout, _stderr, exit_code) = run_intent_lint(content, &[]);
+    assert_eq!(exit_code, 0, "vacuous scenarios are warnings: {stdout}");
+    assert!(stdout.contains("vacuous_scenario"), "{stdout}");
+    assert!(
+        stdout.contains("passes vacuously") || stdout.contains("pass vacuously"),
+        "{stdout}"
+    );
+}
+
+#[test]
 fn intent_lint_accepts_tnt_path_with_paired_intent() {
     use std::io::Write as _;
     let dir = std::env::temp_dir().join(format!("ntnt_lint_pair_{}", std::process::id()));

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -988,6 +988,34 @@ Feature: Home Page
 }
 
 #[test]
+fn intent_lint_warns_on_vacuous_component_scenario() {
+    let content = r#"## Glossary
+
+| Term | Means |
+|------|-------|
+| a user visits {path} | GET {path} |
+
+---
+
+Component: Error Popup
+  id: component.error_popup
+
+  Scenario: Popup appears
+    When a user visits /error
+"#;
+    let (stdout, _stderr, exit_code) = run_intent_lint(content, &[]);
+    assert_eq!(exit_code, 0, "{stdout}");
+    assert!(
+        stdout.contains("vacuous_scenario") && stdout.contains("a user visits /error"),
+        "component scenarios need the same guard: {stdout}"
+    );
+    assert!(
+        !stdout.contains("orphan_term"),
+        "component-scenario clauses count as term usage: {stdout}"
+    );
+}
+
+#[test]
 fn intent_lint_accepts_tnt_path_with_paired_intent() {
     use std::io::Write as _;
     let dir = std::env::temp_dir().join(format!("ntnt_lint_pair_{}", std::process::id()));


### PR DESCRIPTION
## Summary

DD-063 Rec 5 (IAL stub completion), with a diagnosis that differs from the assessment. The DD believed invariant *execution* was a stub. Empirically it's worse and more interesting: **execution via expansion already worked, but a parser state leak made invariants silently vacuous** for a natural file layout.

**The bug:** the intent parser's `Feature:` handler resets every section state *except* `current_invariant`. In any file declaring invariants before features, the stale invariant handler (which runs earlier in the line loop) swallows:
- the feature's `id:` line → overwrites the invariant's id (corrupting the invariant's vocabulary registration too)
- every scenario `→` outcome line → appended to the invariant's assertion list

leaving scenarios with **zero outcomes that pass vacuously**. Verified end-to-end: a `slugify` returning `"TOTALLY BROKEN !!"` passed `intent check` (0 assertions executed); after the fix it fails 2 of 3 invariant assertions, and a correct implementation passes 3 of 3. `Component:` had the sibling bug (dropped pending invariants entirely).

## Changes

1. **Parser fix**: `Feature:` finalizes a pending invariant and resets `in_invariant_assertions`; `Component:` saves instead of dropping.
2. **Phantom primitives removed**: `InvariantCheck` and `Sql` had no construction path anywhere — invariants execute by *expansion* (`invariant.id` → assertion terms → `Check` primitives), never via a primitive. Removed the enum variants, dead match arms, the `execute_invariant_check` stub, and their `ial.toml` entries; the IAL reference now documents the expansion mechanism instead of promising unimplemented primitives (the DD's exact complaint).
3. **`intent lint` guard**: new `vacuous_scenario` warning for scenarios with no outcome lines — the exact shape this bug hid behind. Warnings only (exit 0); zero findings across the repo's 7 intent files.

## Test plan

- 3 new unit tests: invariants-before-features parses with intact invariant + feature id + outcomes; invariant-before-component saved not dropped; `check: invariant.id` resolves to all executable assertions
- 1 new CLI test: vacuous-scenario lint warning
- Manual end-to-end: broken implementation fails / correct passes with 3/3 assertions
- Full suite: 1785 tests, 0 failures; `ntnt docs --generate` synced the IAL reference

Closes DD-063 Rec 5 (checked off in the DD with the corrected root cause). Remaining DD-063 items: Recs 6–9 (small lints/doc restructure).