### PR TITLE
feat(lint): block-binding warning; verification defaults to strict (DD-063 Recs 6-7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ let user = map { "name": "Alice", "age": 30 }   // CORRECT
 let user = { "name": "Alice" }                   // WRONG — {} is a block
 ```
 
+`ntnt lint` flags the silent shapes too (rule `block_binding`): `let e = {}` binds Unit and `let m = { 5 }` binds 5.
+
 ### 2. String interpolation: `#{expr}` — not `${expr}`
 
 ```ntnt

--- a/design-docs/dd-063-language-assessment.md
+++ b/design-docs/dd-063-language-assessment.md
@@ -206,8 +206,8 @@ Implementation (after decisions):
 ### Recs 5–10 — assessed, not yet scheduled
 
 - [ ] **Rec 5** — IAL stub completion: implement invariant execution (expansion already works); decide `Sql` primitive fate (PR-2 makes docs honest in the interim)
-- [ ] **Rec 6** — lint for silent block-binding (`let x = { 5 }` / `let e = {}`)
-- [ ] **Rec 7** — strict type mode in verification contexts (`intent check`, `ntnt test`)
+- [x] **Rec 6** — lint for silent block-binding — shipped 2026-07-08: rule `block_binding` warns (error in strict) on empty and single-expression bare-brace let initializers; multi-statement block expressions stay exempt (intentional scoping feature)
+- [x] **Rec 7** — strict type mode in verification contexts — shipped 2026-07-08: `ntnt test` and `intent check` default to TypeMode::Strict when NTNT_TYPE_MODE is unset (explicit env always wins); verified end-to-end (OOB handler fails verification by default, passes under explicit warn)
 - [ ] **Rec 8** — whitepaper restructure: shipped vs aspirational
 - [ ] **Rec 9** — static contract lint for literal-argument violations (stretch)
 - [ ] **Rec 10** — execute existing DDs: DD-061 phase 1 (fib(30) ≈ 35x CPython baseline recorded above), DD-058 priority-1 stdlib gaps, DD-062 extension model

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -142,8 +142,14 @@ Two independent axes for type control:
 
 **Runtime (`NTNT_TYPE_MODE`):** Controls behavior on type mismatches at runtime.
 - `strict` — crash on mismatch (use for auth/payment apps)
-- `warn` — log `[WARN]` and continue **(default)**
+- `warn` — log `[WARN]` and continue **(default for `ntnt run`)**
 - `forgiving` — silent degradation
+
+**Verification runs strict by default:** `ntnt test` and `ntnt intent check`
+use `strict` when `NTNT_TYPE_MODE` is unset, so degradations that warn mode
+tolerates (out-of-bounds → None, implicit conversions) fail verification
+instead of slipping through it. Set `NTNT_TYPE_MODE=warn` explicitly to
+verify at run-mode tolerance.
 
 **Lint (`NTNT_LINT_MODE`):** Controls annotation requirements.
 - `default` — only check annotated code **(default)**

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,11 +48,25 @@ pub enum LintMode {
 }
 
 #[cfg_attr(test, allow(dead_code))]
+/// Default type mode when NTNT_TYPE_MODE is unset. Verification commands
+/// (`ntnt intent check`, `ntnt test`) set this to Strict before the first
+/// get_type_mode() read so verification means verification (DD-063 Rec 7);
+/// an explicit NTNT_TYPE_MODE always wins.
+static TYPE_MODE_DEFAULT: std::sync::OnceLock<TypeMode> = std::sync::OnceLock::new();
+
+/// Set the default type mode used when NTNT_TYPE_MODE is unset.
+/// Must be called before the first `get_type_mode()` read; later calls
+/// (and calls after the cache is populated) have no effect.
+pub fn set_default_type_mode(mode: TypeMode) {
+    let _ = TYPE_MODE_DEFAULT.set(mode);
+}
+
 fn read_type_mode_from_env() -> TypeMode {
-    match std::env::var("NTNT_TYPE_MODE").as_deref().unwrap_or("warn") {
-        "strict" => TypeMode::Strict,
-        "forgiving" => TypeMode::Forgiving,
-        _ => TypeMode::Warn,
+    match std::env::var("NTNT_TYPE_MODE").as_deref() {
+        Ok("strict") => TypeMode::Strict,
+        Ok("forgiving") => TypeMode::Forgiving,
+        Ok(_) => TypeMode::Warn,
+        Err(_) => TYPE_MODE_DEFAULT.get().copied().unwrap_or(TypeMode::Warn),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,9 +55,22 @@ pub enum LintMode {
 static TYPE_MODE_DEFAULT: std::sync::OnceLock<TypeMode> = std::sync::OnceLock::new();
 
 /// Set the default type mode used when NTNT_TYPE_MODE is unset.
-/// Must be called before the first `get_type_mode()` read; later calls
-/// (and calls after the cache is populated) have no effect.
+/// Must be called before the first `get_type_mode()` read — a late call
+/// cannot take effect (the resolved mode is already cached), so it is
+/// surfaced loudly instead of silently leaving verification in warn mode.
 pub fn set_default_type_mode(mode: TypeMode) {
+    #[cfg(not(test))]
+    if TYPE_MODE_CACHE.get().is_some() {
+        eprintln!(
+            "[WARN] set_default_type_mode({:?}) called after the type mode was already resolved — default not applied",
+            mode
+        );
+        debug_assert!(
+            false,
+            "set_default_type_mode must run before the first get_type_mode() read"
+        );
+        return;
+    }
     let _ = TYPE_MODE_DEFAULT.set(mode);
 }
 
@@ -78,10 +91,11 @@ fn read_type_mode_from_env() -> TypeMode {
 /// is unsafe in multi-threaded contexts on Rust 1.83+). Use
 /// [`set_test_type_mode`] to override in tests.
 #[cfg(not(test))]
+static TYPE_MODE_CACHE: std::sync::OnceLock<TypeMode> = std::sync::OnceLock::new();
+
+#[cfg(not(test))]
 pub fn get_type_mode() -> TypeMode {
-    use std::sync::OnceLock;
-    static TYPE_MODE: OnceLock<TypeMode> = OnceLock::new();
-    *TYPE_MODE.get_or_init(read_type_mode_from_env)
+    *TYPE_MODE_CACHE.get_or_init(read_type_mode_from_env)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -900,16 +900,21 @@ fn main() {
             body,
             port,
             verbose,
-        }) => test_http_server(
-            &file,
-            get_requests,
-            post_requests,
-            put_requests,
-            delete_requests,
-            body,
-            port,
-            verbose,
-        ),
+        }) => {
+            // Verification runs strict by default (DD-063 Rec 7);
+            // explicit NTNT_TYPE_MODE still wins
+            ntnt::config::set_default_type_mode(ntnt::config::TypeMode::Strict);
+            test_http_server(
+                &file,
+                get_requests,
+                post_requests,
+                put_requests,
+                delete_requests,
+                body,
+                port,
+                verbose,
+            )
+        }
         Some(Commands::Parse { file, json }) => parse_file(&file, json),
         Some(Commands::Lex { file }) => lex_file(&file),
         Some(Commands::Check { file }) => check_file(&file),
@@ -3277,6 +3282,7 @@ fn validate_project(path: &PathBuf) -> anyhow::Result<()> {
                             "javascript_style_interpolation"
                         }
                         ntnt::typechecker::DiagnosticKind::UnknownMethod => "unknown_method",
+                        ntnt::typechecker::DiagnosticKind::BlockBinding => "block_binding",
                         _ => "type_check",
                     };
                     let entry = json!({
@@ -3459,6 +3465,7 @@ fn lint_project(
                             "javascript_style_interpolation"
                         }
                         ntnt::typechecker::DiagnosticKind::UnknownMethod => "unknown_method",
+                        ntnt::typechecker::DiagnosticKind::BlockBinding => "block_binding",
                         _ => "type_check",
                     };
                     issues.push(json!({
@@ -4184,6 +4191,11 @@ fn run_intent_check_command(
     verbosity: usize,
     json_output: bool,
 ) -> anyhow::Result<()> {
+    // Verification runs strict by default (DD-063 Rec 7): warn mode's
+    // tolerated degradations (OOB→None, implicit conversions) should fail
+    // verification, not slip through it. Explicit NTNT_TYPE_MODE still wins.
+    ntnt::config::set_default_type_mode(ntnt::config::TypeMode::Strict);
+
     // Suppress banner output in JSON mode
     if !json_output {
         println!("{}", "=== NTNT Intent Check ===".cyan().bold());

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1139,9 +1139,11 @@ impl TypeContext {
                 // Bare-brace bindings are a silent footgun (DD-063 Rec 6):
                 // `let e = {}` binds Unit and `let m = { 5 }` binds 5 — the
                 // author almost always meant `map { ... }` or has a stray
-                // brace. Multi-statement blocks are left alone: block
-                // expressions are an intentional scoping feature.
-                if let Some(Expression::Block(block)) = value {
+                // brace. Multi-statement blocks are left alone (block
+                // expressions are an intentional scoping feature), as are
+                // annotated bindings — `let x: Int = { 5 }` signals intent,
+                // and a wrong annotation surfaces as a type error anyway.
+                if let (None, Some(Expression::Block(block))) = (type_annotation, value) {
                     let bound_to = name.as_str();
                     if block.statements.is_empty() {
                         let line = self.find_line_near(&format!("let {}", bound_to));

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -34,6 +34,9 @@ pub enum DiagnosticKind {
     /// Dot-call on a method name that is not a defined or imported function
     /// (UFCS means `x.f()` needs a reachable function `f`)
     UnknownMethod,
+    /// `let x = { ... }` binds a bare block (Unit or its last expression),
+    /// not a map — almost always a missing `map` keyword or stray brace
+    BlockBinding,
     /// General type error (mismatch, undefined, etc.)
     General,
 }
@@ -220,6 +223,7 @@ pub fn check_program_with_lint_mode(
                         | DiagnosticKind::MissingLambdaParamAnnotation
                         | DiagnosticKind::JsStyleInterpolation
                         | DiagnosticKind::UnknownMethod
+                        | DiagnosticKind::BlockBinding
                 )
             {
                 d.severity = Severity::Error;
@@ -1132,6 +1136,43 @@ impl TypeContext {
                 otherwise,
                 ..
             } => {
+                // Bare-brace bindings are a silent footgun (DD-063 Rec 6):
+                // `let e = {}` binds Unit and `let m = { 5 }` binds 5 — the
+                // author almost always meant `map { ... }` or has a stray
+                // brace. Multi-statement blocks are left alone: block
+                // expressions are an intentional scoping feature.
+                if let Some(Expression::Block(block)) = value {
+                    let bound_to = name.as_str();
+                    if block.statements.is_empty() {
+                        let line = self.find_line_near(&format!("let {}", bound_to));
+                        self.emit_with_kind(
+                            Severity::Warning,
+                            DiagnosticKind::BlockBinding,
+                            format!(
+                                "`let {} = {{}}` binds Unit — a bare {{}} is an empty block, not a map",
+                                bound_to
+                            ),
+                            line,
+                            Some("For an empty map, use `map {}`".to_string()),
+                        );
+                    } else if block.statements.len() == 1 {
+                        let line = self.find_line_near(&format!("let {}", bound_to));
+                        self.emit_with_kind(
+                            Severity::Warning,
+                            DiagnosticKind::BlockBinding,
+                            format!(
+                                "`let {} = {{ ... }}` binds a block's value, not a map",
+                                bound_to
+                            ),
+                            line,
+                            Some(
+                                "For a map, use `map { ... }`; if the block is intentional, this single-expression form is equivalent to binding the expression directly"
+                                    .to_string(),
+                            ),
+                        );
+                    }
+                }
+
                 let inferred = value
                     .as_ref()
                     .map(|v| self.infer_expression(v))

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1029,3 +1029,48 @@ fn workers_flag_reaches_server_banner() {
 
     assert!(found, "banner should show Workers: 3, got: {collected}");
 }
+
+// ===========================================================================
+// Strict verification contexts (DD-063 Rec 7)
+// ===========================================================================
+
+#[test]
+fn ntnt_test_defaults_to_strict_type_mode() {
+    use std::io::Write as _;
+    let dir = std::env::temp_dir().join(format!("ntnt_strict_verify_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let server = dir.join("srv.tnt");
+    write!(
+        std::fs::File::create(&server).unwrap(),
+        "import {{ json }} from \"std/http/server\"\nget(\"/risky\", fn(req) {{\n    let arr = [1, 2]\n    return json(map {{ \"third\": arr[10] }})\n}})\nlisten(8080)\n"
+    )
+    .unwrap();
+
+    let binary = find_ntnt_binary();
+
+    // Default: verification is strict — OOB in the handler fails the request
+    let out = std::process::Command::new(&binary)
+        .args(["test", server.to_str().unwrap(), "--get", "/risky"])
+        .env_remove("NTNT_TYPE_MODE")
+        .output()
+        .expect("run ntnt test");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("0 passed, 1 failed"),
+        "default verification should be strict: {stdout}"
+    );
+
+    // Explicit NTNT_TYPE_MODE=warn wins over the verification default
+    let out = std::process::Command::new(&binary)
+        .args(["test", server.to_str().unwrap(), "--get", "/risky"])
+        .env("NTNT_TYPE_MODE", "warn")
+        .output()
+        .expect("run ntnt test");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("1 passed, 0 failed"),
+        "explicit NTNT_TYPE_MODE must win: {stdout}"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1302,3 +1302,57 @@ print(is_some(x, 99))
         "arity mismatch on is_some should be reported: {stdout}"
     );
 }
+
+// ===========================================================================
+// Block-binding lint (DD-063 Rec 6)
+// ===========================================================================
+
+#[test]
+fn test_block_binding_warns_on_empty_and_single_expression_blocks() {
+    let source = r#"let e = {}
+let m = { 5 }
+print(e)
+print(m)
+"#;
+    let (stdout, _stderr, exit_code) = lint_code(source);
+    assert_eq!(
+        stdout.matches("\"rule\": \"block_binding\"").count(),
+        2,
+        "both footgun shapes should warn: {stdout}"
+    );
+    assert!(stdout.contains("binds Unit"), "{stdout}");
+    assert!(stdout.contains("map {}"), "empty-map hint: {stdout}");
+    assert_eq!(exit_code, 0, "warnings only in default mode");
+}
+
+#[test]
+fn test_block_binding_exempts_multi_statement_blocks() {
+    // Block expressions with real bodies are an intentional scoping feature
+    let source = r#"let x = {
+    let a = 1
+    a + 2
+}
+print(x)
+"#;
+    let (stdout, _stderr, _exit) = lint_code(source);
+    assert!(
+        !stdout.contains("block_binding"),
+        "multi-statement blocks are intentional: {stdout}"
+    );
+}
+
+#[test]
+fn test_block_binding_errors_in_strict_mode() {
+    let source = r#"let e = {}
+print(e)
+"#;
+    let (stdout, _stderr, _exit) = lint_strict_code(source);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let found = json["files"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|f| f["issues"].as_array().cloned().unwrap_or_default())
+        .any(|i| i["rule"] == "block_binding" && i["severity"] == "error");
+    assert!(found, "strict promotes block_binding: {stdout}");
+}

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1342,6 +1342,19 @@ print(x)
 }
 
 #[test]
+fn test_block_binding_exempts_annotated_bindings() {
+    // An explicit annotation signals intent; a wrong one is a type error
+    let source = r#"let x: Int = { 5 }
+print(x)
+"#;
+    let (stdout, _stderr, _exit) = lint_code(source);
+    assert!(
+        !stdout.contains("block_binding"),
+        "annotated bindings are intentional: {stdout}"
+    );
+}
+
+#[test]
 fn test_block_binding_errors_in_strict_mode() {
     let source = r#"let e = {}
 print(e)


### PR DESCRIPTION
## Summary

The last two code-level items on the DD-063 assessment, in one small PR.

### Rec 6 — `block_binding` lint

The one remaining verified silent failure from the assessment's A.3: `let e = {}` binds Unit and `let m = { 5 }` binds 5, with no diagnostic at lint or runtime. New rule `block_binding` warns on both shapes (error in strict mode) with actionable hints (`map {}` for empty maps). Multi-statement block expressions are exempt — they're the intentional scoping feature from DD-048, and only the empty/single-expression shapes are the footgun. Zero findings across all `examples/`.

### Rec 7 — verification runs strict by default

`ntnt test` and `ntnt intent check` now default to `NTNT_TYPE_MODE=strict` so verification means verification: degradations warn mode tolerates (out-of-bounds → None, implicit conversions) fail checks instead of slipping through them. Implemented as a config-level default override (`set_default_type_mode`) consulted only when the env var is unset — an explicit `NTNT_TYPE_MODE` always wins, and `ntnt run`'s warn default is untouched.

Verified end-to-end: a handler returning `arr[10]` on a 2-element array now **fails** `ntnt test` by default (E010 → 500) and passes under explicit `NTNT_TYPE_MODE=warn`. The full test suite passes under the new default — no existing fixture depended on warn-mode tolerance.

## Behavior-change note

Intent/test verification that previously passed by silently tolerating type degradations may now fail — that's the point, and it's the DD's exact recommendation ("run intent check and ntnt test under strict type mode so verification means verification"). Escape hatch: `NTNT_TYPE_MODE=warn`.

## Test plan

- 3 lint tests: both footgun shapes warn in default mode, multi-statement exemption, strict promotion to error
- 1 CLI test: `ntnt test` fails the OOB handler by default and passes with explicit `NTNT_TYPE_MODE=warn`
- Full suite: 1785 tests, 0 failures (includes all existing intent-check fixtures under the new strict default)

With this and #151, every code-level DD-063 item is shipped; the remaining recs are documentation-shaped (Rec 8 whitepaper restructure) plus the stretch static-contract lint (Rec 9).