### PR TITLE
feat(stdlib): paginate + from_now/time_ago quick wins (DD-058 item 5)

### DIFF
--- a/design-docs/dd-058-stdlib-gaps.md
+++ b/design-docs/dd-058-stdlib-gaps.md
@@ -1,6 +1,6 @@
 # DD-058: Stdlib Gap Analysis — Eliminating Common Package Dependencies
 
-**Status:** Draft — items 1 (`std/validate`) and 2 (`std/email`) shipped 2026-07-08
+**Status:** Draft — items 1 (`std/validate`), 2 (`std/email`), and 5 (quick wins: `paginate`, `from_now`/`time_ago`; `slugify` pre-existed) shipped 2026-07-08
 **Author:** Larri + Josh
 **Created:** 2026-03-31
 **App:** ntnt
@@ -303,7 +303,7 @@ let clean = sanitize_html(user_input, map {
 
 ### Priority 3: Nice to Have
 
-#### 9. Slug Generation
+#### 9. Slug Generation — ✅ already shipped (`slugify` in `std/string`)
 
 **The gap:** URL-friendly slugs from titles. Every blog, CMS, or content site needs this.
 
@@ -311,7 +311,7 @@ let clean = sanitize_html(user_input, map {
 
 **Scope:** ~50-100 lines. Straightforward.
 
-#### 10. Pagination Helpers
+#### 10. Pagination Helpers — ✅ SHIPPED (v0.4.12, `paginate` in `std/collections`)
 
 **The gap:** Every list view needs pagination math — offset, limit, total pages, page links.
 
@@ -319,7 +319,7 @@ let clean = sanitize_html(user_input, map {
 
 **Scope:** ~50-100 lines. Pure logic, no dependencies.
 
-#### 11. Human-Friendly Time (`from_now`, `time_ago`)
+#### 11. Human-Friendly Time — ✅ SHIPPED (v0.4.12, `from_now`/`time_ago` in `std/time`)
 
 **The gap:** "3 hours ago", "in 2 days", "just now". `std/time` has `diff()` but not the human-readable relative format.
 
@@ -488,7 +488,7 @@ Based on impact, effort, and dependencies:
 | 2 | `std/email` | Medium (400-600 LOC) | High | ✅ Shipped v0.4.12. `lettre` crate. Every app with users. |
 | 3 | Rate limiting | Medium (300-500 LOC) | High | Covered in DD-051. Middleware-level. |
 | 4 | Multipart uploads | Medium (400-600 LOC) | High | `multer` crate. File upload forms. |
-| 5 | `from_now()` / `slugify()` / `paginate()` | Small (200 LOC total) | Medium | Quick wins, extend existing modules. |
+| 5 | `from_now()` / `slugify()` / `paginate()` | Small (200 LOC total) | Medium | ✅ Shipped v0.4.12 (slugify already existed). |
 | 6 | HTML sanitization | Small (300-400 LOC) | Medium | `ammonia` crate. UGC apps. |
 | 7 | Cron expressions | Small (200-300 LOC) | Medium | `cron` crate. Extend `std/time`. |
 | 8 | `std/xml` | Medium (400-600 LOC) | Medium | `quick-xml` crate. Integrations. |

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -3661,6 +3661,7 @@ import { push, pop, first } from "std/collections"
 | [`keys`](#keys) | Returns an array of all keys in the map. |
 | [`last`](#last) | Returns the last element of an array. |
 | [`merge`](#merge) | Shallow-merges two maps. Values from map2 win on key conflicts. |
+| [`paginate`](#paginate) | Pagination math for list views: offset, limit, page counts, and flags. |
 | [`pop`](#pop) | Returns a tuple of [new array without last element, popped element as Option]. |
 | [`push`](#push) | Returns a new array with the item appended. |
 | [`reverse`](#reverse) | Returns a new array with elements in reverse order. |
@@ -4097,6 +4098,41 @@ merge(map { "a": 1, "b": 2 }, map { "b": 3, "c": 4 })  // => map { "a": 1, "b": 
 **See also:** `get_key`, `get_or`, `has_key`, `keys`, `values`
 
 *Since v0.3.13*
+
+---
+
+#### `paginate`
+
+```ntnt
+paginate(total_items: Int, page: Int, per_page: Int) -> Map<String, Any>
+```
+
+Pagination math for list views: offset, limit, page counts, and flags.
+
+Returns map { "offset", "limit", "page", "per_page", "total_items", "total_pages", "has_next", "has_prev" }. The requested page is clamped into [1, total_pages] (an empty list yields page 1 of 1 with offset 0), so out-of-range requests never produce a negative offset.
+
+**Parameters:**
+
+- `total_items` — Total number of items across all pages.
+- `page` — Requested 1-based page number (clamped).
+- `per_page` — Items per page (must be >= 1).
+
+**Returns:** Pagination map ready for SQL OFFSET/LIMIT and template links.
+
+**Examples:**
+
+```ntnt
+paginate(45, 3, 10)  // => map { "offset": 20, "limit": 10, "page": 3, "per_page": 10, "total_items": 45, "total_pages": 5, "has_next": true, "has_prev": true }  // Middle page
+paginate(45, 99, 10)  // => map { "offset": 40, "limit": 10, "page": 5, "per_page": 10, "total_items": 45, "total_pages": 5, "has_next": false, "has_prev": true }  // Out-of-range page clamps to the last
+```
+
+**Errors:**
+
+- **TypeError**: per_page must be at least 1 — *Fix: Pass a positive page size*
+
+**See also:** `slice`, `len`
+
+*Since v0.4.12*
 
 ---
 
@@ -12728,6 +12764,7 @@ import { now, now_millis, now_nanos } from "std/time"
 | [`format`](#format) | Formats a Unix timestamp as a string using a strftime format pattern (UTC). |
 | [`format_in`](#formatin) | Formats a Unix timestamp as a string in the specified timezone. |
 | [`format_timestamp`](#formattimestamp) | Formats a Unix timestamp as a string (legacy alias for format()). |
+| [`from_now`](#fromnow) | Human-friendly relative time: "3 hours ago", "in 2 days", "just now". |
 | [`hour`](#hour) | Extracts the hour from a Unix timestamp (UTC). |
 | [`is_leap_year`](#isleapyear) | Checks whether the year of the given timestamp is a leap year. |
 | [`list_timezones`](#listtimezones) | Returns a list of commonly used IANA timezone identifiers. |
@@ -12743,6 +12780,7 @@ import { now, now_millis, now_nanos } from "std/time"
 | [`parse_iso`](#parseiso) | Parses an ISO 8601 (RFC 3339) string into a Unix timestamp. |
 | [`second`](#second) | Extracts the second from a Unix timestamp (UTC). |
 | [`sleep`](#sleep) | Pauses execution for the specified number of milliseconds. |
+| [`time_ago`](#timeago) | Alias of from_now(): "3 hours ago", "in 2 days", "just now". |
 | [`to_iso`](#toiso) | Formats a Unix timestamp as an ISO 8601 (RFC 3339) string. |
 | [`to_timezone`](#totimezone) | Converts a Unix timestamp to a datetime map in the specified timezone. |
 | [`to_utc`](#toutc) | Converts a Unix timestamp to a UTC datetime map. |
@@ -13387,6 +13425,36 @@ format_timestamp(0, "%Y-%m-%d")  // => "1970-01-01"  // Epoch date formatted
 
 ---
 
+#### `from_now`
+
+```ntnt
+from_now(timestamp: Int) -> String
+```
+
+Human-friendly relative time: "3 hours ago", "in 2 days", "just now".
+
+Takes a Unix timestamp in seconds (as returned by now()) and renders its distance from the current time. Past timestamps read "N units ago", future ones "in N units"; anything within 60 seconds is "just now". Units step through minutes, hours, days, months (30-day) and years (365-day).
+
+**Parameters:**
+
+- `timestamp` — Unix timestamp in seconds.
+
+**Returns:** The relative description.
+
+**Examples:**
+
+```ntnt
+from_now(now() - 7200)  // => "2 hours ago"  // Past timestamp
+from_now(now() + 172800)  // => "in 2 days"  // Future timestamp
+from_now(now())  // => "just now"  // Current moment
+```
+
+**See also:** `time_ago`, `now`, `diff`, `format`
+
+*Since v0.4.12*
+
+---
+
 #### `hour`
 
 ```ntnt
@@ -13843,6 +13911,34 @@ sleep(100)  // => Unit  // Pauses for 100ms
 **See also:** `elapsed`, `now_millis`
 
 *Since v0.1.0*
+
+---
+
+#### `time_ago`
+
+```ntnt
+time_ago(timestamp: Int) -> String
+```
+
+Alias of from_now(): "3 hours ago", "in 2 days", "just now".
+
+Provided under the name most web developers reach for; identical behavior to from_now().
+
+**Parameters:**
+
+- `timestamp` — Unix timestamp in seconds.
+
+**Returns:** The relative description.
+
+**Examples:**
+
+```ntnt
+time_ago(now() - 60)  // => "1 minute ago"  // One minute back
+```
+
+**See also:** `from_now`, `now`
+
+*Since v0.4.12*
 
 ---
 

--- a/src/stdlib/collections.rs
+++ b/src/stdlib/collections.rs
@@ -1023,7 +1023,10 @@ pub fn init() -> HashMap<String, Value> {
                     ));
                 }
 
-                let total_pages = ((total_items + per_page - 1) / per_page).max(1);
+                // Overflow-safe ceiling division (total_items + per_page - 1
+                // can exceed i64::MAX for adversarial inputs)
+                let total_pages =
+                    (total_items / per_page + i64::from(total_items % per_page != 0)).max(1);
                 let page = page.clamp(1, total_pages);
                 let offset = (page - 1) * per_page;
 

--- a/src/stdlib/collections.rs
+++ b/src/stdlib/collections.rs
@@ -971,6 +971,76 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt paginate
+    // @module std/collections
+    // @signature paginate(total_items: Int, page: Int, per_page: Int) -> Map<String, Any>
+    // Pagination math for list views: offset, limit, page counts, and flags.
+    //
+    // Returns map { "offset", "limit", "page", "per_page", "total_items",
+    // "total_pages", "has_next", "has_prev" }. The requested page is clamped
+    // into [1, total_pages] (an empty list yields page 1 of 1 with offset 0),
+    // so out-of-range requests never produce a negative offset.
+    // @param total_items Total number of items across all pages.
+    // @param page Requested 1-based page number (clamped).
+    // @param per_page Items per page (must be >= 1).
+    // @returns Pagination map ready for SQL OFFSET/LIMIT and template links.
+    // @see_also slice, len
+    // @since v0.4.12
+    // @tags #pagination, #collections, #web
+    // @error TypeError ~ "per_page must be at least 1" fix: "Pass a positive page size"
+    // @example paginate(45, 3, 10) => map { "offset": 20, "limit": 10, "page": 3, "per_page": 10, "total_items": 45, "total_pages": 5, "has_next": true, "has_prev": true } ~ "Middle page"
+    // @example paginate(45, 99, 10) => map { "offset": 40, "limit": 10, "page": 5, "per_page": 10, "total_items": 45, "total_pages": 5, "has_next": false, "has_prev": true } ~ "Out-of-range page clamps to the last"
+    module.insert(
+        "paginate".to_string(),
+        Value::NativeFunction {
+            name: "paginate".to_string(),
+            arity: 3,
+            max_arity: 3,
+            requires: None,
+            func: |args| {
+                let as_int = |value: &Value, name: &str| -> Result<i64, IntentError> {
+                    match value {
+                        Value::Int(n) => Ok(*n),
+                        other => Err(IntentError::type_error(format!(
+                            "paginate() {} must be an Int, got {}",
+                            name,
+                            other.type_name()
+                        ))),
+                    }
+                };
+                let total_items = as_int(&args[0], "total_items")?;
+                let page = as_int(&args[1], "page")?;
+                let per_page = as_int(&args[2], "per_page")?;
+
+                if total_items < 0 {
+                    return Err(IntentError::type_error(
+                        "paginate() total_items must be >= 0".to_string(),
+                    ));
+                }
+                if per_page < 1 {
+                    return Err(IntentError::type_error(
+                        "paginate() per_page must be at least 1".to_string(),
+                    ));
+                }
+
+                let total_pages = ((total_items + per_page - 1) / per_page).max(1);
+                let page = page.clamp(1, total_pages);
+                let offset = (page - 1) * per_page;
+
+                let mut result = HashMap::new();
+                result.insert("offset".to_string(), Value::Int(offset));
+                result.insert("limit".to_string(), Value::Int(per_page));
+                result.insert("page".to_string(), Value::Int(page));
+                result.insert("per_page".to_string(), Value::Int(per_page));
+                result.insert("total_items".to_string(), Value::Int(total_items));
+                result.insert("total_pages".to_string(), Value::Int(total_pages));
+                result.insert("has_next".to_string(), Value::Bool(page < total_pages));
+                result.insert("has_prev".to_string(), Value::Bool(page > 1));
+                Ok(Value::Map(result))
+            },
+        },
+    );
+
     module
 }
 

--- a/src/stdlib/time.rs
+++ b/src/stdlib/time.rs
@@ -1610,5 +1610,101 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt from_now
+    // @module std/time
+    // @signature from_now(timestamp: Int) -> String
+    // Human-friendly relative time: "3 hours ago", "in 2 days", "just now".
+    //
+    // Takes a Unix timestamp in seconds (as returned by now()) and renders
+    // its distance from the current time. Past timestamps read "N units
+    // ago", future ones "in N units"; anything within 60 seconds is
+    // "just now". Units step through minutes, hours, days, months
+    // (30-day) and years (365-day).
+    // @param timestamp Unix timestamp in seconds.
+    // @returns The relative description.
+    // @see_also time_ago, now, diff, format
+    // @since v0.4.12
+    // @tags #time, #formatting
+    // @example from_now(now() - 7200) => "2 hours ago" ~ "Past timestamp"
+    // @example from_now(now() + 172800) => "in 2 days" ~ "Future timestamp"
+    // @example from_now(now()) => "just now" ~ "Current moment"
+    module.insert(
+        "from_now".to_string(),
+        Value::NativeFunction {
+            name: "from_now".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| relative_time(&args[0], "from_now"),
+        },
+    );
+
+    // @ntnt time_ago
+    // @module std/time
+    // @signature time_ago(timestamp: Int) -> String
+    // Alias of from_now(): "3 hours ago", "in 2 days", "just now".
+    //
+    // Provided under the name most web developers reach for; identical
+    // behavior to from_now().
+    // @param timestamp Unix timestamp in seconds.
+    // @returns The relative description.
+    // @see_also from_now, now
+    // @since v0.4.12
+    // @tags #time, #formatting
+    // @example time_ago(now() - 60) => "1 minute ago" ~ "One minute back"
+    module.insert(
+        "time_ago".to_string(),
+        Value::NativeFunction {
+            name: "time_ago".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| relative_time(&args[0], "time_ago"),
+        },
+    );
+
     module
+}
+
+/// Shared implementation for from_now()/time_ago(): render the distance
+/// between a Unix-seconds timestamp and the current time
+fn relative_time(value: &Value, fn_name: &str) -> Result<Value, IntentError> {
+    let timestamp = match value {
+        Value::Int(n) => *n,
+        Value::Float(f) => *f as i64,
+        other => {
+            return Err(IntentError::type_error(format!(
+                "{}() requires a Unix timestamp in seconds, got {}",
+                fn_name,
+                other.type_name()
+            )))
+        }
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    let delta = timestamp - now;
+    let past = delta <= 0;
+    let magnitude = delta.unsigned_abs();
+
+    let (count, unit) = if magnitude < 60 {
+        return Ok(Value::String("just now".to_string()));
+    } else if magnitude < 3600 {
+        (magnitude / 60, "minute")
+    } else if magnitude < 86_400 {
+        (magnitude / 3600, "hour")
+    } else if magnitude < 30 * 86_400 {
+        (magnitude / 86_400, "day")
+    } else if magnitude < 365 * 86_400 {
+        (magnitude / (30 * 86_400), "month")
+    } else {
+        (magnitude / (365 * 86_400), "year")
+    };
+
+    let plural = if count == 1 { "" } else { "s" };
+    let rendered = if past {
+        format!("{} {}{} ago", count, unit, plural)
+    } else {
+        format!("in {} {}{}", count, unit, plural)
+    };
+    Ok(Value::String(rendered))
 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4233,6 +4233,7 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("E", [], Type::Float);
         }
         "std/collections" => {
+            sig!("paginate", ["total_items" => Type::Int, "page" => Type::Int, "per_page" => Type::Int], Type::Map { key_type: Box::new(Type::String), value_type: Box::new(Type::Any) });
             sig!("push", ["array" => Type::Array(Box::new(Type::Any)), "item" => Type::Any], Type::Array(Box::new(Type::Any)));
             sig!("pop", ["array" => Type::Array(Box::new(Type::Any))], Type::Any);
             sig!("keys", ["map" => Type::Any], Type::Array(Box::new(Type::String)));
@@ -4499,6 +4500,8 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("is_absolute", ["path" => Type::String], Type::Bool);
         }
         "std/time" => {
+            sig!("from_now", ["timestamp" => Type::Int], Type::String);
+            sig!("time_ago", ["timestamp" => Type::Int], Type::String);
             sig!("now", [], Type::Any);
             sig!("now_millis", [], Type::Int);
             sig!("format", ["time" => Type::Any, "fmt" => Type::String], Type::String);

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4500,8 +4500,8 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("is_absolute", ["path" => Type::String], Type::Bool);
         }
         "std/time" => {
-            sig!("from_now", ["timestamp" => Type::Int], Type::String);
-            sig!("time_ago", ["timestamp" => Type::Int], Type::String);
+            sig!("from_now", ["timestamp" => Type::Union(vec![Type::Int, Type::Float])], Type::String);
+            sig!("time_ago", ["timestamp" => Type::Union(vec![Type::Int, Type::Float])], Type::String);
             sig!("now", [], Type::Any);
             sig!("now_millis", [], Type::Int);
             sig!("format", ["time" => Type::Any, "fmt" => Type::String], Type::String);

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -6557,7 +6557,7 @@ print("#{clamped["page"]} #{clamped["offset"]} #{clamped["has_next"]}")
 let low = paginate(45, 0, 10)
 print("#{low["page"]} #{low["offset"]} #{low["has_prev"]}")
 let empty = paginate(0, 1, 10)
-print("#{empty["total_pages"]} #{empty["offset"]}")
+print("empty:#{empty["total_pages"]} #{empty["offset"]}")
 "##;
     let (stdout, stderr, exit_code) = run_ntnt_code(code);
     assert_eq!(exit_code, 0, "stderr: {stderr}");
@@ -6565,8 +6565,8 @@ print("#{empty["total_pages"]} #{empty["offset"]}")
     assert!(stdout.contains("5 40 false"), "high page clamps: {stdout}");
     assert!(stdout.contains("1 0 false"), "low page clamps: {stdout}");
     assert!(
-        stdout.contains("1 0"),
-        "empty list is page 1 of 1: {stdout}"
+        stdout.contains("empty:1 0"),
+        "empty list is page 1 of 1 (labeled so the low-clamp line can't satisfy it): {stdout}"
     );
 }
 

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -6520,3 +6520,64 @@ print(b[10])
         "distinct call sites should each warn: {stderr}"
     );
 }
+
+// ===========================================================================
+// std quick wins: from_now/time_ago and paginate (DD-058 item 5)
+// ===========================================================================
+
+#[test]
+fn test_from_now_and_time_ago() {
+    let code = r#"
+import { from_now, time_ago, now } from "std/time"
+
+print(from_now(now() - 7200))
+print(from_now(now() + 172800))
+print(from_now(now()))
+print(time_ago(now() - 60))
+print(from_now(now() - 400 * 86400))
+"#;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("2 hours ago"), "{stdout}");
+    assert!(stdout.contains("in 2 days"), "{stdout}");
+    assert!(stdout.contains("just now"), "{stdout}");
+    assert!(stdout.contains("1 minute ago"), "singular unit: {stdout}");
+    assert!(stdout.contains("1 year ago"), "{stdout}");
+}
+
+#[test]
+fn test_paginate_math_and_clamping() {
+    let code = r##"
+import { paginate } from "std/collections"
+
+let p = paginate(45, 3, 10)
+print("#{p["offset"]} #{p["limit"]} #{p["total_pages"]} #{p["has_next"]} #{p["has_prev"]}")
+let clamped = paginate(45, 99, 10)
+print("#{clamped["page"]} #{clamped["offset"]} #{clamped["has_next"]}")
+let low = paginate(45, 0, 10)
+print("#{low["page"]} #{low["offset"]} #{low["has_prev"]}")
+let empty = paginate(0, 1, 10)
+print("#{empty["total_pages"]} #{empty["offset"]}")
+"##;
+    let (stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_eq!(exit_code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("20 10 5 true true"), "{stdout}");
+    assert!(stdout.contains("5 40 false"), "high page clamps: {stdout}");
+    assert!(stdout.contains("1 0 false"), "low page clamps: {stdout}");
+    assert!(
+        stdout.contains("1 0"),
+        "empty list is page 1 of 1: {stdout}"
+    );
+}
+
+#[test]
+fn test_paginate_rejects_bad_per_page() {
+    let code = r#"
+import { paginate } from "std/collections"
+let p = paginate(45, 1, 0)
+print(p)
+"#;
+    let (_stdout, stderr, exit_code) = run_ntnt_code(code);
+    assert_ne!(exit_code, 0);
+    assert!(stderr.contains("per_page must be at least 1"), "{stderr}");
+}


### PR DESCRIPTION
## Summary

DD-058's quick-wins row, closing the last small gaps in the web-app happy path. Investigating first paid off: `slugify` already shipped in `std/string`, so this PR adds the two genuinely missing pieces (~150 LOC).

**`paginate(total_items, page, per_page)`** — `std/collections`. Every list view's pagination math in one call:

```ntnt
let p = paginate(45, 3, 10)
// map { "offset": 20, "limit": 10, "page": 3, "per_page": 10,
//       "total_items": 45, "total_pages": 5, "has_next": true, "has_prev": true }
let rows = query(db, "SELECT ... LIMIT $1 OFFSET $2", [p["limit"], p["offset"]])
```

Pages clamp into `[1, total_pages]` (an empty list is page 1 of 1, offset 0), so out-of-range query params never produce negative offsets; `per_page < 1` is a type error.

**`from_now(timestamp)` / `time_ago(timestamp)`** — `std/time`. Human-relative rendering of Unix-second timestamps: "just now" within a minute, then minutes/hours/days/30-day months/365-day years — "3 hours ago", "in 2 days", singular/plural handled. `time_ago` is an alias under the name most web developers reach for.

## Test plan

- 3 integration tests: relative-time matrix (past/future/now/singular/year), pagination math + both clamp directions + empty list, per_page validation error
- Full suite: 1800 tests, 0 failures; typechecker signatures registered; STDLIB_REFERENCE regenerated
- DD-058 updated: item 5 shipped, slugify noted as pre-existing

Next: the DD-041 SSE/broadcast design pass, as agreed.