### PR TITLE
docs(dd-041): SSE design review — verified against current architecture, go/no-go ready

### DIFF
--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -30,7 +30,7 @@ hardening, DD-057/DD-063). The architecture holds; three assumptions do
 not, and each changes the plan:
 
 **1. There is no `respond` keyword.** The draft's "`respond` already
-handles `respond file(...)`" is drift — handlers return response VALUES
+handles `return file(...)`" is drift — handlers return response VALUES
 (`json()`, `html()`). This simplifies the design: `sse()` and
 `sse_stream()` are ordinary response builders and Phase 1 needs zero
 parser work:
@@ -45,8 +45,9 @@ get("/metrics/stream", fn(req) {
 })
 ```
 
-All `route`/`respond`/`group` syntax in the examples below should be read
-in this form.
+The body of this document — API sections, all examples, implementation
+notes, and the Phase 1 checklist — has been reconciled to this form and
+to the decisions below.
 
 **2. The bridge buffers whole responses.** `BridgeResponse` is
 `{ status, headers, body: String }` — returned over a oneshot channel and
@@ -102,7 +103,7 @@ variant, worker-mode schedule gate). Awaiting go/no-go.
 
 ---
 
-## Vision## Vision
+## Vision
 
 ntnt already has `schedule()` for periodic sampling and channels for in-process communication. The missing piece for real-time dashboards — compute metrics, network monitoring, live logs, progress bars — is a way to push data from those samplers to a browser the moment it's collected.
 
@@ -110,7 +111,7 @@ ntnt already has `schedule()` for periodic sampling and channels for in-process 
 
 1. **`broadcast()`** — a fan-out channel: every subscriber gets every message
 2. **`subscribe(bc)`** — tap into a broadcast for one connection
-3. **`respond sse(...)`** — hold the HTTP connection open, push events as they arrive
+3. **`return sse(...)`** — hold the HTTP connection open, push events as they arrive
 
 The full real-time stack then looks like:
 ```
@@ -152,9 +153,9 @@ send(bc, value) → all three subscribers receive a copy
 
 The custom approach (Vec of senders) is most consistent with ntnt's existing crossbeam usage.
 
-### How `respond sse(...)` Works
+### How `return sse(...)` Works
 
-When a route handler returns `respond sse(subscription)`:
+When a route handler returns `return sse(subscription)`:
 
 1. The Rust HTTP layer recognizes the SSE response type.
 2. It sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, connection stays open.
@@ -174,7 +175,7 @@ SSE connections die silently when passing through proxies and load balancers tha
 Browser → GET /metrics/stream
   → Route handler runs (interpreter thread)
   → subscribe(metrics_bus) → creates crossbeam receiver, registers in BroadcastRegistry
-  → respond sse(subscription) → returns SSEResponse token to HTTP layer
+  → return sse(subscription) → returns SSEResponse token to HTTP layer
   → HTTP layer spawns write task: poll receiver → write to socket
   → Route handler exits, interpreter thread free
 
@@ -190,28 +191,28 @@ schedule(500ms) loop (separate thread):
 ### Phase 1: Core
 
 ```ntnt
-import { broadcast, subscribe } from "std/sse"
+import { broadcast, subscribe, sse } from "std/sse"
 
-// Create a broadcast channel (typically at module/app level)
-let metrics_bus = broadcast()
+// Create a NAMED broadcast channel (module/app level). The name makes the
+// bus process-global: every worker and every hot-reload re-evaluation
+// resolves the same bus (Design Review).
+let metrics_bus = broadcast("metrics")
 
 // Send a value to all current subscribers
-send(metrics_bus, map { "cpu": 87.3, "ts": unix_ms() })
+send(metrics_bus, map { "cpu": 87.3, "ts": now_millis() })
 
-// Subscribe — creates a per-connection receiver
-let sub = subscribe(metrics_bus)
-
-// In a route: hold the connection open, push events as they arrive
-route GET "/metrics/stream" {
-    respond sse(subscribe(metrics_bus))
-}
+// In a route handler: return the SSE response; the connection stays open
+// and events stream as they arrive
+get("/metrics/stream", fn(req) {
+    return sse(subscribe(metrics_bus))
+})
 ```
 
 **Types:**
-- `broadcast() -> BroadcastHandle`
+- `broadcast(name?: String) -> BroadcastHandle` — named: process-global; anonymous: per-worker
 - `subscribe(BroadcastHandle) -> SSESubscription`
-- `send(BroadcastHandle, Map) -> Unit` — reuses existing `send()` syntax, dispatches on handle type
-- `respond sse(SSESubscription) -> Response` — new response type
+- `send(BroadcastHandle, Map) -> Unit` — reuses existing `send()` dispatch on handle type
+- `sse(SSESubscription) -> Response` — ordinary response builder (like `json()`/`html()`)
 
 ### Per-Connection Streams (No Shared Bus)
 
@@ -220,18 +221,18 @@ For streams that are unique per connection — a clock, a personal notification 
 ```ntnt
 import { sse_stream } from "std/sse"
 
-route GET "/clock" {
-    respond sse_stream(fn(push, on_close) {
+get("/clock", fn(req) {
+    return sse_stream(fn(push, on_close) {
         let sched = schedule(1000, fn() {
             push(map { "time": format_time(now()) })
         })
         on_close(fn() { cancel_schedule(sched) })
     })
-}
+})
 
-route GET "/jobs/:id/progress" {
-    let job_id = params["id"]
-    respond sse_stream(fn(push, on_close) {
+get("/jobs/{id}/progress", fn(req) {
+    let job_id = req.params.id
+    return sse_stream(fn(push, on_close) {
         let poll = schedule(500, fn() {
             let status = unwrap(job_status(job_id))
             push(status)
@@ -242,7 +243,7 @@ route GET "/jobs/:id/progress" {
         })
         on_close(fn() { cancel_schedule(poll) })
     })
-}
+})
 ```
 
 `sse_stream(fn(push, on_close))`:
@@ -271,10 +272,10 @@ es.addEventListener('mem_update', e => updateMemChart(JSON.parse(e.data)))
 ```ntnt
 import { filter } from "std/sse"
 
-route GET "/stream/network/:iface" {
-    let iface = params["iface"]
-    respond sse(filter(subscribe(metrics_bus), fn(m) { m["interface"] == iface }))
-}
+get("/stream/network/{iface}", fn(req) {
+    let iface = req.params.iface
+    return sse(filter(subscribe(metrics_bus), fn(m) { m["interface"] == iface }))
+})
 ```
 
 `filter(SSESubscription, fn(Map) -> Bool) -> SSESubscription`
@@ -285,7 +286,7 @@ Filtering happens server-side before writing to the socket — non-matching even
 
 ```ntnt
 // Server assigns IDs automatically when replay is enabled
-let metrics_bus = broadcast(map { "replay_buffer": 100 })
+let metrics_bus = broadcast("metrics", map { "replay_buffer": 100 })
 
 // Browser automatically sends Last-Event-ID on reconnect
 // ntnt replays the buffer from that ID forward
@@ -309,8 +310,8 @@ import {
 
 Response forms:
 ```ntnt
-respond sse(subscription)                    // push from shared bus
-respond sse_stream(fn(push, on_close) { })   // per-connection generator
+return sse(subscription)                    // push from shared bus
+return sse_stream(fn(push, on_close) { })   // per-connection generator
 ```
 
 ---
@@ -322,7 +323,7 @@ respond sse_stream(fn(push, on_close) { })   // per-connection generator
 ```ntnt
 import { broadcast, subscribe } from "std/sse"
 
-let metrics = broadcast()
+let metrics = broadcast("metrics")
 
 // One sampler loop, feeds all connected browser tabs
 schedule(500, fn() {
@@ -334,13 +335,13 @@ schedule(500, fn() {
     })
 })
 
-route GET "/dashboard" {
-    respond file("dashboard.html")
-}
+get("/dashboard", fn(req) {
+    return file("dashboard.html")
+})
 
-route GET "/stream/metrics" {
-    respond sse(subscribe(metrics))
-}
+get("/stream/metrics", fn(req) {
+    return sse(subscribe(metrics))
+})
 ```
 
 Frontend (40 lines of vanilla JS):
@@ -390,20 +391,20 @@ schedule(5000, fn() {
 })
 
 // All interfaces — live feed
-route GET "/stream/network" {
-    respond sse(subscribe(net_metrics))
-}
+get("/stream/network", fn(req) {
+    return sse(subscribe(net_metrics))
+})
 
 // Per-interface filtered stream
-route GET "/stream/network/:iface" {
-    let iface = params["iface"]
-    respond sse(filter(subscribe(net_metrics), fn(m) { m["name"] == iface }))
-}
+get("/stream/network/{iface}", fn(req) {
+    let iface = req.params.iface
+    return sse(filter(subscribe(net_metrics), fn(m) { m["name"] == iface }))
+})
 
 // Alert stream
-route GET "/stream/alerts" {
-    respond sse(subscribe(net_alerts))
-}
+get("/stream/alerts", fn(req) {
+    return sse(subscribe(net_alerts))
+})
 
 // Job-based alerting wired through std/events
 event_subscribe("interface.down",      "PageOnCall")
@@ -421,16 +422,16 @@ The monitoring stack: `schedule` samples → SSE streams live to browsers + `std
 import { sse_stream } from "std/sse"
 import { job_status } from "std/jobs"
 
-route GET "/jobs/:id/progress" {
-    let job_id = params["id"]
-    respond sse_stream(fn(push, on_close) {
+get("/jobs/{id}/progress", fn(req) {
+    let job_id = req.params.id
+    return sse_stream(fn(push, on_close) {
         let poll = schedule(500, fn() {
             let status = unwrap(job_status(job_id))
             push(status)
         })
         on_close(fn() { cancel_schedule(poll) })
     })
-}
+})
 ```
 
 ---
@@ -447,14 +448,14 @@ on_log(fn(entry) {
     send(log_bus, entry)
 })
 
-route GET "/stream/logs" {
-    respond sse(subscribe(log_bus))
-}
+get("/stream/logs", fn(req) {
+    return sse(subscribe(log_bus))
+})
 
-route GET "/stream/logs/:level" {
+get("/stream/logs/{level}", fn(req) {
     let level = params["level"]
-    respond sse(filter(subscribe(log_bus), fn(e) { e["level"] == level }))
-}
+    return sse(filter(subscribe(log_bus), fn(e) { e["level"] == level }))
+})
 ```
 
 ---
@@ -464,8 +465,15 @@ route GET "/stream/logs/:level" {
 ### BroadcastHandle and BroadcastRegistry
 
 ```rust
-// Global registry of all broadcast channels
-static BROADCAST_REGISTRY: LazyLock<Mutex<HashMap<u64, BroadcastChannel>>> = ...;
+// Global registry of all broadcast channels — process-wide so every
+// worker (and hot-reload re-evaluation) resolves the same named bus.
+// Named buses key by name; anonymous buses key by generated id.
+static BROADCAST_REGISTRY: LazyLock<Mutex<HashMap<BroadcastKey, BroadcastChannel>>> = ...;
+
+enum BroadcastKey {
+    Named(String),  // broadcast("metrics") — shared across workers/reloads
+    Anon(u64),      // broadcast() — per-evaluation, single-worker semantics
+}
 
 struct BroadcastChannel {
     id: u64,
@@ -489,7 +497,11 @@ struct BroadcastMessage {
 5. Drop lock
 
 `subscribe(bc)`:
-1. Create a new `crossbeam::channel::unbounded()` pair
+1. Create a new `crossbeam::channel::bounded(1024)` pair — bounded per the
+   Design Review: a stuck TCP connection with an unbounded queue is
+   slow-motion OOM. On a full queue the send policy is drop-oldest with a
+   deduped warn (unless the bus was created with `"drop_slow": false`,
+   which opts into briefly-blocking sends)
 2. Lock registry, push `sender` into `BroadcastChannel.senders`
 3. Wrap `receiver` in `SSESubscription { receiver, channel_id, last_event_id: None }`
 4. Drop lock
@@ -571,11 +583,11 @@ sig!("connection_count", ["handle" => Type::Named("BroadcastHandle".to_string())
 sig!("sse_stream", ["handler" => Type::Any], Type::Named("SSEResponse".to_string()));
 ```
 
-### `respond sse(...)` Parser Integration
+### `return sse(...)` Parser Integration
 
-`respond` already handles `respond file(...)`, `respond json(...)`, `respond html(...)`. Add:
-- `respond sse(expr)` — where `expr` evaluates to `SSESubscription`
-- `respond sse_stream(expr)` — where `expr` evaluates to a closure
+`respond` already handles `return file(...)`, `return json(...)`, `return html(...)`. Add:
+- `return sse(expr)` — where `expr` evaluates to `SSESubscription`
+- `return sse_stream(expr)` — where `expr` evaluates to a closure
 
 ---
 
@@ -586,14 +598,16 @@ sig!("sse_stream", ["handler" => Type::Any], Type::Named("SSEResponse".to_string
 **Estimated effort:** 3-4 days
 
 - [ ] `Value::BroadcastHandle(u64)` and `Value::SSESubscription(u64)` variants
-- [ ] `BroadcastRegistry` global (LazyLock, same pattern as ConcurrencyRuntime)
-- [ ] `broadcast() -> BroadcastHandle`
-- [ ] `subscribe(BroadcastHandle) -> SSESubscription`
-- [ ] `send(BroadcastHandle, value)` — dispatches on handle type (reuse `send` keyword)
-- [ ] `respond sse(SSESubscription)` — new response type in HTTP layer
+- [ ] `BroadcastRegistry` global, keyed by name for named buses (Design Review: shared across workers and hot reloads) — LazyLock, same pattern as the pool registry
+- [ ] `broadcast(name?) -> BroadcastHandle` — named form is the documented default; anonymous form is per-worker
+- [ ] `subscribe(BroadcastHandle) -> SSESubscription` — bounded per-subscriber queue (1024), drop-oldest with deduped warn; `"drop_slow": false` opts into blocking
+- [ ] `send(BroadcastHandle, value)` — dispatches on handle type (reuse existing `send`)
+- [ ] `sse(SSESubscription) -> Response` — response BUILDER returned from a normal handler (there is no `respond` keyword; zero parser work)
+- [ ] `BridgeBody::Sse { subscription_id }` variant on the bridge response; Axum layer builds the streaming body when it sees it (Design Review item)
+- [ ] `schedule()` registers only outside Worker mode, so module-level samplers run once, not once per worker (Design Review item; own release note)
 - [ ] SSE write loop in Rust: format events, keep-alive pings, disconnect cleanup
 - [ ] Sender cleanup on subscriber disconnect
-- [ ] `sse_stream(fn(push, on_close))` — per-connection callback form
+- [ ] `sse_stream(fn(push, on_close))` — per-connection callback form; `push()` returns Bool (false after disconnect)
 - [ ] `connection_count(BroadcastHandle) -> Int`
 - [ ] Typechecker signatures
 - [ ] `// @ntnt` doc blocks on all functions
@@ -663,10 +677,15 @@ Real-time display: `std/sse`. Durable alerting: `std/events` + `std/jobs`.
 **SSE endpoints go through normal route middleware** — no special cases. Auth middleware added to a route group applies to SSE endpoints in that group:
 
 ```ntnt
-group "/dashboard" middleware: [require_admin] {
-    route GET "/"         { respond file("dashboard.html") }
-    route GET "/stream"   { respond sse(subscribe(metrics_bus)) }
-}
+// Middleware short-circuits before the SSE connection is established
+use_middleware(fn(req) {
+    if starts_with(req.path, "/dashboard") && !is_admin(req) {
+        return status(403, "Forbidden")
+    }
+})
+
+get("/dashboard", fn(req) { return file("dashboard.html") })
+get("/dashboard/stream", fn(req) { return sse(subscribe(metrics_bus)) })
 ```
 
 The middleware runs before the SSE connection is established. If the middleware rejects the request (401, 403), the SSE connection is never opened. This is correct — you don't want to establish the connection and then reject it.
@@ -674,9 +693,9 @@ The middleware runs before the SSE connection is established. If the middleware 
 **CORS:** If the SSE endpoint is consumed from a different origin (e.g. a static frontend), add CORS headers:
 
 ```ntnt
-route GET "/stream/metrics" middleware: [cors("https://app.example.com")] {
-    respond sse(subscribe(metrics_bus))
-}
+get("/stream/metrics", fn(req) {
+    return sse(subscribe(metrics_bus))
+})
 ```
 
 **Rate limiting:** Handled at the route level, same as any other route. `max_connections` on `broadcast()` caps total subscribers regardless of auth status.
@@ -698,7 +717,7 @@ route GET "/stream/metrics" middleware: [cors("https://app.example.com")] {
 | Works with existing scheduler | `schedule()` → `send()` | Separate GenServer | Separate worker | Separate asyncio task | Separate goroutine |
 | Lines for a metrics dashboard | ~15 | ~80 | ~100 | ~60 | ~70 |
 
-ntnt's advantage: the sampler (`schedule`), the bus (`broadcast`), and the endpoint (`respond sse`) are first-class primitives that compose with each other and with `std/jobs`/`std/events`. No framework, no adapter, no external process.
+ntnt's advantage: the sampler (`schedule`), the bus (`broadcast`), and the endpoint (`sse()` responses) are first-class primitives that compose with each other and with `std/jobs`/`std/events`. No framework, no adapter, no external process.
 
 ---
 

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -10,16 +10,17 @@
 
 ## Table of Contents
 
-1. [Vision](#vision)
-2. [Architecture](#architecture)
-3. [API Design](#api-design)
-4. [Full Stack Examples](#full-stack-examples)
-5. [Implementation Notes](#implementation-notes)
-6. [Phase Details](#phase-details)
-7. [Relationship to std/events and std/jobs](#relationship-to-stdevents-and-stdjobs)
-8. [Security](#security)
-9. [Competitive Analysis](#competitive-analysis)
-10. [Open Questions](#open-questions)
+1. [Design Review (2026-07-08)](#design-review-2026-07-08)
+2. [Vision](#vision)
+3. [Architecture](#architecture)
+4. [API Design](#api-design)
+5. [Full Stack Examples](#full-stack-examples)
+6. [Implementation Notes](#implementation-notes)
+7. [Phase Details](#phase-details)
+8. [Relationship to std/events and std/jobs](#relationship-to-stdevents-and-stdjobs)
+9. [Security](#security)
+10. [Competitive Analysis](#competitive-analysis)
+11. [Open Questions](#open-questions)
 
 ---
 
@@ -153,9 +154,9 @@ send(bc, value) → all three subscribers receive a copy
 
 The custom approach (Vec of senders) is most consistent with ntnt's existing crossbeam usage.
 
-### How `return sse(...)` Works
+### How the `sse()` Response Works
 
-When a route handler returns `return sse(subscription)`:
+When a route handler returns `sse(subscription)`:
 
 1. The Rust HTTP layer recognizes the SSE response type.
 2. It sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, connection stays open.
@@ -510,7 +511,7 @@ struct BroadcastMessage {
 
 ### SSE Response Handler (Rust HTTP Layer)
 
-When the HTTP layer sees `Response::SSE(subscription_id)`:
+When the HTTP layer sees `BridgeBody::Sse { subscription_id }` on the bridge response (see Design Review):
 
 ```rust
 async fn sse_handler(subscription_id: u64, req: Request) -> Response {
@@ -586,11 +587,14 @@ sig!("connection_count", ["handle" => Type::Named("BroadcastHandle".to_string())
 sig!("sse_stream", ["handler" => Type::Any], Type::Named("SSEResponse".to_string()));
 ```
 
-### `return sse(...)` Parser Integration
+### No Parser Integration Needed
 
-`respond` already handles `return file(...)`, `return json(...)`, `return html(...)`. Add:
-- `return sse(expr)` — where `expr` evaluates to `SSESubscription`
-- `return sse_stream(expr)` — where `expr` evaluates to a closure
+The original draft planned a `respond sse(...)` keyword form, but there is
+no `respond` keyword in the language (see Design Review). `sse()` and
+`sse_stream()` are ordinary imported response builders, exactly like
+`json()`/`html()`: the handler returns their value, the bridge recognizes
+the SSE response (via the `BridgeBody::Sse` variant), and the parser is
+untouched.
 
 ---
 
@@ -693,13 +697,18 @@ get("/dashboard/stream", fn(req) { return sse(subscribe(metrics_bus)) })
 
 The middleware runs before the SSE connection is established. If the middleware rejects the request (401, 403), the SSE connection is never opened. This is correct — you don't want to establish the connection and then reject it.
 
-**CORS:** If the SSE endpoint is consumed from a different origin (e.g. a static frontend), add CORS headers:
+**CORS:** If the SSE endpoint is consumed from a different origin (e.g. a static frontend), add CORS headers with `with_header` — the same mechanism as any other response:
 
 ```ntnt
+import { with_header } from "std/http/server"
+
 get("/stream/metrics", fn(req) {
-    return sse(subscribe(metrics_bus))
+    let resp = sse(subscribe(metrics_bus))
+    return with_header(resp, "Access-Control-Allow-Origin", "https://app.example.com")
 })
 ```
+
+(Phase 1 must ensure `with_header` composes with the SSE response type — headers are set before the stream body begins.)
 
 **Rate limiting:** Handled at the route level, same as any other route. `max_connections` on `broadcast()` caps total subscribers regardless of auth status.
 
@@ -747,3 +756,4 @@ reconciled into the body):
 | Date | Change |
 |------|--------|
 | 2026-03-17 | Initial draft — vision, architecture, full API, three phases, implementation notes |
+| 2026-07-08 | Design review against current main: response-builder API (no `respond` keyword), `BridgeBody::Sse` bridge variant, named process-global broadcasts, Worker-mode `schedule()` gate, bounded drop-oldest subscriber queues; body reconciled end to end |

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -302,11 +302,13 @@ points:
 > **on_close runs in a fresh interpreter too, not a persistent "scheduler
 > thread."** `schedule()` has no long-lived interpreter — each tick is a
 > fresh interpreter built from the captured closure (`run_in_fresh_interpreter`).
-> On disconnect, the write task likewise runs the registered `on_close`
-> closure in a fresh interpreter; because `ScheduleHandle` is a process-global
-> id, the `cancel_schedule(sched)` inside `on_close` cancels the
-> per-connection timer even though it was registered from a different
-> (also fresh) interpreter.
+> On disconnect, the write task takes the registered `on_close` closure out
+> of the shared `on_close` cell in `SseSource::Generator` (the generator's
+> `on_close(fn)` native wrote it there) and runs it in a fresh interpreter;
+> because `ScheduleHandle` is a process-global id, the
+> `cancel_schedule(sched)` inside `on_close` cancels the per-connection
+> timer even though it was registered from a different (also fresh)
+> interpreter.
 
 ### Phase 2: Named Events, IDs, Filtering
 
@@ -606,7 +608,15 @@ enum SseSource {
     // capture (environment + body); the write task runs it ONCE, in a fresh
     // scheduling-capable interpreter, before entering the drain loop.
     // `wake_tx` is handed to that interpreter's `push` native.
-    Generator { closure: CapturedClosure, wake_tx: flume::Sender<()> },
+    // `on_close` is a pre-allocated shared cell: the generator's `on_close`
+    // native writes its callback here, and the write task reads it back on
+    // disconnect (through the owned `source` — NOT via subscription_id,
+    // which take() already consumed).
+    Generator {
+        closure: CapturedClosure,
+        wake_tx: flume::Sender<()>,
+        on_close: Arc<Mutex<Option<CapturedClosure>>>,
+    },
 }
 
 struct BroadcastMessage {
@@ -684,8 +694,9 @@ the producer differs (the generator's `push()` instead of a bus's `send()`):
    (`validate_and_capture` → environment + body). No broadcast registry
    entry is created — an `sse_stream` has no bus.
 3. Insert `SseSubscription { queue, wake_rx, source: Generator { closure,
-   wake_tx } }` into `SUBSCRIPTION_REGISTRY` under a fresh
-   `subscription_id`.
+   wake_tx, on_close: Arc::new(Mutex::new(None)) } }` into
+   `SUBSCRIPTION_REGISTRY` under a fresh `subscription_id`. The `on_close`
+   cell starts empty; the generator's `on_close(fn)` native fills it.
 4. Return `Value::SSESubscription(subscription_id)`; `sse_stream()` carries
    it to the HTTP layer as `BridgeBody::Sse { subscription_id }` — the
    handler on the worker returns immediately, interpreter thread free.
@@ -704,8 +715,15 @@ async fn sse_handler(subscription_id: u64, req: Request) -> Response {
     // inside the generator register normally, unlike a worker request scope.
     // Its `push`/`on_close` natives are bound to this connection's ring +
     // wake_tx. This runs exactly once; the timers it registers keep pushing.
-    if let SseSource::Generator { closure, wake_tx } = &subscription.source {
-        spawn_generator_interpreter(closure, subscription.queue.clone(), wake_tx.clone());
+    if let SseSource::Generator { closure, wake_tx, on_close } = &subscription.source {
+        // push  → enqueue+wake on (queue, wake_tx); on_close(fn) → store the
+        // callback into the shared `on_close` cell for the cleanup arm below.
+        spawn_generator_interpreter(
+            closure,
+            subscription.queue.clone(),
+            wake_tx.clone(),
+            on_close.clone(),
+        );
     }
 
     let body = Body::new(async_stream::stream! {
@@ -738,10 +756,17 @@ async fn sse_handler(subscription_id: u64, req: Request) -> Response {
             // sse(): drop this subscriber from the bus.
             SseSource::Broadcast { channel_key, sender_id } =>
                 BROADCAST_REGISTRY.lock().remove_sender(channel_key, *sender_id),
-            // sse_stream(): run the generator's on_close in a fresh
-            // interpreter (same mechanism as the generator itself), which
-            // cancel_schedule()s the per-connection timers by their handle.
-            SseSource::Generator { .. } => run_on_close_in_fresh_interpreter(subscription_id),
+            // sse_stream(): take the callback out of the shared cell (owned
+            // here via `source` — subscription_id was consumed by take() at
+            // entry) and run it in a fresh interpreter, same mechanism as the
+            // generator itself. It cancel_schedule()s the per-connection
+            // timers by their handle. None if the generator registered no
+            // on_close.
+            SseSource::Generator { on_close, .. } => {
+                if let Some(cb) = on_close.lock().take() {
+                    run_captured_in_fresh_interpreter(cb);
+                }
+            }
         }
     });
 
@@ -826,7 +851,7 @@ untouched.
 - [ ] Multi-worker integration test: sampler registers once on the primary (the existing `RuntimeCapability::Scheduling` gate — no new code), subscribers connect via workers, each event arrives exactly once per subscriber
 - [ ] SSE write loop in Rust: `recv_async()` the wake + drain the ring, keep-alive pings, `X-Accel-Buffering: no`, source-dependent disconnect cleanup (bus `remove_sender` vs generator `on_close`)
 - [ ] `sse_stream(fn(push, on_close))` — per-connection callback form; `push()` = drop-oldest enqueue + wake (returns Bool, false after disconnect)
-- [ ] `sse_stream` generator handoff: captured (`validate_and_capture`) and run ONCE by the write task via `run_in_fresh_interpreter` in a `Scheduling`-capable mode — so `schedule()`/`cancel_schedule()` inside it register per connection instead of being skipped by the Worker gate; `on_close` runs the same way on disconnect. Multi-worker test: a per-connection timer actually ticks when the request was served by a worker
+- [ ] `sse_stream` generator handoff: captured (`validate_and_capture`) and run ONCE by the write task via `run_in_fresh_interpreter` in a `Scheduling`-capable mode — so `schedule()`/`cancel_schedule()` inside it register per connection instead of being skipped by the Worker gate. `on_close(fn)` stores into a pre-allocated `Arc<Mutex<Option<CapturedClosure>>>` cell in `SseSource::Generator`; on disconnect the write task takes it from the owned `source` (not the consumed `subscription_id`) and runs it the same way. Multi-worker test: a per-connection timer actually ticks when the request was served by a worker
 - [ ] `connection_count(BroadcastHandle) -> Int`
 - [ ] `enable_cors()` headers apply to SSE responses — headers are set before the stream body begins (see Security)
 - [ ] Typechecker signatures

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -1,6 +1,6 @@
 # DD-041: Real-Time Streaming — SSE & Broadcast Channels
 
-**Status:** Draft
+**Status:** Draft — design review 2026-07-08 (see § Design Review below); awaiting maintainer go/no-go for Phase 1
 **Author:** Larri
 **Created:** 2026-03-17
 **Branch:** TBD
@@ -23,7 +23,86 @@
 
 ---
 
-## Vision
+## Design Review (2026-07-08)
+
+The March draft was verified against current main (post multi-worker
+hardening, DD-057/DD-063). The architecture holds; three assumptions do
+not, and each changes the plan:
+
+**1. There is no `respond` keyword.** The draft's "`respond` already
+handles `respond file(...)`" is drift — handlers return response VALUES
+(`json()`, `html()`). This simplifies the design: `sse()` and
+`sse_stream()` are ordinary response builders and Phase 1 needs zero
+parser work:
+
+```ntnt
+import { broadcast, subscribe, sse } from "std/sse"
+
+let metrics_bus = broadcast("metrics")
+
+get("/metrics/stream", fn(req) {
+    return sse(subscribe(metrics_bus))
+})
+```
+
+All `route`/`respond`/`group` syntax in the examples below should be read
+in this form.
+
+**2. The bridge buffers whole responses.** `BridgeResponse` is
+`{ status, headers, body: String }` — returned over a oneshot channel and
+written once. SSE needs the one real structural change: a body variant
+(`BridgeBody::Text(String) | BridgeBody::Sse { subscription_id }`). When
+the Axum layer sees the SSE variant it builds a streaming body (the
+draft's write-task design, unchanged: keep-alive comments, disconnect
+cleanup, `X-Accel-Buffering: no`). The interpreter thread still returns
+immediately — the zero-interpreter-overhead property survives contact
+with the bridge.
+
+**3. Multi-worker breaks the naive design — named broadcasts fix it.**
+Production defaults to `min(num_cpus, 8)` workers, each re-evaluating the
+program. Two consequences the draft predates:
+
+- A module-level `let bus = broadcast()` creates N DISTINCT buses (one
+  per worker). A subscriber lands on whichever worker served its request;
+  a sampler sends on whichever worker runs it. Subscribers on other
+  workers receive nothing.
+- `schedule()` spawns its loop unconditionally, so a module-level sampler
+  runs N times — a pre-existing duplicate-background-work bug that SSE
+  would surface as duplicate events.
+
+Resolution, now part of Phase 1:
+
+- **Broadcasts are named and process-global**: `broadcast("metrics")`
+  returns the same bus for the same name from every worker (registry
+  keyed by name, same `LazyLock<Mutex<HashMap>>` pattern as the pool
+  registry). Named buses also survive hot reload — a re-eval re-attaches
+  to the existing bus instead of orphaning open connections.
+  Anonymous `broadcast()` remains for single-connection/`sse_stream`
+  patterns and is documented as per-worker.
+- **`schedule()` registers only outside Worker mode** (workers 1..N skip
+  it, exactly as they skip `listen()`/`on_shutdown()`). This fixes the
+  duplicate-sampler bug for ALL apps, not just SSE — flagged as its own
+  release-note item since multi-worker apps today silently run N copies
+  of every scheduled loop.
+
+**Open questions resolved (recommendations):**
+
+- Backing: custom `Vec<Sender>` per bus (crossbeam-consistent) — but with
+  **bounded per-subscriber queues** (e.g. 1024) rather than unbounded: a
+  stuck TCP connection with an unbounded queue is slow-motion OOM.
+  Default policy drop-oldest with a deduped warn; `"drop_slow": false`
+  opts into blocking sends for correctness-critical streams.
+- `send()` reuses the existing dispatch on handle type — no new verb.
+- `sse_stream` cleanup stays `on_close(fn)`; `push()` returns Bool so
+  generators can stop on disconnect.
+- WebSockets remain a separate DD; `ntnt sse status` stays Phase 3.
+
+Phase 1 effort holds at 3-4 days with the two additions (BridgeBody
+variant, worker-mode schedule gate). Awaiting go/no-go.
+
+---
+
+## Vision## Vision
 
 ntnt already has `schedule()` for periodic sampling and channels for in-process communication. The missing piece for real-time dashboards — compute metrics, network monitoring, live logs, progress bars — is a way to push data from those samplers to a browser the moment it's collected.
 

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -89,9 +89,12 @@ Resolution, now part of Phase 1:
 
 **Open questions resolved (recommendations):**
 
-- Backing: custom `Vec<Sender>` per bus (crossbeam-consistent) — but with
-  **bounded per-subscriber queues** (e.g. 1024) rather than unbounded: a
-  stuck TCP connection with an unbounded queue is slow-motion OOM.
+- Backing: custom `Vec<flume::Sender>` per bus — flume is already a
+  dependency (the request bridge uses it) and, unlike crossbeam, supports
+  BOTH sync sends from interpreter threads and `recv_async()` in the Axum
+  write task. Per-subscriber queues are **bounded** (e.g. 1024) rather
+  than unbounded: a stuck TCP connection with an unbounded queue is
+  slow-motion OOM.
   Default policy drop-oldest with a deduped warn; `"drop_slow": false`
   opts into blocking sends for correctness-critical streams.
 - `send()` reuses the existing dispatch on handle type — no new verb.
@@ -136,7 +139,7 @@ schedule(500ms) → send(metrics_bus) → [N browser connections] each subscribe
 
 ### The New Primitive: Broadcast Channel
 
-`broadcast()` creates a broadcast channel backed by a multi-sender, multi-receiver bus. Each subscriber gets their own crossbeam receiver that receives a copy of every message sent to the bus. Messages are not consumed — they're fanned out.
+`broadcast()` creates a broadcast channel backed by a multi-sender, multi-receiver bus. Each subscriber gets their own bounded flume receiver that receives a copy of every message sent to the bus. Messages are not consumed — they're fanned out.
 
 ```
 broadcast_channel
@@ -150,9 +153,9 @@ send(bc, value) → all three subscribers receive a copy
 **Implementation options (see Open Questions):**
 - `bus` crate — lock-free SPMC broadcast, fastest, single-producer only
 - `tokio::sync::broadcast` — MPMC, has lag/drop semantics, skip-behind
-- Custom: Vec of crossbeam senders, new sender added per subscriber, clean up on disconnect
+- Custom: Vec of flume senders, new sender added per subscriber, clean up on disconnect
 
-The custom approach (Vec of senders) is most consistent with ntnt's existing crossbeam usage.
+The custom approach (Vec of senders) won — see the Design Review: flume is already the bridge's channel library and its receivers support `recv_async()` in the Axum write task, which crossbeam receivers do not.
 
 ### How the `sse()` Response Works
 
@@ -160,7 +163,7 @@ When a route handler returns `sse(subscription)`:
 
 1. The Rust HTTP layer recognizes the SSE response type.
 2. It sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, connection stays open.
-3. A Rust task (not an interpreter thread) polls the subscription's crossbeam receiver in a loop, formatting each `Value` as an SSE event and writing to the HTTP response body.
+3. A Rust task (not an interpreter thread) awaits the subscription's flume receiver (`recv_async()`) in a loop, formatting each `Value` as an SSE event and writing to the HTTP response body.
 4. When the client disconnects, the write fails, the loop exits, and the subscription is dropped — which removes this subscriber from the broadcast channel's sender list.
 5. The interpreter thread is free after returning the SSE response token. It does not block.
 
@@ -479,9 +482,21 @@ enum BroadcastKey {
 
 struct BroadcastChannel {
     id: u64,
-    senders: Vec<crossbeam::channel::Sender<BroadcastMessage>>,
+    senders: Vec<(u64, flume::Sender<BroadcastMessage>)>, // (sender_id, tx)
     replay_buffer: Option<VecDeque<BroadcastMessage>>,
     replay_buffer_size: usize,
+}
+
+// Holds a subscription between the interpreter returning
+// Value::SSESubscription(id) from the handler and the Axum layer taking
+// ownership to drive the write task. take() consumes the entry, so a
+// subscription streams to exactly one response.
+static SUBSCRIPTION_REGISTRY: LazyLock<Mutex<HashMap<u64, SseSubscription>>> = ...;
+
+struct SseSubscription {
+    receiver: flume::Receiver<BroadcastMessage>,
+    channel_key: BroadcastKey, // for sender cleanup on disconnect
+    sender_id: u64,
 }
 
 struct BroadcastMessage {
@@ -499,11 +514,12 @@ struct BroadcastMessage {
 5. Drop lock
 
 `subscribe(bc)`:
-1. Create a new `crossbeam::channel::bounded(1024)` pair — bounded per the
-   Design Review: a stuck TCP connection with an unbounded queue is
-   slow-motion OOM. On a full queue the send policy is drop-oldest with a
-   deduped warn (unless the bus was created with `"drop_slow": false`,
-   which opts into briefly-blocking sends)
+1. Create a new `flume::bounded(1024)` pair — flume so the Axum write task
+   can `recv_async()` (crossbeam receivers have no async recv); bounded
+   per the Design Review: a stuck TCP connection with an unbounded queue
+   is slow-motion OOM. On a full queue the send policy is drop-oldest
+   with a deduped warn (unless the bus was created with
+   `"drop_slow": false`, which opts into briefly-blocking sends)
 2. Lock registry, push `sender` into `BroadcastChannel.senders`
 3. Wrap `receiver` in `SSESubscription { receiver, channel_id, last_event_id: None }`
 4. Drop lock
@@ -584,7 +600,10 @@ sig!("broadcast", ["name" => Type::String, "opts" => Type::Map { key_type: Box::
 sig!("subscribe", ["handle" => Type::Named("BroadcastHandle".to_string())], Type::Named("SSESubscription".to_string()));
 sig!("filter", ["sub" => Type::Named("SSESubscription".to_string()), "pred" => Type::Any], Type::Named("SSESubscription".to_string()));
 sig!("connection_count", ["handle" => Type::Named("BroadcastHandle".to_string())], Type::Int);
-sig!("sse_stream", ["handler" => Type::Any], Type::Named("SSEResponse".to_string()));
+// Both builders return Response, same as json()/html(), so middleware
+// and with_header() compose without special cases
+sig!("sse", ["sub" => Type::Named("SSESubscription".to_string())], Type::Named("Response".to_string()));
+sig!("sse_stream", ["handler" => Type::Any], Type::Named("Response".to_string()));
 ```
 
 ### No Parser Integration Needed

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -292,9 +292,9 @@ let metrics_bus = broadcast("metrics", map { "replay_buffer": 100 })
 // ntnt replays the buffer from that ID forward
 ```
 
-`broadcast(opts?)`:
+`broadcast(name?, opts?)`:
 - `"replay_buffer": N` — keep the last N events in a ring buffer; replayed on reconnect
-- `"drop_slow": true` — drop events for slow subscribers instead of blocking (default: false, block briefly)
+- `"drop_slow": false` — opt INTO briefly-blocking sends for correctness-critical streams. The default is `true` (drop-oldest from the subscriber's bounded queue, with a deduped warn) — per the Design Review, blocking on a stuck subscriber is the OOM/backpressure hazard
 
 ### Full API Surface
 
@@ -576,7 +576,9 @@ enum Value {
 
 ```rust
 // std/sse module
-sig!("broadcast", [], Type::Named("BroadcastHandle".to_string()), required(0));
+// name and opts are both optional: broadcast(), broadcast("metrics"),
+// broadcast("metrics", map { "replay_buffer": 100 })
+sig!("broadcast", ["name" => Type::String, "opts" => Type::Map { key_type: Box::new(Type::String), value_type: Box::new(Type::Any) }], Type::Named("BroadcastHandle".to_string()), required(0));
 sig!("subscribe", ["handle" => Type::Named("BroadcastHandle".to_string())], Type::Named("SSESubscription".to_string()));
 sig!("filter", ["sub" => Type::Named("SSESubscription".to_string()), "pred" => Type::Any], Type::Named("SSESubscription".to_string()));
 sig!("connection_count", ["handle" => Type::Named("BroadcastHandle".to_string())], Type::Int);
@@ -622,7 +624,7 @@ sig!("sse_stream", ["handler" => Type::Any], Type::Named("SSEResponse".to_string
 
 - [ ] `send(BroadcastHandle, event_name, value)` — named SSE events
 - [ ] `filter(SSESubscription, fn) -> SSESubscription` — server-side predicate filter
-- [ ] `broadcast(opts)` — `replay_buffer: N`, `drop_slow: bool`
+- [ ] `broadcast(name?, opts?)` — `replay_buffer: N`, `drop_slow: bool` (default true = drop-oldest; false opts into blocking)
 - [ ] Replay buffer: ring buffer of last N events, sent on connect with `Last-Event-ID` header
 - [ ] Event ID auto-increment when replay is enabled
 - [ ] Tests: named events, filter, replay on reconnect, drop_slow behavior
@@ -713,7 +715,7 @@ get("/stream/metrics", fn(req) {
 | Filter/transform | `filter(sub, fn)` | Custom handler | Custom handler | Manual | Manual |
 | Keep-alive | Built-in (15s) | Built-in | Built-in | Manual | Manual |
 | Named events | `send(bc, "name", val)` | Topic-based | Channel-based | Manual | Manual |
-| Replay on reconnect | `broadcast(map { "replay_buffer": N })` | ❌ | ❌ | Manual | Manual |
+| Replay on reconnect | `broadcast("bus", map { "replay_buffer": N })` | ❌ | ❌ | Manual | Manual |
 | Works with existing scheduler | `schedule()` → `send()` | Separate GenServer | Separate worker | Separate asyncio task | Separate goroutine |
 | Lines for a metrics dashboard | ~15 | ~80 | ~100 | ~60 | ~70 |
 
@@ -723,16 +725,19 @@ ntnt's advantage: the sampler (`schedule`), the bus (`broadcast`), and the endpo
 
 ## Open Questions
 
-| Question | Options | Notes |
-|----------|---------|-------|
-| Broadcast backing implementation | `bus` crate (SPMC), `Vec<Sender>` (custom), `tokio::sync::broadcast` | Leaning custom Vec<Sender> for consistency with crossbeam |
-| `send()` overload on BroadcastHandle | Reuse existing `send()` dispatch vs. new `publish()` name | `send()` is cleaner, already familiar from channels |
-| `drop_slow` default | Drop (false) vs block briefly (true) | Blocking is safer for dashboards, dropping is safer for high-frequency metrics |
-| `sse_stream` cleanup model | `on_close(fn)` callback vs defer-style | `on_close` is explicit and readable |
-| Backpressure signal | No signal vs `push()` returns Bool | `push()` → Bool lets the handler decide to stop |
-| WebSockets | Separate DD vs extend this one | Separate DD — SSE covers 90% of dashboard needs and is simpler |
-| `ntnt sse status` CLI | Part of this DD vs Phase 3 | Phase 3 — not blocking core |
-| CORS middleware built-in | Yes vs user-defined | Likely a stdlib utility, not SSE-specific |
+All resolved by the 2026-07-08 Design Review (decisions recorded there and
+reconciled into the body):
+
+| Question | Resolution |
+|----------|------------|
+| Broadcast backing implementation | Custom `Vec<Sender>` per bus, crossbeam-consistent — with BOUNDED per-subscriber queues (1024) |
+| `send()` overload on BroadcastHandle | Reuse existing `send()` dispatch on handle type |
+| `drop_slow` default | Drop-oldest with deduped warn (default); `"drop_slow": false` opts into briefly-blocking sends |
+| `sse_stream` cleanup model | `on_close(fn)` callback |
+| Backpressure signal | `push()` returns Bool (false after disconnect) |
+| WebSockets | Separate DD — SSE covers the dashboard cases and is simpler |
+| `ntnt sse status` CLI | Phase 3 |
+| CORS middleware built-in | Stdlib utility, not SSE-specific |
 
 ---
 

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -193,8 +193,9 @@ Browser → GET /metrics/stream
   → Route handler exits, interpreter thread free
 
 schedule(500ms) loop (separate thread):
-  → send(metrics_bus, value) → locks BROADCAST_REGISTRY, evaluates any filter
-    predicates, try_send to each matching subscriber's sender
+  → send(metrics_bus, value) → briefly locks BROADCAST_REGISTRY to snapshot
+    the subscriber list, then (outside the lock) evaluates any filter
+    predicates and try_sends to each matching subscriber's sender
   → Each write task wakes, reads value, writes SSE event to socket
 ```
 
@@ -306,7 +307,7 @@ get("/stream/network/{iface}", fn(req) {
 
 `filter(SSESubscription, fn(Map) -> Bool) -> SSESubscription`
 
-Filtering happens server-side before writing to the socket — non-matching events are dropped, never sent over the wire. Execution point: the predicate is an ntnt closure, which the Rust write task cannot evaluate — so filtered subscriptions register their predicate with the bus and it runs at `send()` fan-out time, on the sending interpreter thread. The write task stays interpreter-free (the zero-overhead property holds); the cost of filtering lands on the publisher, proportional to filtered subscribers.
+Filtering happens server-side before writing to the socket — non-matching events are dropped, never sent over the wire. Execution point: the predicate is an ntnt closure, which the Rust write task cannot evaluate — so filtered subscriptions register their predicate with the bus and it runs at `send()` fan-out time, on the sending interpreter thread — outside the registry lock, against a snapshot of the subscriber list (see the `send()` algorithm in Implementation Notes), so a predicate may itself call `send()` safely. The write task stays interpreter-free (the zero-overhead property holds); the cost of filtering lands on the publisher, proportional to filtered subscribers.
 
 **Event IDs and reconnect:**
 
@@ -565,16 +566,27 @@ struct BroadcastMessage {
 `send(bc, value)`:
 1. Serialize `Value` → `SerializedValue`
 2. Lock registry, look up the `BroadcastChannel` by the handle's
-   `BroadcastKey`
-3. Append to replay buffer if configured
-4. For each `SubscriberEntry`: if `filter` is set, evaluate the predicate
-   against the value (we are on the publishing interpreter thread, so
-   ntnt closures are evaluable here) and skip non-matching subscribers
-5. `try_send` to each remaining sender; on `Disconnected` (receiver
-   dropped) → remove that entry from the list; on `Full` → apply the
-   queue policy (default: pop the oldest event and retry, warn deduped
-   per subscriber; `"drop_slow": false`: block briefly instead)
-6. Drop lock
+   `BroadcastKey`; append to replay buffer if configured; **snapshot the
+   subscriber list** (clone each entry's `flume::Sender` — cheap, it's an
+   Arc internally — plus `sender_id` and filter handle); drop the lock
+3. Outside the lock, for each snapshot entry: if `filter` is set,
+   evaluate the predicate against the value (we are on the publishing
+   interpreter thread, so ntnt closures are evaluable here) and skip
+   non-matching subscribers
+4. `try_send` to each remaining sender; on `Full` → apply the queue
+   policy (default: pop the oldest event and retry, warn deduped per
+   subscriber; `"drop_slow": false`: block briefly instead); collect the
+   `sender_id` of any `Disconnected` sender (receiver dropped)
+5. If any senders were dead, re-lock the registry briefly and remove
+   those entries
+
+Predicates and sends run OUTSIDE the registry lock deliberately:
+`std::sync::Mutex` is non-reentrant, so a filter predicate that itself
+calls `send()` (or `subscribe()`/`broadcast()`) would deadlock if the
+lock were held across evaluation. With the snapshot approach, re-entrant
+`send()` from a predicate simply takes the lock afresh and works;
+recursion depth is bounded by user code. The cost is benign staleness: a
+subscriber added or removed mid-send catches the next event.
 
 `subscribe(bc)`:
 1. Create a new `flume::bounded(1024)` pair — flume so the Axum write task

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -303,6 +303,7 @@ import {
     broadcast,          // create a broadcast channel
     subscribe,          // tap into a broadcast (per-connection)
     filter,             // filter a subscription by predicate
+    sse,                // SSE response builder for a subscription (primary form)
     sse_stream,         // per-connection stream with push/on_close callbacks
     connection_count,   // how many active subscribers on a broadcast channel
 } from "std/sse"
@@ -453,7 +454,7 @@ get("/stream/logs", fn(req) {
 })
 
 get("/stream/logs/{level}", fn(req) {
-    let level = params["level"]
+    let level = req.params.level
     return sse(filter(subscribe(log_bus), fn(e) { e["level"] == level }))
 })
 ```

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -21,6 +21,7 @@
 9. [Security](#security)
 10. [Competitive Analysis](#competitive-analysis)
 11. [Open Questions](#open-questions)
+12. [Version History](#version-history)
 
 ---
 
@@ -65,12 +66,18 @@ Production defaults to `min(num_cpus, 8)` workers, each re-evaluating the
 program. Two consequences the draft predates:
 
 - A module-level `let bus = broadcast()` creates N DISTINCT buses (one
-  per worker). A subscriber lands on whichever worker served its request;
-  a sampler sends on whichever worker runs it. Subscribers on other
-  workers receive nothing.
-- `schedule()` spawns its loop unconditionally, so a module-level sampler
-  runs N times — a pre-existing duplicate-background-work bug that SSE
-  would surface as duplicate events.
+  per worker). A subscriber lands on whichever worker served its request.
+- `schedule()` is already gated correctly — Worker-mode interpreters lack
+  `RuntimeCapability::Scheduling`, so a module-level sampler registers
+  exactly once, on the primary interpreter (verified in source:
+  `schedule`/`after` carry `requires: Some(RuntimeCapability::Scheduling)`
+  and the Worker and HotReload capability sets exclude it; pinned by
+  `test_capability_gate_scheduling_worker_mode_skips`). The March draft
+  feared N× duplicate samplers; the multi-worker hardening already
+  prevents that. But the combination is exactly the trap: the single
+  sampler publishes on the PRIMARY interpreter's bus, while subscribers'
+  handlers run on workers holding their own per-worker buses — so with
+  anonymous module-level buses, subscribers receive nothing at all.
 
 Resolution, now part of Phase 1:
 
@@ -81,11 +88,10 @@ Resolution, now part of Phase 1:
   to the existing bus instead of orphaning open connections.
   Anonymous `broadcast()` remains for single-connection/`sse_stream`
   patterns and is documented as per-worker.
-- **`schedule()` registers only outside Worker mode** (workers 1..N skip
-  it, exactly as they skip `listen()`/`on_shutdown()`). This fixes the
-  duplicate-sampler bug for ALL apps, not just SSE — flagged as its own
-  release-note item since multi-worker apps today silently run N copies
-  of every scheduled loop.
+- **No `schedule()` change needed** — the Worker-mode gate already
+  exists. Phase 1 adds a multi-worker integration test (sampler on
+  primary, subscribers via workers, events arrive once) to pin the
+  behavior, not new gating code.
 
 **Open questions resolved (recommendations):**
 
@@ -102,8 +108,8 @@ Resolution, now part of Phase 1:
   generators can stop on disconnect.
 - WebSockets remain a separate DD; `ntnt sse status` stays Phase 3.
 
-Phase 1 effort holds at 3-4 days with the two additions (BridgeBody
-variant, worker-mode schedule gate). Awaiting go/no-go.
+Phase 1 effort holds at 3-4 days with the one structural addition (the
+BridgeBody variant). Awaiting go/no-go.
 
 ---
 
@@ -135,7 +141,7 @@ schedule(500ms) → send(metrics_bus) → [N browser connections] each subscribe
 
 ### The Problem with ntnt's Current Channel Model
 
-`channel()` creates a `ChannelHandle` backed by a crossbeam unbounded channel — one producer, one consumer (or multiple producers, one consumer via clone). Every `recv()` call removes the message from the queue. This is wrong for SSE: you want every connected browser to receive every metric sample, not one browser to receive each sample in round-robin.
+`channel()` creates a `TxChannelHandle`/`RxChannelHandle` pair backed by a crossbeam unbounded channel — one producer, one consumer (or multiple producers, one consumer via clone). Every `recv()` call removes the message from the queue. This is wrong for SSE: you want every connected browser to receive every metric sample, not one browser to receive each sample in round-robin.
 
 ### The New Primitive: Broadcast Channel
 
@@ -178,13 +184,17 @@ SSE connections die silently when passing through proxies and load balancers tha
 ```
 Browser → GET /metrics/stream
   → Route handler runs (interpreter thread)
-  → subscribe(metrics_bus) → creates crossbeam receiver, registers in BroadcastRegistry
-  → return sse(subscription) → returns SSEResponse token to HTTP layer
-  → HTTP layer spawns write task: poll receiver → write to socket
+  → subscribe(metrics_bus) → creates bounded flume queue (flume::bounded(1024)),
+    registers sender in BROADCAST_REGISTRY, parks the receiver in
+    SUBSCRIPTION_REGISTRY under a fresh subscription_id
+  → return sse(subscription) → BridgeBody::Sse { subscription_id } to HTTP layer
+  → HTTP layer take()s the subscription, spawns write task:
+    recv_async() on the flume receiver → write to socket
   → Route handler exits, interpreter thread free
 
 schedule(500ms) loop (separate thread):
-  → send(metrics_bus, value) → locks BroadcastRegistry, sends to all registered receivers
+  → send(metrics_bus, value) → locks BROADCAST_REGISTRY, evaluates any filter
+    predicates, try_send to each matching subscriber's sender
   → Each write task wakes, reads value, writes SSE event to socket
 ```
 
@@ -196,6 +206,8 @@ schedule(500ms) loop (separate thread):
 
 ```ntnt
 import { broadcast, subscribe, sse } from "std/sse"
+import { send } from "std/concurrent"
+import { now_millis } from "std/time"
 
 // Create a NAMED broadcast channel (module/app level). The name makes the
 // bus process-global: every worker and every hot-reload re-evaluation
@@ -215,7 +227,7 @@ get("/metrics/stream", fn(req) {
 **Types:**
 - `broadcast(name?: String) -> BroadcastHandle` — named: process-global; anonymous: per-worker
 - `subscribe(BroadcastHandle) -> SSESubscription`
-- `send(BroadcastHandle, Map) -> Unit` — reuses existing `send()` dispatch on handle type
+- `send(BroadcastHandle, Map) -> Bool` — reuses existing `send()` dispatch on handle type; returns Bool like channel `send()` (true if the bus had at least one subscriber)
 - `sse(SSESubscription) -> Response` — ordinary response builder (like `json()`/`html()`)
 
 ### Per-Connection Streams (No Shared Bus)
@@ -224,11 +236,14 @@ For streams that are unique per connection — a clock, a personal notification 
 
 ```ntnt
 import { sse_stream } from "std/sse"
+import { now, format } from "std/time"
+import { schedule, cancel_schedule } from "std/concurrent"
+import { job_status } from "std/jobs"
 
 get("/clock", fn(req) {
     return sse_stream(fn(push, on_close) {
         let sched = schedule(1000, fn() {
-            push(map { "time": format_time(now()) })
+            push(map { "time": format(now(), "%H:%M:%S") })
         })
         on_close(fn() { cancel_schedule(sched) })
     })
@@ -240,9 +255,10 @@ get("/jobs/{id}/progress", fn(req) {
         let poll = schedule(500, fn() {
             let status = unwrap(job_status(job_id))
             push(status)
-            if status["status"] in ["completed", "failed", "dead"] {
+            if includes(["completed", "failed", "dead"], status["status"]) {
+                // Terminal event: the browser closes the EventSource on
+                // "done", which fires on_close and cancels the poll
                 push(map { "done": true })
-                // on_close fires automatically when the response ends
             }
         })
         on_close(fn() { cancel_schedule(poll) })
@@ -251,9 +267,15 @@ get("/jobs/{id}/progress", fn(req) {
 ```
 
 `sse_stream(fn(push, on_close))`:
-- `push(value)` — send an event to this connection
+- `push(value)` — send an event to this connection; returns `false` after the client disconnects so generators can stop
 - `on_close(fn)` — register a cleanup callback for when the client disconnects
-- Returns when the connection closes or the handler returns
+- Returns a `Response` immediately, like `sse()` — the handler exits and the connection streams until the client disconnects
+
+> **Implementation note — on_close execution point:** the same constraint as
+> filter predicates applies: an ntnt closure cannot run on the Rust write
+> task. Disconnect is detected in the write task, which enqueues the
+> registered `on_close` callback onto the scheduler's interpreter thread
+> (the same thread that runs `schedule()` callbacks) for execution.
 
 ### Phase 2: Named Events, IDs, Filtering
 
@@ -274,7 +296,7 @@ es.addEventListener('mem_update', e => updateMemChart(JSON.parse(e.data)))
 **Filtering** — create a derived subscription that only passes matching events:
 
 ```ntnt
-import { filter } from "std/sse"
+import { subscribe, filter, sse } from "std/sse"
 
 get("/stream/network/{iface}", fn(req) {
     let iface = req.params.iface
@@ -326,22 +348,27 @@ return sse_stream(fn(push, on_close) { })   // per-connection generator
 ### Compute Dashboard
 
 ```ntnt
-import { broadcast, subscribe } from "std/sse"
+import { broadcast, subscribe, sse } from "std/sse"
+import { html } from "std/http/server"
+import { schedule, send } from "std/concurrent"
+import { now_millis } from "std/time"
+import { read_file } from "std/fs"
 
 let metrics = broadcast("metrics")
 
 // One sampler loop, feeds all connected browser tabs
+// (cpu_percent/mem_used_mb/load_avg are hypothetical samplers)
 schedule(500, fn() {
     send(metrics, map {
         "cpu":    cpu_percent(),
         "mem_mb": mem_used_mb(),
         "load":   load_avg(),
-        "ts":     unix_ms(),
+        "ts":     now_millis(),
     })
 })
 
 get("/dashboard", fn(req) {
-    return file("dashboard.html")
+    return html(read_file("dashboard.html")?)
 })
 
 get("/stream/metrics", fn(req) {
@@ -365,11 +392,15 @@ es.onmessage = e => {
 ### Network Monitoring Dashboard
 
 ```ntnt
-import { broadcast, subscribe, filter } from "std/sse"
+import { broadcast, subscribe, filter, sse } from "std/sse"
+import { schedule, send } from "std/concurrent"
+// std/events is planned, not shipped (DD-037 Phase 7: pub/sub fan-out
+// over the job system) — shown here to illustrate how the layers compose
 import { subscribe as event_subscribe, publish } from "std/events"
 
-let net_metrics = broadcast()
-let net_alerts  = broadcast()
+// Named buses: process-global, shared across workers and hot reloads
+let net_metrics = broadcast("net_metrics")
+let net_alerts  = broadcast("net_alerts")
 
 // Interface sampler
 schedule(1000, fn() {
@@ -403,7 +434,7 @@ get("/stream/network", fn(req) {
 // Per-interface filtered stream
 get("/stream/network/{iface}", fn(req) {
     let iface = req.params.iface
-    return sse(filter(subscribe(net_metrics), fn(m) { m["name"] == iface }))
+    return sse(filter(subscribe(net_metrics), fn(m) { m["interface"] == iface }))
 })
 
 // Alert stream
@@ -426,6 +457,7 @@ The monitoring stack: `schedule` samples → SSE streams live to browsers + `std
 ```ntnt
 import { sse_stream } from "std/sse"
 import { job_status } from "std/jobs"
+import { schedule, cancel_schedule } from "std/concurrent"
 
 get("/jobs/{id}/progress", fn(req) {
     let job_id = req.params.id
@@ -433,6 +465,11 @@ get("/jobs/{id}/progress", fn(req) {
         let poll = schedule(500, fn() {
             let status = unwrap(job_status(job_id))
             push(status)
+            if includes(["completed", "failed", "dead"], status["status"]) {
+                // Terminal event: the browser closes the EventSource on
+                // "done", which fires on_close and cancels the poll
+                push(map { "done": true })
+            }
         })
         on_close(fn() { cancel_schedule(poll) })
     })
@@ -444,11 +481,15 @@ get("/jobs/{id}/progress", fn(req) {
 ### Log Tail
 
 ```ntnt
-import { broadcast, subscribe, filter } from "std/sse"
+import { broadcast, subscribe, filter, sse } from "std/sse"
+import { send } from "std/concurrent"
 
-let log_bus = broadcast()
+let log_bus = broadcast("logs")
 
 // Hook into ntnt's log system (or tail a file)
+// on_log() is illustrative — ntnt has no log-hook API yet; a real
+// version of this example would need one (or a tail-file sampler on
+// schedule())
 on_log(fn(entry) {
     send(log_bus, entry)
 })
@@ -482,9 +523,24 @@ enum BroadcastKey {
 
 struct BroadcastChannel {
     id: u64,
-    senders: Vec<(u64, flume::Sender<BroadcastMessage>)>, // (sender_id, tx)
+    senders: Vec<SubscriberEntry>,
     replay_buffer: Option<VecDeque<BroadcastMessage>>,
     replay_buffer_size: usize,
+}
+
+struct SubscriberEntry {
+    sender_id: u64,
+    tx: flume::Sender<BroadcastMessage>,
+    // Phase 2: set by filter(sub, pred). The predicate is an ntnt closure;
+    // it is evaluated at send() fan-out time on the publishing interpreter
+    // thread (the write task never runs interpreter code).
+    filter: Option<FilterPredicate>,
+}
+
+// Phase 2. Wraps the ntnt closure Value (and its captured environment)
+// so send() fan-out can evaluate it on the publishing interpreter thread.
+struct FilterPredicate {
+    closure: Value, // Value::Function — predicate fn(Map) -> Bool
 }
 
 // Holds a subscription between the interpreter returning
@@ -508,13 +564,17 @@ struct BroadcastMessage {
 
 `send(bc, value)`:
 1. Serialize `Value` → `SerializedValue`
-2. Lock registry, get `BroadcastChannel`
+2. Lock registry, look up the `BroadcastChannel` by the handle's
+   `BroadcastKey`
 3. Append to replay buffer if configured
-4. `try_send` to each sender; on `Disconnected` (receiver dropped) →
-   remove that sender from the list; on `Full` → apply the queue policy
-   (default: pop the oldest event and retry, warn deduped per subscriber;
-   `"drop_slow": false`: block briefly instead)
-5. Drop lock
+4. For each `SubscriberEntry`: if `filter` is set, evaluate the predicate
+   against the value (we are on the publishing interpreter thread, so
+   ntnt closures are evaluable here) and skip non-matching subscribers
+5. `try_send` to each remaining sender; on `Disconnected` (receiver
+   dropped) → remove that entry from the list; on `Full` → apply the
+   queue policy (default: pop the oldest event and retry, warn deduped
+   per subscriber; `"drop_slow": false`: block briefly instead)
+6. Drop lock
 
 `subscribe(bc)`:
 1. Create a new `flume::bounded(1024)` pair — flume so the Axum write task
@@ -524,7 +584,10 @@ struct BroadcastMessage {
    with a deduped warn (unless the bus was created with
    `"drop_slow": false`, which opts into briefly-blocking sends)
 2. Allocate a fresh `sender_id`; lock the broadcast registry, push
-   `(sender_id, sender)` into `BroadcastChannel.senders`, drop the lock
+   `SubscriberEntry { sender_id, tx: sender, filter: None }` into
+   `BroadcastChannel.senders`, drop the lock. (Phase 2's `filter(sub,
+   pred)` later sets `filter` on this entry, located by `channel_key` +
+   `sender_id`.)
 3. Insert `SseSubscription { receiver, channel_key, sender_id }` into
    `SUBSCRIPTION_REGISTRY` under a fresh `subscription_id` — this is the
    bridge handoff: the Axum handler later `take()`s this entry
@@ -592,8 +655,10 @@ fn format_sse_event(msg: &BroadcastMessage) -> Bytes {
 ```rust
 enum Value {
     // ... existing variants ...
-    BroadcastHandle(u64),
-    SSESubscription(u64),
+    BroadcastHandle(BroadcastKey), // carries the registry key, so send()
+                                   // can address named and anonymous
+                                   // buses uniformly
+    SSESubscription(u64),          // subscription_id into SUBSCRIPTION_REGISTRY
 }
 ```
 
@@ -608,7 +673,7 @@ sig!("subscribe", ["handle" => Type::Named("BroadcastHandle".to_string())], Type
 sig!("filter", ["sub" => Type::Named("SSESubscription".to_string()), "pred" => Type::Any], Type::Named("SSESubscription".to_string()));
 sig!("connection_count", ["handle" => Type::Named("BroadcastHandle".to_string())], Type::Int);
 // Both builders return Response, same as json()/html(), so middleware
-// and with_header() compose without special cases
+// and enable_cors() compose without special cases
 sig!("sse", ["sub" => Type::Named("SSESubscription".to_string())], Type::Named("Response".to_string()));
 sig!("sse_stream", ["handler" => Type::Any], Type::Named("Response".to_string()));
 ```
@@ -630,18 +695,19 @@ untouched.
 
 **Estimated effort:** 3-4 days
 
-- [ ] `Value::BroadcastHandle(u64)` and `Value::SSESubscription(u64)` variants
+- [ ] `Value::BroadcastHandle(BroadcastKey)` and `Value::SSESubscription(u64)` variants
 - [ ] `BroadcastRegistry` global, keyed by name for named buses (Design Review: shared across workers and hot reloads) — LazyLock, same pattern as the pool registry
 - [ ] `broadcast(name?) -> BroadcastHandle` — named form is the documented default; anonymous form is per-worker
-- [ ] `subscribe(BroadcastHandle) -> SSESubscription` — bounded per-subscriber queue (1024), drop-oldest with deduped warn; `"drop_slow": false` opts into blocking
-- [ ] `send(BroadcastHandle, value)` — dispatches on handle type (reuse existing `send`)
+- [ ] `subscribe(BroadcastHandle) -> SSESubscription` — bounded per-subscriber queue (1024), drop-oldest with deduped warn (the `"drop_slow": false` blocking opt-in arrives with `opts?` in Phase 2)
+- [ ] `send(BroadcastHandle, value) -> Bool` — dispatches on handle type (existing channel `send` is arity-2 and returns Bool; the broadcast arm keeps that contract. Phase 2's 3-arg named-event form widens `max_arity`)
 - [ ] `sse(SSESubscription) -> Response` — response BUILDER returned from a normal handler (there is no `respond` keyword; zero parser work)
 - [ ] `BridgeBody::Sse { subscription_id }` variant on the bridge response; Axum layer builds the streaming body when it sees it (Design Review item)
-- [ ] `schedule()` registers only outside Worker mode, so module-level samplers run once, not once per worker (Design Review item; own release note)
+- [ ] Multi-worker integration test: sampler registers once on the primary (the existing `RuntimeCapability::Scheduling` gate — no new code), subscribers connect via workers, each event arrives exactly once per subscriber
 - [ ] SSE write loop in Rust: format events, keep-alive pings, disconnect cleanup
 - [ ] Sender cleanup on subscriber disconnect
 - [ ] `sse_stream(fn(push, on_close))` — per-connection callback form; `push()` returns Bool (false after disconnect)
 - [ ] `connection_count(BroadcastHandle) -> Int`
+- [ ] `enable_cors()` headers apply to SSE responses — headers are set before the stream body begins (see Security)
 - [ ] Typechecker signatures
 - [ ] `// @ntnt` doc blocks on all functions
 - [ ] `ntnt docs --generate`
@@ -666,26 +732,32 @@ untouched.
 
 - [ ] SSE-aware middleware — auth runs before SSE connection is established
 - [ ] `max_connections: N` option on `broadcast()` — reject new subscribers over limit (429)
-- [ ] Slow consumer detection: if a subscriber's buffer backs up > threshold, emit warning or drop
-- [ ] `X-Accel-Buffering: no` header set automatically (nginx/Cloudflare compat)
+- [ ] Slow-consumer observability: expose per-subscriber drop counts (the drop policy itself ships in Phase 1: bounded queue, drop-oldest with deduped warn)
 - [ ] `ntnt jobs`-style: `ntnt sse status server.tnt` — list active broadcast channels + connection counts
-- [ ] CORS headers for cross-origin SSE (configurable)
 
 ---
 
 ## Relationship to std/events and std/jobs
 
-These three modules are complementary, not competing. Each operates at a different layer:
+These three modules are complementary, not competing (`std/events` is
+planned, not shipped — DD-037 Phase 7). Each operates at a different
+layer:
 
 | Module | Layer | Transport | Latency | Use for |
 |--------|-------|-----------|---------|---------|
 | `std/jobs` | Background work | KV (SQLite/Redis) | Seconds | Email, cleanup, processing |
-| `std/events` | Application events → jobs | In-process (or Redis pub/sub) | ~ms | "When X happens, run these jobs" |
+| `std/events` (planned — DD-037 Phase 7) | Application events → jobs | In-process (or Redis pub/sub) | ~ms | "When X happens, run these jobs" |
 | `std/sse` | Browser push | HTTP (SSE) | ~ms | Live metrics, dashboards, progress |
 
 They compose naturally:
 
 ```ntnt
+import { broadcast, sse } from "std/sse"
+import { schedule, send } from "std/concurrent"
+import { subscribe as event_subscribe, publish } from "std/events"  // planned (DD-037 Phase 7)
+
+let metrics_bus = broadcast("metrics")
+
 // Sampler fires jobs + pushes to SSE simultaneously
 schedule(500, fn() {
     let m = sample_metrics()
@@ -696,9 +768,10 @@ schedule(500, fn() {
     }
 })
 
-// Job handles the durable response
-subscribe("cpu_critical", "SendPagerAlert")     // std/events wiring
-subscribe("cpu_critical", "LogIncident")
+// Job handles the durable response (std/events subscribe imported as
+// event_subscribe to avoid colliding with std/sse subscribe)
+event_subscribe("cpu_critical", "SendPagerAlert")
+event_subscribe("cpu_critical", "LogIncident")
 ```
 
 Real-time display: `std/sse`. Durable alerting: `std/events` + `std/jobs`.
@@ -710,31 +783,42 @@ Real-time display: `std/sse`. Durable alerting: `std/events` + `std/jobs`.
 **SSE endpoints go through normal route middleware** — no special cases. Auth middleware added to a route group applies to SSE endpoints in that group:
 
 ```ntnt
+import { broadcast, subscribe, sse } from "std/sse"
+import { html, status } from "std/http/server"
+import { starts_with } from "std/string"
+import { read_file } from "std/fs"
+
+let metrics_bus = broadcast("metrics")
+
 // Middleware short-circuits before the SSE connection is established
+// (is_admin is a hypothetical app-level helper)
 use_middleware(fn(req) {
     if starts_with(req.path, "/dashboard") && !is_admin(req) {
         return status(403, "Forbidden")
     }
 })
 
-get("/dashboard", fn(req) { return file("dashboard.html") })
+get("/dashboard", fn(req) { return html(read_file("dashboard.html")?) })
 get("/dashboard/stream", fn(req) { return sse(subscribe(metrics_bus)) })
 ```
 
 The middleware runs before the SSE connection is established. If the middleware rejects the request (401, 403), the SSE connection is never opened. This is correct — you don't want to establish the connection and then reject it.
 
-**CORS:** If the SSE endpoint is consumed from a different origin (e.g. a static frontend), add CORS headers with `with_header` — the same mechanism as any other response:
+**CORS:** If the SSE endpoint is consumed from a different origin (e.g. a static frontend), enable CORS the same way as for any other route — the existing `enable_cors()` server action (a global builtin, like the route functions) applies to SSE responses too:
 
 ```ntnt
-import { with_header } from "std/http/server"
+import { broadcast, subscribe, sse } from "std/sse"
+
+let metrics_bus = broadcast("metrics")
+
+enable_cors(map { "origins": ["https://app.example.com"] })
 
 get("/stream/metrics", fn(req) {
-    let resp = sse(subscribe(metrics_bus))
-    return with_header(resp, "Access-Control-Allow-Origin", "https://app.example.com")
+    return sse(subscribe(metrics_bus))
 })
 ```
 
-(Phase 1 must ensure `with_header` composes with the SSE response type — headers are set before the stream body begins.)
+(Phase 1 must ensure the CORS layer applies its headers to `BridgeBody::Sse` responses — headers are set before the stream body begins.)
 
 **Rate limiting:** Handled at the route level, same as any other route. `max_connections` on `broadcast()` caps total subscribers regardless of auth status.
 
@@ -761,12 +845,12 @@ ntnt's advantage: the sampler (`schedule`), the bus (`broadcast`), and the endpo
 
 ## Open Questions
 
-All resolved by the 2026-07-08 Design Review (decisions recorded there and
+All resolved as of the 2026-07-08 Design Review (resolutions below,
 reconciled into the body):
 
 | Question | Resolution |
 |----------|------------|
-| Broadcast backing implementation | Custom `Vec<Sender>` per bus, crossbeam-consistent — with BOUNDED per-subscriber queues (1024) |
+| Broadcast backing implementation | Custom `Vec<SubscriberEntry>` per bus, flume-backed — with BOUNDED per-subscriber queues (1024) |
 | `send()` overload on BroadcastHandle | Reuse existing `send()` dispatch on handle type |
 | `drop_slow` default | Drop-oldest with deduped warn (default); `"drop_slow": false` opts into briefly-blocking sends |
 | `sse_stream` cleanup model | `on_close(fn)` callback |
@@ -782,4 +866,4 @@ reconciled into the body):
 | Date | Change |
 |------|--------|
 | 2026-03-17 | Initial draft — vision, architecture, full API, three phases, implementation notes |
-| 2026-07-08 | Design review against current main: response-builder API (no `respond` keyword), `BridgeBody::Sse` bridge variant, named process-global broadcasts, Worker-mode `schedule()` gate, bounded drop-oldest subscriber queues; body reconciled end to end |
+| 2026-07-08 | Design review against current main: response-builder API (no `respond` keyword), `BridgeBody::Sse` bridge variant, named process-global broadcasts, bounded drop-oldest subscriber queues; verified the Worker-mode `schedule()` gate already exists (no change needed); body reconciled end to end |

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -284,7 +284,7 @@ get("/stream/network/{iface}", fn(req) {
 
 `filter(SSESubscription, fn(Map) -> Bool) -> SSESubscription`
 
-Filtering happens server-side before writing to the socket — non-matching events are dropped, never sent over the wire.
+Filtering happens server-side before writing to the socket — non-matching events are dropped, never sent over the wire. Execution point: the predicate is an ntnt closure, which the Rust write task cannot evaluate — so filtered subscriptions register their predicate with the bus and it runs at `send()` fan-out time, on the sending interpreter thread. The write task stays interpreter-free (the zero-overhead property holds); the cost of filtering lands on the publisher, proportional to filtered subscribers.
 
 **Event IDs and reconnect:**
 
@@ -510,7 +510,10 @@ struct BroadcastMessage {
 1. Serialize `Value` → `SerializedValue`
 2. Lock registry, get `BroadcastChannel`
 3. Append to replay buffer if configured
-4. Send to each sender; on `SendError` (receiver dropped) → remove that sender from the list
+4. `try_send` to each sender; on `Disconnected` (receiver dropped) →
+   remove that sender from the list; on `Full` → apply the queue policy
+   (default: pop the oldest event and retry, warn deduped per subscriber;
+   `"drop_slow": false`: block briefly instead)
 5. Drop lock
 
 `subscribe(bc)`:
@@ -520,10 +523,14 @@ struct BroadcastMessage {
    is slow-motion OOM. On a full queue the send policy is drop-oldest
    with a deduped warn (unless the bus was created with
    `"drop_slow": false`, which opts into briefly-blocking sends)
-2. Lock registry, push `sender` into `BroadcastChannel.senders`
-3. Wrap `receiver` in `SSESubscription { receiver, channel_id, last_event_id: None }`
-4. Drop lock
-5. Return `Value::SSESubscription(id)` to ntnt
+2. Allocate a fresh `sender_id`; lock the broadcast registry, push
+   `(sender_id, sender)` into `BroadcastChannel.senders`, drop the lock
+3. Insert `SseSubscription { receiver, channel_key, sender_id }` into
+   `SUBSCRIPTION_REGISTRY` under a fresh `subscription_id` — this is the
+   bridge handoff: the Axum handler later `take()`s this entry
+4. Return `Value::SSESubscription(subscription_id)` to ntnt; the handler
+   returns it through `sse()`, which carries the id to the HTTP layer as
+   `BridgeBody::Sse { subscription_id }`
 
 ### SSE Response Handler (Rust HTTP Layer)
 
@@ -541,7 +548,7 @@ async fn sse_handler(subscription_id: u64, req: Request) -> Response {
                 _ = keepalive.tick() => {
                     yield Ok(Bytes::from(":\n\n"));  // SSE comment = keep-alive
                 }
-                msg = subscription.recv_async() => {
+                msg = subscription.receiver.recv_async() => {
                     match msg {
                         Ok(m) => yield Ok(format_sse_event(&m)),
                         Err(_) => break,  // broadcast channel dropped
@@ -551,8 +558,8 @@ async fn sse_handler(subscription_id: u64, req: Request) -> Response {
             }
         }
 
-        // Cleanup: remove sender from broadcast registry
-        BROADCAST_REGISTRY.lock().remove_sender(subscription.channel_id, &subscription.sender_id);
+        // Cleanup: remove this subscriber's sender from the broadcast registry
+        BROADCAST_REGISTRY.lock().remove_sender(&subscription.channel_key, subscription.sender_id);
     });
 
     Response::builder()

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -95,11 +95,15 @@ Resolution, now part of Phase 1:
 
 **Open questions resolved (recommendations):**
 
-- Backing: custom `Vec<flume::Sender>` per bus — flume is already a
-  dependency (the request bridge uses it) and, unlike crossbeam, supports
-  BOTH sync sends from interpreter threads and `recv_async()` in the Axum
-  write task. Per-subscriber queues are **bounded** (e.g. 1024) rather
-  than unbounded: a stuck TCP connection with an unbounded queue is
+- Backing: each subscriber gets a **bounded ring buffer**
+  (`Arc<Mutex<VecDeque>>`, cap ~1024) plus a coalescing flume `bounded(1)`
+  wake signal. The ring — not a channel — is required because the default
+  policy is drop-**oldest** (evict the stalest event so a slow client
+  catches up to *now*), and neither flume nor crossbeam lets the sending
+  end pop the oldest queued item; only the receiver drains. flume carries
+  the payload-free wake so the Axum write task can `recv_async()` (flume
+  is already a bridge dependency; crossbeam has no async recv). Bounded
+  rather than unbounded: a stuck TCP connection with an unbounded queue is
   slow-motion OOM.
   Default policy drop-oldest with a deduped warn; `"drop_slow": false`
   opts into blocking sends for correctness-critical streams.
@@ -145,7 +149,7 @@ schedule(500ms) → send(metrics_bus) → [N browser connections] each subscribe
 
 ### The New Primitive: Broadcast Channel
 
-`broadcast()` creates a broadcast channel backed by a multi-sender, multi-receiver bus. Each subscriber gets their own bounded flume receiver that receives a copy of every message sent to the bus. Messages are not consumed — they're fanned out.
+`broadcast()` creates a broadcast channel backed by a fan-out bus. Each subscriber gets their own bounded per-connection queue that receives a copy of every message sent to the bus. Messages are not consumed by one subscriber at the expense of others — they're fanned out.
 
 ```
 broadcast_channel
@@ -159,9 +163,9 @@ send(bc, value) → all three subscribers receive a copy
 **Implementation options (see Open Questions):**
 - `bus` crate — lock-free SPMC broadcast, fastest, single-producer only
 - `tokio::sync::broadcast` — MPMC, has lag/drop semantics, skip-behind
-- Custom: Vec of flume senders, new sender added per subscriber, clean up on disconnect
+- Custom: per-subscriber bounded ring buffer + coalescing wake signal, added per subscriber, cleaned up on disconnect
 
-The custom approach (Vec of senders) won — see the Design Review: flume is already the bridge's channel library and its receivers support `recv_async()` in the Axum write task, which crossbeam receivers do not.
+The custom approach won — see the Design Review. A ring buffer (not a channel) is needed because the default backpressure policy is drop-**oldest**, a sender-side eviction that channels don't allow; a payload-free flume `bounded(1)` wake lets the Axum write task `recv_async()` and then drain (flume is already the bridge's library; crossbeam has no async recv).
 
 ### How the `sse()` Response Works
 
@@ -169,7 +173,7 @@ When a route handler returns `sse(subscription)`:
 
 1. The Rust HTTP layer recognizes the SSE response type.
 2. It sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, connection stays open.
-3. A Rust task (not an interpreter thread) awaits the subscription's flume receiver (`recv_async()`) in a loop, formatting each `Value` as an SSE event and writing to the HTTP response body.
+3. A Rust task (not an interpreter thread) awaits the subscription's wake signal (`recv_async()`), then drains the per-connection ring buffer, formatting each `Value` as an SSE event and writing to the HTTP response body.
 4. When the client disconnects, the write fails, the loop exits, and the subscription is dropped — which removes this subscriber from the broadcast channel's sender list.
 5. The interpreter thread is free after returning the SSE response token. It does not block.
 
@@ -184,19 +188,20 @@ SSE connections die silently when passing through proxies and load balancers tha
 ```
 Browser → GET /metrics/stream
   → Route handler runs (interpreter thread)
-  → subscribe(metrics_bus) → creates bounded flume queue (flume::bounded(1024)),
-    registers sender in BROADCAST_REGISTRY, parks the receiver in
-    SUBSCRIPTION_REGISTRY under a fresh subscription_id
+  → subscribe(metrics_bus) → creates bounded ring buffer + wake signal,
+    registers the entry in BROADCAST_REGISTRY, parks the subscription
+    (ring + wake receiver) in SUBSCRIPTION_REGISTRY under a subscription_id
   → return sse(subscription) → BridgeBody::Sse { subscription_id } to HTTP layer
   → HTTP layer take()s the subscription, spawns write task:
-    recv_async() on the flume receiver → write to socket
+    recv_async() on the wake signal → drain ring buffer → write to socket
   → Route handler exits, interpreter thread free
 
 schedule(500ms) loop (separate thread):
   → send(metrics_bus, value) → briefly locks BROADCAST_REGISTRY to snapshot
     the subscriber list, then (outside the lock) evaluates any filter
-    predicates and try_sends to each matching subscriber's sender
-  → Each write task wakes, reads value, writes SSE event to socket
+    predicates and, per subscriber, enqueues into the ring (drop-oldest if
+    full) and signals its wake
+  → Each write task wakes, drains the ring, writes SSE events to socket
 ```
 
 ---
@@ -277,6 +282,22 @@ get("/jobs/{id}/progress", fn(req) {
 > task. Disconnect is detected in the write task, which enqueues the
 > registered `on_close` callback onto the scheduler's interpreter thread
 > (the same thread that runs `schedule()` callbacks) for execution.
+
+> **Implementation note — the generator runs in a scheduling-capable
+> context, NOT the worker request scope.** A route handler executes on a
+> worker interpreter, and Worker mode deliberately lacks
+> `RuntimeCapability::Scheduling` — so a bare `schedule()` in a worker
+> handler is silently skipped. That gate exists to stop *module-level*
+> samplers from registering N times (once per worker) during program
+> load; it must NOT disable per-connection timers, or the clock and
+> progress-bar streams above would silently never tick under multi-worker.
+> Resolution: `sse_stream` hands the generator off (like the `sse()`
+> subscription handoff) to run in a per-connection execution scope that
+> grants `Scheduling`. `schedule()`/`cancel_schedule()` inside the
+> generator therefore register normally, and the cardinality is correct by
+> construction — one timer per open connection, not one per worker. (A
+> module-level `schedule()` at app top level is still skipped on workers,
+> unchanged.)
 
 ### Phase 2: Named Events, IDs, Filtering
 
@@ -531,7 +552,14 @@ struct BroadcastChannel {
 
 struct SubscriberEntry {
     sender_id: u64,
-    tx: flume::Sender<BroadcastMessage>,
+    // Per-subscriber bounded ring buffer. Drop-oldest is a SENDER-side
+    // eviction (pop_front on overflow), which a flume/crossbeam channel
+    // cannot do from the sending end — so the queue is an explicit
+    // VecDeque under a Mutex, and `wake` is a coalescing signal that tells
+    // the write task "drain me" without carrying the payload.
+    queue: Arc<Mutex<VecDeque<BroadcastMessage>>>, // cap = queue_size (1024)
+    wake: flume::Sender<()>,                        // bounded(1), coalescing
+    queue_size: usize,
     // Phase 2: set by filter(sub, pred). The predicate is an ntnt closure;
     // it is evaluated at send() fan-out time on the publishing interpreter
     // thread (the write task never runs interpreter code).
@@ -551,7 +579,8 @@ struct FilterPredicate {
 static SUBSCRIPTION_REGISTRY: LazyLock<Mutex<HashMap<u64, SseSubscription>>> = ...;
 
 struct SseSubscription {
-    receiver: flume::Receiver<BroadcastMessage>,
+    queue: Arc<Mutex<VecDeque<BroadcastMessage>>>, // SAME Arc as the entry
+    wake_rx: flume::Receiver<()>,                  // write task awaits this
     channel_key: BroadcastKey, // for sender cleanup on disconnect
     sender_id: u64,
 }
@@ -567,40 +596,54 @@ struct BroadcastMessage {
 1. Serialize `Value` → `SerializedValue`
 2. Lock registry, look up the `BroadcastChannel` by the handle's
    `BroadcastKey`; append to replay buffer if configured; **snapshot the
-   subscriber list** (clone each entry's `flume::Sender` — cheap, it's an
-   Arc internally — plus `sender_id` and filter handle); drop the lock
+   subscriber list** (clone each entry's `queue` Arc and `wake` Sender —
+   both cheap, they're Arc-backed — plus `sender_id` and filter handle);
+   drop the lock
 3. Outside the lock, for each snapshot entry: if `filter` is set,
    evaluate the predicate against the value (we are on the publishing
    interpreter thread, so ntnt closures are evaluable here) and skip
    non-matching subscribers
-4. `try_send` to each remaining sender; on `Full` → apply the queue
-   policy (default: pop the oldest event and retry, warn deduped per
-   subscriber; `"drop_slow": false`: block briefly instead); collect the
-   `sender_id` of any `Disconnected` sender (receiver dropped)
-5. If any senders were dead, re-lock the registry briefly and remove
+4. For each remaining entry, enqueue with drop-oldest: lock the entry's
+   `queue`; if `queue.len() == queue_size`, `pop_front()` (drop the oldest
+   unsent event, warn deduped per subscriber) — unless the bus was created
+   with `"drop_slow": false`, which instead waits briefly for the write
+   task to drain (Phase 2); `push_back(message)`; unlock; then
+   `wake.try_send(())` and ignore a `Full` result (a pending wake already
+   means "drain"). A `Disconnected` wake receiver means the write task is
+   gone → collect this `sender_id` for cleanup.
+5. If any subscribers were dead, re-lock the registry briefly and remove
    those entries
 
-Predicates and sends run OUTSIDE the registry lock deliberately:
+Drop-oldest is a sender-side eviction, so the per-subscriber queue must be
+an explicit `Mutex<VecDeque>`, not a channel: neither flume nor crossbeam
+lets the sending end pop the oldest queued item (only the receiver drains).
+The `wake` channel carries no payload — it is a coalescing "data ready"
+signal (`bounded(1)`), so the write task can `recv_async()` on it and then
+drain the deque.
+
+Predicates and enqueues run OUTSIDE the registry lock deliberately:
 `std::sync::Mutex` is non-reentrant, so a filter predicate that itself
 calls `send()` (or `subscribe()`/`broadcast()`) would deadlock if the
-lock were held across evaluation. With the snapshot approach, re-entrant
-`send()` from a predicate simply takes the lock afresh and works;
-recursion depth is bounded by user code. The cost is benign staleness: a
-subscriber added or removed mid-send catches the next event.
+registry lock were held across evaluation. With the snapshot approach,
+re-entrant `send()` from a predicate simply takes the registry lock afresh
+and works; recursion depth is bounded by user code. The cost is benign
+staleness: a subscriber added or removed mid-send catches the next event.
 
 `subscribe(bc)`:
-1. Create a new `flume::bounded(1024)` pair — flume so the Axum write task
-   can `recv_async()` (crossbeam receivers have no async recv); bounded
-   per the Design Review: a stuck TCP connection with an unbounded queue
-   is slow-motion OOM. On a full queue the send policy is drop-oldest
-   with a deduped warn (unless the bus was created with
-   `"drop_slow": false`, which opts into briefly-blocking sends)
+1. Create the per-subscriber queue — `Arc<Mutex<VecDeque>>` capped at
+   `queue_size` (default 1024) — and a `flume::bounded::<()>(1)` wake pair.
+   Bounded per the Design Review: a stuck TCP connection with an unbounded
+   queue is slow-motion OOM. The wake channel is flume so the Axum write
+   task can `recv_async()` on it (crossbeam has no async recv). On a full
+   queue the policy is drop-oldest with a deduped warn (unless the bus was
+   created with `"drop_slow": false`, which opts into briefly-blocking
+   sends — Phase 2).
 2. Allocate a fresh `sender_id`; lock the broadcast registry, push
-   `SubscriberEntry { sender_id, tx: sender, filter: None }` into
-   `BroadcastChannel.senders`, drop the lock. (Phase 2's `filter(sub,
-   pred)` later sets `filter` on this entry, located by `channel_key` +
-   `sender_id`.)
-3. Insert `SseSubscription { receiver, channel_key, sender_id }` into
+   `SubscriberEntry { sender_id, queue: queue.clone(), wake: wake_tx,
+   queue_size, filter: None }` into `BroadcastChannel.senders`, drop the
+   lock. (Phase 2's `filter(sub, pred)` later sets `filter` on this entry,
+   located by `channel_key` + `sender_id`.)
+3. Insert `SseSubscription { queue, wake_rx, channel_key, sender_id }` into
    `SUBSCRIPTION_REGISTRY` under a fresh `subscription_id` — this is the
    bridge handoff: the Axum handler later `take()`s this entry
 4. Return `Value::SSESubscription(subscription_id)` to ntnt; the handler
@@ -623,17 +666,24 @@ async fn sse_handler(subscription_id: u64, req: Request) -> Response {
                 _ = keepalive.tick() => {
                     yield Ok(Bytes::from(":\n\n"));  // SSE comment = keep-alive
                 }
-                msg = subscription.receiver.recv_async() => {
-                    match msg {
-                        Ok(m) => yield Ok(format_sse_event(&m)),
-                        Err(_) => break,  // broadcast channel dropped
+                woken = subscription.wake_rx.recv_async() => {
+                    if woken.is_err() { break; } // all senders dropped
+                    // Drain everything currently queued (drop-oldest means
+                    // the deque already holds only the freshest queue_size
+                    // events). Hold the lock only to move messages out.
+                    let batch: Vec<BroadcastMessage> = {
+                        let mut q = subscription.queue.lock();
+                        q.drain(..).collect()
+                    };
+                    for m in batch {
+                        yield Ok(format_sse_event(&m));
                     }
                 }
                 _ = req.closed() => break,  // client disconnected
             }
         }
 
-        // Cleanup: remove this subscriber's sender from the broadcast registry
+        // Cleanup: remove this subscriber from the broadcast registry
         BROADCAST_REGISTRY.lock().remove_sender(&subscription.channel_key, subscription.sender_id);
     });
 
@@ -710,7 +760,7 @@ untouched.
 - [ ] `Value::BroadcastHandle(BroadcastKey)` and `Value::SSESubscription(u64)` variants
 - [ ] `BroadcastRegistry` global, keyed by name for named buses (Design Review: shared across workers and hot reloads) — LazyLock, same pattern as the pool registry
 - [ ] `broadcast(name?) -> BroadcastHandle` — named form is the documented default; anonymous form is per-worker
-- [ ] `subscribe(BroadcastHandle) -> SSESubscription` — bounded per-subscriber queue (1024), drop-oldest with deduped warn (the `"drop_slow": false` blocking opt-in arrives with `opts?` in Phase 2)
+- [ ] `subscribe(BroadcastHandle) -> SSESubscription` — per-subscriber bounded ring buffer (`Arc<Mutex<VecDeque>>`, cap 1024) + coalescing `flume::bounded(1)` wake; drop-oldest on overflow with deduped warn (the `"drop_slow": false` blocking opt-in arrives with `opts?` in Phase 2). Ring, not a channel: drop-oldest is a sender-side eviction channels can't do
 - [ ] `send(BroadcastHandle, value) -> Bool` — dispatches on handle type (existing channel `send` is arity-2 and returns Bool; the broadcast arm keeps that contract. Phase 2's 3-arg named-event form widens `max_arity`)
 - [ ] `sse(SSESubscription) -> Response` — response BUILDER returned from a normal handler (there is no `respond` keyword; zero parser work)
 - [ ] `BridgeBody::Sse { subscription_id }` variant on the bridge response; Axum layer builds the streaming body when it sees it (Design Review item)
@@ -718,6 +768,7 @@ untouched.
 - [ ] SSE write loop in Rust: format events, keep-alive pings, disconnect cleanup
 - [ ] Sender cleanup on subscriber disconnect
 - [ ] `sse_stream(fn(push, on_close))` — per-connection callback form; `push()` returns Bool (false after disconnect)
+- [ ] `sse_stream` generator runs in a scheduling-capable per-connection scope (handed off from the worker), so `schedule()`/`cancel_schedule()` inside it register per connection instead of being skipped by the Worker capability gate — with a multi-worker test that a per-connection timer actually ticks when the request was served by a worker
 - [ ] `connection_count(BroadcastHandle) -> Int`
 - [ ] `enable_cors()` headers apply to SSE responses — headers are set before the stream body begins (see Security)
 - [ ] Typechecker signatures
@@ -862,7 +913,7 @@ reconciled into the body):
 
 | Question | Resolution |
 |----------|------------|
-| Broadcast backing implementation | Custom `Vec<SubscriberEntry>` per bus, flume-backed — with BOUNDED per-subscriber queues (1024) |
+| Broadcast backing implementation | Custom `Vec<SubscriberEntry>` per bus; each subscriber has a BOUNDED ring buffer (1024, drop-oldest) + a coalescing flume wake signal |
 | `send()` overload on BroadcastHandle | Reuse existing `send()` dispatch on handle type |
 | `drop_slow` default | Drop-oldest with deduped warn (default); `"drop_slow": false` opts into briefly-blocking sends |
 | `sse_stream` cleanup model | `on_close(fn)` callback |
@@ -878,4 +929,4 @@ reconciled into the body):
 | Date | Change |
 |------|--------|
 | 2026-03-17 | Initial draft — vision, architecture, full API, three phases, implementation notes |
-| 2026-07-08 | Design review against current main: response-builder API (no `respond` keyword), `BridgeBody::Sse` bridge variant, named process-global broadcasts, bounded drop-oldest subscriber queues; verified the Worker-mode `schedule()` gate already exists (no change needed); body reconciled end to end |
+| 2026-07-08 | Design review against current main: response-builder API (no `respond` keyword), `BridgeBody::Sse` bridge variant, named process-global broadcasts; per-subscriber bounded ring buffer + wake signal (drop-oldest needs sender-side eviction, which a channel can't do); `sse_stream` generators run in a scheduling-capable per-connection scope so per-connection timers work under multi-worker; verified the module-level Worker `schedule()` gate already exists; body reconciled end to end |

--- a/design-docs/dd-041-sse-streaming.md
+++ b/design-docs/dd-041-sse-streaming.md
@@ -277,27 +277,36 @@ get("/jobs/{id}/progress", fn(req) {
 - `on_close(fn)` — register a cleanup callback for when the client disconnects
 - Returns a `Response` immediately, like `sse()` — the handler exits and the connection streams until the client disconnects
 
-> **Implementation note — on_close execution point:** the same constraint as
-> filter predicates applies: an ntnt closure cannot run on the Rust write
-> task. Disconnect is detected in the write task, which enqueues the
-> registered `on_close` callback onto the scheduler's interpreter thread
-> (the same thread that runs `schedule()` callbacks) for execution.
+The exact handoff — how the generator closure reaches a scheduling-capable
+interpreter, and where `push`/`on_close` run — is specified in
+Implementation Notes (`sse_stream(generator)` and `sse_handler`). The key
+points:
 
-> **Implementation note — the generator runs in a scheduling-capable
-> context, NOT the worker request scope.** A route handler executes on a
-> worker interpreter, and Worker mode deliberately lacks
-> `RuntimeCapability::Scheduling` — so a bare `schedule()` in a worker
-> handler is silently skipped. That gate exists to stop *module-level*
-> samplers from registering N times (once per worker) during program
-> load; it must NOT disable per-connection timers, or the clock and
-> progress-bar streams above would silently never tick under multi-worker.
-> Resolution: `sse_stream` hands the generator off (like the `sse()`
-> subscription handoff) to run in a per-connection execution scope that
-> grants `Scheduling`. `schedule()`/`cancel_schedule()` inside the
-> generator therefore register normally, and the cardinality is correct by
+> **The generator runs in a fresh scheduling-capable interpreter, NOT the
+> worker request scope.** A route handler executes on a worker interpreter,
+> and Worker mode deliberately lacks `RuntimeCapability::Scheduling` — so a
+> bare `schedule()` in a worker handler is silently skipped. That gate
+> exists to stop *module-level* samplers from registering N times (once per
+> worker) during program load; it must NOT disable per-connection timers,
+> or the clock and progress-bar streams above would silently never tick
+> under multi-worker. Resolution: `sse_stream` parks the captured generator
+> in `SUBSCRIPTION_REGISTRY` (identical bridge handoff to `sse()`); when the
+> write task starts, it runs the generator ONCE via the same
+> `run_in_fresh_interpreter` path `schedule()` ticks already use, in a mode
+> that grants `Scheduling`. So `schedule()`/`cancel_schedule()` inside the
+> generator register normally, and the cardinality is correct by
 > construction — one timer per open connection, not one per worker. (A
 > module-level `schedule()` at app top level is still skipped on workers,
 > unchanged.)
+
+> **on_close runs in a fresh interpreter too, not a persistent "scheduler
+> thread."** `schedule()` has no long-lived interpreter — each tick is a
+> fresh interpreter built from the captured closure (`run_in_fresh_interpreter`).
+> On disconnect, the write task likewise runs the registered `on_close`
+> closure in a fresh interpreter; because `ScheduleHandle` is a process-global
+> id, the `cancel_schedule(sched)` inside `on_close` cancels the
+> per-connection timer even though it was registered from a different
+> (also fresh) interpreter.
 
 ### Phase 2: Named Events, IDs, Filtering
 
@@ -579,10 +588,25 @@ struct FilterPredicate {
 static SUBSCRIPTION_REGISTRY: LazyLock<Mutex<HashMap<u64, SseSubscription>>> = ...;
 
 struct SseSubscription {
-    queue: Arc<Mutex<VecDeque<BroadcastMessage>>>, // SAME Arc as the entry
+    queue: Arc<Mutex<VecDeque<BroadcastMessage>>>, // the ring the write task drains
     wake_rx: flume::Receiver<()>,                  // write task awaits this
-    channel_key: BroadcastKey, // for sender cleanup on disconnect
-    sender_id: u64,
+    source: SseSource,                             // who fills the ring, + cleanup
+}
+
+// Both response builders (`sse()` and `sse_stream()`) share the ring +
+// wake + write-task machinery above. They differ ONLY in who produces
+// events and how the connection is cleaned up — captured here so the
+// bridge handoff and write task are identical for both.
+enum SseSource {
+    // sse(subscribe(bus)): the ring is filled by the bus's send() fan-out.
+    // Cleanup removes this subscriber from the bus.
+    Broadcast { channel_key: BroadcastKey, sender_id: u64 },
+    // sse_stream(gen): the ring is filled by the generator's own push().
+    // `closure` is the generator captured the same way schedule()/spawn()
+    // capture (environment + body); the write task runs it ONCE, in a fresh
+    // scheduling-capable interpreter, before entering the drain loop.
+    // `wake_tx` is handed to that interpreter's `push` native.
+    Generator { closure: CapturedClosure, wake_tx: flume::Sender<()> },
 }
 
 struct BroadcastMessage {
@@ -643,12 +667,28 @@ staleness: a subscriber added or removed mid-send catches the next event.
    queue_size, filter: None }` into `BroadcastChannel.senders`, drop the
    lock. (Phase 2's `filter(sub, pred)` later sets `filter` on this entry,
    located by `channel_key` + `sender_id`.)
-3. Insert `SseSubscription { queue, wake_rx, channel_key, sender_id }` into
-   `SUBSCRIPTION_REGISTRY` under a fresh `subscription_id` — this is the
-   bridge handoff: the Axum handler later `take()`s this entry
+3. Insert `SseSubscription { queue, wake_rx, source: Broadcast {
+   channel_key, sender_id } }` into `SUBSCRIPTION_REGISTRY` under a fresh
+   `subscription_id` — this is the bridge handoff: the Axum handler later
+   `take()`s this entry
 4. Return `Value::SSESubscription(subscription_id)` to ntnt; the handler
    returns it through `sse()`, which carries the id to the HTTP layer as
    `BridgeBody::Sse { subscription_id }`
+
+`sse_stream(generator)` — SAME bridge handoff as `subscribe()`/`sse()`, so
+the write task, ring, and `BridgeBody::Sse` path are reused unchanged; only
+the producer differs (the generator's `push()` instead of a bus's `send()`):
+1. Create the per-connection ring + `flume::bounded::<()>(1)` wake pair,
+   exactly as `subscribe()` step 1.
+2. Capture the `generator` closure the same way `schedule()`/`spawn()` do
+   (`validate_and_capture` → environment + body). No broadcast registry
+   entry is created — an `sse_stream` has no bus.
+3. Insert `SseSubscription { queue, wake_rx, source: Generator { closure,
+   wake_tx } }` into `SUBSCRIPTION_REGISTRY` under a fresh
+   `subscription_id`.
+4. Return `Value::SSESubscription(subscription_id)`; `sse_stream()` carries
+   it to the HTTP layer as `BridgeBody::Sse { subscription_id }` — the
+   handler on the worker returns immediately, interpreter thread free.
 
 ### SSE Response Handler (Rust HTTP Layer)
 
@@ -657,8 +697,18 @@ When the HTTP layer sees `BridgeBody::Sse { subscription_id }` on the bridge res
 ```rust
 async fn sse_handler(subscription_id: u64, req: Request) -> Response {
     let subscription = SUBSCRIPTION_REGISTRY.take(subscription_id); // consume
+
+    // sse_stream only: start the producer. The generator runs in a FRESH
+    // interpreter (the same run_in_fresh_interpreter path schedule() ticks
+    // use) whose mode grants Scheduling — so schedule()/cancel_schedule()
+    // inside the generator register normally, unlike a worker request scope.
+    // Its `push`/`on_close` natives are bound to this connection's ring +
+    // wake_tx. This runs exactly once; the timers it registers keep pushing.
+    if let SseSource::Generator { closure, wake_tx } = &subscription.source {
+        spawn_generator_interpreter(closure, subscription.queue.clone(), wake_tx.clone());
+    }
+
     let body = Body::new(async_stream::stream! {
-        // Keep-alive ping
         let mut keepalive = tokio::time::interval(Duration::from_secs(15));
 
         loop {
@@ -667,7 +717,7 @@ async fn sse_handler(subscription_id: u64, req: Request) -> Response {
                     yield Ok(Bytes::from(":\n\n"));  // SSE comment = keep-alive
                 }
                 woken = subscription.wake_rx.recv_async() => {
-                    if woken.is_err() { break; } // all senders dropped
+                    if woken.is_err() { break; } // producer gone
                     // Drain everything currently queued (drop-oldest means
                     // the deque already holds only the freshest queue_size
                     // events). Hold the lock only to move messages out.
@@ -683,8 +733,16 @@ async fn sse_handler(subscription_id: u64, req: Request) -> Response {
             }
         }
 
-        // Cleanup: remove this subscriber from the broadcast registry
-        BROADCAST_REGISTRY.lock().remove_sender(&subscription.channel_key, subscription.sender_id);
+        // Cleanup depends on the producer:
+        match &subscription.source {
+            // sse(): drop this subscriber from the bus.
+            SseSource::Broadcast { channel_key, sender_id } =>
+                BROADCAST_REGISTRY.lock().remove_sender(channel_key, *sender_id),
+            // sse_stream(): run the generator's on_close in a fresh
+            // interpreter (same mechanism as the generator itself), which
+            // cancel_schedule()s the per-connection timers by their handle.
+            SseSource::Generator { .. } => run_on_close_in_fresh_interpreter(subscription_id),
+        }
     });
 
     Response::builder()
@@ -764,11 +822,11 @@ untouched.
 - [ ] `send(BroadcastHandle, value) -> Bool` — dispatches on handle type (existing channel `send` is arity-2 and returns Bool; the broadcast arm keeps that contract. Phase 2's 3-arg named-event form widens `max_arity`)
 - [ ] `sse(SSESubscription) -> Response` — response BUILDER returned from a normal handler (there is no `respond` keyword; zero parser work)
 - [ ] `BridgeBody::Sse { subscription_id }` variant on the bridge response; Axum layer builds the streaming body when it sees it (Design Review item)
+- [ ] `SUBSCRIPTION_REGISTRY` bridge handoff (`take()`-consumed), `SseSubscription { queue, wake_rx, source }` with `source` = `Broadcast` (`sse()`) or `Generator` (`sse_stream()`) — one shared struct so both builders reuse the ring/wake/write-task machinery
 - [ ] Multi-worker integration test: sampler registers once on the primary (the existing `RuntimeCapability::Scheduling` gate — no new code), subscribers connect via workers, each event arrives exactly once per subscriber
-- [ ] SSE write loop in Rust: format events, keep-alive pings, disconnect cleanup
-- [ ] Sender cleanup on subscriber disconnect
-- [ ] `sse_stream(fn(push, on_close))` — per-connection callback form; `push()` returns Bool (false after disconnect)
-- [ ] `sse_stream` generator runs in a scheduling-capable per-connection scope (handed off from the worker), so `schedule()`/`cancel_schedule()` inside it register per connection instead of being skipped by the Worker capability gate — with a multi-worker test that a per-connection timer actually ticks when the request was served by a worker
+- [ ] SSE write loop in Rust: `recv_async()` the wake + drain the ring, keep-alive pings, `X-Accel-Buffering: no`, source-dependent disconnect cleanup (bus `remove_sender` vs generator `on_close`)
+- [ ] `sse_stream(fn(push, on_close))` — per-connection callback form; `push()` = drop-oldest enqueue + wake (returns Bool, false after disconnect)
+- [ ] `sse_stream` generator handoff: captured (`validate_and_capture`) and run ONCE by the write task via `run_in_fresh_interpreter` in a `Scheduling`-capable mode — so `schedule()`/`cancel_schedule()` inside it register per connection instead of being skipped by the Worker gate; `on_close` runs the same way on disconnect. Multi-worker test: a per-connection timer actually ticks when the request was served by a worker
 - [ ] `connection_count(BroadcastHandle) -> Int`
 - [ ] `enable_cors()` headers apply to SSE responses — headers are set before the stream body begins (see Security)
 - [ ] Typechecker signatures


### PR DESCRIPTION
## Summary

The agreed design pass on DD-041 (SSE streaming + broadcast channels) before any implementation. The March draft is good — vision, API surface, write-task architecture, and phasing all hold. Three of its assumptions don't survive contact with current main, and each changes the plan:

1. **No `respond` keyword exists** (draft drift). `sse()`/`sse_stream()` become ordinary response builders returned from normal `get()` handlers — which deletes all parser work from Phase 1.
2. **The bridge buffers whole responses** (`BridgeResponse.body: String`). Phase 1's one structural change: a `BridgeBody::Sse { subscription_id }` variant that the Axum layer turns into a streaming body (keep-alive, disconnect cleanup, nginx-compat headers, exactly per the draft's write-task design). The interpreter thread still returns immediately.
3. **Multi-worker breaks the naive design.** Production defaults to up to 8 workers, each re-evaluating the program: anonymous module-level buses become N distinct buses (subscribers on other workers hear nothing), and `schedule()` runs module-level samplers N times — a **pre-existing duplicate-background-work bug** that SSE would surface as duplicate events. Fix: **named process-global broadcasts** (`broadcast("metrics")` — same bus from every worker, survives hot reload) and **Worker-mode gating for `schedule()`** (workers 1..N skip it like they skip `listen()`), the latter flagged as its own release-note item since it fixes all multi-worker apps.

Also resolves the draft's open-questions table with recommendations — the notable one: **bounded per-subscriber queues with drop-oldest default** instead of unbounded crossbeam (a stuck TCP connection with an unbounded queue is slow-motion OOM).

## The ask

This PR is docs-only — the updated DD is the go/no-go artifact. If you approve, Phase 1 stays at the draft's 3–4 day estimate with the two additions (BridgeBody variant, schedule gate), delivering: `broadcast(name)`, `subscribe`, `send` dispatch, `sse()`/`sse_stream()` response builders, the streaming write task, `connection_count`, docs/tests/example dashboard.