### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "ntnt"
-version = "0.4.12"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntnt"
-version = "0.4.12"
+version = "0.5.0"
 edition = "2021"
 authors = ["NTNT Language Team"]
 description = "NTNT (Intent) - A programming language designed for AI-driven development"

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -463,6 +463,7 @@ CLI commands for IAL
 | Command | Description |
 |---------|-------------|
 | `ntnt intent check <file>` | Run tests defined in intent file against implementation |
+| `ntnt intent lint <file>` | Statically validate glossary and scenarios without running tests: unresolved terms and when-clauses (with did-you-mean suggestions), definition cycles, and orphan glossary entries. Exit 1 on unresolved terms or cycles; orphans are warnings only. --json for CI |
 | `ntnt intent coverage <file>` | Show which features have implementations |
 | `ntnt intent init <file.intent> -o <output.tnt>` | Generate code scaffolding from intent file |
 | `ntnt intent studio <file.intent>` | Visual preview with live test execution |

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [ial.toml](ial.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.12
+> Last updated: v0.5.0
 
 IAL is a term rewriting engine that translates natural language assertions into executable tests
 

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [runtime.toml](runtime.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.12
+> Last updated: v0.5.0
 
 Runtime configuration, environment variables, and CLI commands for NTNT
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from source code doc comments** - Do not edit directly.
 >
-> Last updated: v0.4.12
+> Last updated: v0.5.0
 
 ## Table of Contents
 

--- a/docs/SYNTAX_REFERENCE.md
+++ b/docs/SYNTAX_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [syntax.toml](syntax.toml)** - Do not edit directly.
 >
-> Last updated: v0.4.12
+> Last updated: v0.5.0
 
 ## Table of Contents
 

--- a/docs/release-notes/v0.5.0.md
+++ b/docs/release-notes/v0.5.0.md
@@ -1,0 +1,50 @@
+# NTNT v0.5.0 Release Notes
+
+v0.5.0 is the verification release. The DD-063 language assessment is fully closed — every silent failure it identified is now loud, the agent repair loop reports everything the error infrastructure can express, and verification commands verify under strict semantics by default. Alongside it: the two most-requested stdlib modules (`std/validate`, `std/email`), a hardened multi-worker runtime, and the last web-app quick wins.
+
+## Highlights
+
+- **Declarative validation (`std/validate`)**
+  - `schema(map { field: [rules...] })` + `validate(schema, data)` → `Ok(cleaned)` with coerced values (unknown keys dropped) or `Err(field → message)`.
+  - Rules compose validators (`required`, `optional`, `email`, `url`, `min_value`/`max_value`, `min_length`/`max_length`, `one_of`, `matches`, `default`), the **global** conversion functions `int`/`float`/`bool`/`str` (and `std/string` `trim`) for coercion, and bare `fn(value)` closures as custom predicates.
+  - Fields are required by default; `optional` permits absence, `default(v)` supplies a value that still runs the remaining rules.
+
+- **Email sending (`std/email`)**
+  - `configure_email(...)` once at startup; `send_email(...)` → `Ok(map { "message_id", "transport" })` or `Err(message)` — bad addresses and SMTP failures are values, never crashes.
+  - `send_email_batch([...])` reuses one pooled connection with per-email results; one bad email never stops the rest.
+  - A log transport (`"transport": "log"`, or `NTNT_EMAIL_MODE=log`) prints emails to stderr and reports them sent — development and CI run the full email path with no SMTP server.
+  - TLS defaults from the port (465 implicit, others STARTTLS); rustls, no openssl.
+
+- **The agent repair loop, completed (DD-063)**
+  - `ntnt lint`/`validate`/`check` recover from parse errors and report up to 5 per file in one pass; semantic checks are suppressed on partial ASTs.
+  - Contract violations (E004) show the failing clause's source frame, the actual runtime values (`where: b = 0`), and the call site.
+  - Unknown method calls get did-you-mean plus a UFCS bridge hint (`try len(s)`); new lint rules `unknown_method`, `block_binding`, and `static_contract_violation` (calls with literal arguments that provably violate a `requires` clause are flagged at lint time).
+  - IAL unknown terms get near-miss suggestions; new **`ntnt intent lint`** statically validates glossaries and scenarios (unresolved terms, definition cycles, vacuous scenarios, orphan entries) with `--json` for CI — no server startup.
+  - Fixed a false-assurance bug: intent files declaring invariants before features silently lost their feature ids and scenario outcomes, letting scenarios pass while verifying nothing.
+
+- **Runtime and workers**
+  - Array/string out-of-bounds reads are loud by type mode: `[WARN]` + `None` in warn, error E010 in strict, silent in forgiving. Map missing-key access stays silent-`None` by design; `arr[i] ?? default`, `arr[i]?`, and `otherwise` suppress the diagnostics entirely.
+  - Crashed HTTP workers are supervised and respawned with backoff; `ntnt run --workers N` joins `NTNT_WORKERS`.
+  - Verified under benchmark: 8 workers take the TechEmpower-style single-query workload from 8.3K to 39K req/s.
+
+- **Quick wins**
+  - `paginate(total, page, per_page)` (`std/collections`) — offset/limit/pages/flags with safe clamping.
+  - `from_now(ts)` / `time_ago(ts)` (`std/time`) — "3 hours ago", "in 2 days", "just now".
+
+## Behavior changes
+
+- **Verification defaults to strict type mode.** `ntnt test` and `ntnt intent check` run with `NTNT_TYPE_MODE=strict` when the variable is unset — degradations that warn mode tolerates (out-of-bounds → `None`, implicit conversions) now fail verification. Set `NTNT_TYPE_MODE=warn` explicitly to restore the old tolerance. `ntnt run` is unchanged.
+- **Strict mode errors on out-of-bounds reads.** Code run under `NTNT_TYPE_MODE=strict` that previously tolerated OOB-as-`None` now stops with E010. Guarded access (`??`, `?`, `otherwise`) is exempt.
+- **`is_some`/`is_none`/`is_ok`/`is_err`/`unwrap_or` are arity-checked** at lint time; wrong-arity calls that previously passed silently now report.
+- **Lint JSON:** a file with N parse errors contributes N to `summary.errors` (previously 1); parse errors now include `column`. **`ntnt parse --json`:** contract clauses serialize as `{expression, line}` objects.
+- **Scheduled loops and multi-worker:** no change yet — note that module-level `schedule()` loops currently run once per worker; a fix is planned alongside SSE (DD-041).
+
+## Docs
+
+- The whitepaper now separates shipped capability from aspiration in a prominent Implementation Status section.
+- IAL reference documents invariant expansion honestly (the never-implemented `Sql`/`InvariantCheck` primitives are removed).
+- Agent guide: indexing semantics, validation, email, worker parallelism, `intent lint` workflow.
+
+## Upgrade notes
+
+If your CI runs `ntnt test` or `ntnt intent check` and relied on warn-mode tolerance, either fix the surfaced issues (recommended — they are real) or set `NTNT_TYPE_MODE=warn` for the affected jobs. Consumers of lint/parse JSON should adopt the new `summary.errors` counting and contract-clause shapes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7321,7 +7321,7 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
         md.push_str("| Command | Description |\n");
         md.push_str("|---------|-------------|\n");
 
-        let cmd_names = ["check", "coverage", "init", "studio"];
+        let cmd_names = ["check", "lint", "coverage", "init", "studio"];
         for cmd in &cmd_names {
             if let Some(c) = commands.get(*cmd) {
                 let command = c.get("command").and_then(|v| v.as_str()).unwrap_or("");


### PR DESCRIPTION
## Summary

Version bump to **0.5.0** plus release notes (`docs/release-notes/v0.5.0.md`), per the versioning discussion: the delta since v0.4.12 carries two new stdlib modules, the complete DD-063 diagnostics overhaul, and several deliberate behavior changes (strict verification defaults, strict-mode OOB errors, arity checking, JSON shape changes) — behavior changes bump the minor under 0.x conventions, and DD-058's phasing already designated the validation/email/quick-wins basket as v0.5.0.

- `Cargo.toml`/`Cargo.lock` → 0.5.0
- Release notes with Highlights / **Behavior changes** / Upgrade notes (the strict-verification default is the headline caveat for existing CI)
- Reference docs regenerated (version-stamp-only diffs)

## Not in this PR

No tag — the maintainer is testing the binary against real apps first. Tagging `v0.5.0` after merge triggers the release workflow.

## Test plan

Full suite: 1800 tests, 0 failures on the bumped tree.