### PR TITLE
fix: correct v0.5.0 release note about schedule() under multi-worker

### DIFF
--- a/docs/release-notes/v0.5.0.md
+++ b/docs/release-notes/v0.5.0.md
@@ -37,7 +37,7 @@ v0.5.0 is the verification release. The DD-063 language assessment is fully clos
 - **Strict mode errors on out-of-bounds reads.** Code run under `NTNT_TYPE_MODE=strict` that previously tolerated OOB-as-`None` now stops with E010. Guarded access (`??`, `?`, `otherwise`) is exempt.
 - **`is_some`/`is_none`/`is_ok`/`is_err`/`unwrap_or` are arity-checked** at lint time; wrong-arity calls that previously passed silently now report.
 - **Lint JSON:** a file with N parse errors contributes N to `summary.errors` (previously 1); parse errors now include `column`. **`ntnt parse --json`:** contract clauses serialize as `{expression, line}` objects.
-- **Scheduled loops and multi-worker:** no change yet — note that module-level `schedule()` loops currently run once per worker; a fix is planned alongside SSE (DD-041).
+- **Scheduled loops and multi-worker:** no change — module-level `schedule()` loops are capability-gated and run exactly once, on the primary interpreter; Worker-mode interpreters skip them (same as `listen()`).
 
 ## Docs
 


### PR DESCRIPTION
The v0.5.0 release notes claim module-level `schedule()` loops "currently run once per worker; a fix is planned alongside SSE (DD-041)". That's incorrect — verified against the source while auditing DD-041 (PR #156):

- `schedule` and `after` are registered with `requires: Some(RuntimeCapability::Scheduling)` (`src/stdlib/concurrent.rs:2894,2919`)
- The `ExecutionMode::Worker` and `ExecutionMode::HotReload` capability sets exclude `Scheduling` (`src/interpreter.rs`), so gated builtins no-op there
- Pinned by `test_capability_gate_scheduling_worker_mode_skips`

So module-level samplers register exactly once, on the primary interpreter — there is no duplicate-loop bug and nothing planned to fix. Worth correcting before the v0.5.0 tag is pushed, since the release workflow will publish these notes.