### PR TITLE
feat(auth): ship purpose-bound magic links in v0.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,12 @@ jobs:
         run: |
           cargo test --locked --lib test_auth_storage_contract_postgres_round_trip_all_record_types -- --test-threads=1 --nocapture
           cargo test --locked --lib test_auth_storage_contract_redis_round_trip_all_record_types -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_postgres_migrates_legacy_password_reset_tokens_without_replay_copy -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_redis_purges_legacy_password_reset_keys_on_upgrade -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_postgres_magic_link_storage_is_atomic_under_concurrency -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_redis_magic_link_storage_is_atomic_under_concurrency -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_postgres_password_reset_consume_is_one_time_under_concurrency -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_redis_password_reset_consume_is_one_time_under_concurrency -- --test-threads=1 --nocapture
         env:
           RUST_MIN_STACK: 8388608
           NTNT_AUTH_TEST_POSTGRES_URL: postgres://postgres:ntnt@localhost:5432/ntnt_auth_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
           cargo test --locked --lib test_redis_magic_link_storage_is_atomic_under_concurrency -- --test-threads=1 --nocapture
           cargo test --locked --lib test_postgres_password_reset_consume_is_one_time_under_concurrency -- --test-threads=1 --nocapture
           cargo test --locked --lib test_redis_password_reset_consume_is_one_time_under_concurrency -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_set_local_password_revokes_outstanding_one_time_tokens -- --test-threads=1 --nocapture
+          cargo test --locked --lib test_password_reset_revokes_outstanding_magic_links -- --test-threads=1 --nocapture
         env:
           RUST_MIN_STACK: 8388608
           NTNT_AUTH_TEST_POSTGRES_URL: postgres://postgres:ntnt@localhost:5432/ntnt_auth_test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "ntnt"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntnt"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["NTNT Language Team"]
 description = "NTNT (Intent) - A programming language designed for AI-driven development"

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -154,7 +154,7 @@ Goal: let apps implement passwordless email sign-in without app-owned authentica
 - [x] Recheck active identity state inside each backend's atomic issuance and consumption path
 - [x] Return generic invalid-token errors and sanitized, distinguishable storage-unavailable errors for password resets and magic links
 - [x] Persist password-reset and magic-link records in the shared one-time-token substrate with an explicit purpose discriminator so tokens cannot cross purposes
-- [x] Migrate legacy durable password-reset rows atomically, drop legacy SQL tables, and purge legacy Redis keys so upgrades cannot resurrect tokens after downgrade
+- [x] Migrate legacy durable password-reset rows atomically, serialize concurrent PostgreSQL startup migrations, drop legacy SQL tables, and purge legacy Redis keys so upgrades cannot resurrect tokens after downgrade
 - [x] Recheck account state during consumption and permanently invalidate links rejected for a non-active identity
 - [x] Preserve backend parity across memory, SQLite, PostgreSQL, and Redis/Valkey
 - [x] Keep app policy outside `std/auth`: apps own email delivery, request throttling, authorization/group checks, confirmation UX, and `sign_in_session(...)`

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -143,7 +143,7 @@ Goal: ship reset password securely enough to use, without owning email delivery 
 - [x] Add local reset tests and backend contract coverage across memory, SQLite, PostgreSQL, and Redis/Valkey
 - Deferred post-v0.4.9 unless app/template pressure proves them: force-password-change-after-reset policy, TOTP reset-on-reset policy, and security-event emission
 
-### Post-v0.5.0 Addendum — Magic-Link Essentials
+### v0.5.1 Addendum — Magic-Link Essentials
 
 Goal: let apps implement passwordless email sign-in without app-owned authentication token tables.
 
@@ -156,6 +156,7 @@ Goal: let apps implement passwordless email sign-in without app-owned authentica
 - [x] Persist password-reset and magic-link records in the shared one-time-token substrate with an explicit purpose discriminator so tokens cannot cross purposes
 - [x] Migrate legacy durable password-reset rows atomically, serialize concurrent PostgreSQL startup migrations, drop legacy SQL tables, and purge legacy Redis keys so upgrades cannot resurrect tokens after downgrade
 - [x] Recheck account state during consumption and permanently invalidate links rejected for a non-active identity
+- [x] Revoke outstanding password-reset and magic-link tokens whenever credentials are changed or reset
 - [x] Preserve backend parity across memory, SQLite, PostgreSQL, and Redis/Valkey
 - [x] Keep app policy outside `std/auth`: apps own email delivery, request throttling, authorization/group checks, confirmation UX, and `sign_in_session(...)`
 

--- a/design-docs/dd-043-auth-excellence.md
+++ b/design-docs/dd-043-auth-excellence.md
@@ -143,6 +143,22 @@ Goal: ship reset password securely enough to use, without owning email delivery 
 - [x] Add local reset tests and backend contract coverage across memory, SQLite, PostgreSQL, and Redis/Valkey
 - Deferred post-v0.4.9 unless app/template pressure proves them: force-password-change-after-reset policy, TOTP reset-on-reset policy, and security-event emission
 
+### Post-v0.5.0 Addendum — Magic-Link Essentials
+
+Goal: let apps implement passwordless email sign-in without app-owned authentication token tables.
+
+- [x] Add `issue_magic_link(identifier, options?) -> Result<Map, String>` for active local identities
+- [x] Add `consume_magic_link(token) -> Result<Map, String>` with a safe local-identity result and no implicit session or role grant
+- [x] Store only opaque selectors and verifier hashes in auth-owned storage
+- [x] Enforce a 15-minute default TTL, one-hour maximum, atomic one-time consumption, replay rejection, and sibling-token invalidation
+- [x] Recheck active identity state inside each backend's atomic issuance and consumption path
+- [x] Return generic invalid-token errors and sanitized, distinguishable storage-unavailable errors for password resets and magic links
+- [x] Persist password-reset and magic-link records in the shared one-time-token substrate with an explicit purpose discriminator so tokens cannot cross purposes
+- [x] Migrate legacy durable password-reset rows atomically, drop legacy SQL tables, and purge legacy Redis keys so upgrades cannot resurrect tokens after downgrade
+- [x] Recheck account state during consumption and permanently invalidate links rejected for a non-active identity
+- [x] Preserve backend parity across memory, SQLite, PostgreSQL, and Redis/Valkey
+- [x] Keep app policy outside `std/auth`: apps own email delivery, request throttling, authorization/group checks, confirmation UX, and `sign_in_session(...)`
+
 ### Template Integration Proof
 
 Completed in `larimonious/larri-site-template` PR #1 (`feat(auth): move template admin to std/auth primitives`), merged before the final v0.4.9 release-readiness pass.

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -2003,7 +2003,7 @@ Full OAuth, session management, CSRF, JWT, TOTP, and local credential bootstrap,
 
 ### Local Auth Quickstart
 
-The 0.4.9 local-auth path is intentionally explicit: `std/auth` owns credentials, reset tokens, TOTP state, sessions, cookies, CSRF, and route protection; the app owns the forms, delivery, roles, and policy copy. Local credentials and reset tokens are stored by the configured auth backend: memory, SQLite, PostgreSQL, or Redis/Valkey.
+The local-auth path is intentionally explicit: `std/auth` owns credentials, reset and magic-link tokens, TOTP state, sessions, cookies, CSRF, and route protection; the app owns forms, email delivery, request throttling, roles, and policy copy. Local credentials and one-time tokens are stored by the configured auth backend: memory, SQLite, PostgreSQL, or Redis/Valkey.
 
 Supported local identifier kinds are:
 
@@ -2092,6 +2092,26 @@ fn post_logout_all(req) {
 ```
 
 Password reset does **not** revoke sessions by default. If the reset form has a “log me out of all active sessions” checkbox, pass `map { "revoke_sessions": true }` to `consume_password_reset(...)`. For a standalone account-security page, use `logout_all(req, keep_current)`; pass `false` to revoke every active session including the current one, or `true` to keep the current session and revoke the rest.
+
+### Passwordless Magic Links
+
+Use `issue_magic_link(...)` and `consume_magic_link(...)` for the reusable authentication token lifecycle. ntnt stores only verifier hashes, applies a 15-minute default TTL (one-hour maximum), replaces older links on issuance, and atomically rejects expiry and replay.
+
+```ntnt
+import { consume_magic_link, issue_magic_link, sign_in_session } from "std/auth"
+
+let issued = issue_magic_link(email)?
+// Deliver issued["token"] out of band. Do not put it in request logs.
+
+let identity = consume_magic_link(submitted_token)?
+return sign_in_session(redirect("/dashboard"), req, map {
+    "provider": "email",
+    "subject_id": identity["id"],
+    "email": identity["identifier_normalized"]
+})
+```
+
+`consume_magic_link(...)` verifies identity only; it does not create a session or grant roles. The app must authorize the identity, send the email (prefer `std/email`), throttle requests, use a scanner-safe confirmation step, and call `sign_in_session(...)`. Keep bearer tokens out of URL paths and query strings; a fragment-to-POST confirmation flow avoids normal server and proxy URL logs.
 
 ### Local Credential Bootstrap and Setup Completion
 

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [ial.toml](ial.toml)** - Do not edit directly.
 >
-> Last updated: v0.5.0
+> Last updated: v0.5.1
 
 IAL is a term rewriting engine that translates natural language assertions into executable tests
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,6 +39,8 @@ Source files:
 | Document | Description |
 |----------|-------------|
 | [Roadmap](../ROADMAP.md) | Implementation phases and progress |
+| [v0.5.1 Release Notes](release-notes/v0.5.1.md) | Purpose-bound magic-link primitives and password-reset hardening |
+| [v0.5.0 Release Notes](release-notes/v0.5.0.md) | Verification, validation, email, and multi-worker improvements |
 | [v0.4.9 Release Notes](release-notes/v0.4.9.md) | Local auth primitives, backend support, demo, and upgrade guidance |
 | [Contributing](../CONTRIBUTING.md) | How to contribute |
 | [Code of Conduct](../CODE_OF_CONDUCT.md) | Community standards |

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [runtime.toml](runtime.toml)** - Do not edit directly.
 >
-> Last updated: v0.5.0
+> Last updated: v0.5.1
 
 Runtime configuration, environment variables, and CLI commands for NTNT
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -1830,6 +1830,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`cancel_auth_challenge`](#cancelauthchallenge) | Cancel the current auth challenge and clear the challenge cookie. |
 | [`complete_auth_challenge`](#completeauthchallenge) | Upgrade the current auth challenge into a full authenticated session. |
 | [`confirm_totp_enrollment`](#confirmtotpenrollment) | Confirm a pending local TOTP enrollment using a code from the authenticator app. |
+| [`consume_magic_link`](#consumemagiclink) | Atomically consume a one-time passwordless sign-in token. |
 | [`consume_password_reset`](#consumepasswordreset) | Consume a one-time password reset token and rotate the local password. |
 | [`create_session_from_oauth`](#createsessionfromoauth) | Create a session from OAuth user info and tokens. |
 | [`csrf_field`](#csrffield) | Get an HTML hidden input field with the CSRF token. |
@@ -1841,6 +1842,7 @@ import { oauth, oauth_discover, oauth_m2m } from "std/auth"
 | [`get_session`](#getsession) | Get the current session from the request. |
 | [`get_user`](#getuser) | Get the current authenticated user from the request. |
 | [`has_group`](#hasgroup) | Check app-owned group IDs from authenticated session data. |
+| [`issue_magic_link`](#issuemagiclink) | Issue a one-time passwordless sign-in token for an active local identity. |
 | [`issue_password_reset`](#issuepasswordreset) | Issue a one-time password reset token for a local identity. |
 | [`jwt_decode`](#jwtdecode) | Decode a JWT token WITHOUT verifying the signature. |
 | [`jwt_sign`](#jwtsign) | Create a signed JWT token from claims. |
@@ -2259,6 +2261,38 @@ confirm_totp_enrollment("admin@example.com", form["code"] ?? "")?  // Finish TOT
 
 ---
 
+#### `consume_magic_link`
+
+```ntnt
+consume_magic_link(token: String) -> Result<Map, String>
+```
+
+Atomically consume a one-time passwordless sign-in token.
+
+Missing, malformed, expired, replayed, wrong-verifier, and non-active-identity tokens return the same generic error. Success returns a safe local identity payload; it does not create a session or grant app roles.
+
+**Parameters:**
+
+- `token` — The `selector.verifier` token returned by issue_magic_link(...)
+
+**Returns:** Ok(map) with safe local identity fields, or a generic Err for invalid tokens
+
+**Examples:**
+
+```ntnt
+let user = consume_magic_link(form["token"] ?? "")?  // Verify a one-time token before creating an app-owned session
+```
+
+**Errors:**
+
+- **RuntimeError**: Magic link verification unavailable — *Fix: Retry after checking the configured auth storage backend*
+
+**See also:** `issue_magic_link`, `sign_in_session`, `local_user`
+
+*Since v0.5.1*
+
+---
+
 #### `consume_password_reset`
 
 ```ntnt
@@ -2275,7 +2309,7 @@ Valid tokens are consumed atomically, verified against the stored hash, and then
 - `new_password` — Replacement plaintext password to hash and store
 - `options` — Optional map with `revoke_sessions` (default false)
 
-**Returns:** Ok(map) with safe local user fields and `revoked_sessions`; Err(message) for invalid/expired/replayed tokens or storage failure
+**Returns:** Ok(map) with safe local user fields and `revoked_sessions`; Err(message) for invalid/expired/replayed tokens or sanitized storage failure
 
 **Examples:**
 
@@ -2283,6 +2317,10 @@ Valid tokens are consumed atomically, verified against the stored hash, and then
 let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "")?  // Finish a password reset without revoking sessions
 let user = consume_password_reset(form["token"] ?? "", form["new_password"] ?? "", map { "revoke_sessions": form["logout_all"] == "on" })?  // Finish a reset and explicitly revoke existing sessions from a checkbox
 ```
+
+**Errors:**
+
+- **RuntimeError**: Password reset verification unavailable — *Fix: Retry after checking the configured auth storage backend*
 
 **See also:** `issue_password_reset`, `verify_local_password`, `logout_all`, `sign_in_session`
 
@@ -2583,6 +2621,39 @@ has_group(current_session(req)?, ["admins", "owners"])  // Check any accepted gr
 
 ---
 
+#### `issue_magic_link`
+
+```ntnt
+issue_magic_link(identifier: String, options?: Map) -> Result<Map, String>
+```
+
+Issue a one-time passwordless sign-in token for an active local identity.
+
+The helper stores only a hashed verifier with an opaque selector. Valid-shaped requests return equivalent token material whether or not an active identity exists; only active identities get a persisted token. Apps own delivery, request throttling, authorization policy, and the final sign_in_session(...) call.
+
+**Parameters:**
+
+- `identifier` — The local user identifier. Email is the default identifier kind.
+- `options` — Optional map with `identifier_kind` and `ttl_seconds` (default 900, maximum 3600)
+
+**Returns:** Ok(map) with `status: "accepted"` and, for valid-shaped requests, one-time token material
+
+**Examples:**
+
+```ntnt
+let issued = issue_magic_link(form["email"] ?? "")?  // Issue a passwordless sign-in token for out-of-band delivery
+```
+
+**Errors:**
+
+- **RuntimeError**: Magic link issuance unavailable — *Fix: Retry after checking the configured auth storage backend*
+
+**See also:** `consume_magic_link`, `sign_in_session`, `local_user`
+
+*Since v0.5.1*
+
+---
+
 #### `issue_password_reset`
 
 ```ntnt
@@ -2605,6 +2676,10 @@ The helper normalizes the identifier (email by default), stores only a hashed ve
 ```ntnt
 let reset = issue_password_reset(form["email"] ?? "")?  // Begin password reset without account enumeration
 ```
+
+**Errors:**
+
+- **RuntimeError**: Password reset issuance unavailable — *Fix: Retry after checking the configured auth storage backend*
 
 **See also:** `consume_password_reset`, `verify_local_password`, `set_local_password`
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from source code doc comments** - Do not edit directly.
 >
-> Last updated: v0.5.0
+> Last updated: v0.5.1
 
 ## Table of Contents
 
@@ -2667,7 +2667,7 @@ The helper normalizes the identifier (email by default), stores only a hashed ve
 **Parameters:**
 
 - `identifier` — The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
-- `options` — Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`) and `ttl_seconds` (default 3600)
+- `options` — Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`) and `ttl_seconds` (default 3600; maximum 86400)
 
 **Returns:** Ok(map) with `status: "accepted"`; syntactically valid reset requests also include `token`, `selector`, `created_at`, and `expires_at` without revealing whether a matching account exists
 

--- a/docs/SYNTAX_REFERENCE.md
+++ b/docs/SYNTAX_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [syntax.toml](syntax.toml)** - Do not edit directly.
 >
-> Last updated: v0.5.0
+> Last updated: v0.5.1
 
 ## Table of Contents
 

--- a/docs/release-notes/v0.5.1.md
+++ b/docs/release-notes/v0.5.1.md
@@ -1,0 +1,38 @@
+# NTNT v0.5.1 Release Notes
+
+v0.5.1 adds the secure token foundation for passwordless email sign-in. Applications can issue and consume purpose-bound magic links through `std/auth` without creating their own token tables or reproducing backend-specific replay protection.
+
+## Highlights
+
+- **Magic-link primitives**
+  - `issue_magic_link(identifier, options?)` creates opaque selector/verifier tokens using OS randomness, stores only the verifier hash, and defaults to a 15-minute lifetime with a one-hour maximum.
+  - `consume_magic_link(token)` atomically verifies and consumes a link, returning a safe local-identity payload without granting application roles or creating a session.
+  - Valid-shaped issuance requests remain account-neutral: missing, disabled, and locked identities receive equivalent response shapes without a persisted usable token.
+
+- **Shared one-time-token substrate**
+  - Password resets and magic links share purpose-discriminated storage while remaining impossible to consume across purposes.
+  - One active magic link per identity, atomic replacement, replay rejection, and active-account checks are enforced across memory, SQLite, PostgreSQL, and Redis/Valkey.
+  - PostgreSQL keeps identity-first lock ordering; Redis issuance and consumption remain atomic Lua operations and return the identity validated inside the consume script.
+
+- **Upgrade safety**
+  - SQLite and PostgreSQL migrate legacy password-reset rows transactionally and remove the old table.
+  - PostgreSQL startup migrations use a transaction-scoped advisory lock so rolling multi-instance upgrades serialize safely.
+  - Redis/Valkey initialization purges legacy reset-token namespaces that lack an explicit purpose discriminator.
+
+- **Password-reset hardening**
+  - Public issuance and verification failures no longer expose storage-backend diagnostics.
+  - Empty-password validation returns a user-facing error without the internal auth prefix.
+  - Caller-configured password-reset lifetimes are capped at 24 hours; the default remains one hour.
+  - Password changes and successful resets revoke every outstanding password-reset and magic-link token for the identity across all backends.
+
+## Application boundary
+
+The v0.5.1 APIs own token security, durable storage, expiry, replacement, atomic consumption, account-state validation, and sanitized errors. Applications still own email delivery, abuse throttling, authorization and group policy, confirmation UX, and final session creation.
+
+A higher-level, configuration-first magic-link experience can be layered over these primitives without weakening that authorization boundary.
+
+## Upgrade notes
+
+- Existing password-reset APIs continue to work through the shared one-time-token substrate.
+- Durable SQL backends migrate automatically on initialization. Redis/Valkey legacy reset tokens are invalidated during initialization because their old records cannot prove token purpose.
+- Applications that explicitly configured password-reset token lifetimes above 24 hours now receive the 24-hour maximum.

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -833,8 +833,10 @@ fn string_arg<'a>(
 }
 
 fn password_reset_error_response(message: String) -> Value {
-    if message == INVALID_PASSWORD_RESET_TOKEN || message == EMPTY_LOCAL_PASSWORD {
+    if message == INVALID_PASSWORD_RESET_TOKEN {
         Value::err(Value::String(message))
+    } else if message == EMPTY_LOCAL_PASSWORD {
+        Value::err(Value::String("Password must not be empty".to_string()))
     } else {
         Value::err(Value::String(
             PASSWORD_RESET_VERIFICATION_UNAVAILABLE.to_string(),
@@ -4714,7 +4716,7 @@ pub fn init() -> HashMap<String, Value> {
     // a generic accepted payload without token material. Store or send the returned
     // `token` out-of-band; std/auth never stores the raw token.
     // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
-    // @param options Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`) and `ttl_seconds` (default 3600)
+    // @param options Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`) and `ttl_seconds` (default 3600; maximum 86400)
     // @returns Ok(map) with `status: "accepted"`; syntactically valid reset requests also include `token`, `selector`, `created_at`, and `expires_at` without revealing whether a matching account exists
     // @error RuntimeError ~ "Password reset issuance unavailable" fix: "Retry after checking the configured auth storage backend"
     // @see_also consume_password_reset, verify_local_password, set_local_password
@@ -8505,7 +8507,7 @@ mod tests {
             result_err_string(password_reset_error_response(
                 EMPTY_LOCAL_PASSWORD.to_string(),
             )),
-            EMPTY_LOCAL_PASSWORD
+            "Password must not be empty"
         );
         assert_eq!(
             result_err_string(magic_link_error_response(
@@ -8519,6 +8521,40 @@ mod tests {
             )),
             INVALID_MAGIC_LINK_TOKEN
         );
+    }
+
+    #[test]
+    fn test_password_reset_ttl_is_capped_at_twenty_four_hours() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Memory);
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        let issue_password_reset = module_fn(&module, "issue_password_reset");
+        result_ok_map(
+            bootstrap_local_user(&[
+                Value::String("reset-cap@example.com".to_string()),
+                Value::String("temporary password".to_string()),
+            ])
+            .unwrap(),
+        );
+
+        let issued = result_ok_map(
+            issue_password_reset(&[
+                Value::String("reset-cap@example.com".to_string()),
+                Value::Map(HashMap::from([(
+                    "ttl_seconds".to_string(),
+                    Value::Int(7 * 24 * 60 * 60),
+                )])),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(
+            map_int(&issued, "expires_at") - map_int(&issued, "created_at"),
+            24 * 60 * 60
+        );
+        reset_auth_test_state();
     }
 
     #[test]
@@ -8783,12 +8819,20 @@ mod tests {
     }
 
     #[test]
-    fn test_set_local_password_revokes_outstanding_password_reset_tokens() {
+    fn test_set_local_password_revokes_outstanding_one_time_tokens() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
-        for store in [
+        let mut stores = vec![
             SessionStore::Memory,
             SessionStore::Sqlite(":memory:".to_string()),
-        ] {
+        ];
+        if let Some(store) = auth_test_postgres_store() {
+            stores.push(store);
+        }
+        if let Some(store) = auth_test_redis_store() {
+            stores.push(store);
+        }
+        for store in stores {
+            let email = format!("manual-rotate-{}@example.com", uuid::Uuid::new_v4());
             reset_auth_test_state();
             init_test_auth(store);
 
@@ -8796,26 +8840,37 @@ mod tests {
             let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
             let issue_password_reset = module_fn(&module, "issue_password_reset");
             let consume_password_reset = module_fn(&module, "consume_password_reset");
+            let issue_magic_link = module_fn(&module, "issue_magic_link");
+            let consume_magic_link = module_fn(&module, "consume_magic_link");
             let set_local_password = module_fn(&module, "set_local_password");
             let verify_local_password = module_fn(&module, "verify_local_password");
 
             result_ok_map(
                 bootstrap_local_user(&[
-                    Value::String("manual-rotate@example.com".to_string()),
+                    Value::String(email.clone()),
                     Value::String("temporary reset password".to_string()),
                 ])
                 .unwrap(),
             );
-            let issued = result_ok_map(
-                issue_password_reset(&[Value::String("manual-rotate@example.com".to_string())])
-                    .unwrap(),
+            result_ok_map(
+                set_local_password(&[
+                    Value::String(email.clone()),
+                    Value::String("temporary reset password".to_string()),
+                    Value::String("active password".to_string()),
+                ])
+                .unwrap(),
             );
+            let issued =
+                result_ok_map(issue_password_reset(&[Value::String(email.clone())]).unwrap());
             let token = map_string(&issued, "token");
+            let magic_link =
+                result_ok_map(issue_magic_link(&[Value::String(email.clone())]).unwrap());
+            let magic_link_token = map_string(&magic_link, "token");
 
             let rotated = result_ok_map(
                 set_local_password(&[
-                    Value::String("manual-rotate@example.com".to_string()),
-                    Value::String("temporary reset password".to_string()),
+                    Value::String(email.clone()),
+                    Value::String("active password".to_string()),
                     Value::String("manually rotated password".to_string()),
                 ])
                 .unwrap(),
@@ -8830,16 +8885,84 @@ mod tests {
                 .unwrap(),
             );
             assert_eq!(stale_reset, "Invalid password reset token");
+            assert_eq!(
+                result_err_string(consume_magic_link(&[Value::String(magic_link_token)]).unwrap()),
+                "Invalid magic link token"
+            );
 
             let current_password_still_valid = result_ok_map(
                 verify_local_password(&[
-                    Value::String("manual-rotate@example.com".to_string()),
+                    Value::String(email.clone()),
                     Value::String("manually rotated password".to_string()),
                 ])
                 .unwrap(),
             );
             assert_eq!(map_string(&current_password_still_valid, "state"), "active");
         }
+    }
+
+    #[test]
+    fn test_password_reset_revokes_outstanding_magic_links() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let mut stores = vec![
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ];
+        if let Some(store) = auth_test_postgres_store() {
+            stores.push(store);
+        }
+        if let Some(store) = auth_test_redis_store() {
+            stores.push(store);
+        }
+
+        for store in stores {
+            let email = format!("reset-revokes-magic-{}@example.com", uuid::Uuid::new_v4());
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let module = init();
+            let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+            let set_local_password = module_fn(&module, "set_local_password");
+            let issue_magic_link = module_fn(&module, "issue_magic_link");
+            let consume_magic_link = module_fn(&module, "consume_magic_link");
+            let issue_password_reset = module_fn(&module, "issue_password_reset");
+            let consume_password_reset = module_fn(&module, "consume_password_reset");
+
+            result_ok_map(
+                bootstrap_local_user(&[
+                    Value::String(email.clone()),
+                    Value::String("temporary password".to_string()),
+                ])
+                .unwrap(),
+            );
+            result_ok_map(
+                set_local_password(&[
+                    Value::String(email.clone()),
+                    Value::String("temporary password".to_string()),
+                    Value::String("active password".to_string()),
+                ])
+                .unwrap(),
+            );
+            let magic_link =
+                result_ok_map(issue_magic_link(&[Value::String(email.clone())]).unwrap());
+            let reset =
+                result_ok_map(issue_password_reset(&[Value::String(email.clone())]).unwrap());
+
+            result_ok_map(
+                consume_password_reset(&[
+                    Value::String(map_string(&reset, "token")),
+                    Value::String("reset password".to_string()),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(
+                result_err_string(
+                    consume_magic_link(&[Value::String(map_string(&magic_link, "token"))]).unwrap(),
+                ),
+                "Invalid magic link token"
+            );
+        }
+        reset_auth_test_state();
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -72,10 +72,14 @@ pub use guards::{
 };
 use local::{
     begin_totp_enrollment_record, bootstrap_local_user_record, confirm_totp_enrollment_record,
-    consume_password_reset_record, issue_password_reset_record, local_identity_to_safe_value,
-    local_user_record, reset_totp_record, set_local_password_record, totp_status_record,
+    consume_magic_link_record, consume_password_reset_record, issue_magic_link_record,
+    issue_password_reset_record, local_identity_to_safe_value, local_user_record,
+    reset_totp_record, set_local_password_record, totp_status_record,
     update_local_user_metadata_record, verified_local_password_to_value,
-    verify_local_password_record, verify_local_totp_record,
+    verify_local_password_record, verify_local_totp_record, EMPTY_LOCAL_PASSWORD,
+    INVALID_MAGIC_LINK_TOKEN, INVALID_PASSWORD_RESET_TOKEN, MAGIC_LINK_ISSUANCE_UNAVAILABLE,
+    MAGIC_LINK_VERIFICATION_UNAVAILABLE, PASSWORD_RESET_ISSUANCE_UNAVAILABLE,
+    PASSWORD_RESET_VERIFICATION_UNAVAILABLE,
 };
 use oauth::extract_user_info;
 pub use oauth::{
@@ -828,7 +832,27 @@ fn string_arg<'a>(
     }
 }
 
-fn parse_password_reset_issue_options(
+fn password_reset_error_response(message: String) -> Value {
+    if message == INVALID_PASSWORD_RESET_TOKEN || message == EMPTY_LOCAL_PASSWORD {
+        Value::err(Value::String(message))
+    } else {
+        Value::err(Value::String(
+            PASSWORD_RESET_VERIFICATION_UNAVAILABLE.to_string(),
+        ))
+    }
+}
+
+fn magic_link_error_response(message: String) -> Value {
+    if message == INVALID_MAGIC_LINK_TOKEN {
+        Value::err(Value::String(message))
+    } else {
+        Value::err(Value::String(
+            MAGIC_LINK_VERIFICATION_UNAVAILABLE.to_string(),
+        ))
+    }
+}
+
+fn parse_local_token_issue_options(
     function_name: &str,
     options: Option<&Value>,
 ) -> Result<(String, Option<i64>)> {
@@ -4588,6 +4612,94 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt issue_magic_link
+    // @module std/auth
+    // @signature issue_magic_link(identifier: String, options?: Map) -> Result<Map, String>
+    // Issue a one-time passwordless sign-in token for an active local identity.
+    //
+    // The helper stores only a hashed verifier with an opaque selector. Valid-shaped
+    // requests return equivalent token material whether or not an active identity exists;
+    // only active identities get a persisted token. Apps own delivery, request throttling,
+    // authorization policy, and the final sign_in_session(...) call.
+    // @param identifier The local user identifier. Email is the default identifier kind.
+    // @param options Optional map with `identifier_kind` and `ttl_seconds` (default 900, maximum 3600)
+    // @returns Ok(map) with `status: "accepted"` and, for valid-shaped requests, one-time token material
+    // @error RuntimeError ~ "Magic link issuance unavailable" fix: "Retry after checking the configured auth storage backend"
+    // @see_also consume_magic_link, sign_in_session, local_user
+    // @since v0.5.1
+    // @tags #auth, #local-auth, #magic-link, #passwordless, #security
+    // @example let issued = issue_magic_link(form["email"] ?? "")? ~ "Issue a passwordless sign-in token for out-of-band delivery"
+    module.insert(
+        "issue_magic_link".to_string(),
+        Value::NativeFunction {
+            name: "issue_magic_link".to_string(),
+            arity: 1,
+            max_arity: 2,
+            requires: None,
+            func: |args| {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(IntentError::type_error(
+                        "[auth] issue_magic_link() requires identifier and optional options"
+                            .to_string(),
+                    ));
+                }
+                require_auth_initialized_for("issue_magic_link")?;
+                let identifier = string_arg("issue_magic_link", args, 0, "identifier")?;
+                let (identifier_kind, ttl_seconds) =
+                    parse_local_token_issue_options("issue_magic_link", args.get(1))?;
+                match issue_magic_link_record(&identifier_kind, identifier, ttl_seconds) {
+                    Ok(payload) => Ok(Value::ok(Value::Map(payload))),
+                    Err(_) => Ok(Value::err(Value::String(
+                        MAGIC_LINK_ISSUANCE_UNAVAILABLE.to_string(),
+                    ))),
+                }
+            },
+        },
+    );
+
+    // @ntnt consume_magic_link
+    // @module std/auth
+    // @signature consume_magic_link(token: String) -> Result<Map, String>
+    // Atomically consume a one-time passwordless sign-in token.
+    //
+    // Missing, malformed, expired, replayed, wrong-verifier, and non-active-identity
+    // tokens return the same generic error. Success returns a safe local identity payload;
+    // it does not create a session or grant app roles.
+    // @param token The `selector.verifier` token returned by issue_magic_link(...)
+    // @returns Ok(map) with safe local identity fields, or a generic Err for invalid tokens
+    // @error RuntimeError ~ "Magic link verification unavailable" fix: "Retry after checking the configured auth storage backend"
+    // @see_also issue_magic_link, sign_in_session, local_user
+    // @since v0.5.1
+    // @tags #auth, #local-auth, #magic-link, #passwordless, #security
+    // @example let user = consume_magic_link(form["token"] ?? "")? ~ "Verify a one-time token before creating an app-owned session"
+    module.insert(
+        "consume_magic_link".to_string(),
+        Value::NativeFunction {
+            name: "consume_magic_link".to_string(),
+            arity: 1,
+            max_arity: 1,
+            requires: None,
+            func: |args| {
+                if args.len() != 1 {
+                    return Err(IntentError::type_error(
+                        "[auth] consume_magic_link() requires token".to_string(),
+                    ));
+                }
+                require_auth_initialized_for("consume_magic_link")?;
+                let token = string_arg("consume_magic_link", args, 0, "token")?;
+                match consume_magic_link_record(token) {
+                    Ok(identity) => match local_identity_to_safe_value(&identity) {
+                        Ok(value) => Ok(Value::ok(value)),
+                        Err(_) => Ok(Value::err(Value::String(
+                            MAGIC_LINK_VERIFICATION_UNAVAILABLE.to_string(),
+                        ))),
+                    },
+                    Err(message) => Ok(magic_link_error_response(message)),
+                }
+            },
+        },
+    );
+
     // @ntnt issue_password_reset
     // @module std/auth
     // @signature issue_password_reset(identifier: String, options?: Map) -> Result<Map, String>
@@ -4604,6 +4716,7 @@ pub fn init() -> HashMap<String, Value> {
     // @param identifier The local user identifier. Supported kinds are `email` (default), `phone`, `username`, and `custom`.
     // @param options Optional map with `identifier_kind` (`"email"`, `"phone"`, `"username"`, or `"custom"`; default `"email"`) and `ttl_seconds` (default 3600)
     // @returns Ok(map) with `status: "accepted"`; syntactically valid reset requests also include `token`, `selector`, `created_at`, and `expires_at` without revealing whether a matching account exists
+    // @error RuntimeError ~ "Password reset issuance unavailable" fix: "Retry after checking the configured auth storage backend"
     // @see_also consume_password_reset, verify_local_password, set_local_password
     // @since v0.4.9
     // @tags #auth, #local-auth, #password-reset, #security
@@ -4625,10 +4738,12 @@ pub fn init() -> HashMap<String, Value> {
                 require_auth_initialized_for("issue_password_reset")?;
                 let identifier = string_arg("issue_password_reset", args, 0, "identifier")?;
                 let (identifier_kind, ttl_seconds) =
-                    parse_password_reset_issue_options("issue_password_reset", args.get(1))?;
+                    parse_local_token_issue_options("issue_password_reset", args.get(1))?;
                 match issue_password_reset_record(&identifier_kind, identifier, ttl_seconds) {
                     Ok(payload) => Ok(Value::ok(Value::Map(payload))),
-                    Err(message) => Ok(Value::err(Value::String(message))),
+                    Err(_) => Ok(Value::err(Value::String(
+                        PASSWORD_RESET_ISSUANCE_UNAVAILABLE.to_string(),
+                    ))),
                 }
             },
         },
@@ -4650,7 +4765,8 @@ pub fn init() -> HashMap<String, Value> {
     // @param token The `selector.verifier` token returned by `issue_password_reset(...)`
     // @param new_password Replacement plaintext password to hash and store
     // @param options Optional map with `revoke_sessions` (default false)
-    // @returns Ok(map) with safe local user fields and `revoked_sessions`; Err(message) for invalid/expired/replayed tokens or storage failure
+    // @returns Ok(map) with safe local user fields and `revoked_sessions`; Err(message) for invalid/expired/replayed tokens or sanitized storage failure
+    // @error RuntimeError ~ "Password reset verification unavailable" fix: "Retry after checking the configured auth storage backend"
     // @see_also issue_password_reset, verify_local_password, logout_all, sign_in_session
     // @since v0.4.9
     // @tags #auth, #local-auth, #password-reset, #security
@@ -4686,7 +4802,7 @@ pub fn init() -> HashMap<String, Value> {
                         }
                         Ok(Value::ok(value))
                     }
-                    Err(message) => Ok(Value::err(Value::String(message))),
+                    Err(message) => Ok(password_reset_error_response(message)),
                 }
             },
         },
@@ -5508,17 +5624,18 @@ pub fn init() -> HashMap<String, Value> {
 mod tests {
     use super::storage::{
         cleanup_expired_oauth_state_records, consume_auth_challenge_record,
-        consume_exchange_token_record,
+        consume_exchange_token_record, consume_local_one_time_token_record,
         consume_local_password_reset_token_and_store_credential_record, consume_oauth_state_record,
         delete_all_session_records_for_user, delete_session_record, extend_session_record_expiry,
         get_auth_challenge_record, get_local_credential_secret_record,
         get_local_identity_by_identifier_record, get_refreshable_session_record,
         get_session_record, list_session_records_for_user, migrate_session_record,
         store_auth_challenge_record, store_exchange_token_record,
-        store_local_identity_and_credential_record, store_local_password_reset_token_record,
-        store_oauth_state_record, store_session_record, update_session_record_data,
-        update_session_record_tokens, LocalAccountState, LocalCredentialSecret, LocalIdentity,
-        LocalPasswordResetToken, OAUTH_STATE_TTL,
+        store_local_identity_and_credential_record, store_local_one_time_token_record,
+        store_oauth_state_record, store_session_record, update_local_identity_by_identifier_record,
+        update_session_record_data, update_session_record_tokens, LocalAccountState,
+        LocalCredentialSecret, LocalIdentity, LocalOneTimeToken, LocalOneTimeTokenPurpose,
+        OAUTH_STATE_TTL,
     };
     use super::*;
 
@@ -5935,19 +6052,66 @@ mod tests {
             stored_local_credential.password_hash,
             local_credential.password_hash
         );
-        let reset_token = LocalPasswordResetToken {
+        let reset_token = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::PasswordReset,
             selector: format!("reset-selector-{}", label),
             local_user_id: local_identity.id.clone(),
             token_hash: format!("reset-hash-{}", label),
             created_at: now,
             expires_at: now + 3600,
         };
-        store_local_password_reset_token_record(&reset_token).unwrap_or_else(|e| {
-            panic!(
-                "{} local password reset token store should succeed: {}",
-                label, e
+        assert!(
+            store_local_one_time_token_record(&reset_token).unwrap_or_else(|e| {
+                panic!(
+                    "{} local password reset token store should succeed: {}",
+                    label, e
+                )
+            })
+        );
+        assert!(
+            consume_local_one_time_token_record(
+                LocalOneTimeTokenPurpose::MagicLink,
+                &reset_token.selector,
+                &reset_token.token_hash,
+                now,
             )
-        });
+            .unwrap_or_else(|e| panic!(
+                "{} cross-purpose reset lookup should succeed safely: {}",
+                label, e
+            ))
+            .is_none(),
+            "{} password-reset token must not consume as a magic link",
+            label
+        );
+        let mut wrong_verifier_builder_called = false;
+        assert!(
+            consume_local_password_reset_token_and_store_credential_record(
+                &reset_token.selector,
+                "wrong-reset-hash",
+                now,
+                |local_user_id| {
+                    wrong_verifier_builder_called = true;
+                    Ok(LocalCredentialSecret {
+                        local_user_id: local_user_id.to_string(),
+                        password_hash: "must-not-be-built".to_string(),
+                        password_hash_algorithm: "bcrypt".to_string(),
+                        password_hash_params_json: "{}".to_string(),
+                        password_changed_at: now + 1,
+                        must_change_password: false,
+                    })
+                },
+            )
+            .unwrap_or_else(|e| panic!(
+                "{} wrong-verifier reset lookup should succeed safely: {}",
+                label, e
+            ))
+            .is_none()
+        );
+        assert!(
+            !wrong_verifier_builder_called,
+            "{} wrong reset verifier must not invoke credential hashing",
+            label
+        );
         let consumed_reset = consume_local_password_reset_token_and_store_credential_record(
             &reset_token.selector,
             &reset_token.token_hash,
@@ -5997,6 +6161,58 @@ mod tests {
             ))
             .is_none()
         );
+
+        let magic_token = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::MagicLink,
+            selector: format!("magic-selector-{}", label),
+            local_user_id: local_identity.id.clone(),
+            token_hash: format!("magic-hash-{}", label),
+            created_at: now,
+            expires_at: now + 900,
+        };
+        assert!(store_local_one_time_token_record(&magic_token)
+            .unwrap_or_else(|e| panic!("{} magic-link token store should succeed: {}", label, e)));
+        assert!(
+            consume_local_password_reset_token_and_store_credential_record(
+                &magic_token.selector,
+                &magic_token.token_hash,
+                now,
+                |local_user_id| {
+                    Ok(LocalCredentialSecret {
+                        local_user_id: local_user_id.to_string(),
+                        password_hash: "unused-cross-purpose".to_string(),
+                        password_hash_algorithm: "bcrypt".to_string(),
+                        password_hash_params_json: "{}".to_string(),
+                        password_changed_at: now + 2,
+                        must_change_password: false,
+                    })
+                },
+            )
+            .unwrap_or_else(|e| panic!(
+                "{} cross-purpose magic-link lookup should succeed safely: {}",
+                label, e
+            ))
+            .is_none(),
+            "{} magic-link token must not consume as a password reset",
+            label
+        );
+        let consumed_magic = consume_local_one_time_token_record(
+            LocalOneTimeTokenPurpose::MagicLink,
+            &magic_token.selector,
+            &magic_token.token_hash,
+            now,
+        )
+        .unwrap_or_else(|e| panic!("{} magic-link consume should succeed: {}", label, e))
+        .unwrap_or_else(|| panic!("{} magic-link token should consume", label));
+        assert_eq!(consumed_magic.id, local_identity.id);
+        assert!(consume_local_one_time_token_record(
+            LocalOneTimeTokenPurpose::MagicLink,
+            &magic_token.selector,
+            &magic_token.token_hash,
+            now,
+        )
+        .unwrap_or_else(|e| panic!("{} magic-link replay lookup should succeed: {}", label, e))
+        .is_none());
 
         let oauth_state = OAuthState {
             state: format!("oauth-{}-active", label),
@@ -6937,7 +7153,7 @@ mod tests {
             LocalAuthRecordKind::Identity,
             LocalAuthRecordKind::CredentialSecret,
             LocalAuthRecordKind::TotpEnrollment,
-            LocalAuthRecordKind::PasswordResetToken,
+            LocalAuthRecordKind::OneTimeToken,
             LocalAuthRecordKind::BootstrapState,
         ] {
             let policy = local_auth_record_fallback_policy(record_kind);
@@ -8029,6 +8245,504 @@ mod tests {
     }
 
     #[test]
+    fn test_magic_link_helpers_issue_consume_reject_replay_and_isolate_token_purpose() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        for store in [
+            SessionStore::Memory,
+            SessionStore::Sqlite(":memory:".to_string()),
+        ] {
+            reset_auth_test_state();
+            init_test_auth(store);
+
+            let module = init();
+            let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+            let set_local_password = module_fn(&module, "set_local_password");
+            let issue_magic_link = module_fn(&module, "issue_magic_link");
+            let consume_magic_link = module_fn(&module, "consume_magic_link");
+            let issue_password_reset = module_fn(&module, "issue_password_reset");
+            let consume_password_reset = module_fn(&module, "consume_password_reset");
+
+            result_ok_map(
+                bootstrap_local_user(&[
+                    Value::String(" Magic@Example.COM ".to_string()),
+                    Value::String("temporary magic password".to_string()),
+                ])
+                .unwrap(),
+            );
+            result_ok_map(
+                set_local_password(&[
+                    Value::String("magic@example.com".to_string()),
+                    Value::String("temporary magic password".to_string()),
+                    Value::String("active magic password".to_string()),
+                ])
+                .unwrap(),
+            );
+
+            let issued = result_ok_map(
+                issue_magic_link(&[Value::String(" magic@example.com ".to_string())]).unwrap(),
+            );
+            let token = map_string(&issued, "token");
+            let selector = map_string(&issued, "selector");
+            assert_eq!(
+                map_int(&issued, "expires_at") - map_int(&issued, "created_at"),
+                900
+            );
+            assert_eq!(selector.len(), 22);
+            assert_eq!(token.len(), 66);
+            assert!(token.starts_with(&format!("{selector}.")));
+            assert!(map_int(&issued, "expires_at") > map_int(&issued, "created_at"));
+            for secret_key in ["token_hash", "local_user_id", "password_hash", "credential"] {
+                assert!(!issued.contains_key(secret_key));
+            }
+
+            let mut token_parts = token.splitn(2, '.');
+            let token_selector = token_parts.next().unwrap();
+            let wrong_token = format!("{}.{}", token_selector, "A".repeat(43));
+            assert_eq!(
+                result_err_string(consume_magic_link(&[Value::String(wrong_token)]).unwrap()),
+                "Invalid magic link token"
+            );
+
+            let consumed =
+                result_ok_map(consume_magic_link(&[Value::String(token.clone())]).unwrap());
+            assert_eq!(
+                map_string(&consumed, "identifier_normalized"),
+                "magic@example.com"
+            );
+            assert_eq!(map_string(&consumed, "state"), "active");
+            for secret_key in [
+                "token",
+                "selector",
+                "token_hash",
+                "password_hash",
+                "credential",
+            ] {
+                assert!(!consumed.contains_key(secret_key));
+            }
+            assert_eq!(
+                result_err_string(consume_magic_link(&[Value::String(token)]).unwrap()),
+                "Invalid magic link token"
+            );
+
+            let replaced = result_ok_map(
+                issue_magic_link(&[Value::String("magic@example.com".to_string())]).unwrap(),
+            );
+            let replaced_token = map_string(&replaced, "token");
+            let replacement = result_ok_map(
+                issue_magic_link(&[Value::String("magic@example.com".to_string())]).unwrap(),
+            );
+            let replacement_token = map_string(&replacement, "token");
+            assert_eq!(
+                result_err_string(consume_magic_link(&[Value::String(replaced_token)]).unwrap()),
+                "Invalid magic link token",
+                "issuing a new link must invalidate older links for that identity"
+            );
+            result_ok_map(consume_magic_link(&[Value::String(replacement_token)]).unwrap());
+
+            let reset = result_ok_map(
+                issue_password_reset(&[Value::String("magic@example.com".to_string())]).unwrap(),
+            );
+            let reset_token = map_string(&reset, "token");
+            assert_eq!(
+                result_err_string(
+                    consume_magic_link(&[Value::String(reset_token.clone())]).unwrap()
+                ),
+                "Invalid magic link token"
+            );
+            result_ok_map(
+                consume_password_reset(&[
+                    Value::String(reset_token),
+                    Value::String("password reset still works".to_string()),
+                ])
+                .unwrap(),
+            );
+
+            let magic = result_ok_map(
+                issue_magic_link(&[Value::String("magic@example.com".to_string())]).unwrap(),
+            );
+            let magic_token = map_string(&magic, "token");
+            assert_eq!(
+                result_err_string(
+                    consume_password_reset(&[
+                        Value::String(magic_token.clone()),
+                        Value::String("must not reset password".to_string()),
+                    ])
+                    .unwrap()
+                ),
+                "Invalid password reset token"
+            );
+            result_ok_map(consume_magic_link(&[Value::String(magic_token)]).unwrap());
+
+            let capped = result_ok_map(
+                issue_magic_link(&[
+                    Value::String("magic@example.com".to_string()),
+                    Value::Map(HashMap::from([(
+                        "ttl_seconds".to_string(),
+                        Value::Int(7200),
+                    )])),
+                ])
+                .unwrap(),
+            );
+            assert_eq!(
+                map_int(&capped, "expires_at") - map_int(&capped, "created_at"),
+                3600,
+                "magic-link TTL must be capped at one hour"
+            );
+            result_ok_map(
+                consume_magic_link(&[Value::String(map_string(&capped, "token"))]).unwrap(),
+            );
+
+            let unknown = result_ok_map(
+                issue_magic_link(&[Value::String("missing@example.com".to_string())]).unwrap(),
+            );
+            let mut known_response_keys = issued.keys().cloned().collect::<Vec<_>>();
+            let mut unknown_response_keys = unknown.keys().cloned().collect::<Vec<_>>();
+            known_response_keys.sort();
+            unknown_response_keys.sort();
+            assert_eq!(
+                unknown_response_keys, known_response_keys,
+                "valid-shaped requests must not reveal account existence through response shape"
+            );
+            let unknown_token = map_string(&unknown, "token");
+            assert_eq!(
+                result_err_string(consume_magic_link(&[Value::String(unknown_token)]).unwrap()),
+                "Invalid magic link token"
+            );
+
+            let state_bound = result_ok_map(
+                issue_magic_link(&[Value::String("magic@example.com".to_string())]).unwrap(),
+            );
+            let state_bound_token = map_string(&state_bound, "token");
+            update_local_identity_by_identifier_record("email", "magic@example.com", |identity| {
+                identity.state = LocalAccountState::Locked;
+                Ok(())
+            })
+            .unwrap();
+            assert_eq!(
+                result_err_string(
+                    consume_magic_link(&[Value::String(state_bound_token.clone())]).unwrap()
+                ),
+                "Invalid magic link token"
+            );
+            update_local_identity_by_identifier_record("email", "magic@example.com", |identity| {
+                identity.state = LocalAccountState::Active;
+                Ok(())
+            })
+            .unwrap();
+            assert_eq!(
+                result_err_string(
+                    consume_magic_link(&[Value::String(state_bound_token)]).unwrap()
+                ),
+                "Invalid magic link token",
+                "a token rejected while the account is non-active must remain unusable after reactivation"
+            );
+
+            update_local_identity_by_identifier_record("email", "magic@example.com", |identity| {
+                identity.state = LocalAccountState::Locked;
+                Ok(())
+            })
+            .unwrap();
+            let locked_issue = result_ok_map(
+                issue_magic_link(&[Value::String("magic@example.com".to_string())]).unwrap(),
+            );
+            let mut locked_response_keys = locked_issue.keys().cloned().collect::<Vec<_>>();
+            locked_response_keys.sort();
+            let mut active_response_keys = issued.keys().cloned().collect::<Vec<_>>();
+            active_response_keys.sort();
+            assert_eq!(locked_response_keys, active_response_keys);
+            let locked_issue_token = map_string(&locked_issue, "token");
+            let locked_identity =
+                get_local_identity_by_identifier_record("email", "magic@example.com")
+                    .unwrap()
+                    .unwrap();
+            let now = chrono::Utc::now().timestamp();
+            let rejected_store_token = LocalOneTimeToken {
+                purpose: LocalOneTimeTokenPurpose::MagicLink,
+                selector: "locked-store-selector".to_string(),
+                local_user_id: locked_identity.id,
+                token_hash: "locked-store-hash".to_string(),
+                created_at: now,
+                expires_at: now + 900,
+            };
+            assert!(!store_local_one_time_token_record(&rejected_store_token).unwrap());
+            update_local_identity_by_identifier_record("email", "magic@example.com", |identity| {
+                identity.state = LocalAccountState::Active;
+                Ok(())
+            })
+            .unwrap();
+            assert_eq!(
+                result_err_string(
+                    consume_magic_link(&[Value::String(locked_issue_token)]).unwrap()
+                ),
+                INVALID_MAGIC_LINK_TOKEN
+            );
+            assert!(consume_local_one_time_token_record(
+                LocalOneTimeTokenPurpose::MagicLink,
+                &rejected_store_token.selector,
+                &rejected_store_token.token_hash,
+                now,
+            )
+            .unwrap()
+            .is_none());
+        }
+    }
+
+    #[test]
+    fn test_one_time_token_backend_failures_are_sanitized_and_distinct_from_invalid_tokens() {
+        assert_eq!(
+            result_err_string(password_reset_error_response(
+                "PostgreSQL transaction failed: backend detail".to_string(),
+            )),
+            PASSWORD_RESET_VERIFICATION_UNAVAILABLE
+        );
+        assert_eq!(
+            result_err_string(password_reset_error_response(
+                INVALID_PASSWORD_RESET_TOKEN.to_string(),
+            )),
+            INVALID_PASSWORD_RESET_TOKEN
+        );
+        assert_eq!(
+            result_err_string(password_reset_error_response(
+                EMPTY_LOCAL_PASSWORD.to_string(),
+            )),
+            EMPTY_LOCAL_PASSWORD
+        );
+        assert_eq!(
+            result_err_string(magic_link_error_response(
+                "Redis GET error: backend detail".to_string()
+            )),
+            MAGIC_LINK_VERIFICATION_UNAVAILABLE
+        );
+        assert_eq!(
+            result_err_string(magic_link_error_response(
+                INVALID_MAGIC_LINK_TOKEN.to_string()
+            )),
+            INVALID_MAGIC_LINK_TOKEN
+        );
+    }
+
+    #[test]
+    fn test_sqlite_migrates_legacy_password_reset_tokens_without_replay_copy() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ntnt-auth-token-migration-{unique}.db"));
+        let path_string = path.to_string_lossy().into_owned();
+
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(path_string.clone()));
+        store_local_identity_and_credential_record(
+            &LocalIdentity {
+                id: "migration-user".to_string(),
+                identifier_kind: "email".to_string(),
+                identifier: "migration@example.com".to_string(),
+                identifier_normalized: "migration@example.com".to_string(),
+                created_at: 100,
+                updated_at: 100,
+                state: LocalAccountState::Active,
+                metadata_json: "{}".to_string(),
+            },
+            &LocalCredentialSecret {
+                local_user_id: "migration-user".to_string(),
+                password_hash: "migration-hash".to_string(),
+                password_hash_algorithm: "bcrypt".to_string(),
+                password_hash_params_json: "{}".to_string(),
+                password_changed_at: 100,
+                must_change_password: false,
+            },
+        )
+        .unwrap();
+        reset_auth_test_state();
+
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute("DROP TABLE auth_local_one_time_tokens", [])
+                .unwrap();
+            conn.execute(
+                "CREATE TABLE auth_local_password_reset_tokens (
+                    selector TEXT PRIMARY KEY,
+                    local_user_id TEXT NOT NULL,
+                    token_hash TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    expires_at INTEGER NOT NULL
+                )",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO auth_local_password_reset_tokens
+                 (selector, local_user_id, token_hash, created_at, expires_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params!["legacy-selector", "migration-user", "legacy-hash", 100, 200],
+            )
+            .unwrap();
+        }
+
+        init_test_auth(SessionStore::Sqlite(path_string));
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            let migrated: (String, String, String) = conn
+                .query_row(
+                    "SELECT purpose, local_user_id, token_hash
+                     FROM auth_local_one_time_tokens WHERE selector = ?1",
+                    rusqlite::params!["legacy-selector"],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .unwrap();
+            assert_eq!(
+                migrated,
+                (
+                    "password_reset".to_string(),
+                    "migration-user".to_string(),
+                    "legacy-hash".to_string()
+                )
+            );
+            let legacy_exists: i64 = conn
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                     WHERE type = 'table' AND name = 'auth_local_password_reset_tokens')",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(legacy_exists, 0);
+        }
+        reset_auth_test_state();
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_postgres_migrates_legacy_password_reset_tokens_without_replay_copy() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let Some(SessionStore::Postgres(url)) = auth_test_postgres_store() else {
+            eprintln!(
+                "[auth-test] skipping Postgres token migration test — set NTNT_AUTH_TEST_POSTGRES_URL"
+            );
+            return;
+        };
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let user_id = format!("migration-user-{unique}");
+        let selector = format!("legacy-selector-{unique}");
+        let email = format!("migration-{unique}@example.com");
+
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Postgres(url.clone()));
+        {
+            let mut client = postgres::Client::connect(&url, postgres::NoTls).unwrap();
+            client
+                .execute(
+                    "INSERT INTO auth_local_identities
+                     (id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json)
+                     VALUES ($1, 'email', $2, $2, 100, 100, 'active', '{}')",
+                    &[&user_id, &email],
+                )
+                .unwrap();
+            client
+                .execute(
+                    "CREATE TABLE IF NOT EXISTS auth_local_password_reset_tokens (
+                        selector TEXT PRIMARY KEY,
+                        local_user_id TEXT NOT NULL REFERENCES auth_local_identities(id) ON DELETE CASCADE,
+                        token_hash TEXT NOT NULL,
+                        created_at BIGINT NOT NULL,
+                        expires_at BIGINT NOT NULL
+                    )",
+                    &[],
+                )
+                .unwrap();
+            client
+                .execute(
+                    "INSERT INTO auth_local_password_reset_tokens
+                     (selector, local_user_id, token_hash, created_at, expires_at)
+                     VALUES ($1, $2, 'legacy-hash', 100, 200)",
+                    &[&selector, &user_id],
+                )
+                .unwrap();
+        }
+
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Postgres(url.clone()));
+        {
+            let mut client = postgres::Client::connect(&url, postgres::NoTls).unwrap();
+            let migrated = client
+                .query_one(
+                    "SELECT purpose, local_user_id, token_hash
+                     FROM auth_local_one_time_tokens WHERE selector = $1",
+                    &[&selector],
+                )
+                .unwrap();
+            assert_eq!(migrated.get::<_, String>(0), "password_reset");
+            assert_eq!(migrated.get::<_, String>(1), user_id);
+            assert_eq!(migrated.get::<_, String>(2), "legacy-hash");
+            let legacy_exists: bool = client
+                .query_one(
+                    "SELECT EXISTS (
+                        SELECT 1 FROM information_schema.tables
+                        WHERE table_schema = current_schema()
+                          AND table_name = 'auth_local_password_reset_tokens'
+                    )",
+                    &[],
+                )
+                .unwrap()
+                .get(0);
+            assert!(!legacy_exists);
+            client
+                .execute(
+                    "DELETE FROM auth_local_identities WHERE id = $1",
+                    &[&user_id],
+                )
+                .unwrap();
+        }
+        reset_auth_test_state();
+    }
+
+    #[test]
+    fn test_redis_purges_legacy_password_reset_keys_on_upgrade() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let Some(SessionStore::Redis(url)) = auth_test_redis_store() else {
+            eprintln!(
+                "[auth-test] skipping Redis token migration test — set NTNT_AUTH_TEST_REDIS_URL"
+            );
+            return;
+        };
+        let unique = uuid::Uuid::new_v4().to_string();
+        let token_key = format!("ntnt:local_password_reset:{unique}");
+        let user_set_key = format!("ntnt:local_password_reset_tokens_for_user:{unique}");
+        {
+            let client = redis::Client::open(url.as_str()).unwrap();
+            let mut conn = client.get_connection().unwrap();
+            redis::cmd("SET")
+                .arg(&token_key)
+                .arg("legacy-token-record")
+                .query::<String>(&mut conn)
+                .unwrap();
+            redis::cmd("SADD")
+                .arg(&user_set_key)
+                .arg(&unique)
+                .query::<usize>(&mut conn)
+                .unwrap();
+        }
+
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Redis(url.clone()));
+        {
+            let client = redis::Client::open(url.as_str()).unwrap();
+            let mut conn = client.get_connection().unwrap();
+            let remaining: usize = redis::cmd("EXISTS")
+                .arg(&token_key)
+                .arg(&user_set_key)
+                .query(&mut conn)
+                .unwrap();
+            assert_eq!(remaining, 0);
+        }
+        reset_auth_test_state();
+    }
+
+    #[test]
     fn test_set_local_password_revokes_outstanding_password_reset_tokens() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         for store in [
@@ -8089,6 +8803,44 @@ mod tests {
     }
 
     #[test]
+    fn test_password_reset_issue_sanitizes_sqlite_storage_failures() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        reset_auth_test_state();
+        init_test_auth(SessionStore::Sqlite(":memory:".to_string()));
+
+        let module = init();
+        let bootstrap_local_user = module_fn(&module, "bootstrap_local_user");
+        let issue_password_reset = module_fn(&module, "issue_password_reset");
+        result_ok_map(
+            bootstrap_local_user(&[
+                Value::String("issue-failure@example.com".to_string()),
+                Value::String("temporary reset password".to_string()),
+            ])
+            .unwrap(),
+        );
+        {
+            let conn_guard = SQLITE_CONN.lock().unwrap();
+            let conn = conn_guard.as_ref().expect("SQLite should be initialized");
+            conn.execute(
+                "CREATE TRIGGER fail_password_reset_issue
+                 BEFORE INSERT ON auth_local_one_time_tokens
+                 BEGIN
+                     SELECT RAISE(ABORT, 'forced password reset issue failure');
+                 END",
+                [],
+            )
+            .expect("test trigger should be installed");
+        }
+
+        let failed = result_err_string(
+            issue_password_reset(&[Value::String("issue-failure@example.com".to_string())])
+                .unwrap(),
+        );
+        assert_eq!(failed, PASSWORD_RESET_ISSUANCE_UNAVAILABLE);
+        assert!(!failed.contains("forced password reset issue failure"));
+    }
+
+    #[test]
     fn test_password_reset_consume_is_atomic_when_sqlite_credential_write_fails() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         reset_auth_test_state();
@@ -8133,10 +8885,8 @@ mod tests {
             ])
             .unwrap(),
         );
-        assert!(
-            failed.contains("forced password reset credential failure"),
-            "unexpected storage failure message: {failed}"
-        );
+        assert_eq!(failed, PASSWORD_RESET_VERIFICATION_UNAVAILABLE);
+        assert!(!failed.contains("forced password reset credential failure"));
 
         let old_password_still_valid = result_ok_map(
             verify_local_password(&[
@@ -9054,24 +9804,250 @@ mod tests {
         run_auth_storage_contract_round_trip(store, "redis");
     }
 
+    fn run_magic_link_concurrency_contract(store: SessionStore, label: &str) {
+        reset_auth_test_state();
+        init_test_auth(store);
+        let now = chrono::Utc::now().timestamp();
+        let unique = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
+        let identity = LocalIdentity {
+            id: format!("local-user-magic-concurrent-{label}-{unique}"),
+            identifier_kind: "email".to_string(),
+            identifier: format!("magic-concurrent-{label}-{unique}@example.com"),
+            identifier_normalized: format!("magic-concurrent-{label}-{unique}@example.com"),
+            created_at: now,
+            updated_at: now,
+            state: LocalAccountState::Active,
+            metadata_json: "{}".to_string(),
+        };
+        let credential = LocalCredentialSecret {
+            local_user_id: identity.id.clone(),
+            password_hash: "unused-magic-concurrency-hash".to_string(),
+            password_hash_algorithm: "bcrypt".to_string(),
+            password_hash_params_json: "{}".to_string(),
+            password_changed_at: now,
+            must_change_password: false,
+        };
+        store_local_identity_and_credential_record(&identity, &credential).unwrap();
+        let token = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::MagicLink,
+            selector: format!("magic-concurrent-selector-{label}-{unique}"),
+            local_user_id: identity.id,
+            token_hash: format!("magic-concurrent-hash-{label}-{unique}"),
+            created_at: now,
+            expires_at: now + 900,
+        };
+        store_local_one_time_token_record(&token).unwrap();
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let barrier = barrier.clone();
+            let selector = token.selector.clone();
+            let token_hash = token.token_hash.clone();
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                consume_local_one_time_token_record(
+                    LocalOneTimeTokenPurpose::MagicLink,
+                    &selector,
+                    &token_hash,
+                    now,
+                )
+            }));
+        }
+        let successes = handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .expect("magic-link consume thread should not panic")
+            })
+            .map(|result| result.expect("magic-link consume should not return storage error"))
+            .filter(Option::is_some)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one concurrent consume should succeed"
+        );
+
+        let issue_a = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::MagicLink,
+            selector: format!("magic-concurrent-issue-a-{label}-{unique}"),
+            local_user_id: token.local_user_id.clone(),
+            token_hash: format!("magic-concurrent-issue-hash-a-{label}-{unique}"),
+            created_at: now,
+            expires_at: now + 900,
+        };
+        let issue_b = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::MagicLink,
+            selector: format!("magic-concurrent-issue-b-{label}-{unique}"),
+            local_user_id: token.local_user_id.clone(),
+            token_hash: format!("magic-concurrent-issue-hash-b-{label}-{unique}"),
+            created_at: now,
+            expires_at: now + 900,
+        };
+        let issue_barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let issue_handles = [issue_a, issue_b]
+            .into_iter()
+            .map(|candidate| {
+                let barrier = issue_barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store_local_one_time_token_record(&candidate)
+                })
+            })
+            .collect::<Vec<_>>();
+        for handle in issue_handles {
+            handle
+                .join()
+                .expect("magic-link issue thread should not panic")
+                .expect("magic-link issue should not return storage error");
+        }
+
+        let active_tokens = match label {
+            "postgres" => {
+                let url = std::env::var("NTNT_AUTH_TEST_POSTGRES_URL").unwrap();
+                let mut client = postgres::Client::connect(&url, postgres::NoTls).unwrap();
+                client
+                    .query_one(
+                        "SELECT COUNT(*) FROM auth_local_one_time_tokens WHERE local_user_id = $1 AND purpose = $2",
+                        &[&token.local_user_id, &LocalOneTimeTokenPurpose::MagicLink.as_str()],
+                    )
+                    .unwrap()
+                    .get::<_, i64>(0)
+            }
+            "redis" => {
+                let url = std::env::var("NTNT_AUTH_TEST_REDIS_URL").unwrap();
+                let client = redis::Client::open(url).unwrap();
+                let mut conn = client.get_connection().unwrap();
+                redis::cmd("SCARD")
+                    .arg(format!(
+                        "ntnt:local_one_time_tokens_for_user:magic_link:{}",
+                        token.local_user_id
+                    ))
+                    .query::<i64>(&mut conn)
+                    .unwrap()
+            }
+            other => panic!("unsupported magic-link concurrency backend: {other}"),
+        };
+        assert_eq!(
+            active_tokens, 1,
+            "concurrent issuance must leave exactly one active token"
+        );
+
+        let race_initial = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::MagicLink,
+            selector: format!("magic-issue-consume-initial-{label}-{unique}"),
+            local_user_id: token.local_user_id.clone(),
+            token_hash: format!("magic-issue-consume-initial-hash-{label}-{unique}"),
+            created_at: now,
+            expires_at: now + 900,
+        };
+        assert!(store_local_one_time_token_record(&race_initial).unwrap());
+        let race_replacement = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::MagicLink,
+            selector: format!("magic-issue-consume-replacement-{label}-{unique}"),
+            local_user_id: token.local_user_id.clone(),
+            token_hash: format!("magic-issue-consume-replacement-hash-{label}-{unique}"),
+            created_at: now,
+            expires_at: now + 900,
+        };
+        let race_barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let consume_barrier = race_barrier.clone();
+        let consume_selector = race_initial.selector.clone();
+        let consume_hash = race_initial.token_hash.clone();
+        let consume_handle = std::thread::spawn(move || {
+            consume_barrier.wait();
+            consume_local_one_time_token_record(
+                LocalOneTimeTokenPurpose::MagicLink,
+                &consume_selector,
+                &consume_hash,
+                now,
+            )
+        });
+        let issue_barrier = race_barrier.clone();
+        let replacement_for_thread = race_replacement.clone();
+        let issue_handle = std::thread::spawn(move || {
+            issue_barrier.wait();
+            store_local_one_time_token_record(&replacement_for_thread)
+        });
+        consume_handle
+            .join()
+            .expect("issue-versus-consume thread should not panic")
+            .expect("issue-versus-consume race should not return storage error");
+        assert!(issue_handle
+            .join()
+            .expect("replacement issue thread should not panic")
+            .expect("replacement issue should not return storage error"));
+        assert!(consume_local_one_time_token_record(
+            LocalOneTimeTokenPurpose::MagicLink,
+            &race_replacement.selector,
+            &race_replacement.token_hash,
+            now,
+        )
+        .unwrap()
+        .is_some());
+
+        let identifier = format!("magic-concurrent-{label}-{unique}@example.com");
+        update_local_identity_by_identifier_record("email", &identifier, |identity| {
+            identity.state = LocalAccountState::Locked;
+            Ok(())
+        })
+        .unwrap();
+        let rejected_while_locked = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::MagicLink,
+            selector: format!("magic-locked-selector-{label}-{unique}"),
+            local_user_id: token.local_user_id.clone(),
+            token_hash: format!("magic-locked-hash-{label}-{unique}"),
+            created_at: now,
+            expires_at: now + 900,
+        };
+        assert!(!store_local_one_time_token_record(&rejected_while_locked).unwrap());
+        update_local_identity_by_identifier_record("email", &identifier, |identity| {
+            identity.state = LocalAccountState::Active;
+            Ok(())
+        })
+        .unwrap();
+        assert!(consume_local_one_time_token_record(
+            LocalOneTimeTokenPurpose::MagicLink,
+            &rejected_while_locked.selector,
+            &rejected_while_locked.token_hash,
+            now,
+        )
+        .unwrap()
+        .is_none());
+    }
+
     #[test]
-    fn test_redis_password_reset_consume_is_one_time_under_concurrency() {
+    fn test_postgres_magic_link_storage_is_atomic_under_concurrency() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
-        let Some(store) = auth_test_redis_store() else {
-            eprintln!(
-                "[auth-test] skipping Redis password reset concurrency test — set NTNT_AUTH_TEST_REDIS_URL"
-            );
+        let Some(store) = auth_test_postgres_store() else {
+            eprintln!("[auth-test] skipping PostgreSQL magic-link concurrency test — set NTNT_AUTH_TEST_POSTGRES_URL");
             return;
         };
+        run_magic_link_concurrency_contract(store, "postgres");
+    }
+
+    #[test]
+    fn test_redis_magic_link_storage_is_atomic_under_concurrency() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let Some(store) = auth_test_redis_store() else {
+            eprintln!("[auth-test] skipping Redis magic-link concurrency test — set NTNT_AUTH_TEST_REDIS_URL");
+            return;
+        };
+        run_magic_link_concurrency_contract(store, "redis");
+    }
+
+    fn run_password_reset_concurrency_contract(store: SessionStore, label: &str) {
         reset_auth_test_state();
         init_test_auth(store);
 
         let now = chrono::Utc::now().timestamp();
+        let unique = format!("{}-{}", now, uuid::Uuid::new_v4());
         let identity = LocalIdentity {
-            id: format!("local-user-redis-concurrent-{now}"),
+            id: format!("local-user-{label}-reset-concurrent-{unique}"),
             identifier_kind: "email".to_string(),
-            identifier: format!("redis-concurrent-{now}@example.com"),
-            identifier_normalized: format!("redis-concurrent-{now}@example.com"),
+            identifier: format!("{label}-reset-concurrent-{unique}@example.com"),
+            identifier_normalized: format!("{label}-reset-concurrent-{unique}@example.com"),
             created_at: now,
             updated_at: now,
             state: LocalAccountState::Active,
@@ -9086,14 +10062,15 @@ mod tests {
             must_change_password: false,
         };
         store_local_identity_and_credential_record(&identity, &credential).unwrap();
-        let reset_token = LocalPasswordResetToken {
-            selector: format!("redis-concurrent-selector-{now}"),
+        let reset_token = LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::PasswordReset,
+            selector: format!("{label}-reset-concurrent-selector-{unique}"),
             local_user_id: identity.id.clone(),
-            token_hash: format!("redis-concurrent-token-hash-{now}"),
+            token_hash: format!("{label}-reset-concurrent-token-hash-{unique}"),
             created_at: now,
             expires_at: now + 3600,
         };
-        store_local_password_reset_token_record(&reset_token).unwrap();
+        assert!(store_local_one_time_token_record(&reset_token).unwrap());
 
         let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
         let mut handles = Vec::new();
@@ -9126,14 +10103,14 @@ mod tests {
             .map(|handle| {
                 handle
                     .join()
-                    .expect("redis consume thread should not panic")
+                    .expect("password reset consume thread should not panic")
             })
-            .map(|result| result.expect("redis consume should not return storage error"))
+            .map(|result| result.expect("password reset consume should not return storage error"))
             .filter(|result| result.is_some())
             .count();
         assert_eq!(
             successes, 1,
-            "exactly one concurrent Redis password reset consume should succeed"
+            "exactly one concurrent {label} password reset consume should succeed"
         );
         assert!(
             consume_local_password_reset_token_and_store_credential_record(
@@ -9153,8 +10130,32 @@ mod tests {
             )
             .unwrap()
             .is_none(),
-            "Redis password reset token should be gone after the successful consume"
+            "{label} password reset token should be gone after the successful consume"
         );
+    }
+
+    #[test]
+    fn test_postgres_password_reset_consume_is_one_time_under_concurrency() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let Some(store) = auth_test_postgres_store() else {
+            eprintln!(
+                "[auth-test] skipping PostgreSQL password reset concurrency test — set NTNT_AUTH_TEST_POSTGRES_URL"
+            );
+            return;
+        };
+        run_password_reset_concurrency_contract(store, "postgres");
+    }
+
+    #[test]
+    fn test_redis_password_reset_consume_is_one_time_under_concurrency() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let Some(store) = auth_test_redis_store() else {
+            eprintln!(
+                "[auth-test] skipping Redis password reset concurrency test — set NTNT_AUTH_TEST_REDIS_URL"
+            );
+            return;
+        };
+        run_password_reset_concurrency_contract(store, "redis");
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -8664,8 +8664,48 @@ mod tests {
                 .unwrap();
         }
 
+        let mut migration_lock_client = postgres::Client::connect(&url, postgres::NoTls).unwrap();
+        let mut migration_lock = migration_lock_client.transaction().unwrap();
+        migration_lock
+            .execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended('ntnt:auth:local-one-time-token-migration', 0))",
+                &[],
+            )
+            .unwrap();
+
         reset_auth_test_state();
-        init_test_auth(SessionStore::Postgres(url.clone()));
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let url = url.clone();
+            let result_tx = result_tx.clone();
+            workers.push(std::thread::spawn(move || {
+                let config = AuthConfig {
+                    session_secret: "test-secret".to_string(),
+                    cookie_secure: false,
+                    session_store: SessionStore::Postgres(url),
+                    ..AuthConfig::default()
+                };
+                result_tx.send(ensure_auth_session_store(&config)).unwrap();
+            }));
+        }
+        drop(result_tx);
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        assert!(
+            result_rx.try_recv().is_err(),
+            "PostgreSQL token migrations must wait for the transaction-scoped migration lock"
+        );
+        migration_lock.commit().unwrap();
+        for _ in 0..2 {
+            result_rx
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .expect("concurrent PostgreSQL auth initialization should complete")
+                .expect("concurrent PostgreSQL auth initialization should succeed");
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+
         {
             let mut client = postgres::Client::connect(&url, postgres::NoTls).unwrap();
             let migrated = client

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -8711,7 +8711,7 @@ mod tests {
         };
         let unique = uuid::Uuid::new_v4().to_string();
         let token_key = format!("ntnt:local_password_reset:{unique}");
-        let user_set_key = format!("ntnt:local_password_reset_tokens_for_user:{unique}");
+        let user_set_key = format!("ntnt:local_password_resets_for_user:{unique}");
         {
             let client = redis::Client::open(url.as_str()).unwrap();
             let mut conn = client.get_connection().unwrap();

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -656,7 +656,7 @@ fn purge_legacy_redis_password_reset_keys(
 ) -> std::result::Result<(), String> {
     for pattern in [
         "ntnt:local_password_reset:*",
-        "ntnt:local_password_reset_tokens_for_user:*",
+        "ntnt:local_password_resets_for_user:*",
     ] {
         let mut cursor = 0_u64;
         loop {

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -612,6 +612,12 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
     let mut migration = client
         .transaction()
         .map_err(|e| format!("Failed to begin local one-time token migration: {}", e))?;
+    migration
+        .execute(
+            "SELECT pg_advisory_xact_lock(hashtextextended('ntnt:auth:local-one-time-token-migration', 0))",
+            &[],
+        )
+        .map_err(|e| format!("Failed to lock local one-time token migration: {}", e))?;
     let has_legacy_reset_table: bool = migration
         .query_one(
             "SELECT EXISTS (

--- a/src/stdlib/auth/config.rs
+++ b/src/stdlib/auth/config.rs
@@ -197,7 +197,7 @@ fn run_postgres_migration(
 
 // Initialize SQLite session storage
 fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
-    let conn =
+    let mut conn =
         rusqlite::Connection::open(path).map_err(|e| format!("Failed to open SQLite: {}", e))?;
 
     conn.execute("PRAGMA foreign_keys = ON", [])
@@ -348,7 +348,8 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
     .map_err(|e| format!("Failed to create auth_local_credentials table: {}", e))?;
 
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS auth_local_password_reset_tokens (
+        "CREATE TABLE IF NOT EXISTS auth_local_one_time_tokens (
+            purpose TEXT NOT NULL CHECK (purpose IN ('password_reset', 'magic_link')),
             selector TEXT PRIMARY KEY,
             local_user_id TEXT NOT NULL,
             token_hash TEXT NOT NULL,
@@ -358,24 +359,56 @@ fn init_sqlite_sessions(path: &str) -> std::result::Result<(), String> {
         )",
         [],
     )
-    .map_err(|e| {
-        format!(
-            "Failed to create auth_local_password_reset_tokens table: {}",
-            e
+    .map_err(|e| format!("Failed to create auth_local_one_time_tokens table: {}", e))?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_auth_local_one_time_tokens_expires ON auth_local_one_time_tokens(purpose, expires_at)",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_local_one_time_tokens index: {}", e))?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_auth_local_one_time_tokens_user_purpose ON auth_local_one_time_tokens(local_user_id, purpose)",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_local_one_time_tokens user index: {}", e))?;
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_local_one_time_tokens_one_magic_link ON auth_local_one_time_tokens(local_user_id) WHERE purpose = 'magic_link'",
+        [],
+    )
+    .map_err(|e| format!("Failed to create auth_local_one_time_tokens magic-link index: {}", e))?;
+
+    let migration = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|e| format!("Failed to begin local one-time token migration: {}", e))?;
+    let has_legacy_reset_table: bool = migration
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'auth_local_password_reset_tokens')",
+            [],
+            |row| row.get::<_, i64>(0),
         )
-    })?;
-
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_auth_local_password_reset_tokens_expires ON auth_local_password_reset_tokens(expires_at)",
-        [],
-    )
-    .map_err(|e| format!("Failed to create auth_local_password_reset_tokens index: {}", e))?;
-
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_auth_local_password_reset_tokens_user ON auth_local_password_reset_tokens(local_user_id)",
-        [],
-    )
-    .map_err(|e| format!("Failed to create auth_local_password_reset_tokens user index: {}", e))?;
+        .map(|exists| exists != 0)
+        .map_err(|e| format!("Failed to inspect legacy password reset table: {}", e))?;
+    if has_legacy_reset_table {
+        migration
+            .execute(
+                "INSERT OR IGNORE INTO auth_local_one_time_tokens
+                 (purpose, selector, local_user_id, token_hash, created_at, expires_at)
+                 SELECT 'password_reset', selector, local_user_id, token_hash, created_at, expires_at
+                 FROM auth_local_password_reset_tokens",
+                [],
+            )
+            .map_err(|e| format!("Failed to migrate legacy password reset tokens: {}", e))?;
+        migration
+            .execute("DELETE FROM auth_local_password_reset_tokens", [])
+            .map_err(|e| format!("Failed to clear legacy password reset tokens: {}", e))?;
+        migration
+            .execute("DROP TABLE auth_local_password_reset_tokens", [])
+            .map_err(|e| format!("Failed to drop legacy password reset table: {}", e))?;
+    }
+    migration
+        .commit()
+        .map_err(|e| format!("Failed to commit local one-time token migration: {}", e))?;
 
     let mut sqlite_conn = SQLITE_CONN.lock().unwrap();
     *sqlite_conn = Some(conn);
@@ -543,7 +576,8 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
 
     client
         .execute(
-            "CREATE TABLE IF NOT EXISTS auth_local_password_reset_tokens (
+            "CREATE TABLE IF NOT EXISTS auth_local_one_time_tokens (
+            purpose TEXT NOT NULL CHECK (purpose IN ('password_reset', 'magic_link')),
             selector TEXT PRIMARY KEY,
             local_user_id TEXT NOT NULL REFERENCES auth_local_identities(id) ON DELETE CASCADE,
             token_hash TEXT NOT NULL,
@@ -552,30 +586,102 @@ fn init_postgres_sessions(url: &str) -> std::result::Result<(), String> {
         )",
             &[],
         )
-        .map_err(|e| {
-            format!(
-                "Failed to create auth_local_password_reset_tokens table: {}",
-                e
+        .map_err(|e| format!("Failed to create auth_local_one_time_tokens table: {}", e))?;
+
+    client
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_auth_local_one_time_tokens_expires ON auth_local_one_time_tokens(purpose, expires_at)",
+            &[],
+        )
+        .map_err(|e| format!("Failed to create auth_local_one_time_tokens expiry index: {}", e))?;
+
+    client
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_auth_local_one_time_tokens_user_purpose ON auth_local_one_time_tokens(local_user_id, purpose)",
+            &[],
+        )
+        .map_err(|e| format!("Failed to create auth_local_one_time_tokens user index: {}", e))?;
+
+    client
+        .execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_local_one_time_tokens_one_magic_link ON auth_local_one_time_tokens(local_user_id) WHERE purpose = 'magic_link'",
+            &[],
+        )
+        .map_err(|e| format!("Failed to create auth_local_one_time_tokens magic-link index: {}", e))?;
+
+    let mut migration = client
+        .transaction()
+        .map_err(|e| format!("Failed to begin local one-time token migration: {}", e))?;
+    let has_legacy_reset_table: bool = migration
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema()
+                  AND table_name = 'auth_local_password_reset_tokens'
+            )",
+            &[],
+        )
+        .map_err(|e| format!("Failed to inspect legacy password reset table: {}", e))?
+        .get(0);
+    if has_legacy_reset_table {
+        migration
+            .execute(
+                "INSERT INTO auth_local_one_time_tokens
+                 (purpose, selector, local_user_id, token_hash, created_at, expires_at)
+                 SELECT 'password_reset', selector, local_user_id, token_hash, created_at, expires_at
+                 FROM auth_local_password_reset_tokens
+                 ON CONFLICT DO NOTHING",
+                &[],
             )
-        })?;
-
-    client
-        .execute(
-            "CREATE INDEX IF NOT EXISTS idx_auth_local_password_reset_tokens_expires ON auth_local_password_reset_tokens(expires_at)",
-            &[],
-        )
-        .ok();
-
-    client
-        .execute(
-            "CREATE INDEX IF NOT EXISTS idx_auth_local_password_reset_tokens_user ON auth_local_password_reset_tokens(local_user_id)",
-            &[],
-        )
-        .ok();
+            .map_err(|e| format!("Failed to migrate legacy password reset tokens: {}", e))?;
+        migration
+            .execute("DELETE FROM auth_local_password_reset_tokens", &[])
+            .map_err(|e| format!("Failed to clear legacy password reset tokens: {}", e))?;
+        migration
+            .execute("DROP TABLE auth_local_password_reset_tokens", &[])
+            .map_err(|e| format!("Failed to drop legacy password reset table: {}", e))?;
+    }
+    migration
+        .commit()
+        .map_err(|e| format!("Failed to commit local one-time token migration: {}", e))?;
 
     // Store URL for later connections
     let mut pg_url = POSTGRES_URL.lock().unwrap();
     *pg_url = Some(url.to_string());
+    Ok(())
+}
+
+fn purge_legacy_redis_password_reset_keys(
+    conn: &mut redis::Connection,
+) -> std::result::Result<(), String> {
+    for pattern in [
+        "ntnt:local_password_reset:*",
+        "ntnt:local_password_reset_tokens_for_user:*",
+    ] {
+        let mut cursor = 0_u64;
+        loop {
+            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(pattern)
+                .arg("COUNT")
+                .arg(256)
+                .query(conn)
+                .map_err(|e| format!("Failed to scan legacy Redis password reset keys: {}", e))?;
+            if !keys.is_empty() {
+                redis::cmd("DEL")
+                    .arg(keys)
+                    .query::<usize>(conn)
+                    .map_err(|e| {
+                        format!("Failed to purge legacy Redis password reset keys: {}", e)
+                    })?;
+            }
+            cursor = next_cursor;
+            if cursor == 0 {
+                break;
+            }
+        }
+    }
     Ok(())
 }
 
@@ -600,6 +706,7 @@ fn init_redis_sessions(url: &str) -> std::result::Result<(), String> {
     let _: String = redis::cmd("PING")
         .query(&mut conn)
         .map_err(|e| format!("Redis PING failed: {}", e))?;
+    purge_legacy_redis_password_reset_keys(&mut conn)?;
 
     // Store URL for later connections
     let mut redis_url_store = REDIS_URL.lock().unwrap();

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -12,7 +12,7 @@ use super::storage::{
     delete_all_session_records_for_user, get_local_credential_secret_record,
     get_local_identity_by_identifier_record, normalize_local_identifier,
     store_local_identity_and_credential_record,
-    store_local_identity_and_credential_revoke_password_resets_record,
+    store_local_identity_and_credential_revoke_one_time_tokens_record,
     store_local_one_time_token_record, update_local_identity_by_identifier_record,
     LocalAccountState, LocalCredentialSecret, LocalIdentity, LocalOneTimeToken,
     LocalOneTimeTokenPurpose,
@@ -34,6 +34,7 @@ pub(in crate::stdlib::auth) const MAGIC_LINK_ISSUANCE_UNAVAILABLE: &str =
 pub(in crate::stdlib::auth) const MAGIC_LINK_VERIFICATION_UNAVAILABLE: &str =
     "Magic link verification unavailable";
 const DEFAULT_PASSWORD_RESET_TTL_SECONDS: i64 = 60 * 60;
+const MAX_PASSWORD_RESET_TTL_SECONDS: i64 = 24 * 60 * 60;
 const DEFAULT_MAGIC_LINK_TTL_SECONDS: i64 = 15 * 60;
 const MAX_MAGIC_LINK_TTL_SECONDS: i64 = 60 * 60;
 const INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH: &str =
@@ -577,7 +578,7 @@ pub(in crate::stdlib::auth) fn set_local_password_record(
         must_change_password: false,
     };
 
-    store_local_identity_and_credential_revoke_password_resets_record(&identity, &credential)?;
+    store_local_identity_and_credential_revoke_one_time_tokens_record(&identity, &credential)?;
 
     Ok(VerifiedLocalPassword {
         identity,
@@ -590,7 +591,9 @@ pub(in crate::stdlib::auth) fn issue_password_reset_record(
     identifier: &str,
     ttl_seconds: Option<i64>,
 ) -> std::result::Result<HashMap<String, Value>, String> {
-    let ttl_seconds = ttl_seconds.unwrap_or(DEFAULT_PASSWORD_RESET_TTL_SECONDS);
+    let ttl_seconds = ttl_seconds
+        .unwrap_or(DEFAULT_PASSWORD_RESET_TTL_SECONDS)
+        .min(MAX_PASSWORD_RESET_TTL_SECONDS);
     let kind = identifier_kind.trim().to_ascii_lowercase();
     let identifier_normalized = match normalize_local_identifier(&kind, identifier.trim()) {
         Ok(identifier_normalized) => identifier_normalized,
@@ -613,7 +616,8 @@ pub(in crate::stdlib::auth) fn issue_password_reset_record(
             identity.state,
             LocalAccountState::Disabled | LocalAccountState::Locked
         ) {
-            store_local_one_time_token_record(&LocalOneTimeToken {
+            // A false result is intentionally indistinguishable from success to callers.
+            let _stored = store_local_one_time_token_record(&LocalOneTimeToken {
                 purpose: LocalOneTimeTokenPurpose::PasswordReset,
                 selector: selector.clone(),
                 local_user_id: identity.id.clone(),
@@ -707,7 +711,8 @@ pub(in crate::stdlib::auth) fn issue_magic_link_record(
     if let Some(identity) = get_local_identity_by_identifier_record(&kind, &identifier_normalized)?
     {
         if identity.state == LocalAccountState::Active {
-            store_local_one_time_token_record(&LocalOneTimeToken {
+            // A false result is intentionally indistinguishable from success to callers.
+            let _stored = store_local_one_time_token_record(&LocalOneTimeToken {
                 purpose: LocalOneTimeTokenPurpose::MagicLink,
                 selector: selector.clone(),
                 local_user_id: identity.id,
@@ -727,10 +732,7 @@ pub(in crate::stdlib::auth) fn consume_magic_link_record(
     let Some((selector, verifier)) = token.split_once('.') else {
         return Err(INVALID_MAGIC_LINK_TOKEN.to_string());
     };
-    if !is_urlsafe_token_component(selector, 22)
-        || !is_urlsafe_token_component(verifier, 43)
-        || token.split('.').count() != 2
-    {
+    if !is_urlsafe_token_component(selector, 22) || !is_urlsafe_token_component(verifier, 43) {
         return Err(INVALID_MAGIC_LINK_TOKEN.to_string());
     }
 

--- a/src/stdlib/auth/local.rs
+++ b/src/stdlib/auth/local.rs
@@ -7,19 +7,35 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
 use super::storage::{
+    consume_local_one_time_token_record,
     consume_local_password_reset_token_and_store_credential_record,
     delete_all_session_records_for_user, get_local_credential_secret_record,
     get_local_identity_by_identifier_record, normalize_local_identifier,
     store_local_identity_and_credential_record,
     store_local_identity_and_credential_revoke_password_resets_record,
-    store_local_password_reset_token_record, update_local_identity_by_identifier_record,
-    LocalAccountState, LocalCredentialSecret, LocalIdentity, LocalPasswordResetToken,
+    store_local_one_time_token_record, update_local_identity_by_identifier_record,
+    LocalAccountState, LocalCredentialSecret, LocalIdentity, LocalOneTimeToken,
+    LocalOneTimeTokenPurpose,
 };
 
 const INVALID_LOCAL_CREDENTIALS: &str = "Invalid local credentials";
 const INVALID_LOCAL_TOTP_CODE: &str = "Invalid local TOTP code";
-const INVALID_PASSWORD_RESET_TOKEN: &str = "Invalid password reset token";
+pub(in crate::stdlib::auth) const INVALID_PASSWORD_RESET_TOKEN: &str =
+    "Invalid password reset token";
+pub(in crate::stdlib::auth) const EMPTY_LOCAL_PASSWORD: &str =
+    "[auth] local password must not be empty";
+pub(in crate::stdlib::auth) const PASSWORD_RESET_ISSUANCE_UNAVAILABLE: &str =
+    "Password reset issuance unavailable";
+pub(in crate::stdlib::auth) const PASSWORD_RESET_VERIFICATION_UNAVAILABLE: &str =
+    "Password reset verification unavailable";
+pub(in crate::stdlib::auth) const INVALID_MAGIC_LINK_TOKEN: &str = "Invalid magic link token";
+pub(in crate::stdlib::auth) const MAGIC_LINK_ISSUANCE_UNAVAILABLE: &str =
+    "Magic link issuance unavailable";
+pub(in crate::stdlib::auth) const MAGIC_LINK_VERIFICATION_UNAVAILABLE: &str =
+    "Magic link verification unavailable";
 const DEFAULT_PASSWORD_RESET_TTL_SECONDS: i64 = 60 * 60;
+const DEFAULT_MAGIC_LINK_TTL_SECONDS: i64 = 15 * 60;
+const MAX_MAGIC_LINK_TTL_SECONDS: i64 = 60 * 60;
 const INVALID_OR_UNSUPPORTED_LOCAL_CREDENTIAL_HASH: &str =
     "[auth] local credential hash is invalid or unsupported";
 const DUMMY_LOCAL_TOTP_SECRET: &str = "JBSWY3DPEHPK3PXP";
@@ -535,7 +551,7 @@ pub(in crate::stdlib::auth) fn set_local_password_record(
     let identifier = identifier.trim();
 
     if new_password.trim().is_empty() {
-        return Err("[auth] local password must not be empty".to_string());
+        return Err(EMPTY_LOCAL_PASSWORD.to_string());
     }
 
     let verified = verify_local_password_record(&kind, identifier, current_password)?;
@@ -578,13 +594,13 @@ pub(in crate::stdlib::auth) fn issue_password_reset_record(
     let kind = identifier_kind.trim().to_ascii_lowercase();
     let identifier_normalized = match normalize_local_identifier(&kind, identifier.trim()) {
         Ok(identifier_normalized) => identifier_normalized,
-        Err(_) => return Ok(password_reset_accepted_response()),
+        Err(_) => return Ok(local_token_accepted_response()),
     };
 
     let now = chrono::Utc::now().timestamp();
     let expires_at = now.saturating_add(ttl_seconds.max(0));
     if expires_at <= now {
-        return Ok(password_reset_accepted_response());
+        return Ok(local_token_accepted_response());
     }
 
     let selector = random_urlsafe_token(16);
@@ -597,19 +613,18 @@ pub(in crate::stdlib::auth) fn issue_password_reset_record(
             identity.state,
             LocalAccountState::Disabled | LocalAccountState::Locked
         ) {
-            store_local_password_reset_token_record(&LocalPasswordResetToken {
+            store_local_one_time_token_record(&LocalOneTimeToken {
+                purpose: LocalOneTimeTokenPurpose::PasswordReset,
                 selector: selector.clone(),
                 local_user_id: identity.id.clone(),
-                token_hash: hash_password_reset_verifier(&verifier),
+                token_hash: hash_local_token_verifier(&verifier),
                 created_at: now,
                 expires_at,
             })?;
         }
     }
 
-    Ok(password_reset_token_response(
-        selector, token, now, expires_at,
-    ))
+    Ok(local_token_response(selector, token, now, expires_at))
 }
 
 pub(in crate::stdlib::auth) fn consume_password_reset_record(
@@ -618,7 +633,7 @@ pub(in crate::stdlib::auth) fn consume_password_reset_record(
     revoke_sessions: bool,
 ) -> std::result::Result<(VerifiedLocalPassword, u64), String> {
     if new_password.trim().is_empty() {
-        return Err("[auth] local password must not be empty".to_string());
+        return Err(EMPTY_LOCAL_PASSWORD.to_string());
     }
 
     let Some((selector, verifier)) = token.split_once('.') else {
@@ -629,7 +644,7 @@ pub(in crate::stdlib::auth) fn consume_password_reset_record(
     }
 
     let now = chrono::Utc::now().timestamp();
-    let submitted_hash = hash_password_reset_verifier(verifier);
+    let submitted_hash = hash_local_token_verifier(verifier);
     let Some((identity, credential)) =
         consume_local_password_reset_token_and_store_credential_record(
             selector,
@@ -666,11 +681,75 @@ pub(in crate::stdlib::auth) fn consume_password_reset_record(
     ))
 }
 
-fn password_reset_accepted_response() -> HashMap<String, Value> {
+pub(in crate::stdlib::auth) fn issue_magic_link_record(
+    identifier_kind: &str,
+    identifier: &str,
+    ttl_seconds: Option<i64>,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    let ttl_seconds = ttl_seconds
+        .unwrap_or(DEFAULT_MAGIC_LINK_TTL_SECONDS)
+        .min(MAX_MAGIC_LINK_TTL_SECONDS);
+    let kind = identifier_kind.trim().to_ascii_lowercase();
+    let identifier_normalized = match normalize_local_identifier(&kind, identifier.trim()) {
+        Ok(identifier_normalized) => identifier_normalized,
+        Err(_) => return Ok(local_token_accepted_response()),
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    let expires_at = now.saturating_add(ttl_seconds.max(0));
+    if expires_at <= now {
+        return Ok(local_token_accepted_response());
+    }
+
+    let selector = random_urlsafe_token(16);
+    let verifier = random_urlsafe_token(32);
+    let token = format!("{selector}.{verifier}");
+    if let Some(identity) = get_local_identity_by_identifier_record(&kind, &identifier_normalized)?
+    {
+        if identity.state == LocalAccountState::Active {
+            store_local_one_time_token_record(&LocalOneTimeToken {
+                purpose: LocalOneTimeTokenPurpose::MagicLink,
+                selector: selector.clone(),
+                local_user_id: identity.id,
+                token_hash: hash_local_token_verifier(&verifier),
+                created_at: now,
+                expires_at,
+            })?;
+        }
+    }
+
+    Ok(local_token_response(selector, token, now, expires_at))
+}
+
+pub(in crate::stdlib::auth) fn consume_magic_link_record(
+    token: &str,
+) -> std::result::Result<LocalIdentity, String> {
+    let Some((selector, verifier)) = token.split_once('.') else {
+        return Err(INVALID_MAGIC_LINK_TOKEN.to_string());
+    };
+    if !is_urlsafe_token_component(selector, 22)
+        || !is_urlsafe_token_component(verifier, 43)
+        || token.split('.').count() != 2
+    {
+        return Err(INVALID_MAGIC_LINK_TOKEN.to_string());
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let submitted_hash = hash_local_token_verifier(verifier);
+    consume_local_one_time_token_record(
+        LocalOneTimeTokenPurpose::MagicLink,
+        selector,
+        &submitted_hash,
+        now,
+    )?
+    .ok_or_else(|| INVALID_MAGIC_LINK_TOKEN.to_string())
+}
+
+fn local_token_accepted_response() -> HashMap<String, Value> {
     HashMap::from([("status".to_string(), Value::String("accepted".to_string()))])
 }
 
-fn password_reset_token_response(
+fn local_token_response(
     selector: String,
     token: String,
     created_at: i64,
@@ -685,13 +764,20 @@ fn password_reset_token_response(
     ])
 }
 
+fn is_urlsafe_token_component(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+}
+
 fn random_urlsafe_token(byte_count: usize) -> String {
     let mut bytes = vec![0_u8; byte_count];
     rand::rngs::OsRng.fill_bytes(&mut bytes);
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
 }
 
-fn hash_password_reset_verifier(verifier: &str) -> String {
+fn hash_local_token_verifier(verifier: &str) -> String {
     hex::encode(Sha256::digest(verifier.as_bytes()))
 }
 

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -1,6 +1,6 @@
 // Local-auth storage includes write-side helpers for credential lifecycle.
 // DD-043 keeps app-specific extensions in metadata_json, while security-critical
-// lifecycle state such as reset tokens may still require auth-owned helpers/storage.
+// lifecycle state such as purpose-bound one-time tokens may still require auth-owned helpers/storage.
 #![cfg_attr(not(test), allow(dead_code))]
 
 use super::*;
@@ -17,7 +17,7 @@ pub(in crate::stdlib::auth) enum LocalAuthRecordKind {
     Identity,
     CredentialSecret,
     TotpEnrollment,
-    PasswordResetToken,
+    OneTimeToken,
     BootstrapState,
 }
 
@@ -106,8 +106,52 @@ pub(in crate::stdlib::auth) struct LocalCredentialSecret {
     pub(in crate::stdlib::auth) must_change_password: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::stdlib::auth) enum LocalOneTimeTokenPurpose {
+    PasswordReset,
+    MagicLink,
+}
+
+impl LocalOneTimeTokenPurpose {
+    pub(in crate::stdlib::auth) fn as_str(self) -> &'static str {
+        match self {
+            LocalOneTimeTokenPurpose::PasswordReset => "password_reset",
+            LocalOneTimeTokenPurpose::MagicLink => "magic_link",
+        }
+    }
+
+    pub(in crate::stdlib::auth) fn from_str(value: &str) -> std::result::Result<Self, String> {
+        match value {
+            "password_reset" => Ok(LocalOneTimeTokenPurpose::PasswordReset),
+            "magic_link" => Ok(LocalOneTimeTokenPurpose::MagicLink),
+            other => Err(format!(
+                "[auth] unknown local one-time token purpose \"{}\". Expected one of: password_reset, magic_link",
+                other
+            )),
+        }
+    }
+
+    fn storage_label(self) -> &'static str {
+        match self {
+            LocalOneTimeTokenPurpose::PasswordReset => "password reset",
+            LocalOneTimeTokenPurpose::MagicLink => "magic-link",
+        }
+    }
+
+    fn state_is_eligible(self, state: LocalAccountState) -> bool {
+        match self {
+            LocalOneTimeTokenPurpose::PasswordReset => !matches!(
+                state,
+                LocalAccountState::Disabled | LocalAccountState::Locked
+            ),
+            LocalOneTimeTokenPurpose::MagicLink => state == LocalAccountState::Active,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::stdlib::auth) struct LocalPasswordResetToken {
+pub(in crate::stdlib::auth) struct LocalOneTimeToken {
+    pub(in crate::stdlib::auth) purpose: LocalOneTimeTokenPurpose,
     pub(in crate::stdlib::auth) selector: String,
     pub(in crate::stdlib::auth) local_user_id: String,
     pub(in crate::stdlib::auth) token_hash: String,
@@ -225,7 +269,7 @@ pub(in crate::stdlib::auth) struct LocalAuthMemoryStore {
     identities_by_id: HashMap<String, LocalIdentity>,
     identity_id_by_lookup_key: HashMap<String, String>,
     credential_secrets_by_local_user_id: HashMap<String, LocalCredentialSecret>,
-    password_reset_tokens_by_selector: HashMap<String, LocalPasswordResetToken>,
+    one_time_tokens_by_selector: HashMap<String, LocalOneTimeToken>,
 }
 
 impl LocalAuthMemoryStore {
@@ -372,8 +416,10 @@ impl LocalAuthMemoryStore {
         self.credential_secrets_by_local_user_id
             .insert(identity.id.clone(), credential);
         if revoke_password_resets {
-            self.password_reset_tokens_by_selector
-                .retain(|_, token| token.local_user_id != identity.id);
+            self.one_time_tokens_by_selector.retain(|_, token| {
+                token.local_user_id != identity.id
+                    || token.purpose != LocalOneTimeTokenPurpose::PasswordReset
+            });
         }
         Ok(())
     }
@@ -388,19 +434,28 @@ impl LocalAuthMemoryStore {
             .cloned())
     }
 
-    pub(in crate::stdlib::auth) fn store_password_reset_token(
+    pub(in crate::stdlib::auth) fn store_one_time_token(
         &mut self,
-        token: LocalPasswordResetToken,
-    ) -> std::result::Result<(), String> {
-        validate_local_password_reset_token_for_storage(&token)?;
-        if !self.identities_by_id.contains_key(&token.local_user_id) {
-            return Err(
-                "[auth] password reset token must reference an existing local identity".to_string(),
-            );
+        token: LocalOneTimeToken,
+    ) -> std::result::Result<bool, String> {
+        validate_local_one_time_token_for_storage(&token)?;
+        let Some(identity) = self.identities_by_id.get(&token.local_user_id) else {
+            return Err(format!(
+                "[auth] {} token must reference an existing local identity",
+                token.purpose.storage_label()
+            ));
+        };
+        if !token.purpose.state_is_eligible(identity.state) {
+            return Ok(false);
         }
-        self.password_reset_tokens_by_selector
+        if token.purpose == LocalOneTimeTokenPurpose::MagicLink {
+            self.one_time_tokens_by_selector.retain(|_, existing| {
+                existing.local_user_id != token.local_user_id || existing.purpose != token.purpose
+            });
+        }
+        self.one_time_tokens_by_selector
             .insert(token.selector.clone(), token);
-        Ok(())
+        Ok(true)
     }
 
     pub(in crate::stdlib::auth) fn consume_password_reset_token_and_store_credential<F>(
@@ -413,15 +468,14 @@ impl LocalAuthMemoryStore {
     where
         F: FnOnce(&str) -> std::result::Result<LocalCredentialSecret, String>,
     {
-        let Some(reset_token) = self
-            .password_reset_tokens_by_selector
-            .get(selector)
-            .cloned()
-        else {
+        let Some(reset_token) = self.one_time_tokens_by_selector.get(selector).cloned() else {
             return Ok(None);
         };
+        if reset_token.purpose != LocalOneTimeTokenPurpose::PasswordReset {
+            return Ok(None);
+        }
         if reset_token.expires_at <= now {
-            self.password_reset_tokens_by_selector.remove(selector);
+            self.one_time_tokens_by_selector.remove(selector);
             return Ok(None);
         }
         if !constant_time_compare(&reset_token.token_hash, token_hash) {
@@ -448,9 +502,49 @@ impl LocalAuthMemoryStore {
             ..identity
         };
         self.store_identity_and_credential(identity.clone(), credential.clone())?;
-        self.password_reset_tokens_by_selector
-            .retain(|_, token| token.local_user_id != reset_token.local_user_id);
+        self.one_time_tokens_by_selector.retain(|_, token| {
+            token.local_user_id != reset_token.local_user_id
+                || token.purpose != LocalOneTimeTokenPurpose::PasswordReset
+        });
         Ok(Some((identity, credential)))
+    }
+
+    pub(in crate::stdlib::auth) fn consume_one_time_token(
+        &mut self,
+        purpose: LocalOneTimeTokenPurpose,
+        selector: &str,
+        token_hash: &str,
+        now: i64,
+    ) -> std::result::Result<Option<LocalIdentity>, String> {
+        let Some(token) = self.one_time_tokens_by_selector.get(selector).cloned() else {
+            return Ok(None);
+        };
+        if token.purpose != purpose {
+            return Ok(None);
+        }
+        if token.expires_at <= now {
+            self.one_time_tokens_by_selector.remove(selector);
+            return Ok(None);
+        }
+        if !constant_time_compare(&token.token_hash, token_hash) {
+            return Ok(None);
+        }
+        let Some(identity) = self.identities_by_id.get(&token.local_user_id).cloned() else {
+            self.one_time_tokens_by_selector.retain(|_, existing| {
+                existing.local_user_id != token.local_user_id || existing.purpose != purpose
+            });
+            return Ok(None);
+        };
+        if !purpose.state_is_eligible(identity.state) {
+            self.one_time_tokens_by_selector.retain(|_, existing| {
+                existing.local_user_id != token.local_user_id || existing.purpose != purpose
+            });
+            return Ok(None);
+        }
+        self.one_time_tokens_by_selector.retain(|_, existing| {
+            existing.local_user_id != token.local_user_id || existing.purpose != purpose
+        });
+        Ok(Some(identity))
     }
 }
 
@@ -493,20 +587,25 @@ fn validate_local_credential_secret_for_storage(
     Ok(())
 }
 
-fn validate_local_password_reset_token_for_storage(
-    token: &LocalPasswordResetToken,
+fn validate_local_one_time_token_for_storage(
+    token: &LocalOneTimeToken,
 ) -> std::result::Result<(), String> {
+    let label = token.purpose.storage_label();
     if token.selector.trim().is_empty() {
-        return Err("[auth] password reset token selector must not be empty".to_string());
+        return Err(format!("[auth] {label} token selector must not be empty"));
     }
     if token.local_user_id.trim().is_empty() {
-        return Err("[auth] password reset token local_user_id must not be empty".to_string());
+        return Err(format!(
+            "[auth] {label} token local_user_id must not be empty"
+        ));
     }
     if token.token_hash.trim().is_empty() {
-        return Err("[auth] password reset token hash must not be empty".to_string());
+        return Err(format!("[auth] {label} token hash must not be empty"));
     }
     if token.expires_at <= token.created_at {
-        return Err("[auth] password reset token expires_at must be after created_at".to_string());
+        return Err(format!(
+            "[auth] {label} token expires_at must be after created_at"
+        ));
     }
     Ok(())
 }
@@ -678,18 +777,18 @@ pub(in crate::stdlib::auth) fn get_local_credential_secret_record(
     }
 }
 
-pub(in crate::stdlib::auth) fn store_local_password_reset_token_record(
-    token: &LocalPasswordResetToken,
-) -> std::result::Result<(), String> {
+pub(in crate::stdlib::auth) fn store_local_one_time_token_record(
+    token: &LocalOneTimeToken,
+) -> std::result::Result<bool, String> {
     match active_auth_storage_backend() {
         AuthStorageBackend::Memory => SESSION_STORE
             .lock()
             .unwrap()
             .local_auth
-            .store_password_reset_token(token.clone()),
-        AuthStorageBackend::Sqlite => store_local_password_reset_token_sqlite(token),
-        AuthStorageBackend::Postgres => store_local_password_reset_token_postgres(token),
-        AuthStorageBackend::Redis => store_local_password_reset_token_redis(token),
+            .store_one_time_token(token.clone()),
+        AuthStorageBackend::Sqlite => store_local_one_time_token_sqlite(token),
+        AuthStorageBackend::Postgres => store_local_one_time_token_postgres(token),
+        AuthStorageBackend::Redis => store_local_one_time_token_redis(token),
     }
 }
 
@@ -735,6 +834,30 @@ where
             now,
             credential_builder,
         ),
+    }
+}
+
+pub(in crate::stdlib::auth) fn consume_local_one_time_token_record(
+    purpose: LocalOneTimeTokenPurpose,
+    selector: &str,
+    token_hash: &str,
+    now: i64,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    match active_auth_storage_backend() {
+        AuthStorageBackend::Memory => SESSION_STORE
+            .lock()
+            .unwrap()
+            .local_auth
+            .consume_one_time_token(purpose, selector, token_hash, now),
+        AuthStorageBackend::Sqlite => {
+            consume_local_one_time_token_sqlite(purpose, selector, token_hash, now)
+        }
+        AuthStorageBackend::Postgres => {
+            consume_local_one_time_token_postgres(purpose, selector, token_hash, now)
+        }
+        AuthStorageBackend::Redis => {
+            consume_local_one_time_token_redis(purpose, selector, token_hash, now)
+        }
     }
 }
 
@@ -830,8 +953,11 @@ fn store_local_identity_and_credential_sqlite(
 
     if revoke_password_resets {
         tx.execute(
-            "DELETE FROM auth_local_password_reset_tokens WHERE local_user_id = ?1",
-            rusqlite::params![identity.id],
+            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1 AND purpose = ?2",
+            rusqlite::params![
+                identity.id,
+                LocalOneTimeTokenPurpose::PasswordReset.as_str()
+            ],
         )
         .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
     }
@@ -1016,22 +1142,78 @@ fn get_local_credential_secret_sqlite(
     .map_err(|e| format!("[auth] failed to lookup local credential: {}", e))
 }
 
-fn store_local_password_reset_token_sqlite(
-    token: &LocalPasswordResetToken,
-) -> std::result::Result<(), String> {
-    validate_local_password_reset_token_for_storage(token)?;
-    let conn_guard = SQLITE_CONN.lock().unwrap();
-    let conn = conn_guard.as_ref().ok_or("SQLite not initialized")?;
-    conn.execute(
-        "INSERT INTO auth_local_password_reset_tokens
-         (selector, local_user_id, token_hash, created_at, expires_at)
-         VALUES (?1, ?2, ?3, ?4, ?5)
-         ON CONFLICT(selector) DO UPDATE SET
-            local_user_id = excluded.local_user_id,
-            token_hash = excluded.token_hash,
-            created_at = excluded.created_at,
-            expires_at = excluded.expires_at",
+fn local_one_time_token_from_sqlite_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<LocalOneTimeToken> {
+    let purpose: String = row.get(0)?;
+    let purpose = LocalOneTimeTokenPurpose::from_str(&purpose).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+    Ok(LocalOneTimeToken {
+        purpose,
+        selector: row.get(1)?,
+        local_user_id: row.get(2)?,
+        token_hash: row.get(3)?,
+        created_at: row.get(4)?,
+        expires_at: row.get(5)?,
+    })
+}
+
+fn store_local_one_time_token_sqlite(
+    token: &LocalOneTimeToken,
+) -> std::result::Result<bool, String> {
+    validate_local_one_time_token_for_storage(token)?;
+    let mut conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|e| {
+            format!(
+                "[auth] failed to begin one-time token store transaction: {}",
+                e
+            )
+        })?;
+    let state: Option<String> = tx
+        .query_row(
+            "SELECT state FROM auth_local_identities WHERE id = ?1",
+            rusqlite::params![token.local_user_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| format!("[auth] failed to validate one-time token identity: {}", e))?;
+    let Some(state) = state else {
+        return Err(format!(
+            "[auth] {} token must reference an existing local identity",
+            token.purpose.storage_label()
+        ));
+    };
+    let state = LocalAccountState::from_str(&state)?;
+    if !token.purpose.state_is_eligible(state) {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit rejected one-time token store transaction: {}",
+                e
+            )
+        })?;
+        return Ok(false);
+    }
+    if token.purpose == LocalOneTimeTokenPurpose::MagicLink {
+        tx.execute(
+            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1 AND purpose = ?2",
+            rusqlite::params![token.local_user_id, token.purpose.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to replace one-time tokens: {}", e))?;
+    }
+    tx.execute(
+        "INSERT INTO auth_local_one_time_tokens
+         (purpose, selector, local_user_id, token_hash, created_at, expires_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         rusqlite::params![
+            token.purpose.as_str(),
             token.selector,
             token.local_user_id,
             token.token_hash,
@@ -1039,8 +1221,14 @@ fn store_local_password_reset_token_sqlite(
             token.expires_at,
         ],
     )
-    .map_err(|e| format!("[auth] failed to store password reset token: {}", e))?;
-    Ok(())
+    .map_err(|e| format!("[auth] failed to store one-time token: {}", e))?;
+    tx.commit().map_err(|e| {
+        format!(
+            "[auth] failed to commit one-time token store transaction: {}",
+            e
+        )
+    })?;
+    Ok(true)
 }
 
 fn consume_local_password_reset_token_and_store_credential_sqlite<F>(
@@ -1054,28 +1242,22 @@ where
 {
     let mut conn_guard = SQLITE_CONN.lock().unwrap();
     let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
-    let tx = conn.transaction().map_err(|e| {
-        format!(
-            "[auth] failed to begin password reset consume transaction: {}",
-            e
-        )
-    })?;
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|e| {
+            format!(
+                "[auth] failed to begin password reset consume transaction: {}",
+                e
+            )
+        })?;
 
     let Some(reset_token) = tx
         .query_row(
-            "SELECT selector, local_user_id, token_hash, created_at, expires_at
-             FROM auth_local_password_reset_tokens
-             WHERE selector = ?1",
-            rusqlite::params![selector],
-            |row| {
-                Ok(LocalPasswordResetToken {
-                    selector: row.get(0)?,
-                    local_user_id: row.get(1)?,
-                    token_hash: row.get(2)?,
-                    created_at: row.get(3)?,
-                    expires_at: row.get(4)?,
-                })
-            },
+            "SELECT purpose, selector, local_user_id, token_hash, created_at, expires_at
+             FROM auth_local_one_time_tokens
+             WHERE selector = ?1 AND purpose = ?2",
+            rusqlite::params![selector, LocalOneTimeTokenPurpose::PasswordReset.as_str()],
+            local_one_time_token_from_sqlite_row,
         )
         .optional()
         .map_err(|e| format!("[auth] failed to lookup password reset token: {}", e))?
@@ -1091,8 +1273,8 @@ where
 
     if reset_token.expires_at <= now {
         tx.execute(
-            "DELETE FROM auth_local_password_reset_tokens WHERE selector = ?1",
-            rusqlite::params![selector],
+            "DELETE FROM auth_local_one_time_tokens WHERE selector = ?1 AND purpose = ?2",
+            rusqlite::params![selector, LocalOneTimeTokenPurpose::PasswordReset.as_str()],
         )
         .map_err(|e| {
             format!(
@@ -1185,8 +1367,11 @@ where
     )
     .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
     tx.execute(
-        "DELETE FROM auth_local_password_reset_tokens WHERE local_user_id = ?1",
-        rusqlite::params![reset_token.local_user_id],
+        "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1 AND purpose = ?2",
+        rusqlite::params![
+            reset_token.local_user_id,
+            LocalOneTimeTokenPurpose::PasswordReset.as_str()
+        ],
     )
     .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
     tx.commit().map_err(|e| {
@@ -1197,6 +1382,105 @@ where
     })?;
 
     Ok(Some((identity, credential.clone())))
+}
+
+fn consume_local_one_time_token_sqlite(
+    purpose: LocalOneTimeTokenPurpose,
+    selector: &str,
+    token_hash: &str,
+    now: i64,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    let mut conn_guard = SQLITE_CONN.lock().unwrap();
+    let conn = conn_guard.as_mut().ok_or("SQLite not initialized")?;
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|e| {
+            format!(
+                "[auth] failed to begin one-time token consume transaction: {}",
+                e
+            )
+        })?;
+
+    let Some(token) = tx
+        .query_row(
+            "SELECT purpose, selector, local_user_id, token_hash, created_at, expires_at
+             FROM auth_local_one_time_tokens WHERE selector = ?1 AND purpose = ?2",
+            rusqlite::params![selector, purpose.as_str()],
+            local_one_time_token_from_sqlite_row,
+        )
+        .optional()
+        .map_err(|e| format!("[auth] failed to lookup one-time token: {}", e))?
+    else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+
+    if token.expires_at <= now {
+        tx.execute(
+            "DELETE FROM auth_local_one_time_tokens WHERE selector = ?1 AND purpose = ?2",
+            rusqlite::params![selector, purpose.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to delete expired one-time token: {}", e))?;
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    if !constant_time_compare(&token.token_hash, token_hash) {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+
+    let identity = tx
+        .query_row(
+            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+             FROM auth_local_identities WHERE id = ?1",
+            rusqlite::params![token.local_user_id],
+            local_identity_from_row,
+        )
+        .optional()
+        .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))?;
+    let Some(identity) = identity.filter(|identity| purpose.state_is_eligible(identity.state))
+    else {
+        tx.execute(
+            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1 AND purpose = ?2",
+            rusqlite::params![token.local_user_id, purpose.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to delete unusable one-time tokens: {}", e))?;
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+
+    tx.execute(
+        "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1 AND purpose = ?2",
+        rusqlite::params![token.local_user_id, purpose.as_str()],
+    )
+    .map_err(|e| format!("[auth] failed to delete consumed one-time tokens: {}", e))?;
+    tx.commit().map_err(|e| {
+        format!(
+            "[auth] failed to commit one-time token consume transaction: {}",
+            e
+        )
+    })?;
+    Ok(Some(identity))
 }
 
 fn postgres_url() -> std::result::Result<String, String> {
@@ -1325,8 +1609,11 @@ fn store_local_identity_and_credential_postgres(
 
     if revoke_password_resets {
         tx.execute(
-            "DELETE FROM auth_local_password_reset_tokens WHERE local_user_id = $1",
-            &[&identity.id],
+            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1 AND purpose = $2",
+            &[
+                &identity.id,
+                &LocalOneTimeTokenPurpose::PasswordReset.as_str(),
+            ],
         )
         .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
     }
@@ -1484,32 +1771,83 @@ fn get_local_credential_secret_postgres(
     }))
 }
 
-fn store_local_password_reset_token_postgres(
-    token: &LocalPasswordResetToken,
-) -> std::result::Result<(), String> {
-    validate_local_password_reset_token_for_storage(token)?;
+fn local_one_time_token_from_postgres_row(
+    row: &postgres::Row,
+) -> std::result::Result<LocalOneTimeToken, String> {
+    let purpose: String = row.get(0);
+    Ok(LocalOneTimeToken {
+        purpose: LocalOneTimeTokenPurpose::from_str(&purpose)?,
+        selector: row.get(1),
+        local_user_id: row.get(2),
+        token_hash: row.get(3),
+        created_at: row.get(4),
+        expires_at: row.get(5),
+    })
+}
+
+fn store_local_one_time_token_postgres(
+    token: &LocalOneTimeToken,
+) -> std::result::Result<bool, String> {
+    validate_local_one_time_token_for_storage(token)?;
     let url = postgres_url()?;
     let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
-    client
-        .execute(
-            "INSERT INTO auth_local_password_reset_tokens
-         (selector, local_user_id, token_hash, created_at, expires_at)
-         VALUES ($1, $2, $3, $4, $5)
-         ON CONFLICT (selector) DO UPDATE SET
-            local_user_id = EXCLUDED.local_user_id,
-            token_hash = EXCLUDED.token_hash,
-            created_at = EXCLUDED.created_at,
-            expires_at = EXCLUDED.expires_at",
-            &[
-                &token.selector,
-                &token.local_user_id,
-                &token.token_hash,
-                &token.created_at,
-                &token.expires_at,
-            ],
+    let mut tx = client.transaction().map_err(|e| {
+        format!(
+            "[auth] failed to begin one-time token store transaction: {}",
+            e
         )
-        .map_err(|e| format!("[auth] failed to store password reset token: {}", e))?;
-    Ok(())
+    })?;
+    let state_row = tx
+        .query_opt(
+            "SELECT state FROM auth_local_identities WHERE id = $1 FOR UPDATE",
+            &[&token.local_user_id],
+        )
+        .map_err(|e| format!("[auth] failed to lock one-time token identity: {}", e))?;
+    let Some(state_row) = state_row else {
+        return Err(format!(
+            "[auth] {} token must reference an existing local identity",
+            token.purpose.storage_label()
+        ));
+    };
+    let state: String = state_row.get(0);
+    let state = LocalAccountState::from_str(&state)?;
+    if !token.purpose.state_is_eligible(state) {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit rejected one-time token store transaction: {}",
+                e
+            )
+        })?;
+        return Ok(false);
+    }
+    if token.purpose == LocalOneTimeTokenPurpose::MagicLink {
+        tx.execute(
+            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1 AND purpose = $2",
+            &[&token.local_user_id, &token.purpose.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to replace one-time tokens: {}", e))?;
+    }
+    tx.execute(
+        "INSERT INTO auth_local_one_time_tokens
+         (purpose, selector, local_user_id, token_hash, created_at, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6)",
+        &[
+            &token.purpose.as_str(),
+            &token.selector,
+            &token.local_user_id,
+            &token.token_hash,
+            &token.created_at,
+            &token.expires_at,
+        ],
+    )
+    .map_err(|e| format!("[auth] failed to store one-time token: {}", e))?;
+    tx.commit().map_err(|e| {
+        format!(
+            "[auth] failed to commit one-time token store transaction: {}",
+            e
+        )
+    })?;
+    Ok(true)
 }
 
 fn consume_local_password_reset_token_and_store_credential_postgres<F>(
@@ -1530,11 +1868,36 @@ where
         )
     })?;
 
+    let owner_rows = tx
+        .query(
+            "SELECT local_user_id FROM auth_local_one_time_tokens WHERE selector = $1 AND purpose = $2",
+            &[&selector, &LocalOneTimeTokenPurpose::PasswordReset.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to locate password reset owner: {}", e))?;
+    let Some(owner_row) = owner_rows.first() else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+    let initial_owner_id: String = owner_row.get(0);
+
+    let identity_rows = tx
+        .query(
+            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+             FROM auth_local_identities WHERE id = $1 FOR UPDATE",
+            &[&initial_owner_id],
+        )
+        .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))?;
+
     let rows = tx
         .query(
-            "SELECT selector, local_user_id, token_hash, created_at, expires_at
-             FROM auth_local_password_reset_tokens WHERE selector = $1 FOR UPDATE",
-            &[&selector],
+            "SELECT purpose, selector, local_user_id, token_hash, created_at, expires_at
+             FROM auth_local_one_time_tokens WHERE selector = $1 AND purpose = $2 FOR UPDATE",
+            &[&selector, &LocalOneTimeTokenPurpose::PasswordReset.as_str()],
         )
         .map_err(|e| format!("[auth] failed to lookup password reset token: {}", e))?;
     let Some(row) = rows.first() else {
@@ -1546,17 +1909,20 @@ where
         })?;
         return Ok(None);
     };
-    let reset_token = LocalPasswordResetToken {
-        selector: row.get(0),
-        local_user_id: row.get(1),
-        token_hash: row.get(2),
-        created_at: row.get(3),
-        expires_at: row.get(4),
-    };
+    let reset_token = local_one_time_token_from_postgres_row(row)?;
+    if reset_token.local_user_id != initial_owner_id {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit password reset consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
     if reset_token.expires_at <= now {
         tx.execute(
-            "DELETE FROM auth_local_password_reset_tokens WHERE selector = $1",
-            &[&selector],
+            "DELETE FROM auth_local_one_time_tokens WHERE selector = $1 AND purpose = $2",
+            &[&selector, &LocalOneTimeTokenPurpose::PasswordReset.as_str()],
         )
         .map_err(|e| {
             format!(
@@ -1583,14 +1949,7 @@ where
     }
     let credential = credential_builder(&reset_token.local_user_id)?;
     validate_local_credential_secret_for_storage(&credential)?;
-    let rows = tx
-        .query(
-            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
-             FROM auth_local_identities WHERE id = $1 FOR UPDATE",
-            &[&reset_token.local_user_id],
-        )
-        .map_err(|e| format!("[auth] failed to lookup local identity: {}", e))?;
-    let Some(row) = rows.first() else {
+    let Some(row) = identity_rows.first() else {
         tx.commit().map_err(|e| {
             format!(
                 "[auth] failed to commit password reset consume transaction: {}",
@@ -1600,10 +1959,7 @@ where
         return Ok(None);
     };
     let identity = local_identity_from_postgres_row(row)?;
-    if matches!(
-        identity.state,
-        LocalAccountState::Disabled | LocalAccountState::Locked
-    ) {
+    if !LocalOneTimeTokenPurpose::PasswordReset.state_is_eligible(identity.state) {
         tx.commit().map_err(|e| {
             format!(
                 "[auth] failed to commit password reset consume transaction: {}",
@@ -1642,8 +1998,11 @@ where
         ],
     ).map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
     tx.execute(
-        "DELETE FROM auth_local_password_reset_tokens WHERE local_user_id = $1",
-        &[&reset_token.local_user_id],
+        "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1 AND purpose = $2",
+        &[
+            &reset_token.local_user_id,
+            &LocalOneTimeTokenPurpose::PasswordReset.as_str(),
+        ],
     )
     .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
     tx.commit().map_err(|e| {
@@ -1671,12 +2030,23 @@ fn redis_local_credential_key(local_user_id: &str) -> String {
     format!("ntnt:local_credential:{}", local_user_id)
 }
 
-fn redis_local_password_reset_key(selector: &str) -> String {
-    format!("ntnt:local_password_reset:{}", selector)
+fn redis_local_one_time_token_key(purpose: LocalOneTimeTokenPurpose, selector: &str) -> String {
+    format!(
+        "ntnt:local_one_time_token:{}:{}",
+        purpose.as_str(),
+        selector
+    )
 }
 
-fn redis_local_password_reset_user_set_key(local_user_id: &str) -> String {
-    format!("ntnt:local_password_resets_for_user:{}", local_user_id)
+fn redis_local_one_time_token_user_set_key(
+    purpose: LocalOneTimeTokenPurpose,
+    local_user_id: &str,
+) -> String {
+    format!(
+        "ntnt:local_one_time_tokens_for_user:{}:{}",
+        purpose.as_str(),
+        local_user_id
+    )
 }
 
 fn local_identity_to_json(identity: &LocalIdentity) -> String {
@@ -1775,8 +2145,9 @@ fn local_credential_from_json(
     })
 }
 
-fn local_password_reset_token_to_json(token: &LocalPasswordResetToken) -> String {
+fn local_one_time_token_to_json(token: &LocalOneTimeToken) -> String {
     serde_json::json!({
+        "purpose": token.purpose.as_str(),
         "selector": token.selector,
         "local_user_id": token.local_user_id,
         "token_hash": token.token_hash,
@@ -1786,31 +2157,156 @@ fn local_password_reset_token_to_json(token: &LocalPasswordResetToken) -> String
     .to_string()
 }
 
-fn local_password_reset_token_from_json(
+fn local_one_time_token_from_json(
     json_str: &str,
-) -> std::result::Result<LocalPasswordResetToken, String> {
+) -> std::result::Result<LocalOneTimeToken, String> {
     let json: serde_json::Value = serde_json::from_str(json_str)
-        .map_err(|e| format!("[auth] failed to parse password reset JSON: {}", e))?;
-    Ok(LocalPasswordResetToken {
+        .map_err(|e| format!("[auth] failed to parse one-time token JSON: {}", e))?;
+    let purpose = json["purpose"]
+        .as_str()
+        .ok_or_else(|| "[auth] one-time token JSON missing purpose".to_string())?;
+    Ok(LocalOneTimeToken {
+        purpose: LocalOneTimeTokenPurpose::from_str(purpose)?,
         selector: json["selector"]
             .as_str()
-            .ok_or_else(|| "[auth] password reset JSON missing selector".to_string())?
+            .ok_or_else(|| "[auth] one-time token JSON missing selector".to_string())?
             .to_string(),
         local_user_id: json["local_user_id"]
             .as_str()
-            .ok_or_else(|| "[auth] password reset JSON missing local_user_id".to_string())?
+            .ok_or_else(|| "[auth] one-time token JSON missing local_user_id".to_string())?
             .to_string(),
         token_hash: json["token_hash"]
             .as_str()
-            .ok_or_else(|| "[auth] password reset JSON missing token_hash".to_string())?
+            .ok_or_else(|| "[auth] one-time token JSON missing token_hash".to_string())?
             .to_string(),
         created_at: json["created_at"]
             .as_i64()
-            .ok_or_else(|| "[auth] password reset JSON missing created_at".to_string())?,
+            .ok_or_else(|| "[auth] one-time token JSON missing created_at".to_string())?,
         expires_at: json["expires_at"]
             .as_i64()
-            .ok_or_else(|| "[auth] password reset JSON missing expires_at".to_string())?,
+            .ok_or_else(|| "[auth] one-time token JSON missing expires_at".to_string())?,
     })
+}
+
+fn consume_local_one_time_token_postgres(
+    purpose: LocalOneTimeTokenPurpose,
+    selector: &str,
+    token_hash: &str,
+    now: i64,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    let url = postgres_url()?;
+    let mut client = postgres::Client::connect(&url, postgres::NoTls).map_err(|e| e.to_string())?;
+    let mut tx = client.transaction().map_err(|e| {
+        format!(
+            "[auth] failed to begin one-time token consume transaction: {}",
+            e
+        )
+    })?;
+    let owner_rows = tx
+        .query(
+            "SELECT local_user_id FROM auth_local_one_time_tokens WHERE selector = $1 AND purpose = $2",
+            &[&selector, &purpose.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to locate one-time token owner: {}", e))?;
+    let Some(owner_row) = owner_rows.first() else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+    let initial_owner_id: String = owner_row.get(0);
+
+    let identity_rows = tx
+        .query(
+            "SELECT id, identifier_kind, identifier, identifier_normalized, created_at, updated_at, state, metadata_json
+             FROM auth_local_identities WHERE id = $1 FOR UPDATE",
+            &[&initial_owner_id],
+        )
+        .map_err(|e| format!("[auth] failed to lock local identity: {}", e))?;
+    let identity = identity_rows
+        .first()
+        .map(local_identity_from_postgres_row)
+        .transpose()?;
+
+    let rows = tx
+        .query(
+            "SELECT purpose, selector, local_user_id, token_hash, created_at, expires_at
+             FROM auth_local_one_time_tokens WHERE selector = $1 AND purpose = $2 FOR UPDATE",
+            &[&selector, &purpose.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to lock one-time token: {}", e))?;
+    let Some(row) = rows.first() else {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+    let token = local_one_time_token_from_postgres_row(row)?;
+    if token.local_user_id != initial_owner_id {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    if token.expires_at <= now {
+        tx.execute(
+            "DELETE FROM auth_local_one_time_tokens WHERE selector = $1 AND purpose = $2",
+            &[&selector, &purpose.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to delete expired one-time token: {}", e))?;
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    if !constant_time_compare(&token.token_hash, token_hash) {
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    }
+    let Some(identity) = identity.filter(|identity| purpose.state_is_eligible(identity.state))
+    else {
+        tx.execute(
+            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1 AND purpose = $2",
+            &[&token.local_user_id, &purpose.as_str()],
+        )
+        .map_err(|e| format!("[auth] failed to delete unusable one-time tokens: {}", e))?;
+        tx.commit().map_err(|e| {
+            format!(
+                "[auth] failed to commit one-time token consume transaction: {}",
+                e
+            )
+        })?;
+        return Ok(None);
+    };
+    tx.execute(
+        "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1 AND purpose = $2",
+        &[&token.local_user_id, &purpose.as_str()],
+    )
+    .map_err(|e| format!("[auth] failed to delete consumed one-time tokens: {}", e))?;
+    tx.commit().map_err(|e| {
+        format!(
+            "[auth] failed to commit one-time token consume transaction: {}",
+            e
+        )
+    })?;
+    Ok(Some(identity))
 }
 
 fn store_local_identity_redis(identity: &LocalIdentity) -> std::result::Result<(), String> {
@@ -1876,7 +2372,10 @@ fn store_local_identity_and_credential_redis(
     let lookup_key =
         redis_local_identity_lookup_key(&identity.identifier_kind, &identity.identifier_normalized);
     let credential_key = redis_local_credential_key(&credential.local_user_id);
-    let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
+    let reset_set_key = redis_local_one_time_token_user_set_key(
+        LocalOneTimeTokenPurpose::PasswordReset,
+        &identity.id,
+    );
     let stored: i64 = redis::Script::new(
         r#"
         local existing_id = redis.call('GET', KEYS[2])
@@ -2013,44 +2512,79 @@ fn get_local_credential_secret_redis(
         .transpose()
 }
 
-fn store_local_password_reset_token_redis(
-    token: &LocalPasswordResetToken,
-) -> std::result::Result<(), String> {
-    validate_local_password_reset_token_for_storage(token)?;
-    if get_local_identity_by_id_redis(&token.local_user_id)?.is_none() {
-        return Err(
-            "[auth] password reset token must reference an existing local identity".to_string(),
-        );
-    }
+fn store_local_one_time_token_redis(
+    token: &LocalOneTimeToken,
+) -> std::result::Result<bool, String> {
+    validate_local_one_time_token_for_storage(token)?;
     let mut conn = redis_connection()?;
     let now = chrono::Utc::now().timestamp();
     let ttl = token.expires_at.saturating_sub(now);
     if ttl <= 0 {
-        return Err("[auth] password reset token expires before it can be stored".to_string());
+        return Err(format!(
+            "[auth] {} token expires before it can be stored",
+            token.purpose.storage_label()
+        ));
     }
-    let token_key = redis_local_password_reset_key(&token.selector);
-    let user_set_key = redis_local_password_reset_user_set_key(&token.local_user_id);
-    redis::Script::new(
+    let token_key = redis_local_one_time_token_key(token.purpose, &token.selector);
+    let user_set_key = redis_local_one_time_token_user_set_key(token.purpose, &token.local_user_id);
+    let identity_key = redis_local_identity_key(&token.local_user_id);
+    let stored: i64 = redis::Script::new(
         r#"
-        redis.call('SETEX', KEYS[1], ARGV[1], ARGV[2])
-        redis.call('SADD', KEYS[2], KEYS[1])
-
-        local current_ttl = redis.call('TTL', KEYS[2])
-        local token_ttl = tonumber(ARGV[1])
-        if current_ttl < token_ttl then
-            redis.call('EXPIRE', KEYS[2], token_ttl)
+        local identity_json = redis.call('GET', KEYS[3])
+        if not identity_json then
+            return -1
+        end
+        local identity = cjson.decode(identity_json)
+        if identity.id ~= ARGV[4] then
+            return -1
+        end
+        if ARGV[3] == 'password_reset' then
+            if identity.state == 'disabled' or identity.state == 'locked' then
+                return 0
+            end
+        elseif ARGV[3] == 'magic_link' then
+            if identity.state ~= 'active' then
+                return 0
+            end
+        else
+            return -2
         end
 
+        if ARGV[3] == 'magic_link' then
+            local existing_keys = redis.call('SMEMBERS', KEYS[2])
+            for _, key in ipairs(existing_keys) do
+                redis.call('DEL', key)
+            end
+            redis.call('DEL', KEYS[2])
+        end
+        redis.call('SETEX', KEYS[1], ARGV[1], ARGV[2])
+        redis.call('SADD', KEYS[2], KEYS[1])
+        local current_ttl = redis.call('TTL', KEYS[2])
+        local token_ttl = tonumber(ARGV[1])
+        if ARGV[3] == 'magic_link' or current_ttl < token_ttl then
+            redis.call('EXPIRE', KEYS[2], token_ttl)
+        end
         return 1
         "#,
     )
     .key(&token_key)
     .key(&user_set_key)
+    .key(&identity_key)
     .arg(ttl)
-    .arg(local_password_reset_token_to_json(token))
+    .arg(local_one_time_token_to_json(token))
+    .arg(token.purpose.as_str())
+    .arg(&token.local_user_id)
     .invoke::<i64>(&mut conn)
-    .map(|_| ())
-    .map_err(|e| format!("Redis password reset token store error: {}", e))
+    .map_err(|e| format!("Redis one-time token store error: {}", e))?;
+    match stored {
+        1 => Ok(true),
+        0 => Ok(false),
+        -1 => Err(format!(
+            "[auth] {} token must reference an existing local identity",
+            token.purpose.storage_label()
+        )),
+        _ => Err("[auth] unsupported one-time token purpose".to_string()),
+    }
 }
 
 fn invoke_redis_password_reset_consume_script(
@@ -2078,7 +2612,7 @@ fn invoke_redis_password_reset_consume_script(
             return 0
         end
 
-        if token.token_hash ~= ARGV[2] or token.local_user_id ~= ARGV[3] then
+        if token.purpose ~= 'password_reset' or token.token_hash ~= ARGV[2] or token.local_user_id ~= ARGV[3] then
             return 0
         end
 
@@ -2136,7 +2670,8 @@ where
     F: FnOnce(&str) -> std::result::Result<LocalCredentialSecret, String>,
 {
     let mut conn = redis_connection()?;
-    let token_key = redis_local_password_reset_key(selector);
+    let token_key =
+        redis_local_one_time_token_key(LocalOneTimeTokenPurpose::PasswordReset, selector);
     let token_json: Option<String> = redis::cmd("GET")
         .arg(&token_key)
         .query(&mut conn)
@@ -2144,51 +2679,28 @@ where
     let Some(token_json) = token_json else {
         return Ok(None);
     };
-    let reset_token = local_password_reset_token_from_json(&token_json)?;
-    if reset_token.expires_at <= now {
-        redis::pipe()
-            .atomic()
-            .cmd("DEL")
-            .arg(&token_key)
-            .ignore()
-            .cmd("SREM")
-            .arg(redis_local_password_reset_user_set_key(
-                &reset_token.local_user_id,
-            ))
-            .arg(&token_key)
-            .ignore()
-            .query::<()>(&mut conn)
-            .map_err(|e| format!("Redis expired password reset cleanup error: {}", e))?;
+    let reset_token = local_one_time_token_from_json(&token_json)?;
+    if reset_token.purpose != LocalOneTimeTokenPurpose::PasswordReset
+        || reset_token.expires_at <= now
+        || !constant_time_compare(&reset_token.token_hash, token_hash)
+    {
         return Ok(None);
     }
-    if !constant_time_compare(&reset_token.token_hash, token_hash) {
-        return Ok(None);
-    }
-    let identity_json: Option<String> = redis::cmd("GET")
-        .arg(redis_local_identity_key(&reset_token.local_user_id))
-        .query(&mut conn)
-        .map_err(|e| format!("Redis GET error: {}", e))?;
-    let Some(identity_json) = identity_json else {
+    let Some(identity) = get_local_identity_by_id_redis(&reset_token.local_user_id)? else {
         return Ok(None);
     };
-    let identity = local_identity_from_json(&identity_json)?;
-    if matches!(
-        identity.state,
-        LocalAccountState::Disabled | LocalAccountState::Locked
-    ) {
+    if !LocalOneTimeTokenPurpose::PasswordReset.state_is_eligible(identity.state) {
         return Ok(None);
     }
     let credential = credential_builder(&reset_token.local_user_id)?;
     validate_local_credential_secret_for_storage(&credential)?;
-    let identity = normalize_local_identity_for_storage(LocalIdentity {
-        updated_at: now,
-        state: LocalAccountState::Active,
-        ..identity
-    })?;
 
-    let identity_key = redis_local_identity_key(&identity.id);
+    let identity_key = redis_local_identity_key(&reset_token.local_user_id);
     let credential_key = redis_local_credential_key(&credential.local_user_id);
-    let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
+    let reset_set_key = redis_local_one_time_token_user_set_key(
+        LocalOneTimeTokenPurpose::PasswordReset,
+        &reset_token.local_user_id,
+    );
     let consumed = invoke_redis_password_reset_consume_script(
         &mut conn,
         &token_key,
@@ -2197,23 +2709,119 @@ where
         &reset_set_key,
         now,
         token_hash,
-        &identity.id,
+        &reset_token.local_user_id,
         &local_credential_to_json(&credential),
     )?;
 
     if consumed == -1 {
-        return Err(format!(
-            "[auth] local identity identifier already exists for {}",
-            identity.identifier_kind
-        ));
+        return Err("[auth] local identity identifier already exists".to_string());
     }
     if consumed != 1 {
         return Ok(None);
     }
-    let stored_identity = get_local_identity_by_id_redis(&identity.id)?.ok_or_else(|| {
-        "[auth] Redis password reset consumed token but local identity is missing".to_string()
-    })?;
+    let stored_identity =
+        get_local_identity_by_id_redis(&reset_token.local_user_id)?.ok_or_else(|| {
+            "[auth] Redis password reset consumed token but local identity is missing".to_string()
+        })?;
     Ok(Some((stored_identity, credential)))
+}
+
+fn consume_local_one_time_token_redis(
+    purpose: LocalOneTimeTokenPurpose,
+    selector: &str,
+    token_hash: &str,
+    now: i64,
+) -> std::result::Result<Option<LocalIdentity>, String> {
+    let mut conn = redis_connection()?;
+    let token_key = redis_local_one_time_token_key(purpose, selector);
+    let token_json: Option<String> = redis::cmd("GET")
+        .arg(&token_key)
+        .query(&mut conn)
+        .map_err(|e| format!("Redis GET error: {}", e))?;
+    let Some(token_json) = token_json else {
+        return Ok(None);
+    };
+    let token = local_one_time_token_from_json(&token_json)?;
+    if token.purpose != purpose {
+        return Ok(None);
+    }
+    let identity_key = redis_local_identity_key(&token.local_user_id);
+    let user_set_key = redis_local_one_time_token_user_set_key(purpose, &token.local_user_id);
+    let consumed: i64 = redis::Script::new(
+        r#"
+        local token_json = redis.call('GET', KEYS[1])
+        if not token_json then
+            return 0
+        end
+        local token = cjson.decode(token_json)
+        if tonumber(token.expires_at) <= tonumber(ARGV[1]) then
+            redis.call('DEL', KEYS[1])
+            redis.call('SREM', KEYS[3], KEYS[1])
+            return 0
+        end
+        if token.purpose ~= ARGV[4] or token.token_hash ~= ARGV[2] or token.local_user_id ~= ARGV[3] then
+            return 0
+        end
+        local identity_json = redis.call('GET', KEYS[2])
+        if not identity_json then
+            local missing_identity_keys = redis.call('SMEMBERS', KEYS[3])
+            for _, key in ipairs(missing_identity_keys) do
+                redis.call('DEL', key)
+            end
+            redis.call('DEL', KEYS[3])
+            return 0
+        end
+        local identity = cjson.decode(identity_json)
+        if identity.id ~= ARGV[3] then
+            local unusable_keys = redis.call('SMEMBERS', KEYS[3])
+            for _, key in ipairs(unusable_keys) do
+                redis.call('DEL', key)
+            end
+            redis.call('DEL', KEYS[3])
+            return 0
+        end
+        if ARGV[4] == 'password_reset' then
+            if identity.state == 'disabled' or identity.state == 'locked' then
+                local unusable_keys = redis.call('SMEMBERS', KEYS[3])
+                for _, key in ipairs(unusable_keys) do
+                    redis.call('DEL', key)
+                end
+                redis.call('DEL', KEYS[3])
+                return 0
+            end
+        elseif ARGV[4] == 'magic_link' then
+            if identity.state ~= 'active' then
+                local unusable_keys = redis.call('SMEMBERS', KEYS[3])
+                for _, key in ipairs(unusable_keys) do
+                    redis.call('DEL', key)
+                end
+                redis.call('DEL', KEYS[3])
+                return 0
+            end
+        else
+            return 0
+        end
+        local token_keys = redis.call('SMEMBERS', KEYS[3])
+        for _, key in ipairs(token_keys) do
+            redis.call('DEL', key)
+        end
+        redis.call('DEL', KEYS[3])
+        return 1
+        "#,
+    )
+    .key(&token_key)
+    .key(&identity_key)
+    .key(&user_set_key)
+    .arg(now)
+    .arg(token_hash)
+    .arg(&token.local_user_id)
+    .arg(purpose.as_str())
+    .invoke(&mut conn)
+    .map_err(|e| format!("Redis one-time token consume error: {}", e))?;
+    if consumed != 1 {
+        return Ok(None);
+    }
+    get_local_identity_by_id_redis(&token.local_user_id)
 }
 
 #[cfg(test)]
@@ -2383,10 +2991,15 @@ mod tests {
         identity: &LocalIdentity,
         selectors: &[&str],
     ) {
-        let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
+        let reset_set_key = redis_local_one_time_token_user_set_key(
+            LocalOneTimeTokenPurpose::PasswordReset,
+            &identity.id,
+        );
         let keys: Vec<String> = selectors
             .iter()
-            .map(|selector| redis_local_password_reset_key(selector))
+            .map(|selector| {
+                redis_local_one_time_token_key(LocalOneTimeTokenPurpose::PasswordReset, selector)
+            })
             .chain([
                 redis_local_identity_key(&identity.id),
                 redis_local_identity_lookup_key(
@@ -2414,29 +3027,34 @@ mod tests {
 
         store_local_identity_redis_with_connection(&mut conn, &identity).unwrap();
         let now = chrono::Utc::now().timestamp();
-        store_local_password_reset_token_redis(&LocalPasswordResetToken {
+        assert!(store_local_one_time_token_redis(&LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::PasswordReset,
             selector: selector_long.clone(),
             local_user_id: identity.id.clone(),
             token_hash: "long-token-hash".to_string(),
             created_at: now,
             expires_at: now + 3600,
         })
-        .unwrap();
-        let reset_set_key = redis_local_password_reset_user_set_key(&identity.id);
+        .unwrap());
+        let reset_set_key = redis_local_one_time_token_user_set_key(
+            LocalOneTimeTokenPurpose::PasswordReset,
+            &identity.id,
+        );
         let ttl_after_long = redis::cmd("TTL")
             .arg(&reset_set_key)
             .query::<i64>(&mut conn)
             .unwrap();
         assert!(ttl_after_long > 0);
 
-        store_local_password_reset_token_redis(&LocalPasswordResetToken {
+        assert!(store_local_one_time_token_redis(&LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::PasswordReset,
             selector: selector_short.clone(),
             local_user_id: identity.id.clone(),
             token_hash: "short-token-hash".to_string(),
             created_at: now,
             expires_at: now + 60,
         })
-        .unwrap();
+        .unwrap());
         let ttl_after_short = redis::cmd("TTL")
             .arg(&reset_set_key)
             .query::<i64>(&mut conn)
@@ -2463,14 +3081,15 @@ mod tests {
         store_local_identity_redis_with_connection(&mut conn, &identity).unwrap();
         let now = chrono::Utc::now().timestamp();
         let token_hash = "reset-token-hash";
-        store_local_password_reset_token_redis(&LocalPasswordResetToken {
+        assert!(store_local_one_time_token_redis(&LocalOneTimeToken {
+            purpose: LocalOneTimeTokenPurpose::PasswordReset,
             selector: selector.clone(),
             local_user_id: identity.id.clone(),
             token_hash: token_hash.to_string(),
             created_at: now,
             expires_at: now + 3600,
         })
-        .unwrap();
+        .unwrap());
 
         let mut locked_identity = identity.clone();
         locked_identity.state = LocalAccountState::Locked;
@@ -2480,10 +3099,13 @@ mod tests {
         let credential = redis_test_credential(&identity.id);
         let consumed = invoke_redis_password_reset_consume_script(
             &mut conn,
-            &redis_local_password_reset_key(&selector),
+            &redis_local_one_time_token_key(LocalOneTimeTokenPurpose::PasswordReset, &selector),
             &redis_local_identity_key(&identity.id),
             &redis_local_credential_key(&identity.id),
-            &redis_local_password_reset_user_set_key(&identity.id),
+            &redis_local_one_time_token_user_set_key(
+                LocalOneTimeTokenPurpose::PasswordReset,
+                &identity.id,
+            ),
             now + 20,
             token_hash,
             &identity.id,
@@ -2498,7 +3120,10 @@ mod tests {
             .unwrap();
         assert!(stored_credential.is_none());
         let stored_token: Option<String> = redis::cmd("GET")
-            .arg(redis_local_password_reset_key(&selector))
+            .arg(redis_local_one_time_token_key(
+                LocalOneTimeTokenPurpose::PasswordReset,
+                &selector,
+            ))
             .query(&mut conn)
             .unwrap();
         assert!(stored_token.is_some());

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -2747,20 +2747,20 @@ fn consume_local_one_time_token_redis(
     }
     let identity_key = redis_local_identity_key(&token.local_user_id);
     let user_set_key = redis_local_one_time_token_user_set_key(purpose, &token.local_user_id);
-    let consumed: i64 = redis::Script::new(
+    let consumed_identity_json: Option<String> = redis::Script::new(
         r#"
         local token_json = redis.call('GET', KEYS[1])
         if not token_json then
-            return 0
+            return false
         end
         local token = cjson.decode(token_json)
         if tonumber(token.expires_at) <= tonumber(ARGV[1]) then
             redis.call('DEL', KEYS[1])
             redis.call('SREM', KEYS[3], KEYS[1])
-            return 0
+            return false
         end
         if token.purpose ~= ARGV[4] or token.token_hash ~= ARGV[2] or token.local_user_id ~= ARGV[3] then
-            return 0
+            return false
         end
         local identity_json = redis.call('GET', KEYS[2])
         if not identity_json then
@@ -2769,7 +2769,7 @@ fn consume_local_one_time_token_redis(
                 redis.call('DEL', key)
             end
             redis.call('DEL', KEYS[3])
-            return 0
+            return false
         end
         local identity = cjson.decode(identity_json)
         if identity.id ~= ARGV[3] then
@@ -2778,7 +2778,7 @@ fn consume_local_one_time_token_redis(
                 redis.call('DEL', key)
             end
             redis.call('DEL', KEYS[3])
-            return 0
+            return false
         end
         if ARGV[4] == 'password_reset' then
             if identity.state == 'disabled' or identity.state == 'locked' then
@@ -2787,7 +2787,7 @@ fn consume_local_one_time_token_redis(
                     redis.call('DEL', key)
                 end
                 redis.call('DEL', KEYS[3])
-                return 0
+                return false
             end
         elseif ARGV[4] == 'magic_link' then
             if identity.state ~= 'active' then
@@ -2796,17 +2796,17 @@ fn consume_local_one_time_token_redis(
                     redis.call('DEL', key)
                 end
                 redis.call('DEL', KEYS[3])
-                return 0
+                return false
             end
         else
-            return 0
+            return false
         end
         local token_keys = redis.call('SMEMBERS', KEYS[3])
         for _, key in ipairs(token_keys) do
             redis.call('DEL', key)
         end
         redis.call('DEL', KEYS[3])
-        return 1
+        return identity_json
         "#,
     )
     .key(&token_key)
@@ -2818,10 +2818,9 @@ fn consume_local_one_time_token_redis(
     .arg(purpose.as_str())
     .invoke(&mut conn)
     .map_err(|e| format!("Redis one-time token consume error: {}", e))?;
-    if consumed != 1 {
-        return Ok(None);
-    }
-    get_local_identity_by_id_redis(&token.local_user_id)
+    consumed_identity_json
+        .map(|identity_json| local_identity_from_json(&identity_json))
+        .transpose()
 }
 
 #[cfg(test)]

--- a/src/stdlib/auth/storage/local.rs
+++ b/src/stdlib/auth/storage/local.rs
@@ -375,14 +375,14 @@ impl LocalAuthMemoryStore {
         identity: LocalIdentity,
         credential: LocalCredentialSecret,
     ) -> std::result::Result<(), String> {
-        self.store_identity_and_credential_with_reset_revocation(identity, credential, false)
+        self.store_identity_and_credential_with_token_revocation(identity, credential, false)
     }
 
-    pub(in crate::stdlib::auth) fn store_identity_and_credential_with_reset_revocation(
+    pub(in crate::stdlib::auth) fn store_identity_and_credential_with_token_revocation(
         &mut self,
         identity: LocalIdentity,
         credential: LocalCredentialSecret,
-        revoke_password_resets: bool,
+        revoke_one_time_tokens: bool,
     ) -> std::result::Result<(), String> {
         let identity = normalize_local_identity_for_storage(identity)?;
         validate_local_credential_secret_for_storage(&credential)?;
@@ -415,11 +415,9 @@ impl LocalAuthMemoryStore {
             .insert(identity.id.clone(), identity.clone());
         self.credential_secrets_by_local_user_id
             .insert(identity.id.clone(), credential);
-        if revoke_password_resets {
-            self.one_time_tokens_by_selector.retain(|_, token| {
-                token.local_user_id != identity.id
-                    || token.purpose != LocalOneTimeTokenPurpose::PasswordReset
-            });
+        if revoke_one_time_tokens {
+            self.one_time_tokens_by_selector
+                .retain(|_, token| token.local_user_id != identity.id);
         }
         Ok(())
     }
@@ -502,10 +500,8 @@ impl LocalAuthMemoryStore {
             ..identity
         };
         self.store_identity_and_credential(identity.clone(), credential.clone())?;
-        self.one_time_tokens_by_selector.retain(|_, token| {
-            token.local_user_id != reset_token.local_user_id
-                || token.purpose != LocalOneTimeTokenPurpose::PasswordReset
-        });
+        self.one_time_tokens_by_selector
+            .retain(|_, token| token.local_user_id != reset_token.local_user_id);
         Ok(Some((identity, credential)))
     }
 
@@ -642,7 +638,7 @@ pub(in crate::stdlib::auth) fn store_local_identity_and_credential_record(
     store_local_identity_and_credential_record_inner(identity, credential, false)
 }
 
-pub(in crate::stdlib::auth) fn store_local_identity_and_credential_revoke_password_resets_record(
+pub(in crate::stdlib::auth) fn store_local_identity_and_credential_revoke_one_time_tokens_record(
     identity: &LocalIdentity,
     credential: &LocalCredentialSecret,
 ) -> std::result::Result<(), String> {
@@ -652,28 +648,28 @@ pub(in crate::stdlib::auth) fn store_local_identity_and_credential_revoke_passwo
 fn store_local_identity_and_credential_record_inner(
     identity: &LocalIdentity,
     credential: &LocalCredentialSecret,
-    revoke_password_resets: bool,
+    revoke_one_time_tokens: bool,
 ) -> std::result::Result<(), String> {
     match active_auth_storage_backend() {
         AuthStorageBackend::Memory => SESSION_STORE
             .lock()
             .unwrap()
             .local_auth
-            .store_identity_and_credential_with_reset_revocation(
+            .store_identity_and_credential_with_token_revocation(
                 identity.clone(),
                 credential.clone(),
-                revoke_password_resets,
+                revoke_one_time_tokens,
             ),
         AuthStorageBackend::Sqlite => {
-            store_local_identity_and_credential_sqlite(identity, credential, revoke_password_resets)
+            store_local_identity_and_credential_sqlite(identity, credential, revoke_one_time_tokens)
         }
         AuthStorageBackend::Postgres => store_local_identity_and_credential_postgres(
             identity,
             credential,
-            revoke_password_resets,
+            revoke_one_time_tokens,
         ),
         AuthStorageBackend::Redis => {
-            store_local_identity_and_credential_redis(identity, credential, revoke_password_resets)
+            store_local_identity_and_credential_redis(identity, credential, revoke_one_time_tokens)
         }
     }
 }
@@ -894,7 +890,7 @@ fn store_local_identity_sqlite(identity: &LocalIdentity) -> std::result::Result<
 fn store_local_identity_and_credential_sqlite(
     identity: &LocalIdentity,
     credential: &LocalCredentialSecret,
-    revoke_password_resets: bool,
+    revoke_one_time_tokens: bool,
 ) -> std::result::Result<(), String> {
     let identity = normalize_local_identity_for_storage(identity.clone())?;
     validate_local_credential_secret_for_storage(credential)?;
@@ -951,15 +947,12 @@ fn store_local_identity_and_credential_sqlite(
     )
     .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
 
-    if revoke_password_resets {
+    if revoke_one_time_tokens {
         tx.execute(
-            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1 AND purpose = ?2",
-            rusqlite::params![
-                identity.id,
-                LocalOneTimeTokenPurpose::PasswordReset.as_str()
-            ],
+            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1",
+            rusqlite::params![identity.id],
         )
-        .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
+        .map_err(|e| format!("[auth] failed to delete one-time tokens: {}", e))?;
     }
 
     tx.commit()
@@ -1367,13 +1360,10 @@ where
     )
     .map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
     tx.execute(
-        "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1 AND purpose = ?2",
-        rusqlite::params![
-            reset_token.local_user_id,
-            LocalOneTimeTokenPurpose::PasswordReset.as_str()
-        ],
+        "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = ?1",
+        rusqlite::params![reset_token.local_user_id],
     )
-    .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
+    .map_err(|e| format!("[auth] failed to delete one-time tokens: {}", e))?;
     tx.commit().map_err(|e| {
         format!(
             "[auth] failed to commit password reset consume transaction: {}",
@@ -1552,7 +1542,7 @@ fn store_local_identity_postgres(identity: &LocalIdentity) -> std::result::Resul
 fn store_local_identity_and_credential_postgres(
     identity: &LocalIdentity,
     credential: &LocalCredentialSecret,
-    revoke_password_resets: bool,
+    revoke_one_time_tokens: bool,
 ) -> std::result::Result<(), String> {
     let identity = normalize_local_identity_for_storage(identity.clone())?;
     validate_local_credential_secret_for_storage(credential)?;
@@ -1607,15 +1597,12 @@ fn store_local_identity_and_credential_postgres(
         ],
     ).map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
 
-    if revoke_password_resets {
+    if revoke_one_time_tokens {
         tx.execute(
-            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1 AND purpose = $2",
-            &[
-                &identity.id,
-                &LocalOneTimeTokenPurpose::PasswordReset.as_str(),
-            ],
+            "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1",
+            &[&identity.id],
         )
-        .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
+        .map_err(|e| format!("[auth] failed to delete one-time tokens: {}", e))?;
     }
 
     tx.commit()
@@ -1998,13 +1985,10 @@ where
         ],
     ).map_err(|e| format!("[auth] failed to store local credential: {}", e))?;
     tx.execute(
-        "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1 AND purpose = $2",
-        &[
-            &reset_token.local_user_id,
-            &LocalOneTimeTokenPurpose::PasswordReset.as_str(),
-        ],
+        "DELETE FROM auth_local_one_time_tokens WHERE local_user_id = $1",
+        &[&reset_token.local_user_id],
     )
-    .map_err(|e| format!("[auth] failed to delete password reset tokens: {}", e))?;
+    .map_err(|e| format!("[auth] failed to delete one-time tokens: {}", e))?;
     tx.commit().map_err(|e| {
         format!(
             "[auth] failed to commit password reset consume transaction: {}",
@@ -2362,7 +2346,7 @@ fn store_local_identity_redis_with_connection(
 fn store_local_identity_and_credential_redis(
     identity: &LocalIdentity,
     credential: &LocalCredentialSecret,
-    revoke_password_resets: bool,
+    revoke_one_time_tokens: bool,
 ) -> std::result::Result<(), String> {
     let identity = normalize_local_identity_for_storage(identity.clone())?;
     validate_local_credential_secret_for_storage(credential)?;
@@ -2376,6 +2360,8 @@ fn store_local_identity_and_credential_redis(
         LocalOneTimeTokenPurpose::PasswordReset,
         &identity.id,
     );
+    let magic_link_set_key =
+        redis_local_one_time_token_user_set_key(LocalOneTimeTokenPurpose::MagicLink, &identity.id);
     let stored: i64 = redis::Script::new(
         r#"
         local existing_id = redis.call('GET', KEYS[2])
@@ -2397,11 +2383,13 @@ fn store_local_identity_and_credential_redis(
         redis.call('SET', KEYS[3], ARGV[3])
 
         if ARGV[4] == '1' then
-            local reset_keys = redis.call('SMEMBERS', KEYS[4])
-            for _, key in ipairs(reset_keys) do
-                redis.call('DEL', key)
+            for _, set_key in ipairs({KEYS[4], KEYS[5]}) do
+                local token_keys = redis.call('SMEMBERS', set_key)
+                for _, key in ipairs(token_keys) do
+                    redis.call('DEL', key)
+                end
+                redis.call('DEL', set_key)
             end
-            redis.call('DEL', KEYS[4])
         end
 
         return 1
@@ -2411,10 +2399,11 @@ fn store_local_identity_and_credential_redis(
     .key(&lookup_key)
     .key(&credential_key)
     .key(&reset_set_key)
+    .key(&magic_link_set_key)
     .arg(&identity.id)
     .arg(local_identity_to_json(&identity))
     .arg(local_credential_to_json(credential))
-    .arg(if revoke_password_resets { "1" } else { "0" })
+    .arg(if revoke_one_time_tokens { "1" } else { "0" })
     .invoke(&mut conn)
     .map_err(|e| format!("Redis local identity+credential store error: {}", e))?;
 
@@ -2593,6 +2582,7 @@ fn invoke_redis_password_reset_consume_script(
     identity_key: &str,
     credential_key: &str,
     reset_set_key: &str,
+    magic_link_set_key: &str,
     now: i64,
     token_hash: &str,
     local_user_id: &str,
@@ -2640,11 +2630,13 @@ fn invoke_redis_password_reset_consume_script(
         redis.call('SET', current_lookup_key, ARGV[3])
         redis.call('SET', KEYS[3], ARGV[4])
 
-        local reset_keys = redis.call('SMEMBERS', KEYS[4])
-        for _, key in ipairs(reset_keys) do
-            redis.call('DEL', key)
+        for _, set_key in ipairs({KEYS[4], KEYS[5]}) do
+            local token_keys = redis.call('SMEMBERS', set_key)
+            for _, key in ipairs(token_keys) do
+                redis.call('DEL', key)
+            end
+            redis.call('DEL', set_key)
         end
-        redis.call('DEL', KEYS[4])
         return 1
         "#,
     )
@@ -2652,6 +2644,7 @@ fn invoke_redis_password_reset_consume_script(
     .key(identity_key)
     .key(credential_key)
     .key(reset_set_key)
+    .key(magic_link_set_key)
     .arg(now)
     .arg(token_hash)
     .arg(local_user_id)
@@ -2701,12 +2694,17 @@ where
         LocalOneTimeTokenPurpose::PasswordReset,
         &reset_token.local_user_id,
     );
+    let magic_link_set_key = redis_local_one_time_token_user_set_key(
+        LocalOneTimeTokenPurpose::MagicLink,
+        &reset_token.local_user_id,
+    );
     let consumed = invoke_redis_password_reset_consume_script(
         &mut conn,
         &token_key,
         &identity_key,
         &credential_key,
         &reset_set_key,
+        &magic_link_set_key,
         now,
         token_hash,
         &reset_token.local_user_id,
@@ -3103,6 +3101,10 @@ mod tests {
             &redis_local_credential_key(&identity.id),
             &redis_local_one_time_token_user_set_key(
                 LocalOneTimeTokenPurpose::PasswordReset,
+                &identity.id,
+            ),
+            &redis_local_one_time_token_user_set_key(
+                LocalOneTimeTokenPurpose::MagicLink,
                 &identity.id,
             ),
             now + 20,

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -3,13 +3,14 @@ use super::*;
 mod local;
 
 pub(super) use local::{
+    consume_local_one_time_token_record,
     consume_local_password_reset_token_and_store_credential_record,
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
     normalize_local_identifier, store_local_identity_and_credential_record,
     store_local_identity_and_credential_revoke_password_resets_record,
-    store_local_password_reset_token_record, update_local_identity_by_identifier_record,
+    store_local_one_time_token_record, update_local_identity_by_identifier_record,
     LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
-    LocalPasswordResetToken,
+    LocalOneTimeToken, LocalOneTimeTokenPurpose,
 };
 #[cfg(test)]
 pub(super) use local::{

--- a/src/stdlib/auth/storage/mod.rs
+++ b/src/stdlib/auth/storage/mod.rs
@@ -7,7 +7,7 @@ pub(super) use local::{
     consume_local_password_reset_token_and_store_credential_record,
     get_local_credential_secret_record, get_local_identity_by_identifier_record,
     normalize_local_identifier, store_local_identity_and_credential_record,
-    store_local_identity_and_credential_revoke_password_resets_record,
+    store_local_identity_and_credential_revoke_one_time_tokens_record,
     store_local_one_time_token_record, update_local_identity_by_identifier_record,
     LocalAccountState, LocalAuthMemoryStore, LocalCredentialSecret, LocalIdentity,
     LocalOneTimeToken, LocalOneTimeTokenPurpose,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4812,6 +4812,42 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                 required(1)
             );
             sig!(
+                "issue_magic_link",
+                [
+                    "identifier" => Type::String,
+                    "options" => Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    }
+                ],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(1)
+            );
+            sig!(
+                "consume_magic_link",
+                ["token" => Type::String],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![
+                        Type::Map {
+                            key_type: Box::new(Type::String),
+                            value_type: Box::new(Type::Any),
+                        },
+                        Type::String,
+                    ],
+                },
+                required(1)
+            );
+            sig!(
                 "issue_password_reset",
                 [
                     "identifier" => Type::String,
@@ -5444,6 +5480,33 @@ mod tests {
         assert_eq!(errs.len(), 1);
         assert!(errs[0].message.contains("expected String"));
         assert!(errs[0].message.contains("got Int"));
+    }
+
+    #[test]
+    fn test_std_auth_magic_link_signatures_check_args() {
+        let errs = check_errors(
+            r#"
+            import { issue_magic_link, consume_magic_link } from "std/auth"
+            issue_magic_link(42)
+            consume_magic_link(123)
+            "#,
+        );
+        assert_eq!(errs.len(), 2);
+        assert!(errs
+            .iter()
+            .all(|err| err.message.contains("expected String")));
+    }
+
+    #[test]
+    fn test_std_auth_magic_link_signatures_accept_valid_calls() {
+        let errs = check_errors(
+            r#"
+            import { issue_magic_link, consume_magic_link } from "std/auth"
+            let issued = issue_magic_link("admin@example.com", map { "identifier_kind": "email", "ttl_seconds": 900 })
+            let consumed = consume_magic_link("selector.verifier")
+            "#,
+        );
+        assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `std/auth.issue_magic_link(...)` and `std/auth.consume_magic_link(...)`
- reuse a purpose-bound one-time-token substrate for password resets and magic links across memory, SQLite, PostgreSQL, and Redis/Valkey
- keep email delivery, application authorization, role/group policy, confirmation UX, and final `sign_in_session(...)` calls outside `std/auth`
- migrate legacy SQL password-reset rows atomically and purge legacy Redis reset keys to avoid downgrade replay
- add generated API docs, integration guidance, backend CI coverage, migration tests, and concurrency regressions

## Security properties

- opaque selector/verifier tokens generated with OS randomness
- verifier hashes only at rest; raw tokens are returned once and never persisted
- exact URL-safe token-shape validation
- explicit purpose isolation between password resets and magic links
- 15-minute default TTL and one-hour maximum
- one active magic link per local identity
- atomic sibling replacement and single-use consumption
- active-identity checks inside each backend's atomic store/consume operation
- consistent identity-first PostgreSQL lock ordering
- generic unknown-account behavior and sanitized public backend failures
- consumption returns a safe identity payload but does not create a session or grant roles

## Compatibility and migration

- existing password-reset APIs continue using the shared one-time-token substrate
- SQLite and PostgreSQL migrate `auth_local_password_reset_tokens` into `auth_local_one_time_tokens` in a transaction, then drop the legacy table
- Redis initialization purges the legacy reset-token key namespaces because legacy records do not carry an explicit purpose discriminator

## Verification

- [x] full `cargo test` with PostgreSQL and Redis backend URLs configured
- [x] PostgreSQL and Redis storage-contract tests
- [x] PostgreSQL and Redis concurrent magic-link issuance/consumption tests
- [x] PostgreSQL and Redis concurrent password-reset consumption tests
- [x] SQLite and PostgreSQL legacy migration tests
- [x] Redis legacy-key purge test
- [x] `cargo build --profile dev-release`
- [x] generated docs and docs validation
- [x] examples and intent lint validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib` (existing warnings only)
- [x] `git diff --check`
- [x] independent final security review — passed after password-reset error-sanitization remediation
