### PR TITLE
fix: make v0.5.1 upgrade-safe for existing apps

### DIFF
--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1909,7 +1909,7 @@ The most-used stdlib functions are auto-injected — no import needed:
 | `std/time` | `now`, `format` |
 | `std/crypto` | `uuid`, `sha256` |
 
-**NOT in prelude** (still need explicit import): `fetch` (std/http), `std/net` IPAM/probe helpers, `connect`/`query`/`execute` (database modules), `set_cookie`/`get_cookie`/`with_cookie` (std/http/server), `sort_by`/`first`/`last`/`push`/`pop` (std/collections), KV, jobs, fs, csv, concurrent.
+**NOT in prelude** (still need explicit import): `fetch` (std/http), `get_secret`/`require_secret` (std/secrets), `std/net` IPAM/probe helpers, `connect`/`query`/`execute` (database modules), `set_cookie`/`get_cookie`/`with_cookie` (std/http/server), `sort_by`/`first`/`last`/`push`/`pop` (std/collections), KV, jobs, fs, csv, concurrent.
 
 Explicit imports still work — prelude just makes them unnecessary for common functions.
 
@@ -3163,6 +3163,54 @@ let sig = hmac_sha256("message", "secret-key")      // HMAC signature
 
 ---
 
+## Environment Configuration and Optional Secrets
+
+Existing environment-variable configuration remains the default compatibility path:
+
+```ntnt
+import { get_env, load_env } from "std/env"
+
+load_env(".env")?
+let database_url = get_env("DATABASE_URL") ?? "sqlite:./app.db"
+```
+
+`std/env` is unchanged in v0.5.1. `get_env`, `load_env`, and `.env` files continue to work when `NTNT_ENV=production`. The optional `std/secrets` subsystem does not intercept, migrate, disable, or reinterpret those values.
+
+Use `std/secrets` only when the application deliberately wants opaque values with restricted sinks:
+
+```ntnt
+import { require_secret } from "std/secrets"
+import { fetch } from "std/http"
+
+let authorization = require_secret("PAYMENTS_AUTHORIZATION")
+let response = fetch(map {
+    "url": "https://payments.example.com/v1/account",
+    "headers": map { "Authorization": authorization }
+})?
+```
+
+When an `ntnt.toml` exists, declare each logical name without storing its value:
+
+```toml
+[secrets.PAYMENTS_AUTHORIZATION]
+required = true
+description = "Complete payments Authorization header value"
+```
+
+`NTNT_SECRETS_PROVIDER` is consulted only by `get_secret(...)` and `require_secret(...)`. Applications that do not call those functions require no provider or deployment changes. The development `env` provider performs exact-name lookup and is intentionally unavailable through `std/secrets` in production; this does **not** affect ordinary `std/env` access. Production Unix deployments can select the generic local-agent protocol:
+
+```text
+NTNT_SECRETS_PROVIDER=unix-socket
+NTNT_SECRETS_SOCKET_ENDPOINTS=/run/ntnt-secrets/agent.sock
+NTNT_SECRETS_AUTHORIZATION_SCOPE=deployment-a
+```
+
+A `Secret` can enter approved `fetch()` header, cookie, auth, body, JSON-leaf, or form sinks. Secret-bearing requests require HTTPS and never follow redirects. Logging, diagnostics, display, and error rendering redact secret values. Templates, public responses, string/JSON/CSV conversion, URL query construction, caches, databases, KV, jobs, and task/channel payloads reject them. There is no general reveal-to-String function.
+
+See [the secrets-agent protocol](secrets-agent-protocol.md) and the [`std/secrets` reference](STDLIB_REFERENCE.md#stdsecrets) for the full provider and sink contracts.
+
+---
+
 ## File System (`std/fs`)
 
 ```ntnt
@@ -3474,6 +3522,7 @@ import { fetch, download } from "std/http"
 import { read_file, write_file, exists } from "std/fs"
 import { parse_json, stringify } from "std/json"
 import { get_env, load_env } from "std/env"
+import { get_secret, require_secret } from "std/secrets"
 import { now, format } from "std/time"
 import { sha256, uuid } from "std/crypto"
 import { first, last, keys, values, entries, has_key, get_key, get_index } from "std/collections"

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -3205,7 +3205,7 @@ NTNT_SECRETS_SOCKET_ENDPOINTS=/run/ntnt-secrets/agent.sock
 NTNT_SECRETS_AUTHORIZATION_SCOPE=deployment-a
 ```
 
-A `Secret` can enter approved `fetch()` header, cookie, auth, body, JSON-leaf, or form sinks. Secret-bearing requests require HTTPS and never follow redirects. Logging, diagnostics, display, and error rendering redact secret values. Templates, public responses, string/JSON/CSV conversion, URL query construction, caches, databases, KV, jobs, and task/channel payloads reject them. There is no general reveal-to-String function.
+A `Secret` can enter approved `fetch()` header, cookie, auth, body, JSON-leaf, or form sinks. Secret-bearing requests require HTTPS and never follow redirects. `str(secret)`, logging, diagnostics, display, and error rendering emit `[REDACTED]`. Templates, public responses, JSON/CSV serialization, URL query construction, caches, databases, KV, jobs, and task/channel payloads reject secret-bearing values. There is no general plaintext reveal function.
 
 See [the secrets-agent protocol](secrets-agent-protocol.md) and the [`std/secrets` reference](STDLIB_REFERENCE.md#stdsecrets) for the full provider and sink contracts.
 
@@ -3271,7 +3271,7 @@ let name = day_name(ts)                             // "Wednesday"
 
 ---
 
-> **Complete function listings:** For every function signature, parameter, and example across all 21 modules, see [STDLIB_REFERENCE.md](STDLIB_REFERENCE.md) or run `ntnt docs <module>` (e.g., `ntnt docs std/time`).
+> **Complete function listings:** For every function signature, parameter, and example across all 25 modules, see [STDLIB_REFERENCE.md](STDLIB_REFERENCE.md) or run `ntnt docs <module>` (e.g., `ntnt docs std/time`).
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,7 +39,7 @@ Source files:
 | Document | Description |
 |----------|-------------|
 | [Roadmap](../ROADMAP.md) | Implementation phases and progress |
-| [v0.5.1 Release Notes](release-notes/v0.5.1.md) | Purpose-bound magic-link primitives, coordinated passwordless flow, durable limiting, and password-reset hardening |
+| [v0.5.1 Release Notes](release-notes/v0.5.1.md) | Passwordless magic-link flow, opaque provider-neutral secrets, compatibility guarantees, and auth hardening |
 | [v0.5.0 Release Notes](release-notes/v0.5.0.md) | Verification, validation, email, and multi-worker improvements |
 | [v0.4.9 Release Notes](release-notes/v0.4.9.md) | Local auth primitives, backend support, demo, and upgrade guidance |
 | [Contributing](../CONTRIBUTING.md) | How to contribute |

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -30,7 +30,7 @@ Environment variables that control NTNT runtime behavior
 | `NTNT_MAX_RECURSION` | integer | 256 | Maximum recursion depth for function calls. Prevents stack overflow from runaway recursion. |
 | `NTNT_NET_ALLOW_PRIVATE` | `1`, `true`, `yes` | unset (disabled — private targets blocked) | Process-level opt-in for `std/net` probes (`ping`, `tcp_connect`, `reachable`, `port_scan`, `tls_info`, `traceroute`) against private/internal targets. Each call must also pass `allow_private: true`. Special-purpose targets such as cloud metadata, multicast, broadcast, unspecified, and documentation ranges remain blocked. This is separate from `NTNT_ALLOW_PRIVATE_IPS`, which only applies to `fetch()`. |
 | `NTNT_SECRETS_AUTHORIZATION_SCOPE` | opaque ASCII deployment identifier | unset (required for unix-socket) | Trusted non-credential deployment scope expected in every secrets-agent response. It detects endpoint miswiring but is not authentication and is never rendered in diagnostics. Leading or trailing whitespace is rejected. |
-| `NTNT_SECRETS_PROVIDER` | `env`, `unix-socket` | env | Selects the provider behind `std/secrets`. The exact-name environment provider is development-only and is rejected when `NTNT_ENV` is `production` or `prod`. `unix-socket` is Unix-only and talks to any local secrets agent implementing the documented protocol, without depending directly on a secrets backend. |
+| `NTNT_SECRETS_PROVIDER` | `env`, `unix-socket` | env | Selects the provider behind the opt-in `std/secrets` API. This setting does not affect `std/env`, `get_env`, `load_env`, or existing `.env` workflows. Provider configuration is evaluated only when an application calls `get_secret` or `require_secret`. The exact-name environment provider is development-only and is rejected when `NTNT_ENV` is `production` or `prod`; that restriction applies only to `std/secrets`. `unix-socket` is Unix-only and talks to any local secrets agent implementing the documented protocol, without depending directly on a secrets backend. |
 | `NTNT_SECRETS_SOCKET_ENDPOINTS` | comma-separated absolute Unix socket paths | unset (required for unix-socket) | Ordered local secrets-agent endpoints for secret lookup. One through eight unique paths are allowed. Each endpoint is tried twice, and failover occurs only for bounded unavailable results. Production paths must be beneath the host-controlled `/run/ntnt-secrets` root; raw paths are never included in runtime diagnostics. |
 | `NTNT_SECRETS_TIMEOUT_MS` | integer (milliseconds) | 1000 | Per-attempt Unix-socket connect, write, and read timeout. Values must be between 10 and 10000 milliseconds. |
 | `NTNT_STRICT` | `1`, `true` | unset (disabled) | **Deprecated — use `NTNT_LINT_MODE=strict` instead.** Enable strict type checking. Still works but emits a deprecation warning. |
@@ -61,7 +61,7 @@ NTNT_NET_ALLOW_PRIVATE=1 ntnt run monitor.tnt
 # Trusted non-credential deployment scope expected in every secrets-agent response
 NTNT_SECRETS_AUTHORIZATION_SCOPE=deployment-a
 
-# Selects the provider behind `std/secrets`
+# Selects the provider behind the opt-in `std/secrets` API
 NTNT_SECRETS_PROVIDER=unix-socket ntnt run server.tnt
 
 # Ordered local secrets-agent endpoints for secret lookup

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -5906,7 +5906,7 @@ get_env(name: String) -> Option<String>
 
 Gets an environment variable by name.
 
-Returns Some(value) if the variable is set, or None if it is not defined in the current process environment.
+Returns Some(value) if the variable is set, or None if it is not defined in the current process environment. This API is independent of optional `std/secrets` providers and remains available when `NTNT_ENV=production`.
 
 **Parameters:**
 
@@ -5935,7 +5935,7 @@ load_env(path: String) -> Result<Unit, String>
 
 Loads environment variables from a .env file.
 
-Reads the file line by line, parsing KEY=VALUE pairs. Lines starting with # are treated as comments and skipped. Variables are set in the current process environment.
+Reads the file line by line, parsing KEY=VALUE pairs. Lines starting with # are treated as comments and skipped. Variables are set in the current process environment. Loading `.env` files remains supported in production and is not replaced or restricted by optional `std/secrets`.
 
 **Parameters:**
 
@@ -10904,6 +10904,8 @@ get_secret(name: String) -> Option<Secret>
 ```
 
 Looks up a secret by its provider-neutral logical name.
+
+`std/secrets` is opt-in and independent of `std/env`: existing `get_env`, `load_env`, and `.env` workflows keep the same behavior in every runtime mode. Secrets-provider configuration is evaluated only when an application calls `get_secret` or `require_secret`.
 
 The environment provider reads the exact environment variable name and is disabled when `NTNT_ENV` is `production` or `prod`. Unix deployments can instead select the generic local secrets-agent provider with `NTNT_SECRETS_PROVIDER=unix-socket`, a comma-separated list of absolute `NTNT_SECRETS_SOCKET_ENDPOINTS`, and the expected non-credential deployment identifier in `NTNT_SECRETS_AUTHORIZATION_SCOPE`. Optional `NTNT_SECRETS_TIMEOUT_MS` is bounded from 10 through 10000 milliseconds. Production socket paths must be beneath `/run/ntnt-secrets`; endpoints are retried twice and failed over only for bounded unavailable results. Plaintext caching remains in the host agent rather than ntnt. Projects with an `ntnt.toml` must declare accessible names under `[secrets.<NAME>]`; undeclared lookups fail before contacting the provider. Declaration metadata may contain `label`, `description`, `required`, and `environments`; secret values are never accepted in the manifest. Secret values remain opaque and redact themselves in output and diagnostics.
 

--- a/docs/release-notes/v0.5.1.md
+++ b/docs/release-notes/v0.5.1.md
@@ -60,7 +60,7 @@ v0.5.1 adds two opt-in capabilities: a secure passwordless email sign-in flow an
 - Empty-password validation returns a user-facing error without the internal auth prefix.
 - Caller-configured password-reset lifetimes are capped at 24 hours; the default remains one hour.
 - Password changes and successful resets revoke every outstanding password-reset and magic-link token for the identity across all backends.
-- OAuth callback inference now defaults public hosts to HTTPS when `SITE_URL` is absent, avoiding synthetic origin-side HTTP behind TLS-terminating proxies. Explicit `SITE_URL` remains authoritative, and localhost development remains HTTP-compatible.
+- OAuth callback inference now lets `x-forwarded-proto: https` upgrade a synthetic origin-side HTTP scheme behind TLS-terminating proxies without downgrading an HTTPS request. Explicit `SITE_URL` remains authoritative; public plain-HTTP origins without an HTTPS proxy signal and localhost development retain their existing HTTP behavior.
 - The typechecker now accepts both documented `cache_fetch(cache, url)` and `cache_fetch(cache, options)` forms.
 
 ## Compatibility with v0.5.0 applications
@@ -88,5 +88,5 @@ The optional `std/secrets` APIs own opaque values, declaration enforcement, prov
 - Existing password-reset APIs continue to work through the shared one-time-token substrate.
 - Durable SQL backends migrate automatically on initialization. Redis/Valkey legacy reset tokens are invalidated during initialization because their old records cannot prove token purpose.
 - Applications that explicitly configured password-reset token lifetimes above 24 hours now receive the 24-hour maximum.
-- Set `SITE_URL` to the canonical public origin for explicit OAuth callback control. Without it, public hosts default to HTTPS and localhost remains HTTP-compatible.
+- Set `SITE_URL` to the canonical public origin for explicit OAuth callback control. Without it, forwarded HTTPS upgrades an origin-side synthetic HTTP scheme, while public plain-HTTP and localhost requests keep their existing protocol.
 - No secrets configuration is required unless the application opts into `std/secrets`.

--- a/docs/release-notes/v0.5.1.md
+++ b/docs/release-notes/v0.5.1.md
@@ -1,49 +1,92 @@
 # NTNT v0.5.1 Release Notes
 
-v0.5.1 adds the secure token foundation and coordinated application flow for passwordless email sign-in. Applications can use the low-level purpose-bound magic-link primitives directly or mount `magic_link_flow(req, options)` for the common security ceremony without creating token tables, backend-specific replay protection, or generic request/session orchestration.
+v0.5.1 adds two opt-in capabilities: a secure passwordless email sign-in flow and provider-neutral opaque secrets. Existing v0.5.0 applications continue to run without adopting either feature. In particular, `std/env`, `get_env`, `load_env`, and `.env` files keep their existing behavior in development and production.
 
 ## Highlights
 
-- **Magic-link primitives**
-  - `issue_magic_link(identifier, options?)` creates opaque selector/verifier tokens using OS randomness, stores only the verifier hash, and defaults to a 15-minute lifetime with a one-hour maximum.
-  - `consume_magic_link(token)` atomically verifies and consumes a link, returning a safe local-identity payload without granting application roles or creating a session.
-  - Valid-shaped issuance requests remain account-neutral: missing, disabled, and locked identities receive equivalent response shapes without a persisted usable token.
+### Magic-link primitives
 
-- **Coordinated magic-link flow**
-  - `magic_link_flow(req, options)` serves the request page, a generic response with best-effort padding, fragment-clearing confirmation page, token consumption, application authorization, and request-aware session completion.
-  - Applications retain narrow `eligible`, `deliver`, and post-consume `authorize` callbacks; `eligible` must return `bool` or `Result<bool>` so ambiguous policy records cannot imply approval.
-  - Bearer tokens remain in URL fragments until explicit confirmation. Links use an explicit trusted `base_url` or `SITE_URL`, never request host or forwarded protocol headers.
-  - The coordinator forces provider, subject ID, and canonical email from the consumed identity; application authorization may add session metadata but cannot replace the authenticated principal.
+- `issue_magic_link(identifier, options?)` creates opaque selector/verifier tokens using OS randomness, stores only the verifier hash, and defaults to a 15-minute lifetime with a one-hour maximum.
+- `consume_magic_link(token)` atomically verifies and consumes a link, returning a safe local-identity payload without granting application roles or creating a session.
+- Valid-shaped issuance requests remain account-neutral: missing, disabled, and locked identities receive equivalent response shapes without a persisted usable token.
 
-- **Durable abuse and delivery controls**
-  - Client limits run before eligibility checks; eligible-identity limits run before issuance.
-  - Counters are atomic across memory, SQLite, PostgreSQL, and Redis/Valkey, use immutable socket-peer identity by default, and store only HMAC-scoped keys, counts, and expirations.
-  - Failed delivery discards the exact issued token without revoking a newer concurrent token. Delivery budget hints are advisory and timing padding remains best-effort, so production callbacks should enqueue quickly.
+### Coordinated magic-link flow
 
-- **Shared one-time-token substrate**
-  - Password resets and magic links share purpose-discriminated storage while remaining impossible to consume across purposes.
-  - One active magic link per identity, atomic replacement, replay rejection, and active-account checks are enforced across memory, SQLite, PostgreSQL, and Redis/Valkey.
-  - PostgreSQL keeps identity-first lock ordering; Redis issuance and consumption remain atomic Lua operations and return the identity validated inside the consume script.
+- `magic_link_flow(req, options)` serves the request page, a generic response with best-effort padding, fragment-clearing confirmation page, token consumption, application authorization, and request-aware session completion.
+- Applications retain narrow `eligible`, `deliver`, and post-consume `authorize` callbacks; `eligible` must return `bool` or `Result<bool>` so ambiguous policy records cannot imply approval.
+- Bearer tokens remain in URL fragments until explicit confirmation. Links use an explicit trusted `base_url` or `SITE_URL`, never request host or forwarded protocol headers.
+- The coordinator forces provider, subject ID, and canonical email from the consumed identity; application authorization may add session metadata but cannot replace the authenticated principal.
 
-- **Upgrade safety**
-  - SQLite and PostgreSQL migrate legacy password-reset rows transactionally and remove the old table.
-  - PostgreSQL startup migrations use a transaction-scoped advisory lock so rolling multi-instance upgrades serialize safely.
-  - Redis/Valkey initialization purges legacy reset-token namespaces that lack an explicit purpose discriminator.
+### Durable abuse and delivery controls
 
-- **Password-reset hardening**
-  - Public issuance and verification failures no longer expose storage-backend diagnostics.
-  - Empty-password validation returns a user-facing error without the internal auth prefix.
-  - Caller-configured password-reset lifetimes are capped at 24 hours; the default remains one hour.
-  - Password changes and successful resets revoke every outstanding password-reset and magic-link token for the identity across all backends.
+- Client limits run before eligibility checks; eligible-identity limits run before issuance.
+- Counters are atomic across memory, SQLite, PostgreSQL, and Redis/Valkey, use immutable socket-peer identity by default, and store only HMAC-scoped keys, counts, and expirations.
+- Failed delivery discards the exact issued token without revoking a newer concurrent token. Delivery budget hints are advisory and timing padding remains best-effort, so production callbacks should enqueue quickly.
+
+### Shared one-time-token substrate
+
+- Password resets and magic links share purpose-discriminated storage while remaining impossible to consume across purposes.
+- One active magic link per identity, atomic replacement, replay rejection, and active-account checks are enforced across memory, SQLite, PostgreSQL, and Redis/Valkey.
+- PostgreSQL keeps identity-first lock ordering; Redis issuance and consumption remain atomic Lua operations and return the identity validated inside the consume script.
+
+### Provider-neutral secrets
+
+- `get_secret(name) -> Option<Secret>` and `require_secret(name) -> Secret` provide opt-in lookup by logical name through `std/secrets`.
+- `Secret` is an opaque runtime and typechecker value with redacted display/debug behavior and zeroized internal storage. There is intentionally no general Secret-to-String reveal function.
+- Projects that use `std/secrets` and have an `ntnt.toml` declare allowed names under `[secrets.<NAME>]`. Declarations contain metadata only; secret values never belong in the manifest.
+- The development environment provider performs exact-name lookup. Production Unix deployments can select the generic local secrets-agent provider without coupling ntnt to a particular secrets backend.
+
+### Secret transport and sink safety
+
+- Secret values can enter explicit outbound `fetch()` sinks: headers, cookies, basic-auth fields, raw bodies, JSON leaves, and form fields.
+- Secret-bearing requests require HTTPS, do not follow redirects, and allow plaintext HTTP only for direct localhost/loopback development requests when `APP_ENV=development`.
+- Secret values are rejected from caches, database parameters, KV and job payloads, task/channel serialization, templates, public responses, URL query construction, and CSV/JSON/string conversion. Logs, diagnostics, display, and error formatting redact them.
+- `cache_fetch()` rejects secret-bearing options because its cache key does not include credential identity.
+
+### Generic Unix-socket secrets provider
+
+- `NTNT_SECRETS_PROVIDER=unix-socket` connects to any local agent implementing `docs/secrets-agent-protocol.md`.
+- One to eight ordered endpoints are supported, with bounded attempts and failover only for transient `unavailable` results.
+- Production endpoints must live beneath `/run/ntnt-secrets`; filesystem ownership and permissions authenticate the local endpoint.
+- Protocol version, request ID, logical scope, message shape, frame size, value size, and one monotonic attempt deadline are validated before returning a value.
+- Raw paths, scopes, backend errors, response fragments, and secret values are omitted from diagnostics.
+
+### Upgrade and auth hardening
+
+- SQLite and PostgreSQL migrate legacy password-reset rows transactionally and remove the old table.
+- PostgreSQL startup migrations use a transaction-scoped advisory lock so rolling multi-instance upgrades serialize safely.
+- Redis/Valkey initialization purges legacy reset-token namespaces that lack an explicit purpose discriminator.
+- Public issuance and verification failures no longer expose storage-backend diagnostics.
+- Empty-password validation returns a user-facing error without the internal auth prefix.
+- Caller-configured password-reset lifetimes are capped at 24 hours; the default remains one hour.
+- Password changes and successful resets revoke every outstanding password-reset and magic-link token for the identity across all backends.
+- OAuth callback inference now defaults public hosts to HTTPS when `SITE_URL` is absent, avoiding synthetic origin-side HTTP behind TLS-terminating proxies. Explicit `SITE_URL` remains authoritative, and localhost development remains HTTP-compatible.
+- The typechecker now accepts both documented `cache_fetch(cache, url)` and `cache_fetch(cache, options)` forms.
+
+## Compatibility with v0.5.0 applications
+
+`std/secrets` does not replace `std/env` and is not activated merely by upgrading the runtime:
+
+- Existing calls to `get_env(...)` behave exactly as before.
+- Existing calls to `load_env(".env")` remain supported when `NTNT_ENV=production`.
+- `NTNT_SECRETS_PROVIDER` and the other `NTNT_SECRETS_*` variables affect only `get_secret(...)` and `require_secret(...)` lookups.
+- An application that does not call `std/secrets` does not need a secrets provider, socket, manifest declaration, or deployment change.
+- Existing environment variables and `.env` files are not converted, invalidated, or migrated.
+
+The `std/secrets` environment provider itself is development-only and fails closed in production. That restriction applies only to the new opaque-secret API; it does not disable ordinary environment-variable configuration through `std/env`.
 
 ## Application boundary
 
-The v0.5.1 low-level APIs own token security, durable storage, expiry, replacement, atomic consumption, account-state validation, and sanitized errors. Applications using those primitives directly own delivery, throttling, authorization, confirmation UX, and session creation.
+The low-level magic-link APIs own token security, durable storage, expiry, replacement, atomic consumption, account-state validation, and sanitized errors. Applications using those primitives directly own delivery, throttling, authorization, confirmation UX, and session creation.
 
 The optional `magic_link_flow(...)` coordinator owns the common request, confirmation, rate-limit, delivery-cleanup, consume-ordering, and session ceremony. Applications still own eligibility, actual delivery, and post-consume authorization policy.
+
+The optional `std/secrets` APIs own opaque values, declaration enforcement, provider lookup, sink restrictions, and safe diagnostics. Deployment operators own the selected production secrets agent and its filesystem permissions.
 
 ## Upgrade notes
 
 - Existing password-reset APIs continue to work through the shared one-time-token substrate.
 - Durable SQL backends migrate automatically on initialization. Redis/Valkey legacy reset tokens are invalidated during initialization because their old records cannot prove token purpose.
 - Applications that explicitly configured password-reset token lifetimes above 24 hours now receive the 24-hour maximum.
+- Set `SITE_URL` to the canonical public origin for explicit OAuth callback control. Without it, public hosts default to HTTPS and localhost remains HTTP-compatible.
+- No secrets configuration is required unless the application opts into `std/secrets`.

--- a/docs/release-notes/v0.5.1.md
+++ b/docs/release-notes/v0.5.1.md
@@ -1,6 +1,6 @@
 # NTNT v0.5.1 Release Notes
 
-v0.5.1 adds two opt-in capabilities: a secure passwordless email sign-in flow and provider-neutral opaque secrets. Existing v0.5.0 applications continue to run without adopting either feature. In particular, `std/env`, `get_env`, `load_env`, and `.env` files keep their existing behavior in development and production.
+v0.5.1 adds two opt-in capabilities: a secure passwordless email sign-in flow and provider-neutral opaque secrets. Applications can keep using existing `std/env` configuration without adopting either feature: `get_env`, `load_env`, and `.env` files retain their behavior in development and production. Existing authentication deployments should review the upgrade notes below for callback-origin and token-lifetime hardening.
 
 ## Highlights
 
@@ -40,7 +40,7 @@ v0.5.1 adds two opt-in capabilities: a secure passwordless email sign-in flow an
 
 - Secret values can enter explicit outbound `fetch()` sinks: headers, cookies, basic-auth fields, raw bodies, JSON leaves, and form fields.
 - Secret-bearing requests require HTTPS, do not follow redirects, and allow plaintext HTTP only for direct localhost/loopback development requests when `APP_ENV=development`.
-- Secret values are rejected from caches, database parameters, KV and job payloads, task/channel serialization, templates, public responses, URL query construction, and CSV/JSON/string conversion. Logs, diagnostics, display, and error formatting redact them.
+- Secret values are rejected from caches, database parameters, KV and job payloads, task/channel serialization, templates, public responses, URL query construction, and CSV/JSON serialization. `str(secret)`, logs, diagnostics, display, and error formatting emit `[REDACTED]` instead of the secret value.
 - `cache_fetch()` rejects secret-bearing options because its cache key does not include credential identity.
 
 ### Generic Unix-socket secrets provider
@@ -61,6 +61,7 @@ v0.5.1 adds two opt-in capabilities: a secure passwordless email sign-in flow an
 - Caller-configured password-reset lifetimes are capped at 24 hours; the default remains one hour.
 - Password changes and successful resets revoke every outstanding password-reset and magic-link token for the identity across all backends.
 - OAuth callback inference now lets `x-forwarded-proto: https` upgrade a synthetic origin-side HTTP scheme behind TLS-terminating proxies without downgrading an HTTPS request. Explicit `SITE_URL` remains authoritative; public plain-HTTP origins without an HTTPS proxy signal and localhost development retain their existing HTTP behavior.
+- The typechecker now matches the documented `load_env(path) -> Result<Unit, String>` contract and accepts typed wrappers that propagate the result.
 - The typechecker now accepts both documented `cache_fetch(cache, url)` and `cache_fetch(cache, options)` forms.
 
 ## Compatibility with v0.5.0 applications

--- a/docs/runtime.toml
+++ b/docs/runtime.toml
@@ -23,7 +23,7 @@ affects = ["hot-reload"]
 [env_vars.NTNT_SECRETS_PROVIDER]
 values = ["env", "unix-socket"]
 default = "env"
-description = "Selects the provider behind `std/secrets`. The exact-name environment provider is development-only and is rejected when `NTNT_ENV` is `production` or `prod`. `unix-socket` is Unix-only and talks to any local secrets agent implementing the documented protocol, without depending directly on a secrets backend."
+description = "Selects the provider behind the opt-in `std/secrets` API. This setting does not affect `std/env`, `get_env`, `load_env`, or existing `.env` workflows. Provider configuration is evaluated only when an application calls `get_secret` or `require_secret`. The exact-name environment provider is development-only and is rejected when `NTNT_ENV` is `production` or `prod`; that restriction applies only to `std/secrets`. `unix-socket` is Unix-only and talks to any local secrets agent implementing the documented protocol, without depending directly on a secrets backend."
 example = "NTNT_SECRETS_PROVIDER=unix-socket ntnt run server.tnt"
 affects = ["std-secrets", "security"]
 

--- a/docs/secrets-agent-protocol.md
+++ b/docs/secrets-agent-protocol.md
@@ -57,7 +57,7 @@ Supported statuses:
 | `invalid_request` | The request is semantically invalid. | No |
 | `invalid_configuration` | The agent cannot safely serve the configured deployment. | No |
 
-Agents must not return backend error text, stack traces, paths, credentials, or secret fragments. ntnt validates the protocol version, request ID, exact scope, status shape, frame size, value size, and connection completion before exposing a value to `std/secrets`.
+Agents must not return backend error text, stack traces, paths, credentials, or secret fragments. ntnt validates the protocol version, request ID, exact scope, status shape, frame size, value size, newline frame completion, and any immediately available trailing byte before exposing a value to `std/secrets`.
 
 ## Deployment configuration
 

--- a/docs/secrets-agent-protocol.md
+++ b/docs/secrets-agent-protocol.md
@@ -1,6 +1,8 @@
 # Local secrets-agent protocol v1
 
-ntnt's `unix-socket` secrets provider can use any local agent that implements this protocol. The protocol is backend-neutral: an agent may obtain values from a managed secrets service, an operating-system key store, an HSM-backed service, or another deployment-owned source.
+ntnt's opt-in `unix-socket` secrets provider can use any local agent that implements this protocol. The protocol is backend-neutral: an agent may obtain values from a managed secrets service, an operating-system key store, an HSM-backed service, or another deployment-owned source.
+
+This provider does not replace or alter `std/env`: existing `get_env`, `load_env`, and `.env` workflows remain available in development and production. An application needs this protocol only when it deliberately calls `get_secret(...)` or `require_secret(...)` with `NTNT_SECRETS_PROVIDER=unix-socket`.
 
 This is an integration contract for `std/secrets`; it is not a general socket API for ntnt programs.
 

--- a/examples/collections_demo.tnt
+++ b/examples/collections_demo.tnt
@@ -44,19 +44,19 @@ let doubled = transform(numbers, fn(x) { x * 2 })
 print("Doubled: " + str(doubled))
 
 // === find ===
-let found = find(people, fn(p) { p["name"] == "Bob" })
+let found = find(people, fn(p) { str(p["name"]) == "Bob" })
 match found {
     Some(p) => print("Found: " + p["name"] + ", age " + str(p["age"])),
     None => print("Not found")
 }
 
 // === any / all ===
-let has_senior = any(people, fn(p) { p["age"] >= 35 })
-let all_adults = all(people, fn(p) { p["age"] >= 18 })
+let has_senior = any(people, fn(p) { (int(p["age"]) ?? 0) >= 35 })
+let all_adults = all(people, fn(p) { (int(p["age"]) ?? 0) >= 18 })
 print("Has senior: " + str(has_senior) + ", All adults: " + str(all_adults))
 
 // === count ===
-let over_25 = count(people, fn(p) { p["age"] > 25 })
+let over_25 = count(people, fn(p) { (int(p["age"]) ?? 0) > 25 })
 print("Over 25: " + str(over_25))
 
 // === reduce ===

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,7 @@ pub fn set_default_type_mode(mode: TypeMode) {
     let _ = TYPE_MODE_DEFAULT.set(mode);
 }
 
+#[cfg(not(test))]
 fn read_type_mode_from_env() -> TypeMode {
     match std::env::var("NTNT_TYPE_MODE").as_deref() {
         Ok("strict") => TypeMode::Strict,

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -5749,6 +5749,40 @@ mod tests {
     static AUTH_TEST_MUTEX: std::sync::LazyLock<std::sync::Mutex<()>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
 
+    struct TestEnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl TestEnvVarGuard {
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for TestEnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
     fn reset_auth_test_state() {
         let mut store = SESSION_STORE.lock().unwrap();
         store.sessions.clear();
@@ -13985,7 +14019,9 @@ response.status
     }
 
     #[test]
-    fn test_get_host_and_proto_prefers_request_protocol_field() {
+    fn test_get_host_and_proto_does_not_downgrade_public_https_from_forwarded_header() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let _site_url = TestEnvVarGuard::unset("SITE_URL");
         let req = Value::Map(HashMap::from([
             ("protocol".to_string(), Value::String("https".to_string())),
             (
@@ -14007,12 +14043,74 @@ response.status
     }
 
     #[test]
+    fn test_get_host_and_proto_does_not_use_synthetic_http_for_public_host() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let _site_url = TestEnvVarGuard::unset("SITE_URL");
+        let req = Value::Map(HashMap::from([
+            ("protocol".to_string(), Value::String("http".to_string())),
+            (
+                "headers".to_string(),
+                Value::Map(HashMap::from([(
+                    "host".to_string(),
+                    Value::String("public.example.com".to_string()),
+                )])),
+            ),
+        ]));
+
+        assert_eq!(
+            get_host_and_proto(&req),
+            ("public.example.com".to_string(), "https".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_host_and_proto_does_not_treat_localhost_substring_as_local() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let _site_url = TestEnvVarGuard::unset("SITE_URL");
+        let req = Value::Map(HashMap::from([
+            ("protocol".to_string(), Value::String("http".to_string())),
+            (
+                "headers".to_string(),
+                Value::Map(HashMap::from([(
+                    "host".to_string(),
+                    Value::String("notlocalhost.example.com".to_string()),
+                )])),
+            ),
+        ]));
+
+        assert_eq!(
+            get_host_and_proto(&req),
+            ("notlocalhost.example.com".to_string(), "https".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_host_and_proto_keeps_http_for_localhost() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let _site_url = TestEnvVarGuard::unset("SITE_URL");
+        for host in ["localhost:8080", "127.0.0.1:8080", "::1", "[::1]:8080"] {
+            let req = Value::Map(HashMap::from([
+                ("protocol".to_string(), Value::String("http".to_string())),
+                (
+                    "headers".to_string(),
+                    Value::Map(HashMap::from([(
+                        "host".to_string(),
+                        Value::String(host.to_string()),
+                    )])),
+                ),
+            ]));
+
+            assert_eq!(
+                get_host_and_proto(&req),
+                (host.to_string(), "http".to_string())
+            );
+        }
+    }
+
+    #[test]
     fn test_get_host_and_proto_prefers_site_url_when_present() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
-        let previous = std::env::var("SITE_URL").ok();
-        unsafe {
-            std::env::set_var("SITE_URL", "https://canonical.example.com/app");
-        }
+        let _site_url = TestEnvVarGuard::set("SITE_URL", "http://canonical.example.com/app");
 
         let req = Value::Map(HashMap::from([(
             "headers".to_string(),
@@ -14024,13 +14122,8 @@ response.status
 
         assert_eq!(
             get_host_and_proto(&req),
-            ("canonical.example.com".to_string(), "https".to_string())
+            ("canonical.example.com".to_string(), "http".to_string())
         );
-
-        match previous {
-            Some(val) => unsafe { std::env::set_var("SITE_URL", val) },
-            None => unsafe { std::env::remove_var("SITE_URL") },
-        }
     }
 
     #[test]

--- a/src/stdlib/auth.rs
+++ b/src/stdlib/auth.rs
@@ -14043,17 +14043,23 @@ response.status
     }
 
     #[test]
-    fn test_get_host_and_proto_does_not_use_synthetic_http_for_public_host() {
+    fn test_get_host_and_proto_uses_forwarded_https_over_synthetic_public_http() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         let _site_url = TestEnvVarGuard::unset("SITE_URL");
         let req = Value::Map(HashMap::from([
             ("protocol".to_string(), Value::String("http".to_string())),
             (
                 "headers".to_string(),
-                Value::Map(HashMap::from([(
-                    "host".to_string(),
-                    Value::String("public.example.com".to_string()),
-                )])),
+                Value::Map(HashMap::from([
+                    (
+                        "host".to_string(),
+                        Value::String("public.example.com".to_string()),
+                    ),
+                    (
+                        "x-forwarded-proto".to_string(),
+                        Value::String("https".to_string()),
+                    ),
+                ])),
             ),
         ]));
 
@@ -14064,7 +14070,7 @@ response.status
     }
 
     #[test]
-    fn test_get_host_and_proto_does_not_treat_localhost_substring_as_local() {
+    fn test_get_host_and_proto_preserves_public_http_without_proxy_signal() {
         let _guard = AUTH_TEST_MUTEX.lock().unwrap();
         let _site_url = TestEnvVarGuard::unset("SITE_URL");
         let req = Value::Map(HashMap::from([
@@ -14073,10 +14079,28 @@ response.status
                 "headers".to_string(),
                 Value::Map(HashMap::from([(
                     "host".to_string(),
-                    Value::String("notlocalhost.example.com".to_string()),
+                    Value::String("plain-http.example.com".to_string()),
                 )])),
             ),
         ]));
+
+        assert_eq!(
+            get_host_and_proto(&req),
+            ("plain-http.example.com".to_string(), "http".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_host_and_proto_does_not_treat_localhost_substring_as_local() {
+        let _guard = AUTH_TEST_MUTEX.lock().unwrap();
+        let _site_url = TestEnvVarGuard::unset("SITE_URL");
+        let req = Value::Map(HashMap::from([(
+            "headers".to_string(),
+            Value::Map(HashMap::from([(
+                "host".to_string(),
+                Value::String("notlocalhost.example.com".to_string()),
+            )])),
+        )]));
 
         assert_eq!(
             get_host_and_proto(&req),

--- a/src/stdlib/auth/request_helpers.rs
+++ b/src/stdlib/auth/request_helpers.rs
@@ -343,33 +343,36 @@ pub(super) fn get_host_and_proto(req: &Value) -> (String, String) {
             })
             .unwrap_or_else(|| "localhost:8080".to_string());
 
-        let local_host = is_local_host(&host);
-        let proto = if local_host {
-            req_map
-                .get("protocol")
-                .and_then(|v| match v {
+        let request_proto = req_map.get("protocol").and_then(|value| match value {
+            Value::String(value) => normalized_proto(value),
+            _ => None,
+        });
+        let forwarded_proto = req_map.get("headers").and_then(|headers| match headers {
+            Value::Map(headers) => headers
+                .get("x-forwarded-proto")
+                .and_then(|value| match value {
                     Value::String(value) => normalized_proto(value),
                     _ => None,
-                })
-                .or_else(|| {
-                    req_map.get("headers").and_then(|headers| match headers {
-                        Value::Map(headers) => {
-                            headers
-                                .get("x-forwarded-proto")
-                                .and_then(|value| match value {
-                                    Value::String(value) => normalized_proto(value),
-                                    _ => None,
-                                })
-                        }
-                        _ => None,
-                    })
-                })
+                }),
+            _ => None,
+        });
+
+        let proto = if is_local_host(&host) {
+            request_proto
+                .or(forwarded_proto)
                 .unwrap_or_else(|| "http".to_string())
-        } else {
-            // Public OAuth callbacks should be HTTPS unless the deployment owner
-            // explicitly chooses another canonical origin with SITE_URL. The HTTP
-            // server's request protocol can be synthetic behind a TLS terminator.
+        } else if request_proto.as_deref() == Some("https")
+            || forwarded_proto.as_deref() == Some("https")
+        {
+            // Never downgrade an HTTPS request, and allow a TLS terminator's
+            // forwarded HTTPS signal to upgrade the origin server's synthetic HTTP.
             "https".to_string()
+        } else {
+            // Preserve existing public plain-HTTP deployments when there is no
+            // HTTPS proxy signal. SITE_URL remains the explicit canonical override.
+            request_proto
+                .or(forwarded_proto)
+                .unwrap_or_else(|| "https".to_string())
         };
 
         (host, proto)

--- a/src/stdlib/auth/request_helpers.rs
+++ b/src/stdlib/auth/request_helpers.rs
@@ -289,6 +289,22 @@ fn normalized_proto(proto: &str) -> Option<String> {
     }
 }
 
+fn is_local_host(host: &str) -> bool {
+    let host = host.trim().to_ascii_lowercase();
+    if host == "localhost"
+        || host.starts_with("localhost:")
+        || host == "::1"
+        || host == "[::1]"
+        || host.starts_with("[::1]:")
+    {
+        return true;
+    }
+
+    let ipv4 = host.split_once(':').map_or(host.as_str(), |(host, _)| host);
+    ipv4.parse::<std::net::Ipv4Addr>()
+        .is_ok_and(|address| address.is_loopback())
+}
+
 fn normalized_host(host: &str) -> Option<String> {
     let trimmed = host.trim();
     if trimmed.is_empty()
@@ -327,37 +343,34 @@ pub(super) fn get_host_and_proto(req: &Value) -> (String, String) {
             })
             .unwrap_or_else(|| "localhost:8080".to_string());
 
-        let proto = req_map
-            .get("protocol")
-            .and_then(|v| {
-                if let Value::String(s) = v {
-                    normalized_proto(s)
-                } else {
-                    None
-                }
-            })
-            .or_else(|| {
-                req_map.get("headers").and_then(|h| {
-                    if let Value::Map(headers) = h {
-                        headers.get("x-forwarded-proto").and_then(|v| {
-                            if let Value::String(s) = v {
-                                normalized_proto(s)
-                            } else {
-                                None
-                            }
-                        })
-                    } else {
-                        None
-                    }
+        let local_host = is_local_host(&host);
+        let proto = if local_host {
+            req_map
+                .get("protocol")
+                .and_then(|v| match v {
+                    Value::String(value) => normalized_proto(value),
+                    _ => None,
                 })
-            })
-            .unwrap_or_else(|| {
-                if host.contains("localhost") || host.starts_with("127.") {
-                    "http".to_string()
-                } else {
-                    "https".to_string()
-                }
-            });
+                .or_else(|| {
+                    req_map.get("headers").and_then(|headers| match headers {
+                        Value::Map(headers) => {
+                            headers
+                                .get("x-forwarded-proto")
+                                .and_then(|value| match value {
+                                    Value::String(value) => normalized_proto(value),
+                                    _ => None,
+                                })
+                        }
+                        _ => None,
+                    })
+                })
+                .unwrap_or_else(|| "http".to_string())
+        } else {
+            // Public OAuth callbacks should be HTTPS unless the deployment owner
+            // explicitly chooses another canonical origin with SITE_URL. The HTTP
+            // server's request protocol can be synthetic behind a TLS terminator.
+            "https".to_string()
+        };
 
         (host, proto)
     } else {

--- a/src/stdlib/env.rs
+++ b/src/stdlib/env.rs
@@ -15,7 +15,8 @@ pub fn init() -> HashMap<String, Value> {
     // Gets an environment variable by name.
     //
     // Returns Some(value) if the variable is set, or None if it is not defined
-    // in the current process environment.
+    // in the current process environment. This API is independent of optional
+    // `std/secrets` providers and remains available when `NTNT_ENV=production`.
     // @param name The environment variable name
     // @returns Option containing the value or None
     // @see_also load_env
@@ -98,7 +99,8 @@ pub fn init() -> HashMap<String, Value> {
     //
     // Reads the file line by line, parsing KEY=VALUE pairs. Lines starting
     // with # are treated as comments and skipped. Variables are set in
-    // the current process environment.
+    // the current process environment. Loading `.env` files remains supported
+    // in production and is not replaced or restricted by optional `std/secrets`.
     // @param path Path to the .env file
     // @returns Result indicating success or file read error
     // @see_also get_env

--- a/src/stdlib/secrets.rs
+++ b/src/stdlib/secrets.rs
@@ -416,6 +416,22 @@ fn parse_socket_provider_config(
     timeout_ms: Option<&str>,
     production: bool,
 ) -> Result<SocketProviderConfig> {
+    parse_socket_provider_config_with_root(
+        endpoints,
+        authorization_scope,
+        timeout_ms,
+        production,
+        Path::new(PRODUCTION_SOCKET_ROOT),
+    )
+}
+
+fn parse_socket_provider_config_with_root(
+    endpoints: Option<&str>,
+    authorization_scope: Option<&str>,
+    timeout_ms: Option<&str>,
+    production: bool,
+    production_root: &Path,
+) -> Result<SocketProviderConfig> {
     let raw_endpoints = endpoints.ok_or_else(socket_config_error)?;
     let parts: Vec<&str> = raw_endpoints.split(',').map(str::trim).collect();
     if parts.len() > MAX_SOCKET_ENDPOINTS {
@@ -436,9 +452,7 @@ fn parse_socket_provider_config(
             || path
                 .components()
                 .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
-            || (production
-                && (path == Path::new(PRODUCTION_SOCKET_ROOT)
-                    || !path.starts_with(PRODUCTION_SOCKET_ROOT)))
+            || (production && (path == production_root || !path.starts_with(production_root)))
             || !seen.insert(path.clone())
         {
             return Err(socket_config_error());
@@ -588,6 +602,11 @@ pub fn init() -> HashMap<String, Value> {
     // @signature get_secret(name: String) -> Option<Secret>
     // Looks up a secret by its provider-neutral logical name.
     //
+    // `std/secrets` is opt-in and independent of `std/env`: existing `get_env`,
+    // `load_env`, and `.env` workflows keep the same behavior in every runtime mode.
+    // Secrets-provider configuration is evaluated only when an application calls
+    // `get_secret` or `require_secret`.
+    //
     // The environment provider reads the exact environment variable name and is
     // disabled when `NTNT_ENV` is `production` or `prod`. Unix deployments can
     // instead select the generic local secrets-agent provider with
@@ -681,6 +700,18 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn socket_provider_config_is_bounded_and_production_scoped() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::path::PathBuf::from("/tmp")
+            .canonicalize()
+            .unwrap_or_else(|_| std::env::temp_dir());
+        let production_root =
+            temp_root.join(format!("ntnt-secrets-{}-{suffix}", std::process::id()));
+        std::fs::create_dir_all(&production_root).expect("create production root");
+        let production_endpoint = production_root.join("agent.sock");
+
         let config = parse_socket_provider_config(
             Some("/tmp/one.sock,/tmp/two.sock"),
             Some("deployment-a"),
@@ -691,11 +722,12 @@ mod tests {
         assert_eq!(config.endpoints.len(), 2);
         assert_eq!(config.authorization_scope, "deployment-a");
         assert_eq!(config.timeout, std::time::Duration::from_millis(250));
-        parse_socket_provider_config(
-            Some("/run/ntnt-secrets/agent.sock"),
+        parse_socket_provider_config_with_root(
+            Some(production_endpoint.to_string_lossy().as_ref()),
             Some("deployment-a"),
             None,
             true,
+            &production_root,
         )
         .expect("valid production socket root");
 
@@ -748,6 +780,7 @@ mod tests {
             parse_socket_provider_config(Some(&overlong), Some("deployment-a"), None, false,)
                 .is_err()
         );
+        std::fs::remove_dir_all(production_root).ok();
     }
 
     #[cfg(not(unix))]

--- a/src/stdlib/secrets/socket.rs
+++ b/src/stdlib/secrets/socket.rs
@@ -2,7 +2,8 @@
 //!
 //! Each lookup opens one Unix stream, writes exactly one newline-delimited JSON
 //! request, half-closes the write side, reads one bounded newline-delimited JSON
-//! response through EOF, and closes the stream. Requests contain only
+//! response, performs an immediate nonblocking trailing-byte check, and closes
+//! the stream. Requests contain only
 //! `protocol`, a non-credential numeric `request_id`, `op = "get"`, and the
 //! validated logical secret `name`. Responses echo `protocol` and `request_id`,
 //! include the expected deployment authorization `scope`, and use one of:

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4361,7 +4361,16 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             }, variadic);
             sig!("download", ["url" => Type::String, "path" => Type::String], Type::Any);
             sig!("Cache", ["ttl" => Type::Int], Type::Any);
-            sig!("cache_fetch", ["cache" => Type::Any, "url" => Type::String], Type::Any, variadic);
+            sig!("cache_fetch", [
+                "cache" => Type::Any,
+                "url_or_options" => Type::Union(vec![
+                    Type::String,
+                    Type::Map {
+                        key_type: Box::new(Type::String),
+                        value_type: Box::new(Type::Any),
+                    },
+                ])
+            ], Type::Any, variadic);
         }
         "std/http/server" => {
             sig!("json", ["data" => Type::Any], Type::Named("Response".to_string()), variadic);

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4341,7 +4341,14 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
             sig!("get_env", ["name" => Type::String], Type::Optional(Box::new(Type::String)));
             sig!("set_env", ["name" => Type::String, "value" => Type::String], Type::Unit);
             sig!("all_env", [], Type::Any);
-            sig!("load_env", ["path" => Type::String], Type::Unit);
+            sig!(
+                "load_env",
+                ["path" => Type::String],
+                Type::Generic {
+                    name: "Result".to_string(),
+                    args: vec![Type::Unit, Type::String],
+                }
+            );
             sig!("args", [], Type::Array(Box::new(Type::String)));
             sig!("cwd", [], Type::String);
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -135,6 +135,23 @@ impl Type {
             // A concrete value is compatible with a union TARGET if it matches ANY member
             (other, Type::Union(types)) => types.iter().any(|t| other.is_compatible(t)),
             (Type::Named(a), Type::Named(b)) => a == b,
+            (
+                Type::Generic {
+                    name: name_a,
+                    args: args_a,
+                },
+                Type::Generic {
+                    name: name_b,
+                    args: args_b,
+                },
+            ) => {
+                name_a == name_b
+                    && args_a.len() == args_b.len()
+                    && args_a
+                        .iter()
+                        .zip(args_b.iter())
+                        .all(|(a, b)| a.is_compatible(b))
+            }
             (Type::Tuple(a), Type::Tuple(b)) => {
                 a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.is_compatible(y))
             }

--- a/tests/language_features_tests.rs
+++ b/tests/language_features_tests.rs
@@ -177,6 +177,50 @@ fn run_ntnt_file(path: &std::path::Path, env_vars: &[(&str, &str)]) -> (String, 
     (stdout, stderr, exit_code)
 }
 
+#[test]
+fn test_std_env_dotenv_remains_available_in_production_when_secrets_are_unused() {
+    let project = unique_test_dir("dotenv_compat");
+    fs::create_dir_all(&project).expect("create dotenv compatibility project");
+    let dotenv = project.join(".env");
+    let source = project.join("main.tnt");
+    let variable = format!(
+        "NTNT_DOTENV_COMPAT_{}_{}",
+        std::process::id(),
+        TEST_COUNTER.fetch_add(1, Ordering::SeqCst)
+    );
+    fs::write(&dotenv, format!("{variable}=still-works\n")).expect("write .env fixture");
+    let dotenv_path = dotenv.to_string_lossy().replace('\\', "\\\\");
+    write_test_file(
+        &source,
+        &format!(
+            r#"import {{ get_env, load_env }} from "std/env"
+import {{ get_secret }} from "std/secrets"
+
+let loaded = load_env("{dotenv_path}")
+print(is_ok(loaded))
+print(get_env("{variable}") ?? "missing")
+"#,
+        ),
+    );
+
+    let (stdout, stderr, exit) = run_ntnt_file(
+        &source,
+        &[
+            ("NTNT_ENV", "production"),
+            ("APP_ENV", "production"),
+            ("NTNT_SECRETS_PROVIDER", "not-a-provider"),
+        ],
+    );
+
+    assert_eq!(exit, 0, "stderr={stderr}\nstdout={stdout}");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        ["true", "still-works"],
+        "std/env .env loading changed under production mode"
+    );
+    fs::remove_dir_all(project).ok();
+}
+
 /// Helper to run ntnt with a code string
 fn run_ntnt_code(code: &str) -> (String, String, i32) {
     let test_file = unique_test_file("feature_test");

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1563,6 +1563,21 @@ read_user_secret(token)
 }
 
 #[test]
+fn test_load_env_matches_documented_result_type() {
+    let source = r#"import { load_env } from "std/env"
+
+fn load_config(path: String) -> Result<Unit, String> {
+    return load_env(path)
+}
+
+load_config(".env")
+"#;
+    let (stdout, stderr, exit) = lint_strict_code(source);
+    assert_eq!(exit, 0, "stderr={stderr}\nstdout={stdout}");
+    assert!(!stdout.contains("type_check"), "{stdout}");
+}
+
+#[test]
 fn test_cache_fetch_accepts_documented_url_and_options_forms() {
     let source = r#"import { Cache, cache_fetch } from "std/http"
 

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1561,3 +1561,21 @@ read_user_secret(token)
         "provider Secret must not unify with a user-defined Secret: {stdout}"
     );
 }
+
+#[test]
+fn test_cache_fetch_accepts_documented_url_and_options_forms() {
+    let source = r#"import { Cache, cache_fetch } from "std/http"
+
+let cache = Cache(60)
+let from_url = cache_fetch(cache, "https://api.example.com/data")
+let from_options = cache_fetch(cache, map {
+    "url": "https://api.example.com/data",
+    "headers": map { "Accept": "application/json" }
+})
+print(from_url)
+print(from_options)
+"#;
+    let (stdout, stderr, exit) = lint_strict_code(source);
+    assert_eq!(exit, 0, "stderr={stderr}\nstdout={stdout}");
+    assert!(!stdout.contains("type_check"), "{stdout}");
+}


### PR DESCRIPTION
## Summary

This makes the current v0.5.1 candidate safe to adopt from v0.5.0 without forcing existing applications onto the new secrets subsystem.

- preserves `std/env`, `get_env`, `load_env`, and `.env` behavior in development and production
- keeps `std/secrets` fully opt-in: provider configuration is evaluated only when `get_secret` or `require_secret` is called
- fixes public OAuth callback scheme inference behind TLS-terminating proxies
- aligns the `load_env` and `cache_fetch` typechecker signatures with their documented runtime contracts
- makes the Unix-socket production-scope test independent of host `/run` state
- removes the remaining example type warnings and truth-syncs generated/reference/release documentation

## v0.5.0 compatibility contract

An existing application can upgrade to v0.5.1 without changing its environment configuration:

- `get_env(...)` behaves as before.
- `load_env(".env")` remains available with `NTNT_ENV=production` and `APP_ENV=production`.
- `NTNT_SECRETS_PROVIDER` and other `NTNT_SECRETS_*` settings affect only explicit `std/secrets` lookups.
- Merely importing `std/secrets` does not initialize or validate a provider.
- Applications that never call `get_secret(...)` or `require_secret(...)` need no provider, socket, manifest declarations, or deployment changes.
- Existing environment values and `.env` files are not migrated, invalidated, or reinterpreted.

The new `std/secrets` environment provider remains development-only by design. That restriction applies only to opaque secret lookups; it does not disable ordinary `std/env` access.

`src/stdlib/env.rs` had no implementation delta between v0.5.0 and the pre-PR `origin/main`; this PR adds explicit regression coverage and documentation for that compatibility boundary.

## Fixes and hardening

### OAuth canonical scheme

A public request keeps its existing `http`/`https` protocol unless `x-forwarded-proto: https` upgrades a synthetic origin-side HTTP scheme from a TLS terminator. An HTTPS request is never downgraded, `SITE_URL` remains the explicit canonical override, and public plain-HTTP deployments without an HTTPS proxy signal remain compatible. Local-host detection is exact rather than substring-based, so a host such as `notlocalhost.example.com` cannot enter the local exception.

Closes #130.

### Typechecker agreement

`load_env(path)` returns `Result<Unit, String>` at runtime and in the generated reference. The strict typechecker previously modeled it as `Unit`; it now models the documented result and accepts typed wrappers that propagate it.

The `cache_fetch` runtime and generated reference already accepted:

- `cache_fetch(cache, url)`
- `cache_fetch(cache, options)`

The strict typechecker accepted only the String form. It now models the documented `String | Map<String, Any>` input and regression-tests both forms.

### Hermetic secrets-provider tests

The production socket-policy test previously used `/run/ntnt-secrets/agent.sock` directly. On hosts with a real but restricted `/run/ntnt-secrets`, the unit test depended on host filesystem state and failed despite correct runtime policy. The parser now has an internal trusted-root seam so the test can use a short, controlled Unix temp root while production still passes the fixed `/run/ntnt-secrets` root.

## Release documentation

The v0.5.1 notes and references now cover both merged feature tracks:

- passwordless magic-link authentication from #159 and #160
- provider-neutral secrets and hardening from #161, #162, #163, and #165

They explicitly state that secrets are optional and do not replace `.env` workflows.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --profile dev-release --locked`
- [x] `cargo test --locked`
- [x] `cargo build --release --locked` (`ntnt 0.5.1`)
- [x] `ntnt docs --generate`
- [x] `ntnt docs --validate` — 478 functions across 25 modules plus builtins
- [x] `ntnt validate examples/` — 60 examples valid
- [x] `ntnt lint examples/` — 0 errors, 0 warnings, 146 advisory contract suggestions
- [x] intent lint for the simple-server and IAL fixtures — 0 errors, 0 warnings
- [x] strict lint of the new `std/secrets` HTTP example — 0 issues
- [x] production-mode `.env` regression with an intentionally invalid unused secrets provider
- [x] v0.5.0-style environment and auth-demo application canaries under the v0.5.1 binary

## Deliberately out of scope

#128 (`int_or`) and #142 (bounded shared PostgreSQL pools) remain useful follow-up work, but they are not release blockers and should not expand this compatibility-focused patch.
