### PR TITLE
test: stabilize oversized socket frame on macOS

### DIFF
--- a/src/stdlib/secrets/socket.rs
+++ b/src/stdlib/secrets/socket.rs
@@ -817,7 +817,16 @@ mod tests {
 
         for (label, frame) in frames {
             let (path, _request_rx, server) = serve_response(label, frame);
-            let Err(error) = provider(path.clone()).lookup("API_KEY") else {
+            // Oversized responses must transfer the full 64 KiB boundary before
+            // they can be classified. Keep this bounded, but allow hosted macOS
+            // runners enough scheduling headroom to exercise the protocol check.
+            let Err(error) = SocketSecretProvider::new(
+                path.clone(),
+                ProviderEndpointLabel::socket(1),
+                "deployment-a".to_string(),
+                Duration::from_secs(2),
+            )
+            .lookup("API_KEY") else {
                 panic!("malformed frame '{label}' must fail closed");
             };
             let expected = if label == "no-newline" {


### PR DESCRIPTION
## Summary
- give the malformed-frame socket fixture a bounded 2-second deadline instead of the generic 250 ms fixture deadline
- preserve the 64 KiB oversized-frame rejection and all production timeout behavior
- document why hosted macOS runners need scheduling headroom for the 65,537-byte transfer

## Failure
Release run [30167798422](https://github.com/ntntlang/ntnt/actions/runs/30167798422) failed on `macos-26-arm64`: the oversized frame timed out as `Unavailable` before the provider received enough bytes to classify it as `InvalidConfiguration`. Linux, Windows, documentation, and main CI passed.

## Verification
- `cargo fmt --check`
- targeted release-profile socket regression
- `cargo test --release --locked --lib` — 1,305 passed
- `cargo build --profile dev-release --locked`
- `cargo test --locked`
- generated docs produced no diff
- examples validate/lint
- intent files lint
- `git diff --check`

Production socket behavior is unchanged; this only removes a platform-dependent test timing assumption.