### PR TITLE
ci: serialize macOS release socket tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,12 @@ jobs:
           ls -la target/${{ matrix.target }}/release/
           test -f target/${{ matrix.target }}/release/${{ matrix.binary }}
 
-      - name: Run unit tests (skip integration tests that spawn servers)
+      - name: Run unit tests (macOS, serialized local-socket fixtures)
+        if: runner.os == 'macOS'
+        run: cargo test --release --locked --target ${{ matrix.target }} --lib -- --test-threads=1
+
+      - name: Run unit tests
+        if: runner.os != 'macOS'
         run: cargo test --release --locked --target ${{ matrix.target }} --lib
 
       - name: Package (Unix)


### PR DESCRIPTION
## Summary
- run macOS release-profile library tests with one libtest thread
- keep Linux and Windows release tests unchanged

## Why
The macOS 26 arm64 release runner consistently timed out the 65,537-byte Unix-socket malformed-frame fixture only when `cargo test --lib` ran the full suite concurrently. The same test passes in isolated nextest CI. Serializing macOS release tests removes unrelated suite contention while preserving the release-profile protocol assertion.

## Verification
- serialized release-profile library suite: 1,305 passed
- release workflow structure assertion
- `git diff --check`

This is limited to the release workflow; production code and Linux/Windows jobs are unchanged.