### PR TITLE
docs: design third-party MIB catalogs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "ntnt"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntnt"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["NTNT Language Team"]
 description = "NTNT (Intent) - A programming language designed for AI-driven development"

--- a/design-docs/dd-047-std-netmon.md
+++ b/design-docs/dd-047-std-netmon.md
@@ -11,7 +11,7 @@
 
 ## Summary
 
-Design and incrementally ship a bundled `std/netmon` module for building real network monitoring systems in ntnt: bounded SNMP device telemetry first, followed by interface counters, topology hints, composite checks, and carefully scoped monitoring data helpers.
+Design and incrementally ship a bundled `std/netmon` module for building real network monitoring systems in ntnt: bounded SNMP device telemetry first, followed by offline-compiled third-party MIB catalogs, data-driven device recognition and inventory plans, interface counters, topology hints, composite checks, and carefully scoped monitoring data helpers.
 
 The packaging decision is now settled: `std/netmon` is a standard-library module. That makes its contracts compatibility-sensitive, so each protocol and data-shape slice must be independently useful, bounded, and fixture-tested before the next layer lands.
 
@@ -35,6 +35,7 @@ DD-046 owns the low-level, generally safe primitives:
 DD-047 owns higher-level monitoring concerns:
 
 - SNMP polling/walking
+- offline-compiled MIB schemas, device profiles, and finite walk plans
 - interface telemetry and counter normalization
 - device inventory and profile helpers
 - topology hints from LLDP/CDP/SNMP tables
@@ -50,7 +51,7 @@ DD-047 owns higher-level monitoring concerns:
 
 `std/netmon` ships as a bundled, explicitly imported standard-library module.
 
-That decision does **not** make it a monitoring product framework. The stdlib owns reusable protocol, normalization, policy, and bounded-computation primitives. Applications continue to own device inventories, tenants, schedules, incidents, notification delivery, persistence schemas, and product-specific state machines.
+That decision does **not** make it a monitoring product framework. The stdlib owns reusable protocol, schema/catalog, normalization, policy, and bounded-computation primitives. Applications continue to own target inventories, tenants, schedules, incidents, notification delivery, persistence schemas, catalog rollout policy, and product-specific state machines.
 
 The implementation is intentionally sliced:
 
@@ -93,6 +94,8 @@ DD-077's future general `NetCapability` object is not invented locally here. `st
 
 8. **Prefer jobs over request-path polling.** Heavy polling belongs in `std/jobs` / worker loops, not HTTP route handlers.
 
+9. **MIB schema is not execution policy.** MIB modules describe names, types, tables, indexes, access, and display semantics. Separate declarative device profiles classify observed identity, and separate finite inventory plans select read-only walks. No layer may contain credentials, targets, callbacks, templates, shell commands, or arbitrary ntnt code.
+
 ---
 
 ## Security and Deployment Model
@@ -121,6 +124,88 @@ Policy:
 - Default examples perform no traffic; protocol tests use a deterministic localhost mock agent.
 
 A future deployment-issued `NetCapability` can replace process-global authority once that cross-cutting contract ships. DD-047 does not invent a monitoring-only capability system first.
+
+## Third-Party MIB Catalog Model
+
+Third-party updates are distributed as operator-owned source bundles, but raw ASN.1/SMI text is never parsed on a poll, HTTP request, or ordinary stdlib call. ntnt uses two stages:
+
+1. `ntnt netmon mib compile <source-root> --output <catalog>` validates bounded MIB/profile/plan source in an offline compiler process and emits one canonical catalog.
+2. Application startup loads only that canonical catalog from the application manifest. Runtime readers clone one immutable `Arc<CatalogSnapshot>` for the complete operation.
+
+The compiler performs no network fetch, system MIB-directory discovery, shell execution, dynamic library loading, template evaluation, or `.tnt` execution. A parser crash, memory exhaustion, or timeout can fail the compiler process without replacing the application's last-known-good runtime catalog.
+
+### Three separately typed layers
+
+One catalog publishes three independently validated snapshots together:
+
+1. **MIB schemas** — modules, imports, qualified symbols, numeric OIDs, syntax, textual conventions, enum/bit metadata, table/index relationships, access, and provenance.
+2. **Device profiles** — advisory exact/prefix `sysObjectID` and bounded secondary identity matchers plus vendor/family/model labels. Recognition never grants network authority or selects credentials.
+3. **Walk/inventory plans** — finite read-only roots and an allowlisted normalization DSL compiled to numeric OIDs against the candidate MIB snapshot.
+
+MIB source cannot define recognition or polling behavior. Profiles cannot contain targets, ports, credentials, protocol authority, SNMP SET operations, cap increases, or executable hooks. Plans cannot contain callbacks, general expressions, or data-dependent unbounded expansion.
+
+The catalog is published atomically only after every profile and plan recompiles against the candidate MIB schema. A MIB-only update that invalidates an active profile or plan rejects the complete candidate.
+
+### Source and compiled formats
+
+The source root contains an explicit manifest and separately typed files:
+
+```text
+netmon/
+├── catalog.toml
+├── mibs/
+│   ├── ACME-SMI.mib
+│   └── ACME-SWITCH-MIB.mib
+├── profiles/
+│   └── acme-switch.toml
+└── plans/
+    └── acme-switch-inventory.toml
+```
+
+The manifest lists every file and expected module/profile/plan identity. Imports resolve only within the candidate source set plus ntnt's synthetic SMI foundation modules. Absolute paths, parent components, symlinks, duplicate paths, case/Unicode-normalization collisions, unknown fields, duplicate module/profile/plan IDs, unresolved required imports, and cycles fail closed.
+
+Plans use module-qualified symbols such as `IF-MIB::ifName`. Unqualified lookup succeeds only when exactly one candidate exists. Exact `sysObjectID` matches precede longest-prefix matches; equal top matches are compile-time ambiguity errors rather than file-order tie breakers.
+
+The compiler emits a bounded canonical catalog with a magic/version header, canonical serialized payload, payload length, and SHA-256 integrity digest. Runtime revalidates the header, length, digest, compiler-semantics version, structural bounds, sorted uniqueness, and OID depth before publication. Raw source descriptions remain inert provenance and are omitted from ordinary runtime results.
+
+### Resource ceilings
+
+Initial hard ceilings are defensive implementation limits rather than SMI-standard limits:
+
+| Resource | Hard cap |
+|---|---:|
+| Source files | 512 |
+| One source file | 4 MiB |
+| Total source bytes | 64 MiB |
+| MIB modules | 128 |
+| Definitions/symbols | 100,000 |
+| Imports per module | 256 |
+| Import/type/OID chain depth | 64 |
+| OID arcs | 128 |
+| Profiles | 1,024 |
+| Recognition rules | 8,192 |
+| Plans | 4,096 |
+| Walk roots per plan | 32 |
+| Collected diagnostics | 10,000 |
+| Canonical catalog bytes | 64 MiB |
+| Estimated runtime registry heap | 256 MiB |
+
+Compiler code uses checked counters before collection growth, iterative/depth-bounded graph traversal, deterministic `BTreeMap`/sorted-vector output, and a single parser worker by default. Diagnostics expose bounded code/module/line metadata without absolute host paths, source excerpts, or terminal control characters.
+
+### Catalog identity and update semantics
+
+Content hashes use SHA-256 with domain separation and canonical serialization:
+
+- `mib_registry_hash`
+- `profiles_hash`
+- `plans_hash`
+- `catalog_hash = SHA256(domain || format_version || compiler_semantics_version || mib_hash || profiles_hash || plans_hash)`
+
+Filesystem metadata, installation paths, source ordering, and timestamps do not affect identity. Declared versions are human labels, not content identity. Reusing one catalog ID/version with different content is rejected unless deployment explicitly selects a new version.
+
+Production v1 uses restart or rolling restart after an external updater stages, fsyncs, and atomically renames a validated catalog. Runtime never auto-downloads updates. Each process loads its own snapshot and reports the catalog hash through readiness/telemetry; an expected hash mismatch fails readiness. Live reload may follow only with serialized candidate compilation/loading, compare-and-swap generation checks, and last-known-good retention.
+
+Queued monitoring runs persist the selected catalog/profile/plan hashes. A delayed worker must load the exact retained version or fail/retry; it must not silently reinterpret a run through whichever catalog is current later.
 
 ---
 
@@ -206,7 +291,7 @@ The auth map is strict: `version` must be `"2c"`, `community` must be an opaque 
 - `retries`: additional bounded attempts, default 0, maximum 3
 - `allow_private`: default false; still requires `NTNT_NET_ALLOW_PRIVATE=1`
 
-The OID array accepts 1–64 unique numeric OIDs, each at most 255 bytes and 128 unsigned 32-bit arcs. Named MIB syntax is deferred. Encoded requests are capped at 8 KiB and response datagrams at 8 KiB. Explicit values outside any bound fail rather than clamp.
+The OID array accepts 1–64 unique numeric OIDs, each at most 255 bytes and 128 unsigned 32-bit arcs. `snmp_get` remains numeric; named resolution is provided separately through the immutable catalog APIs. Encoded requests are capped at 8 KiB and response datagrams at 8 KiB. Explicit values outside any bound fail rather than clamp.
 
 Result shape:
 
@@ -231,13 +316,35 @@ Ok(map {
 
 `Counter64` values use decimal strings so ntnt's signed 64-bit `Int` cannot truncate them, including legal values above `i64::MAX`. Binary octet strings and opaque values use lowercase hex with explicit encoding metadata. Protocol exceptions such as `no_such_object` retain their type and use `None` as the value. Agent `error_status`/`error_index`, transport timeouts, malformed BER, and authentication mismatches return `Err(String)` rather than partial telemetry.
 
-#### `snmp_walk(target, auth, oid, opts?) -> Result<Array<Map>, String>` *(next slice)*
+#### `snmp_walk(target, auth, oid, opts?) -> Result<Map, String>` *(next slice)*
 
-Walk a subtree with strict row/result caps. This follows GET rather than sharing its first compatibility commit.
+Walk a numeric subtree with strict row, request, byte, and result caps. This follows GET rather than sharing its first compatibility commit. Low-level transport stays numeric and never resolves a mutable MIB symbol implicitly.
 
-Planned options add `max_results` with a conservative default and hard cap. WALK reuses the same strict auth contract, global timeout budget, checked-address transport binding, and normalized varbind shapes.
+Planned options add `max_results` (default 256, hard maximum 2,048) and `on_limit` (`"error"` by default; optional `"partial"`). WALK reuses the same strict auth contract, global timeout budget, checked-address transport binding, and normalized varbind shapes.
 
-#### `snmp_bulk_walk(target, auth, oid, opts?) -> Result<Array<Map>, String>`
+Result shape:
+
+```ntnt
+Ok(map {
+    "target": "10.0.50.1",
+    "address": "10.0.50.1",
+    "port": 161,
+    "version": "2c",
+    "root_oid": "1.3.6.1.2.1.2.2",
+    "duration_ms": 123,
+    "requests": 17,
+    "attempts": 18,
+    "complete": true,
+    "stop_reason": "out_of_subtree",
+    "values": [...]
+})
+```
+
+GETNEXT requests use one cursor and require one response varbind. Every accepted OID must be lexicographically greater than the prior cursor. Equal, descending, or repeated OIDs are protocol errors. `endOfMibView` and the first OID outside the requested subtree are successful completion and are not included. A walk that reaches exactly `max_results` may perform one bounded look-ahead request to distinguish complete from truncated.
+
+The one global deadline begins before first request construction and covers every cursor, retry, decode, normalization step, and final result build. `max_results + 1` logical requests, 4,096 datagrams, 8 MiB cumulative receive bytes, and 4 MiB cumulative normalized output are hard ceilings; option combinations that could exceed them fail before transport.
+
+#### `snmp_bulk_walk(target, auth, oid, opts?) -> Result<Map, String>`
 
 Optional optimization after basic walk is stable. SNMP GETBULK can reduce polling overhead but should not be in PR 1 unless the implementation stays small and testable.
 
@@ -250,9 +357,55 @@ snmp_capabilities("10.0.50.1", auth)
 // Ok(map { "reachable": true, "version": "2c", "sys_object_id": "...", "vendor_hint": "mikrotik" })
 ```
 
+### Catalog and recognition APIs
+
+The active catalog is configured by deployment, not loaded from a path supplied by ordinary ntnt code:
+
+```toml
+[netmon.catalog]
+path = "netmon/catalog.ntnt.json"
+expected_sha256 = "..."
+```
+
+The path is relative to the closest `ntnt.toml`. Absolute paths, parent traversal, missing files, symlink escape, oversize input, digest mismatch, and conflicting application roots fail closed during startup. One process-global immutable snapshot is shared by HTTP interpreter workers; separate worker processes load and report their own copy.
+
+#### `netmon_catalog_info() -> Result<Map, String>`
+
+Return only schema/compiler versions, declared catalog identity, content hashes, counts, and load state. Never return host paths, source text, or the full registry.
+
+#### `mib_resolve(symbol_or_oid) -> Result<Map, String>`
+
+Resolve a module-qualified symbol, unambiguous bare symbol, or numeric OID against one snapshot:
+
+```ntnt
+mib_resolve("IF-MIB::ifHCInOctets")
+// Ok(map {
+//   "oid": "1.3.6.1.2.1.31.1.1.1.6",
+//   "qualified_symbol": "IF-MIB::ifHCInOctets",
+//   "module": "IF-MIB",
+//   "kind": "column",
+//   "syntax": "Counter64",
+//   "catalog_hash": "..."
+// })
+```
+
+The result may include bounded access, status, table/index, enum, bit, and alias metadata. Ambiguous names are errors; there is no file-order primary symbol.
+
+#### `device_recognize(target, auth, opts?) -> Result<Map, String>`
+
+Read a fixed bounded SYSTEM identity set, then classify observed data through exact `sysObjectID`, longest-prefix `sysObjectID`, and optional bounded secondary matchers. Return profile ID/hash, confidence class, catalog hash, and matched evidence. Device-controlled identity is advisory and never changes target policy, credentials, port, hard caps, or protocol authority.
+
+#### `device_walk_plan(identity_or_profile, opts?) -> Result<Array<Map>, String>`
+
+Return the selected plan's precompiled numeric roots and caller-visible limits without performing network I/O. Callers may lower limits but cannot raise plan or runtime hard caps. A persisted job stores the catalog/profile/plan hashes returned here.
+
+#### `mib_walk(target, auth, root, opts?) -> Result<Map, String>`
+
+Resolve one module-qualified root against the active catalog snapshot, then execute `snmp_walk` numerically while reporting the catalog hash. Symbol resolution occurs once at operation start; reload cannot change the walk mid-operation.
+
 ### Interface telemetry
 
-#### `interface_list(target, opts?) -> Result<Array<Map>, String>`
+#### `interface_list(target, auth, opts?) -> Result<Array<Map>, String>`
 
 Return normalized interface inventory from IF-MIB.
 
@@ -270,7 +423,7 @@ Recommended fields:
 - `mac`
 - `last_change`
 
-#### `interface_counters(target, opts?) -> Result<Array<Map>, String>`
+#### `interface_counters(target, auth, opts?) -> Result<Array<Map>, String>`
 
 Return 64-bit counters where available, falling back to 32-bit with explicit metadata.
 
@@ -311,7 +464,7 @@ This helper is important enough to design early. Good monitoring lives on rates,
 
 ### Device inventory
 
-#### `device_identity(target, opts?) -> Result<Map, String>`
+#### `device_identity(target, auth, opts?) -> Result<Map, String>`
 
 Read basic identity:
 
@@ -325,30 +478,46 @@ Read basic identity:
 - `model_hint`
 - `os_hint`
 
-#### `device_inventory(target, opts?) -> Result<Map, String>`
+#### `device_inventory(target, auth, opts?) -> Result<Map, String>`
 
 Higher-level inventory bundle:
 
 ```ntnt
 Ok(map {
+    "schema_version": "netmon.inventory/v1",
+    "catalog": map {
+        "catalog_hash": "...",
+        "mib_hash": "...",
+        "profiles_hash": "...",
+        "plans_hash": "..."
+    },
+    "recognition": map {
+        "profile_id": "acme-switch",
+        "profile_hash": "...",
+        "confidence": "exact_sys_object_id",
+        "evidence": [...]
+    },
     "identity": map { ... },
     "interfaces": [...],
     "neighbors": [...],
     "routes_summary": map { ... },
     "poll_status": "partial",
-    "warnings": ["LLDP table unavailable"]
+    "sections": [
+        map { "name": "interfaces", "status": "complete", "rows": 24 }
+    ],
+    "warnings": [map { "code": "lldp_unavailable", "section": "neighbors" }]
 })
 ```
 
-V1 should tolerate partial results. A device that refuses LLDP should not discard interface counters.
+V1 should tolerate partial results. A device that refuses LLDP should not discard interface counters. Malformed or capped tables never report `complete`; warning/error codes are stable and prose is secondary. Device-controlled text is sanitized and capped, raw enum codes are preserved beside optional MIB labels, and raw varbinds are omitted by default.
 
 ### Topology hints
 
-#### `lldp_neighbors(target, opts?) -> Result<Array<Map>, String>`
+#### `lldp_neighbors(target, auth, opts?) -> Result<Array<Map>, String>`
 
 Read LLDP-MIB where available.
 
-#### `cdp_neighbors(target, opts?) -> Result<Array<Map>, String>`
+#### `cdp_neighbors(target, auth, opts?) -> Result<Array<Map>, String>`
 
 Optional Cisco CDP support. Candidate for vendor-profile phase, not initial core.
 
@@ -386,7 +555,7 @@ Wrapper over DD-046 DNS helpers with latency and expected-record matching.
 
 Wrapper over DD-046 `tls_info()` with expiry thresholds.
 
-#### `check_snmp(target, opts?) -> Result<Map, String>`
+#### `check_snmp(target, auth, opts?) -> Result<Map, String>`
 
 SNMP liveness/identity check.
 
@@ -518,6 +687,8 @@ Retention, rollups, dashboards, and notification delivery should live in the ref
 ### `std/netmon` / DD-047
 
 - SNMP device telemetry
+- offline-compiled MIB catalogs and symbol metadata
+- data-driven device recognition and finite walk plans
 - interface counters/rates
 - topology hints
 - device inventory normalization
@@ -556,10 +727,12 @@ Some of these may become useful later, but they carry OS permissions, abuse risk
 
 - [x] **Slice 0 — standard-library packaging and security contract**
 - [x] **Slice 1A — bounded SNMPv2c GET**
-- [ ] **Slice 1B — bounded SNMP WALK**
-- [ ] **PR 2 — interface inventory and counters**
-- [ ] **PR 3 — counter-rate normalization**
-- [ ] **PR 4 — device identity and inventory bundle**
+- [ ] **Slice 1B — bounded numeric SNMP WALK**
+- [ ] **Slice 1C — offline MIB compiler and fixture corpus**
+- [ ] **Slice 1D — immutable catalog, symbol resolution, profiles, and plans**
+- [ ] **PR 2 — device recognition and inventory execution**
+- [ ] **PR 3 — interface inventory and counters**
+- [ ] **PR 4 — counter-rate normalization**
 - [ ] **PR 5 — topology hints from LLDP**
 - [ ] **PR 6 — composite checks over DD-046 primitives**
 - [ ] **PR 7 — broadly reusable alert-state helpers, if proven**
@@ -606,38 +779,101 @@ Acceptance:
 - [x] Tests require no real network device.
 - [x] Community material enters only as `Secret`.
 
-### Slice 1B — SNMP WALK
+### Slice 1B — Bounded Numeric SNMP WALK
 
 Scope:
 
-- [ ] `snmp_walk(target, auth, oid, opts?)`
-- [ ] Strict subtree and result-count enforcement.
-- [ ] GETNEXT first; GETBULK only after equivalent fixture coverage.
-- [ ] Loop, out-of-subtree, malformed-order, and premature-end detection.
-- [ ] Reuse Slice 1A auth, policy, timeout, and normalization contracts.
+- [ ] `snmp_walk(target, auth, oid, opts?) -> Result<Map, String>`.
+- [ ] GETNEXT with one cursor and exactly one correlated response varbind.
+- [ ] Strict subtree, monotonic-order, result, request, datagram, cumulative-byte, and normalized-output enforcement.
+- [ ] Explicit `complete` and `stop_reason` output, including bounded look-ahead at `max_results`.
+- [ ] Loop, equal/descending OID, malformed-order, `endOfMibView`, and out-of-subtree handling.
+- [ ] One whole-operation deadline covering retries, decode, normalization, and result construction.
+- [ ] Reuse Slice 1A auth, target policy, packet caps, and normalization contracts.
+- [ ] GETBULK only after equivalent fixture coverage.
 
-### PR 2 — Interface Inventory and Counters
+Acceptance:
+
+- [ ] No walk can silently return a truncated table as complete.
+- [ ] Mid-walk transport/protocol failure returns `Err` rather than apparently complete telemetry.
+- [ ] Independent UDP fixtures cover malicious loops, subtree escape, retries, caps, and valid termination.
+
+### Slice 1C — Offline MIB Compiler and Fixture Corpus
 
 Scope:
 
-- [ ] `interface_list(target, opts?)`
-- [ ] `interface_counters(target, opts?)`
-- [ ] IF-MIB OID constants/helpers.
+- [ ] `ntnt netmon mib compile <source-root> --output <catalog>`.
+- [ ] ntnt-controlled pinned/vendor SMIv1/SMIv2 parser-resolver substrate with one parser worker by default.
+- [ ] Explicit source manifest, bounded bytes/files/modules/tokens/definitions/imports/depth, and deterministic import index.
+- [ ] No runtime/request-path ASN.1 parsing, implicit directory recursion, system MIB discovery, network fetch, shell, plugin, or dynamic library.
+- [ ] Canonical, versioned, length-prefixed, SHA-256-protected catalog output.
+- [ ] Valid, malformed, cyclic, conflicting, deeply nested, and vendor-sloppy fixture corpus.
+
+Acceptance:
+
+- [ ] Compiler failure cannot replace an existing runtime catalog.
+- [ ] Duplicate/ambiguous definitions and unresolved required imports fail closed.
+- [ ] Output and hashes are deterministic across file creation/order and Linux/macOS/Windows.
+- [ ] Diagnostics are bounded, sanitized, and contain no absolute source paths or excerpts.
+
+### Slice 1D — Immutable Catalog, Profiles, and Plans
+
+Scope:
+
+- [ ] Startup-configured process-global `Arc<CatalogSnapshot>` with expected-hash readiness enforcement.
+- [ ] `netmon_catalog_info()` and `mib_resolve(symbol_or_oid)`.
+- [ ] Separately typed device profiles and walk/inventory plans compiled against one MIB snapshot.
+- [ ] `device_walk_plan(identity_or_profile, opts?)` with precompiled numeric roots.
+- [ ] Exact/longest-prefix recognition precedence and compile-time tie rejection.
+- [ ] Restart/rolling-restart update model with last-known-good retention; no ordinary `mib_load(path)` API.
+
+Acceptance:
+
+- [ ] All interpreter workers in one process observe the same catalog hash.
+- [ ] Separate web/job processes report deterministic matching hashes or fail readiness.
+- [ ] Invalid catalog/profile/plan updates never clear or partially mutate the live snapshot.
+- [ ] Plans cannot contain credentials, targets, cap increases, callbacks, code, or SNMP SET.
+
+### PR 2 — Device Recognition and Inventory Execution
+
+Scope:
+
+- [ ] `device_recognize(target, auth, opts?)`.
+- [ ] `mib_walk(target, auth, root, opts?)`.
+- [ ] `device_identity(target, auth, opts?)`.
+- [ ] `device_inventory(target, auth, opts?)`.
+- [ ] Fixed bounded SYSTEM identity probes, profile matching, and profile-selected finite plan execution.
+- [ ] Versioned normalized envelope with catalog/profile/plan hashes and section-level partial status.
+
+Acceptance:
+
+- [ ] Recognition returns exact evidence and ambiguity rather than treating device-controlled identity as authorization.
+- [ ] Inventory preserves complete/partial/failed section status and stable warning codes.
+- [ ] Every persisted run can record the exact catalog/profile/plan hashes used.
+- [ ] Optional table failure does not discard independently complete sections.
+
+### PR 3 — Interface Inventory and Counters
+
+Scope:
+
+- [ ] `interface_list(target, auth, opts?)`.
+- [ ] `interface_counters(target, auth, opts?)`.
+- [ ] IF-MIB table/index normalization through compiled catalog metadata.
 - [ ] Prefer high-capacity 64-bit counters when present.
 - [ ] Explicit fallback metadata for 32-bit counters.
 
 Acceptance:
 
-- [ ] Interfaces have stable normalized fields.
+- [ ] Interfaces have stable normalized fields and deterministic numeric-index ordering.
 - [ ] Counters include timestamp and counter width.
 - [ ] Missing optional fields degrade gracefully.
 - [ ] Fixture covers up/down/admin-down interfaces.
 
-### PR 3 — Counter-Rate Normalization
+### PR 4 — Counter-Rate Normalization
 
 Scope:
 
-- [ ] `interface_rates(previous, current, opts?)`
+- [ ] `interface_rates(previous, current, opts?)`.
 - [ ] Counter wrap/reset detection.
 - [ ] Utilization percentage from speed when available.
 - [ ] Invalid delta filtering.
@@ -649,26 +885,11 @@ Acceptance:
 - [ ] Negative/impossible deltas do not produce bogus traffic spikes.
 - [ ] Tests cover missing speed and zero interval.
 
-### PR 4 — Device Identity and Inventory Bundle
-
-Scope:
-
-- [ ] `device_identity(target, opts?)`
-- [ ] `device_inventory(target, opts?)`
-- [ ] sysDescr/sysObjectID/vendor-hint mapping.
-- [ ] Partial-result warnings.
-
-Acceptance:
-
-- [ ] Identity includes name, description, object ID, location/contact, uptime, vendor hint.
-- [ ] Inventory bundle returns partial data rather than failing the whole poll when optional tables are unavailable.
-- [ ] Vendor-hint mapping is data-driven and easy to extend.
-
 ### PR 5 — Topology Hints from LLDP
 
 Scope:
 
-- [ ] `lldp_neighbors(target, opts?)`
+- [ ] `lldp_neighbors(target, auth, opts?)`
 - [ ] `topology_edges(devices, opts?)`
 - [ ] Normalize neighbor identities and local/remote port names.
 - [ ] Optional CDP design stub, but do not implement unless tiny.
@@ -744,6 +965,10 @@ Slice 1A uses a small ntnt-owned SNMPv2c GET codec instead of a general SNMP dep
 
 SNMPv3 remains deferred until the v2c data shapes and failure contract survive real use. WALK/GETBULK must reuse this boundary rather than exposing the dependency directly.
 
+Raw MIB compilation uses an ntnt-controlled, exact-source snapshot derived from the MIT-licensed `mib-rs` SMIv1/SMIv2 parser/resolver. A direct upstream parser API is not exposed to ntnt programs or the polling runtime. The compiler wrapper disables default CLI/Serde features not needed by ntnt, removes implicit/system path sources, fixes parser parallelism to one by default, adds checked resource budgets and graph-depth limits, and normalizes only the catalog records ntnt needs. If those controls cannot be maintained as a pinned fork/vendor snapshot with three-platform corpus coverage, the compiler slice does not ship.
+
+The runtime catalog reader is ntnt-owned and does not depend on the ASN.1 parser. It validates only the canonical format and publishes immutable sorted schema/profile/plan data.
+
 Supporting test infrastructure:
 
 - deterministic localhost UDP mock agent in default CI;
@@ -765,6 +990,12 @@ Required tests:
 - [x] malformed or mismatched SNMP response handling
 - [x] complete BER consumption, version/PDU/request/community correlation, and full-width Counter64 decoding
 - [x] noSuchObject/noSuchName normalization
+- [ ] MIB source manifest path/symlink/collision and byte/count/depth ceilings
+- [ ] SMIv1/SMIv2 imports, table/index/type chains, cycles, conflicts, and vendor-sloppy fixtures
+- [ ] deterministic canonical catalog bytes and hashes across source ordering/platforms
+- [ ] runtime catalog length/digest/version/structural validation and expected-hash readiness
+- [ ] profile recognition precedence, ambiguity rejection, and plan-to-numeric compilation
+- [ ] multi-worker/process catalog hash consistency and failed-update last-known-good retention
 - [ ] interface inventory normalization
 - [ ] 32-bit and 64-bit counter snapshots
 - [ ] counter wrap/reset detection
@@ -790,9 +1021,7 @@ Optional/manual tests:
 
    Recommendation: defer. v2c still dominates small/internal monitoring; v3 adds auth/privacy/key-handling complexity that should not block normalized telemetry shapes.
 
-4. **OID/MIB strategy:** ship hardcoded IF-MIB/SYSTEM/LLDP constants or parse MIB files?
-
-   Recommendation: hardcoded curated constants first. MIB parsing is a swamp with paperwork.
+4. **OID/MIB strategy — resolved:** use hardcoded numeric OIDs only for fixed bootstrap probes such as `sysObjectID.0`; compile third-party SMIv1/SMIv2 source offline into one canonical catalog for general symbols, table metadata, profiles, and plans. Ordinary ntnt code cannot load raw MIB paths, and polling never parses ASN.1.
 
 5. **Discovery scope:** should `std/netmon` include subnet discovery?
 
@@ -808,4 +1037,4 @@ Optional/manual tests:
 
 `std/netmon` is now the standard-library home for bounded monitoring protocols and reusable normalization on top of DD-046's safe network policy.
 
-Start narrow. Keep credentials opaque. Bind transport to checked addresses. Normalize without truncating. Let applications own the monitoring product around those primitives. This gives ntnt a credible SNMP foundation without turning the default stdlib into a closet full of enterprise networking adapters wearing one trench coat.
+Start narrow. Keep credentials opaque. Bind transport to checked addresses. Compile untrusted MIB source outside the polling runtime. Publish schema, recognition, and finite plan data as one immutable catalog. Normalize without truncating, and let applications own target inventory and the monitoring product around those primitives. This gives ntnt a credible third-party SNMP inventory foundation without turning the default stdlib into a closet full of enterprise networking adapters wearing one trench coat.

--- a/design-docs/dd-047-std-netmon.md
+++ b/design-docs/dd-047-std-netmon.md
@@ -129,10 +129,10 @@ A future deployment-issued `NetCapability` can replace process-global authority 
 
 Third-party updates are distributed as operator-owned source bundles, but raw ASN.1/SMI text is never parsed on a poll, HTTP request, or ordinary stdlib call. ntnt uses two stages:
 
-1. `ntnt netmon mib compile <source-root> --output <catalog>` validates bounded MIB/profile/plan source in an offline compiler process and emits one canonical catalog.
+1. `ntnt netmon mib compile <source-root> --output-dir <directory>` validates bounded MIB/profile/plan source in an isolated offline compiler worker and emits one immutable content-addressed catalog.
 2. Application startup loads only that canonical catalog from the application manifest. Runtime readers clone one immutable `Arc<CatalogSnapshot>` for the complete operation.
 
-The compiler performs no network fetch, system MIB-directory discovery, shell execution, dynamic library loading, template evaluation, or `.tnt` execution. A parser crash, memory exhaustion, or timeout can fail the compiler process without replacing the application's last-known-good runtime catalog.
+The compiler performs no network fetch, system MIB-directory discovery, shell execution, dynamic library loading, template evaluation, or `.tnt` execution. A parser crash, memory-budget failure, or timeout cannot publish a new immutable artifact or change application configuration; previously selected artifacts remain untouched.
 
 ### Three separately typed layers
 
@@ -146,7 +146,7 @@ MIB source cannot define recognition or polling behavior. Profiles cannot contai
 
 The catalog is published atomically only after every profile and plan recompiles against the candidate MIB schema. A MIB-only update that invalidates an active profile or plan rejects the complete candidate.
 
-### Source and compiled formats
+### Source schemas
 
 The source root contains an explicit manifest and separately typed files:
 
@@ -162,50 +162,218 @@ netmon/
     └── acme-switch-inventory.toml
 ```
 
-The manifest lists every file and expected module/profile/plan identity. Imports resolve only within the candidate source set plus ntnt's synthetic SMI foundation modules. Absolute paths, parent components, symlinks, duplicate paths, case/Unicode-normalization collisions, unknown fields, duplicate module/profile/plan IDs, unresolved required imports, and cycles fail closed.
+`catalog.toml` v1 is a closed schema:
 
-Plans use module-qualified symbols such as `IF-MIB::ifName`. Unqualified lookup succeeds only when exactly one candidate exists. Exact `sysObjectID` matches precede longest-prefix matches; equal top matches are compile-time ambiguity errors rather than file-order tie breakers.
+```toml
+schema = 1
+id = "acme-network"
+version = "2026.07.26"
 
-The compiler emits a bounded canonical catalog with a magic/version header, canonical serialized payload, payload length, and SHA-256 integrity digest. Runtime revalidates the header, length, digest, compiler-semantics version, structural bounds, sorted uniqueness, and OID depth before publication. Raw source descriptions remain inert provenance and are omitted from ordinary runtime results.
+[[mibs]]
+path = "mibs/ACME-SMI.mib"
+module = "ACME-SMI"
 
-### Resource ceilings
+[[mibs]]
+path = "mibs/ACME-SWITCH-MIB.mib"
+module = "ACME-SWITCH-MIB"
+
+[[profiles]]
+path = "profiles/acme-switch.toml"
+id = "acme-switch"
+
+[[plans]]
+path = "plans/acme-switch-inventory.toml"
+id = "acme-switch-inventory"
+```
+
+Every file and expected module/profile/plan identity is explicit; each profile or plan file contains exactly one top-level record. Imports resolve only within the candidate source set plus ntnt's synthetic SMI foundation modules. Absolute paths, parent components, symlinks, duplicate paths, case/Unicode-normalization collisions, unknown fields, duplicate identities, unresolved required imports, and cycles fail closed.
+
+A device profile is classification data only:
+
+```toml
+schema = 1
+id = "acme-switch"
+version = "1"
+vendor = "Acme"
+family = "Switch"
+model = "1000 series"
+plans = ["acme-switch-inventory"]
+default_plan = "acme-switch-inventory"
+
+[match]
+sys_object_ids = ["ACME-SWITCH-MIB::acmeSwitch1000"]
+sys_object_id_prefixes = ["1.3.6.1.4.1.424242.10"]
+
+[[match.sys_descr]]
+op = "contains"
+value = "ACME Switch"
+ascii_case_insensitive = true
+```
+
+Profile v1 permits only `equals`, `prefix`, and `contains` literal `sysDescr` operators over a compiler-capped 512-byte value. It has no regex, inheritance, includes, priorities, negation, or executable predicates. Recognition precedence is exact `sysObjectID`, longest `sysObjectID` prefix, then `sysDescr`. Multiple profiles matching at the winning tier return runtime `ambiguous`; duplicate exact rules and equal static prefixes are rejected during compilation.
+
+An inventory plan is finite read-only acquisition data:
+
+```toml
+schema = 1
+id = "acme-switch-inventory"
+version = "1"
+
+[[sections]]
+id = "interfaces"
+kind = "table"
+root = "IF-MIB::ifTable"
+index = "IF-MIB::ifIndex"
+required = true
+max_results = 1024
+
+[[sections.fields]]
+name = "name"
+oid = "IF-MIB::ifName"
+format = "string"
+
+[[sections.fields]]
+name = "in_octets"
+oid = "IF-MIB::ifHCInOctets"
+format = "counter"
+```
+
+Section v1 permits `scalars` and `table` only. Field formats are the allowlisted values `string`, `integer`, `unsigned`, `counter`, `enum`, `bits`, `mac`, `ipv4`, `ipv6`, `oid`, and `hex`. Every symbol is module-qualified and compiles to a numeric OID. V1 has no joins, callbacks, general expressions, templates, includes, inheritance, scripts, targets, credentials, SNMP SET, or data-dependent expansion.
+
+All source objects use closed TOML schemas; unknown or duplicate keys are errors. IDs are 1–128-byte ASCII values matching `[A-Za-z0-9][A-Za-z0-9._-]*`; versions are 1–128-byte strings; paths are 1–512-byte normalized relative paths. Additional normative fields and constraints are:
+
+| Record | Required fields | Optional fields | Cross-field constraints |
+|---|---|---|---|
+| Manifest | `schema=1`, `id`, `version`, `mibs`, `profiles`, `plans` | none | `mibs` has 1–128 unique `(module,path)` entries; `profiles` and `plans` each have 1–256 entries; their combined source-file count is at most 512; profile/plan entry IDs and paths are unique and match the referenced file's top-level ID |
+| MIB entry | `path`, `module` | none | `module` follows SMI module-identifier syntax and exactly matches parsed module identity |
+| Profile/plan entry | `path`, `id` | none | referenced file contains exactly one record with that ID |
+| Profile | `schema=1`, `id`, `version`, `vendor`, `family`, `plans`, `default_plan`, `match` | `model` | `plans` has 1–32 unique IDs; `default_plan` is a member of `plans`; at least one matcher exists |
+| Match set | `sys_object_ids`, `sys_object_id_prefixes`, `sys_descr` | none | arrays may individually be empty; OID entries are unique, numeric or module-qualified, and compile to at most 128 arcs |
+| `sys_descr` matcher | `op`, `value`, `ascii_case_insensitive` | none | `op` is `equals`, `prefix`, or `contains`; `value` is 1–512 bytes |
+| Plan | `schema=1`, `id`, `version`, `sections` | none | 1–32 sections with unique IDs; aggregate request formula below must fit |
+| Section | `id`, `kind`, `root`, `required`, `max_results`, `fields` | `index` | `max_results` is 1–2,048; `fields` has 1–256 unique names/OIDs; `index` is required for `table` and forbidden for `scalars` |
+| Field | `name`, `oid`, `format` | none | `name` is a unique ID; `oid` is module-qualified; `format` is from the v1 allowlist and compatible with resolved syntax |
+
+### Canonical catalog artifact
+
+`ntnt netmon mib compile <source-root> --output-dir <directory>` compiles all three source schemas together. There is no independently published MIB-only intermediate: compiler and runtime reader for `netmon.catalog/v1` ship in the same slice.
+
+The artifact extension is `.ntntc`, not JSON. Its framing is exactly:
+
+```text
+8 bytes   magic = "NTNTMIB\0"
+2 bytes   format_version, unsigned big-endian = 1
+2 bytes   compiler_semantics_version, unsigned big-endian = 1
+8 bytes   payload_length, unsigned big-endian
+32 bytes  payload_sha256
+N bytes   canonical UTF-8 JSON payload
+```
+
+Canonical JSON uses RFC 8785 JSON Canonicalization Scheme (JCS), with the additional restrictions that ntnt emits no floating-point values and accepts only valid Unicode scalar-value strings. JCS defines UTF-8 encoding, object-key ordering, string escaping, and integer rendering; no alternate escaping is accepted as canonical output.
+
+Array order is also normative: modules by `name`; symbols by `(module, name)`; profiles and plans by `id`; profile plan IDs and aliases by UTF-8 bytes; numeric OID rules by numeric arc sequence; secondary rules by `(op, value, ascii_case_insensitive)`; sections and fields by `id` and `name`; enums and bits by numeric value/bit then label. Runtime rejects any noncanonical array order.
+
+The payload is a closed object with these required top-level keys:
+
+```text
+schema: "netmon.catalog/v1"
+format_version: 1
+compiler_semantics_version: 1
+catalog: { id: String, version: String }
+hashes: { mib_hash, profiles_hash, plans_hash, catalog_hash }
+modules: Array<ModuleRecord>
+symbols: Array<SymbolRecord>
+profiles: Array<ResolvedProfileRecord>
+plans: Array<ResolvedPlanRecord>
+```
+
+`ModuleRecord` requires `name`, `language`, and `module_hash`. `SymbolRecord` requires `module`, `name`, `qualified_name`, canonical numeric `oid`, `kind`, `syntax`, `access`, `status`, sorted `aliases`, nullable table/index metadata, sorted enum/bit metadata, and `symbol_hash`. `ResolvedProfileRecord` requires ID/version/hash, vendor/family/model labels, default/supported plan IDs, numeric exact/prefix rules, and literal secondary rules. `ResolvedPlanRecord` requires ID/version/hash and sorted sections; each section contains ID/kind/numeric root/index, required flag, result ceiling, and sorted fields with name/numeric OID/format. Nullable fields are explicit JSON `null`; omitted keys and unknown keys are invalid.
+
+Every record hash is computed from a named **hashless preimage record** containing every field above except its own `*_hash` field. Define the framing function:
+
+```text
+H(domain, parts...) = SHA256(
+    u16be(len(domain_utf8)) || domain_utf8 ||
+    for each part: u64be(len(part)) || part
+)
+```
+
+Versions are two-byte unsigned big-endian parts. Digests passed to `H` are raw 32-byte values, never hexadecimal text. Digest fields stored in canonical JSON and manifest configuration are lowercase 64-character hexadecimal.
+
+Hash definitions are:
+
+```text
+symbol_hash  = H("ntnt-netmon-symbol-v1", JCS(hashless SymbolRecord))
+module_hash  = H("ntnt-netmon-module-v1",
+                 JCS(hashless ModuleRecord),
+                 each raw symbol_hash for that module in canonical symbol order)
+profile_hash = H("ntnt-netmon-profile-v1", JCS(hashless ResolvedProfileRecord))
+plan_hash    = H("ntnt-netmon-plan-v1", JCS(hashless ResolvedPlanRecord))
+mib_hash      = H("ntnt-netmon-mibs-v1", each raw module_hash in canonical module order)
+profiles_hash = H("ntnt-netmon-profiles-v1", each raw profile_hash in canonical profile order)
+plans_hash    = H("ntnt-netmon-plans-v1", each raw plan_hash in canonical plan order)
+catalog_hash  = H("ntnt-netmon-catalog-v1",
+                  u16be(format_version), u16be(compiler_semantics_version),
+                  raw mib_hash, raw profiles_hash, raw plans_hash)
+payload_sha256  = SHA256(the exact canonical payload bytes)
+artifact_sha256 = SHA256(the complete framed artifact bytes)
+```
+
+The 32-byte header field is raw `payload_sha256`. Runtime reconstructs every hashless record, recomputes every symbol/module/profile/plan and aggregate hash, compares all stored digest fields, and only then publishes the snapshot. This binds unreferenced symbol/type/table metadata as strongly as profile-referenced data.
+
+`expected_sha256` always means `artifact_sha256`, never `payload_sha256` or semantic `catalog_hash`. Filesystem metadata, installation paths, source ordering, and timestamps do not affect semantic hashes. Declared versions are human labels, not identity; the compiler rejects a same-ID/version artifact with a different `catalog_hash` when that prior artifact is present in the selected output directory, and deployment policy must otherwise use hashes as authority.
+
+### Compiler and runtime ceilings
 
 Initial hard ceilings are defensive implementation limits rather than SMI-standard limits:
 
 | Resource | Hard cap |
 |---|---:|
+| Manifest bytes | 256 KiB |
 | Source files | 512 |
-| One source file | 4 MiB |
-| Total source bytes | 64 MiB |
+| One MIB source file | 4 MiB |
+| Total MIB source bytes | 64 MiB |
+| One profile or plan source | 256 KiB |
+| Total profile source bytes | 4 MiB |
+| Total plan source bytes | 4 MiB |
+| Lexical tokens | 1,000,000 total |
+| Identifier/path bytes | 128 / 512 |
+| Quoted string bytes | 1 MiB |
 | MIB modules | 128 |
-| Definitions/symbols | 100,000 |
-| Imports per module | 256 |
+| Definitions/symbols/AST nodes | 100,000 / 100,000 / 250,000 |
+| Imports per module / total import edges | 256 / 4,096 |
 | Import/type/OID chain depth | 64 |
 | OID arcs | 128 |
-| Profiles | 1,024 |
-| Recognition rules | 8,192 |
-| Plans | 4,096 |
-| Walk roots per plan | 32 |
-| Collected diagnostics | 10,000 |
+| Profiles / recognition rules | 256 / 8,192 |
+| Plans / sections / fields | 256 / 4,096 / 100,000 |
+| Sections per plan | 32 |
+| Collected diagnostics / diagnostic text | 10,000 / 256 bytes each |
+| Compiler wall clock | 30 seconds default / 120 seconds hard |
+| Compiler worker tracked heap | 512 MiB |
 | Canonical catalog bytes | 64 MiB |
-| Estimated runtime registry heap | 256 MiB |
+| Runtime registry tracked heap | 256 MiB |
 
-Compiler code uses checked counters before collection growth, iterative/depth-bounded graph traversal, deterministic `BTreeMap`/sorted-vector output, and a single parser worker by default. Diagnostics expose bounded code/module/line metadata without absolute host paths, source excerpts, or terminal control characters.
+The CLI parent directly spawns a hidden compiler-worker mode of the same executable, never a shell. The parent enforces the wall-clock deadline and kills the worker on expiry. The worker uses one parser thread by default, a counting allocator for its heap ceiling, pre-parser byte/token/string checks, checked counters before collection growth, and iterative/depth-bounded graph traversal. Worker crash, timeout, or budget failure leaves no publishable candidate. Diagnostics expose bounded code/module/line metadata without absolute host paths, source excerpts, or terminal control characters.
 
-### Catalog identity and update semantics
+### Publication, startup, and job semantics
 
-Content hashes use SHA-256 with domain separation and canonical serialization:
+The compiler writes a same-directory temporary artifact with exclusive creation, validates it through the production runtime reader, and fsyncs the file. Publication uses an OS/filesystem atomic **no-replace** primitive; environments that cannot guarantee no-replace fail closed. On `AlreadyExists`, the compiler opens the existing destination, validates its complete bytes and `artifact_sha256`, and discards the temporary file only when they are identical. It never replaces an existing path. After successful publication it fsyncs the output directory and never changes application configuration. Existing content-addressed artifacts therefore remain the deployment-owned rollback set.
 
-- `mib_registry_hash`
-- `profiles_hash`
-- `plans_hash`
-- `catalog_hash = SHA256(domain || format_version || compiler_semantics_version || mib_hash || profiles_hash || plans_hash)`
+The optional application manifest configuration is:
 
-Filesystem metadata, installation paths, source ordering, and timestamps do not affect identity. Declared versions are human labels, not content identity. Reusing one catalog ID/version with different content is rejected unless deployment explicitly selects a new version.
+```toml
+[netmon.catalog]
+path = "netmon/catalogs/<artifact_sha256>.ntntc"
+expected_sha256 = "<artifact_sha256>"
+```
 
-Production v1 uses restart or rolling restart after an external updater stages, fsyncs, and atomically renames a validated catalog. Runtime never auto-downloads updates. Each process loads its own snapshot and reports the catalog hash through readiness/telemetry; an expected hash mismatch fails readiness. Live reload may follow only with serialized candidate compilation/loading, compare-and-swap generation checks, and last-known-good retention.
+The path is interpreted beneath the canonical directory containing the closest `ntnt.toml`. Absolute paths, `..`, empty/control-character components, symlinks in any component, non-regular files, and artifacts larger than the framing bytes plus 64 MiB payload cap are rejected. Runtime opens through a rooted directory handle with no-follow semantics and validates length, complete `artifact_sha256`, payload, and registry from that same opened file handle, so a path swap cannot change the validated bytes.
 
-Queued monitoring runs persist the selected catalog/profile/plan hashes. A delayed worker must load the exact retained version or fail/retry; it must not silently reinterpret a run through whichever catalog is current later.
+A new common application-bootstrap step runs before main-source execution in `run`, `test`, HTTP server workers, `ntnt worker`, and job-worker startup. Repeated configuration for the same canonical application root and artifact is idempotent; a second distinct root or artifact in one process fails as `conflicting_application`. If the section is absent, numeric `snmp_get`/`snmp_walk` remain usable and catalog APIs return `Err("catalog_not_configured")`. If the section is present but its path, digest, format, or contents are invalid, process startup fails before serving traffic or claiming jobs. This is a specific netmon bootstrap contract, not a claim that ntnt already has a generic readiness subsystem.
+
+Every process loads one active immutable `Arc<CatalogSnapshot>` and reports both `artifact_sha256` and `catalog_hash` through `netmon_catalog_info()`. Live reload and runtime garbage collection are deferred. Deployment performs a rolling restart to select a new immutable artifact and retains/removes old files by application policy.
+
+Queued monitoring runs persist catalog/profile/plan IDs and hashes, but Slice 1C does not alter generic `std/jobs` retry semantics or claim a netmon pre-execution hook. PR 2 adds an optional closed `expected` hash fence to `device_inventory`; on mismatch it performs no network I/O and returns an `Ok` inventory envelope with `poll_status="catalog_mismatch"`. The application job handler records that terminal outcome and returns success to `std/jobs`, then may explicitly create a new run under the current catalog. Omitting `expected` remains valid for immediate interactive calls. Multi-version runtime lookup, leases, and garbage collection are deferred.
 
 ---
 
@@ -320,7 +488,16 @@ Ok(map {
 
 Walk a numeric subtree with strict row, request, byte, and result caps. This follows GET rather than sharing its first compatibility commit. Low-level transport stays numeric and never resolves a mutable MIB symbol implicitly.
 
-Planned options add `max_results` (default 256, hard maximum 2,048) and `on_limit` (`"error"` by default; optional `"partial"`). WALK reuses the same strict auth contract, global timeout budget, checked-address transport binding, and normalized varbind shapes.
+Options add `max_results` (default 256, hard maximum 2,048) and `on_limit` (`"error"` by default; optional `"partial"`). WALK reuses the same strict auth contract, global timeout budget, checked-address transport binding, and normalized varbind shapes.
+
+Before transport, compute:
+
+```text
+logical_request_ceiling = max_results + 1       # includes mandatory look-ahead
+datagram_attempt_ceiling = logical_request_ceiling * (retries + 1)
+```
+
+Reject the option set when checked arithmetic overflows or `datagram_attempt_ceiling > 4,096`. Therefore `max_results = 2,048` is valid with `retries = 0`; callers requesting retries must lower `max_results`. The 8 MiB actual cumulative receive-byte ceiling and 4 MiB conservative normalized-output ceiling are dynamic independent budgets: exceeding either returns `Err` even when the count ceilings have not been reached. A count maximum is not a promise that maximum-size values fit the byte budgets.
 
 Result shape:
 
@@ -340,9 +517,24 @@ Ok(map {
 })
 ```
 
-GETNEXT requests use one cursor and require one response varbind. Every accepted OID must be lexicographically greater than the prior cursor. Equal, descending, or repeated OIDs are protocol errors. `endOfMibView` and the first OID outside the requested subtree are successful completion and are not included. A walk that reaches exactly `max_results` may perform one bounded look-ahead request to distinguish complete from truncated.
+`requests` counts logical GETNEXT cursors, including look-ahead. `attempts` counts every transmitted datagram, including retries. GETNEXT requests use one cursor and require exactly one response varbind. Every accepted OID must be lexicographically greater than the prior cursor. Equal, descending, or repeated OIDs are protocol errors.
 
-The one global deadline begins before first request construction and covers every cursor, retry, decode, normalization step, and final result build. `max_results + 1` logical requests, 4,096 datagrams, 8 MiB cumulative receive bytes, and 4 MiB cumulative normalized output are hard ceilings; option combinations that could exceed them fail before transport.
+The one global deadline begins before first request construction and covers every cursor, retry, decode, normalization step, mandatory look-ahead, and final result build. Terminal behavior is normative:
+
+| Condition | Return | `complete` | `stop_reason` | Include terminal varbind? |
+|---|---|---:|---|---:|
+| First OID outside root subtree | `Ok` | `true` | `out_of_subtree` | no |
+| `endOfMibView` | `Ok` | `true` | `end_of_mib_view` | no |
+| `noSuchObject` | `Ok` | `true` | `no_such_object` | no |
+| `noSuchInstance` | `Ok` | `true` | `no_such_instance` | no |
+| Empty walk terminated by any row above | same `Ok` shape with empty `values` | `true` | corresponding reason | no |
+| Exactly `max_results`, look-ahead terminates | `Ok` | `true` | look-ahead reason | no |
+| Exactly `max_results`, look-ahead finds another valid in-subtree value and `on_limit="partial"` | `Ok` | `false` | `max_results` | no |
+| Same condition and `on_limit="error"` | `Err` | n/a | n/a | no |
+| Deadline, datagram, receive-byte, or output budget exhausted, including during look-ahead | `Err` | n/a | n/a | no |
+| Agent error status, malformed BER, wrong correlation, invalid OID progression, or transport failure | `Err` | n/a | n/a | no |
+
+The look-ahead request is mandatory whenever `max_results` values have been accepted and completion is to be claimed. Low-level WALK never returns mid-operation transport/protocol failures as partial telemetry.
 
 #### `snmp_bulk_walk(target, auth, oid, opts?) -> Result<Map, String>`
 
@@ -359,19 +551,11 @@ snmp_capabilities("10.0.50.1", auth)
 
 ### Catalog and recognition APIs
 
-The active catalog is configured by deployment, not loaded from a path supplied by ordinary ntnt code:
-
-```toml
-[netmon.catalog]
-path = "netmon/catalog.ntnt.json"
-expected_sha256 = "..."
-```
-
-The path is relative to the closest `ntnt.toml`. Absolute paths, parent traversal, missing files, symlink escape, oversize input, digest mismatch, and conflicting application roots fail closed during startup. One process-global immutable snapshot is shared by HTTP interpreter workers; separate worker processes load and report their own copy.
+The active catalog is configured by deployment, not loaded from a path supplied by ordinary ntnt code. The manifest points at an immutable `.ntntc` artifact and pins the SHA-256 of the entire framed file as defined above. Catalog absence leaves numeric SNMP primitives available; invalid configured catalog data aborts application startup.
 
 #### `netmon_catalog_info() -> Result<Map, String>`
 
-Return only schema/compiler versions, declared catalog identity, content hashes, counts, and load state. Never return host paths, source text, or the full registry.
+Return only schema/compiler versions, declared catalog identity, `artifact_sha256`, semantic hashes, counts, and load state. Never return host paths, source text, or the full registry. When no catalog is configured, return `Err("catalog_not_configured")`.
 
 #### `mib_resolve(symbol_or_oid) -> Result<Map, String>`
 
@@ -391,17 +575,70 @@ mib_resolve("IF-MIB::ifHCInOctets")
 
 The result may include bounded access, status, table/index, enum, bit, and alias metadata. Ambiguous names are errors; there is no file-order primary symbol.
 
+#### `profile_match(identity) -> Result<Map, String>`
+
+Purely classify an already observed identity map without network I/O. The closed input requires `sys_object_id: String`, permits `sys_descr: String`, and rejects unknown keys. The result always has one of these shapes:
+
+```ntnt
+Ok(map {
+    "status": "matched",
+    "catalog_hash": "...",
+    "profile_id": "acme-switch",
+    "profile_hash": "...",
+    "default_plan_id": "acme-switch-inventory",
+    "evidence": [map { "field": "sys_object_id", "kind": "exact", "rule": "..." }]
+})
+
+Ok(map { "status": "no_match", "catalog_hash": "...", "evidence": [] })
+
+Ok(map {
+    "status": "ambiguous",
+    "catalog_hash": "...",
+    "candidate_profile_ids": ["acme-a", "acme-b"],
+    "evidence": [...]
+})
+```
+
+Candidate IDs and evidence are deterministically sorted. Static duplicate exact/prefix rules fail compilation; runtime ambiguity remains possible for overlapping literal `sysDescr` rules and is never broken by file order.
+
 #### `device_recognize(target, auth, opts?) -> Result<Map, String>`
 
-Read a fixed bounded SYSTEM identity set, then classify observed data through exact `sysObjectID`, longest-prefix `sysObjectID`, and optional bounded secondary matchers. Return profile ID/hash, confidence class, catalog hash, and matched evidence. Device-controlled identity is advisory and never changes target policy, credentials, port, hard caps, or protocol authority.
+Read a fixed bounded SYSTEM identity set, then pass its closed identity map through `profile_match`. Return the same recognition envelope plus sanitized observed identity. Device-controlled identity is advisory and never changes target policy, credentials, port, hard caps, or protocol authority.
 
-#### `device_walk_plan(identity_or_profile, opts?) -> Result<Array<Map>, String>`
+#### `device_walk_plan(profile_id, plan_id, opts?) -> Result<Map, String>`
 
-Return the selected plan's precompiled numeric roots and caller-visible limits without performing network I/O. Callers may lower limits but cannot raise plan or runtime hard caps. A persisted job stores the catalog/profile/plan hashes returned here.
+Return one selected plan's precompiled numeric sections without network I/O:
+
+```ntnt
+Ok(map {
+    "catalog": map { "artifact_sha256": "...", "catalog_hash": "..." },
+    "profile": map { "id": "acme-switch", "hash": "..." },
+    "plan": map { "id": "acme-switch-inventory", "hash": "..." },
+    "limits": map {
+        "timeout_ms": 30000,
+        "max_requests": 4096,
+        "max_attempts": 4096,
+        "max_rows": 4096,
+        "max_received_bytes": 8388608,
+        "max_output_bytes": 4194304,
+        "max_concurrency": 1
+    },
+    "sections": [map {
+        "id": "interfaces",
+        "kind": "table",
+        "root_oid": "1.3.6.1.2.1.2.2",
+        "required": true,
+        "max_results": 1024,
+        "fields": [...]
+    }]
+})
+```
+
+Callers may lower effective limits through the closed options map but cannot raise plan or runtime hard caps. The explicit profile and plan IDs avoid a forgeable union-shaped `identity_or_profile` argument. The function rejects unknown profiles, plans not listed by that profile, and invalid options. Persisted jobs store the returned IDs and hashes.
 
 #### `mib_walk(target, auth, root, opts?) -> Result<Map, String>`
 
-Resolve one module-qualified root against the active catalog snapshot, then execute `snmp_walk` numerically while reporting the catalog hash. Symbol resolution occurs once at operation start; reload cannot change the walk mid-operation.
+Resolve one module-qualified root against the active catalog snapshot, then execute `snmp_walk` numerically while reporting `artifact_sha256` and `catalog_hash`. Symbol resolution occurs once at operation start; restart/reconfiguration cannot change the walk mid-operation.
 
 ### Interface telemetry
 
@@ -480,36 +717,91 @@ Read basic identity:
 
 #### `device_inventory(target, auth, opts?) -> Result<Map, String>`
 
+The closed options map may include `expected`, a closed all-or-none map containing `artifact_sha256`, `catalog_hash`, `profile_id`, `profile_hash`, `plan_id`, and `plan_hash`. Before any identity probe or other network I/O, runtime compares those values with the active snapshot and referenced profile/plan records. Any mismatch returns the terminal `Ok` envelope described below with `poll_status="catalog_mismatch"`; invalid field types or partial expected maps return `Err`. Applications pass this map for queued runs and may omit it for immediate calls.
+
 Higher-level inventory bundle:
 
 ```ntnt
 Ok(map {
     "schema_version": "netmon.inventory/v1",
     "catalog": map {
+        "artifact_sha256": "...",
         "catalog_hash": "...",
         "mib_hash": "...",
         "profiles_hash": "...",
         "plans_hash": "..."
     },
     "recognition": map {
+        "status": "matched",
         "profile_id": "acme-switch",
         "profile_hash": "...",
-        "confidence": "exact_sys_object_id",
         "evidence": [...]
+    },
+    "plan": map {
+        "id": "acme-switch-inventory",
+        "hash": "..."
     },
     "identity": map { ... },
     "interfaces": [...],
     "neighbors": [...],
     "routes_summary": map { ... },
     "poll_status": "partial",
-    "sections": [
-        map { "name": "interfaces", "status": "complete", "rows": 24 }
-    ],
-    "warnings": [map { "code": "lldp_unavailable", "section": "neighbors" }]
+    "sections": [map {
+        "id": "interfaces",
+        "plan_id": "acme-switch-inventory",
+        "plan_hash": "...",
+        "root_oid": "1.3.6.1.2.1.2.2",
+        "status": "complete",
+        "rows": 24,
+        "walk_complete": true,
+        "walk_stop_reason": "out_of_subtree",
+        "requests": 25,
+        "attempts": 25
+    }],
+    "warnings": [map { "code": "lldp_unsupported", "section": "neighbors" }]
 })
 ```
 
-V1 should tolerate partial results. A device that refuses LLDP should not discard interface counters. Malformed or capped tables never report `complete`; warning/error codes are stable and prose is secondary. Device-controlled text is sanitized and capped, raw enum codes are preserved beside optional MIB labels, and raw varbinds are omitted by default.
+Hash-fence mismatch shape:
+
+```ntnt
+Ok(map {
+    "schema_version": "netmon.inventory/v1",
+    "poll_status": "catalog_mismatch",
+    "network_attempted": false,
+    "expected": map { ... },
+    "actual": map {
+        "artifact_sha256": "...",
+        "catalog_hash": "...",
+        "profile_id": "...",
+        "profile_hash": "...",
+        "plan_id": "...",
+        "plan_hash": "..."
+    },
+    "sections": [],
+    "warnings": [map { "code": "catalog_mismatch" }]
+})
+```
+
+One `device_inventory` call holds one catalog snapshot and one whole-operation budget across recognition and every plan section:
+
+| Inventory resource | Hard cap |
+|---|---:|
+| Whole-operation timeout | 30,000 ms |
+| Recognition probes | 8 |
+| Plan sections | 32 |
+| Concurrent section walks | 1 |
+| Logical requests, including probes/look-aheads | 4,096 |
+| Datagram attempts, including retries | 4,096 |
+| Accepted rows across all sections | 4,096 |
+| Actual received bytes | 8 MiB |
+| Conservative normalized output | 4 MiB |
+
+The compiler requires `recognition_probe_ceiling + Σ(section.max_results + 1) <= 4,096`, where each `+ 1` reserves mandatory WALK look-ahead. Runtime recomputes the same checked equation from caller-lowered section limits, then multiplies every probe/section request ceiling by `(retries + 1)` and rejects the call before transport if its datagram-attempt ceiling exceeds 4,096. Each section's effective result limit is the lower of its compiled limit, caller-lowered limit, and remaining aggregate row/request budget. Recognition probes consume the same deadline/request/attempt/receive-byte budgets as inventory walks.
+
+V1 tolerates only explicit optional-section absence as partial inventory: `noSuchObject`, `noSuchInstance`, or an agent's supported-table absence marks an optional section `unsupported` and continues. The same outcome for a required section returns `Err`. Any authentication/policy failure, malformed or mismatched protocol response, transport failure, whole-operation deadline, aggregate budget exhaustion, or required-section truncation returns `Err`; it is never disguised as partial inventory. Optional-section truncation returns `Ok` with `poll_status="partial"`, `walk_complete=false`, and the exact stop reason. A fully executed plan returns `complete`; `no_match` or `ambiguous` recognition returns a stable non-inventory `Ok` envelope without executing a plan.
+
+Device-controlled text is sanitized and capped, raw enum codes are preserved beside optional MIB labels, raw varbinds are omitted by default, and every section preserves plan/root/WALK completion provenance.
 
 ### Topology hints
 
@@ -728,8 +1020,7 @@ Some of these may become useful later, but they carry OS permissions, abuse risk
 - [x] **Slice 0 — standard-library packaging and security contract**
 - [x] **Slice 1A — bounded SNMPv2c GET**
 - [ ] **Slice 1B — bounded numeric SNMP WALK**
-- [ ] **Slice 1C — offline MIB compiler and fixture corpus**
-- [ ] **Slice 1D — immutable catalog, symbol resolution, profiles, and plans**
+- [ ] **Slice 1C — canonical MIB catalog compiler, runtime registry, profiles, and plans**
 - [ ] **PR 2 — device recognition and inventory execution**
 - [ ] **PR 3 — interface inventory and counters**
 - [ ] **PR 4 — counter-rate normalization**
@@ -798,40 +1089,34 @@ Acceptance:
 - [ ] Mid-walk transport/protocol failure returns `Err` rather than apparently complete telemetry.
 - [ ] Independent UDP fixtures cover malicious loops, subtree escape, retries, caps, and valid termination.
 
-### Slice 1C — Offline MIB Compiler and Fixture Corpus
+### Slice 1C — Canonical MIB Catalog Compiler and Runtime Registry
 
-Scope:
+Compiler scope:
 
-- [ ] `ntnt netmon mib compile <source-root> --output <catalog>`.
+- [ ] `ntnt netmon mib compile <source-root> --output-dir <directory>` parent/isolated-worker command.
 - [ ] ntnt-controlled pinned/vendor SMIv1/SMIv2 parser-resolver substrate with one parser worker by default.
-- [ ] Explicit source manifest, bounded bytes/files/modules/tokens/definitions/imports/depth, and deterministic import index.
-- [ ] No runtime/request-path ASN.1 parsing, implicit directory recursion, system MIB discovery, network fetch, shell, plugin, or dynamic library.
-- [ ] Canonical, versioned, length-prefixed, SHA-256-protected catalog output.
-- [ ] Valid, malformed, cyclic, conflicting, deeply nested, and vendor-sloppy fixture corpus.
+- [ ] Closed manifest/profile/plan v1 schemas, explicit sources, all documented byte/token/node/import/depth/time/heap limits, and deterministic import index.
+- [ ] No request-path ASN.1 parsing, implicit directory recursion, system MIB discovery, network fetch, shell, plugin, or dynamic library.
+- [ ] Exact `.ntntc` framing, RFC 8785 canonical payload, per-symbol/record/aggregate hashes, atomic no-replace content-addressed publication, and production-reader validation before publication.
+- [ ] Valid, malformed, cyclic, conflicting, deeply nested, vendor-sloppy, timeout, memory-cap, and crash fixture coverage.
+
+Runtime scope:
+
+- [ ] Optional `[netmon.catalog]` manifest parsing and one common fallible bootstrap used by `run`, `test`, HTTP server, `ntnt worker`, and job workers.
+- [ ] Process-global immutable `Arc<CatalogSnapshot>` with exact artifact-hash enforcement; no public mutable `mib_load(path)` API.
+- [ ] `netmon_catalog_info()`, `mib_resolve(symbol_or_oid)`, pure `profile_match(identity)`, and `device_walk_plan(profile_id, plan_id, opts?)`.
+- [ ] Separately typed MIB/profile/plan records compiled and published together against one snapshot.
+- [ ] Restart/rolling-restart selection of immutable artifacts and catalog inspection for application-owned hash persistence; live reload, job enforcement, and multi-version runtime retention deferred.
 
 Acceptance:
 
-- [ ] Compiler failure cannot replace an existing runtime catalog.
-- [ ] Duplicate/ambiguous definitions and unresolved required imports fail closed.
-- [ ] Output and hashes are deterministic across file creation/order and Linux/macOS/Windows.
-- [ ] Diagnostics are bounded, sanitized, and contain no absolute source paths or excerpts.
-
-### Slice 1D — Immutable Catalog, Profiles, and Plans
-
-Scope:
-
-- [ ] Startup-configured process-global `Arc<CatalogSnapshot>` with expected-hash readiness enforcement.
-- [ ] `netmon_catalog_info()` and `mib_resolve(symbol_or_oid)`.
-- [ ] Separately typed device profiles and walk/inventory plans compiled against one MIB snapshot.
-- [ ] `device_walk_plan(identity_or_profile, opts?)` with precompiled numeric roots.
-- [ ] Exact/longest-prefix recognition precedence and compile-time tie rejection.
-- [ ] Restart/rolling-restart update model with last-known-good retention; no ordinary `mib_load(path)` API.
-
-Acceptance:
-
-- [ ] All interpreter workers in one process observe the same catalog hash.
-- [ ] Separate web/job processes report deterministic matching hashes or fail readiness.
-- [ ] Invalid catalog/profile/plan updates never clear or partially mutate the live snapshot.
+- [ ] Compiler failure cannot overwrite or select an application catalog.
+- [ ] Duplicate/ambiguous definitions, unresolved imports/symbols, invalid profile ties, and plans exceeding aggregate caps fail closed.
+- [ ] Artifact bytes and every semantic hash are deterministic across source creation/order and Linux/macOS/Windows.
+- [ ] Diagnostics are bounded and sanitized; parser crash/timeout/heap exhaustion remains outside the application runtime.
+- [ ] Missing catalog configuration leaves numeric GET/WALK working while catalog APIs return `catalog_not_configured`.
+- [ ] Invalid configured artifacts abort every application/worker startup path before traffic or job claims.
+- [ ] All interpreter workers in one process observe the same hashes; separate processes either report matching hashes or fail their configured hash check.
 - [ ] Plans cannot contain credentials, targets, cap increases, callbacks, code, or SNMP SET.
 
 ### PR 2 — Device Recognition and Inventory Execution
@@ -841,7 +1126,7 @@ Scope:
 - [ ] `device_recognize(target, auth, opts?)`.
 - [ ] `mib_walk(target, auth, root, opts?)`.
 - [ ] `device_identity(target, auth, opts?)`.
-- [ ] `device_inventory(target, auth, opts?)`.
+- [ ] `device_inventory(target, auth, opts?)` with the optional all-or-none `expected` catalog/profile/plan hash fence.
 - [ ] Fixed bounded SYSTEM identity probes, profile matching, and profile-selected finite plan execution.
 - [ ] Versioned normalized envelope with catalog/profile/plan hashes and section-level partial status.
 
@@ -850,6 +1135,7 @@ Acceptance:
 - [ ] Recognition returns exact evidence and ambiguity rather than treating device-controlled identity as authorization.
 - [ ] Inventory preserves complete/partial/failed section status and stable warning codes.
 - [ ] Every persisted run can record the exact catalog/profile/plan hashes used.
+- [ ] A queued run passing mismatched `expected` hashes performs zero network I/O, returns terminal `catalog_mismatch`, and can be acknowledged successfully by the application handler without `std/jobs` retrying it.
 - [ ] Optional table failure does not discard independently complete sections.
 
 ### PR 3 — Interface Inventory and Counters
@@ -993,9 +1279,10 @@ Required tests:
 - [ ] MIB source manifest path/symlink/collision and byte/count/depth ceilings
 - [ ] SMIv1/SMIv2 imports, table/index/type chains, cycles, conflicts, and vendor-sloppy fixtures
 - [ ] deterministic canonical catalog bytes and hashes across source ordering/platforms
-- [ ] runtime catalog length/digest/version/structural validation and expected-hash readiness
-- [ ] profile recognition precedence, ambiguity rejection, and plan-to-numeric compilation
-- [ ] multi-worker/process catalog hash consistency and failed-update last-known-good retention
+- [ ] runtime catalog framing/length/digest/version/structural validation and configured-artifact startup failure
+- [ ] profile recognition precedence, no-match/ambiguity envelopes, and plan-to-numeric compilation
+- [ ] multi-worker/process catalog hash consistency and immutable artifact rollback
+- [ ] queued-run expected-hash mismatch with zero network I/O and application-owned terminal acknowledgement
 - [ ] interface inventory normalization
 - [ ] 32-bit and 64-bit counter snapshots
 - [ ] counter wrap/reset detection

--- a/design-docs/dd-047-std-netmon.md
+++ b/design-docs/dd-047-std-netmon.md
@@ -484,7 +484,7 @@ Ok(map {
 
 `Counter64` values use decimal strings so ntnt's signed 64-bit `Int` cannot truncate them, including legal values above `i64::MAX`. Binary octet strings and opaque values use lowercase hex with explicit encoding metadata. Protocol exceptions such as `no_such_object` retain their type and use `None` as the value. Agent `error_status`/`error_index`, transport timeouts, malformed BER, and authentication mismatches return `Err(String)` rather than partial telemetry.
 
-#### `snmp_walk(target, auth, oid, opts?) -> Result<Map, String>` *(next slice)*
+#### `snmp_walk(target, auth, oid, opts?) -> Result<Map, String>` *(implemented in v0.5.3)*
 
 Walk a numeric subtree with strict row, request, byte, and result caps. This follows GET rather than sharing its first compatibility commit. Low-level transport stays numeric and never resolves a mutable MIB symbol implicitly.
 
@@ -517,7 +517,7 @@ Ok(map {
 })
 ```
 
-`requests` counts logical GETNEXT cursors, including look-ahead. `attempts` counts every transmitted datagram, including retries. GETNEXT requests use one cursor and require exactly one response varbind. Every accepted OID must be lexicographically greater than the prior cursor. Equal, descending, or repeated OIDs are protocol errors.
+`requests` counts logical GETNEXT cursors, including look-ahead. `attempts` counts every transmitted datagram, including retries. GETNEXT requests use one cursor and require exactly one response varbind. Every accepted ordinary-value OID must be lexicographically greater than the prior cursor. Equal, descending, or repeated OIDs are protocol errors. Terminal exception OIDs must equal the requested cursor. A same-agent datagram carrying an older request ID is ignored on the same connected socket while the current attempt deadline and cumulative receive-byte budget continue to apply.
 
 The one global deadline begins before first request construction and covers every cursor, retry, decode, normalization step, mandatory look-ahead, and final result build. Terminal behavior is normative:
 
@@ -1019,7 +1019,7 @@ Some of these may become useful later, but they carry OS permissions, abuse risk
 
 - [x] **Slice 0 — standard-library packaging and security contract**
 - [x] **Slice 1A — bounded SNMPv2c GET**
-- [ ] **Slice 1B — bounded numeric SNMP WALK**
+- [x] **Slice 1B — bounded numeric SNMP WALK**
 - [ ] **Slice 1C — canonical MIB catalog compiler, runtime registry, profiles, and plans**
 - [ ] **PR 2 — device recognition and inventory execution**
 - [ ] **PR 3 — interface inventory and counters**
@@ -1074,20 +1074,20 @@ Acceptance:
 
 Scope:
 
-- [ ] `snmp_walk(target, auth, oid, opts?) -> Result<Map, String>`.
-- [ ] GETNEXT with one cursor and exactly one correlated response varbind.
-- [ ] Strict subtree, monotonic-order, result, request, datagram, cumulative-byte, and normalized-output enforcement.
-- [ ] Explicit `complete` and `stop_reason` output, including bounded look-ahead at `max_results`.
-- [ ] Loop, equal/descending OID, malformed-order, `endOfMibView`, and out-of-subtree handling.
-- [ ] One whole-operation deadline covering retries, decode, normalization, and result construction.
-- [ ] Reuse Slice 1A auth, target policy, packet caps, and normalization contracts.
-- [ ] GETBULK only after equivalent fixture coverage.
+- [x] `snmp_walk(target, auth, oid, opts?) -> Result<Map, String>`.
+- [x] GETNEXT with one cursor and exactly one correlated response varbind.
+- [x] Strict subtree, monotonic-order, result, request, datagram, cumulative-byte, and normalized-output enforcement.
+- [x] Explicit `complete` and `stop_reason` output, including bounded look-ahead at `max_results`.
+- [x] Loop, equal/descending OID, malformed-order, `endOfMibView`, and out-of-subtree handling.
+- [x] One whole-operation deadline covering retries, decode, normalization, and result construction.
+- [x] Reuse Slice 1A auth, target policy, packet caps, and normalization contracts.
+- [x] GETBULK remains deferred until equivalent fixture coverage exists.
 
 Acceptance:
 
-- [ ] No walk can silently return a truncated table as complete.
-- [ ] Mid-walk transport/protocol failure returns `Err` rather than apparently complete telemetry.
-- [ ] Independent UDP fixtures cover malicious loops, subtree escape, retries, caps, and valid termination.
+- [x] No walk can silently return a truncated table as complete.
+- [x] Mid-walk transport/protocol failure returns `Err` rather than apparently complete telemetry.
+- [x] Independent UDP fixtures cover malicious loops, subtree escape, retries, caps, forged sources, delayed request IDs, and valid termination.
 
 ### Slice 1C — Canonical MIB Catalog Compiler and Runtime Registry
 

--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [ial.toml](ial.toml)** - Do not edit directly.
 >
-> Last updated: v0.5.2
+> Last updated: v0.5.3
 
 IAL is a term rewriting engine that translates natural language assertions into executable tests
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,6 +39,7 @@ Source files:
 | Document | Description |
 |----------|-------------|
 | [Roadmap](../ROADMAP.md) | Implementation phases and progress |
+| [v0.5.3 Release Notes](release-notes/v0.5.3.md) | Bounded numeric SNMPv2c GETNEXT WALK with strict completion and resource ceilings |
 | [v0.5.2 Release Notes](release-notes/v0.5.2.md) | Gated, bounded SNMPv2c GET through the new explicitly imported `std/netmon` module |
 | [v0.5.1 Release Notes](release-notes/v0.5.1.md) | Passwordless magic-link flow, opaque provider-neutral secrets, compatibility guarantees, and auth hardening |
 | [v0.5.0 Release Notes](release-notes/v0.5.0.md) | Verification, validation, email, and multi-worker improvements |

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [runtime.toml](runtime.toml)** - Do not edit directly.
 >
-> Last updated: v0.5.2
+> Last updated: v0.5.3
 
 Runtime configuration, environment variables, and CLI commands for NTNT
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from source code doc comments** - Do not edit directly.
 >
-> Last updated: v0.5.2
+> Last updated: v0.5.3
 
 ## Table of Contents
 
@@ -10301,7 +10301,7 @@ traceroute("example.com", map { "method": "tcp", "port": 443 })  // TCP-SYN trac
 Bounded network-monitoring protocols with opaque credentials and normalized results
 
 ```ntnt
-import { snmp_get } from "std/netmon"
+import { snmp_get, snmp_walk } from "std/netmon"
 ```
 
 ### Functions
@@ -10309,6 +10309,7 @@ import { snmp_get } from "std/netmon"
 | Function | Description |
 |----------|-------------|
 | [`snmp_get`](#snmpget) | Reads one bounded set of numeric OIDs from an SNMP agent. Slice 1 supports SNMPv2c only. The strict auth map must contain `version: "2c"` and a `community` Secret, normally returned by `require_secret()`; plaintext community strings are rejected. Unknown auth and option keys are rejected. SNMPv2c does not encrypt or authenticate its community or payload; use this slice only on trusted management networks or protected tunnels. |
+| [`snmp_walk`](#snmpwalk) | Walks one numeric OID subtree with bounded SNMPv2c GETNEXT requests. The community must be an opaque Secret. SNMPv2c is plaintext; use a trusted management network or protected tunnel. Every call requires `NTNT_NETMON_ENABLE=1`; private targets also require the shared process opt-in and `allow_private: true`. |
 
 #### `snmp_get`
 
@@ -10344,6 +10345,44 @@ snmp_get("10.0.50.1", map { "version": "2c", "community": require_secret("SNMP_C
 **See also:** `require_secret`, `net_capabilities`
 
 *Since v0.5.2*
+
+---
+
+#### `snmp_walk`
+
+```ntnt
+snmp_walk(target: String, auth: Map, oid: String, opts?: Map) -> Result<Map, String>
+```
+
+Walks one numeric OID subtree with bounded SNMPv2c GETNEXT requests. The community must be an opaque Secret. SNMPv2c is plaintext; use a trusted management network or protected tunnel. Every call requires `NTNT_NETMON_ENABLE=1`; private targets also require the shared process opt-in and `allow_private: true`.
+
+The closed options map accepts the common SNMP options plus `max_results` (default 256, hard maximum 2048) and `on_limit` (`"error"`, the default, or `"partial"`). One global deadline covers all cursors, retries, response validation, the mandatory limit look-ahead, normalization, and result construction. Requests and responses are capped at 8 KiB, cumulative received bytes at 8 MiB, and conservative normalized output at 4 MiB.
+
+A successful map has exactly: `target: String`, `address: String`, `port: Int`, `version: String` (`"2c"`), `root_oid: String`, `duration_ms: Int`, `requests: Int`, `attempts: Int`, `complete: Bool`, `stop_reason: String`, and `values: Array<Map>`. Each value uses the same normalized `oid`, `type`, `value`, and optional `encoding` fields as `snmp_get`. `stop_reason` is one of `out_of_subtree`, `end_of_mib_view`, `no_such_object`, `no_such_instance`, or `max_results`. Only `max_results` has `complete: false`, and it is returned only when `on_limit: "partial"`; all transport, protocol, ordering, deadline, and byte-budget failures are `Err(String)` without prior-row telemetry.
+
+**Parameters:**
+
+- `target` — Literal IPv4 or IPv6 address without a port
+- `auth` — Strict map with version (`"2c"`) and community (Secret)
+- `oid` — Numeric root OID in dotted notation
+- `opts` — Optional strict map with port, timeout_ms, retries, allow_private, max_results, and on_limit
+
+**Returns:** Result whose Ok map has exactly target, address, port, version, root_oid, duration_ms, requests, attempts, complete, stop_reason, and values
+
+**Examples:**
+
+```ntnt
+snmp_walk("10.0.50.1", map { "version": "2c", "community": require_secret("SNMP_COMMUNITY") }, "1.3.6.1.2.1.2.2", map { "allow_private": true, "max_results": 128 })  // Walk a bounded interface table
+```
+
+**Errors:**
+
+- **RuntimeError**: std/netmon is disabled — *Fix: Set NTNT_NETMON_ENABLE=1 for the process*
+- **RuntimeError**: snmp_walk() auth.community must be Secret — *Fix: Load it with std/secrets.require_secret()*
+
+**See also:** `snmp_get`, `require_secret`, `net_capabilities`
+
+*Since v0.5.3*
 
 ---
 

--- a/docs/SYNTAX_REFERENCE.md
+++ b/docs/SYNTAX_REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated from [syntax.toml](syntax.toml)** - Do not edit directly.
 >
-> Last updated: v0.5.2
+> Last updated: v0.5.3
 
 ## Table of Contents
 

--- a/docs/release-notes/v0.5.3.md
+++ b/docs/release-notes/v0.5.3.md
@@ -1,0 +1,38 @@
+# NTNT v0.5.3 Release Notes
+
+v0.5.3 adds bounded numeric SNMPv2c GETNEXT walks to the explicitly imported `std/netmon` module. It extends the v0.5.2 transport and credential boundary without adding MIB parsing, DNS targets, GETBULK, SNMP SET, or background network behavior.
+
+## Added
+
+- `snmp_walk(target, auth, oid, opts?) -> Result<Map, String>` for one numeric OID subtree.
+- Strict GETNEXT cursor progression with exactly one correlated response varbind per logical request.
+- Explicit successful completion reasons:
+  - `out_of_subtree`
+  - `end_of_mib_view`
+  - `no_such_object`
+  - `no_such_instance`
+- Mandatory bounded look-ahead at `max_results`, distinguishing exact completion from true truncation.
+- Optional `on_limit: "partial"` for result-limit truncation only. Transport, protocol, ordering, deadline, and byte-budget failures still return `Err(String)` without prior-row telemetry.
+- Stable result metadata: target/address/port/version/root OID, duration, logical requests, datagram attempts, completion state, stop reason, and ordered normalized values.
+
+## Bounds and security
+
+- SNMPv2c communities remain opaque `Secret` values loaded through `std/secrets`.
+- Live calls still require `NTNT_NETMON_ENABLE=1`.
+- Private targets still require both `NTNT_NET_ALLOW_PRIVATE=1` and call-local `allow_private: true`.
+- Targets remain literal IPv4/IPv6 addresses and use connected UDP sockets.
+- One operation-wide timeout covers every cursor, retry, decode, normalization step, look-ahead, and result construction.
+- Requests and individual responses are capped at 8 KiB.
+- Cumulative received datagrams are capped at 8 MiB and conservative normalized output at 4 MiB.
+- `max_results` is 1–2,048, retries are 0–3, and option preflight enforces `(max_results + 1) * (retries + 1) <= 4,096`.
+- Equal, repeated, descending, mismatched terminal-exception, malformed, uncorrelated, and oversized responses fail closed.
+- Same-agent packets carrying stale request IDs are ignored only within the current connected attempt, while deadline and receive-byte budgets continue to apply.
+
+SNMPv2c remains plaintext on the wire. Use it only on trusted management networks, VPNs, or protected tunnels.
+
+## Compatibility
+
+- Existing `snmp_get` behavior and result normalization remain compatible.
+- `std/netmon` remains explicitly imported and is not added to the prelude.
+- No network traffic occurs on import.
+- Numeric WALK does not load or resolve MIB symbols. The separately designed immutable MIB catalog pipeline remains a later delivery slice.

--- a/examples/netmon_snmp.tnt
+++ b/examples/netmon_snmp.tnt
@@ -1,5 +1,5 @@
-// std/netmon Slice 1: bounded SNMPv2c GET without performing traffic on import.
-import { snmp_get } from "std/netmon"
+// std/netmon Slice 1B: bounded SNMPv2c GET and GETNEXT WALK without traffic on import.
+import { snmp_get, snmp_walk } from "std/netmon"
 
 fn read_system_info(
     target: String,
@@ -24,6 +24,30 @@ requires len(target) > 0
             "timeout_ms": 2000,
             "retries": 1,
             "allow_private": allow_private
+        }
+    )
+}
+
+fn walk_interface_table(
+    target: String,
+    community: Secret,
+    allow_private: Bool
+) -> Result<Map<String, Any>, String>
+requires len(target) > 0
+{
+    return snmp_walk(
+        target,
+        map {
+            "version": "2c",
+            "community": community
+        },
+        "1.3.6.1.2.1.2.2.1", // IF-MIB::ifEntry
+        map {
+            "timeout_ms": 5000,
+            "retries": 0,
+            "allow_private": allow_private,
+            "max_results": 512,
+            "on_limit": "partial"
         }
     )
 }

--- a/src/stdlib/netmon.rs
+++ b/src/stdlib/netmon.rs
@@ -7,7 +7,10 @@
 #[path = "netmon_codec.rs"]
 mod codec;
 
-use self::codec::{decode_response, encode_get_request, DecodedValue};
+use self::codec::{
+    decode_response, decode_response_allow_stale, encode_get_next_request, encode_get_request,
+    DecodedValue,
+};
 use crate::error::{IntentError, Result};
 use crate::interpreter::Value;
 use crate::stdlib::net::enforce_resolved_target_policy;
@@ -30,6 +33,11 @@ const MAX_OID_BYTES: usize = 255;
 const MAX_OID_SEGMENTS: usize = 128;
 const MAX_REQUEST_BYTES: usize = 8 * 1024;
 const MAX_RESPONSE_BYTES: usize = 8 * 1024;
+const DEFAULT_MAX_RESULTS: usize = 256;
+const MAX_WALK_RESULTS: usize = 2_048;
+const MAX_WALK_OPERATIONS: usize = 4_096;
+const MAX_WALK_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_WALK_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy)]
 struct SnmpOptions {
@@ -37,6 +45,19 @@ struct SnmpOptions {
     timeout: Duration,
     retries: usize,
     allow_private: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OnLimit {
+    Error,
+    Partial,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SnmpWalkOptions {
+    common: SnmpOptions,
+    max_results: usize,
+    on_limit: OnLimit,
 }
 
 struct SnmpV2cAuth<'a> {
@@ -94,7 +115,500 @@ pub fn init() -> HashMap<String, Value> {
         },
     );
 
+    // @ntnt snmp_walk
+    // @module std/netmon
+    // @signature snmp_walk(target: String, auth: Map, oid: String, opts?: Map) -> Result<Map, String>
+    // Walks one numeric OID subtree with bounded SNMPv2c GETNEXT requests. The
+    // community must be an opaque Secret. SNMPv2c is plaintext; use a trusted
+    // management network or protected tunnel. Every call requires
+    // `NTNT_NETMON_ENABLE=1`; private targets also require the shared process
+    // opt-in and `allow_private: true`.
+    //
+    // The closed options map accepts the common SNMP options plus `max_results`
+    // (default 256, hard maximum 2048) and `on_limit` (`"error"`, the default,
+    // or `"partial"`). One global deadline covers all cursors, retries, response
+    // validation, the mandatory limit look-ahead, normalization, and result
+    // construction. Requests and responses are capped at 8 KiB, cumulative
+    // received bytes at 8 MiB, and conservative normalized output at 4 MiB.
+    //
+    // A successful map has exactly: `target: String`, `address: String`,
+    // `port: Int`, `version: String` (`"2c"`), `root_oid: String`,
+    // `duration_ms: Int`, `requests: Int`, `attempts: Int`, `complete: Bool`,
+    // `stop_reason: String`, and `values: Array<Map>`. Each value uses the same
+    // normalized `oid`, `type`, `value`, and optional `encoding` fields as
+    // `snmp_get`. `stop_reason` is one of `out_of_subtree`, `end_of_mib_view`,
+    // `no_such_object`, `no_such_instance`, or `max_results`. Only
+    // `max_results` has `complete: false`, and it is returned only when
+    // `on_limit: "partial"`; all transport, protocol, ordering, deadline, and
+    // byte-budget failures are `Err(String)` without prior-row telemetry.
+    // @param target Literal IPv4 or IPv6 address without a port
+    // @param auth Strict map with version (`"2c"`) and community (Secret)
+    // @param oid Numeric root OID in dotted notation
+    // @param opts Optional strict map with port, timeout_ms, retries, allow_private, max_results, and on_limit
+    // @returns Result whose Ok map has exactly target, address, port, version, root_oid, duration_ms, requests, attempts, complete, stop_reason, and values
+    // @error RuntimeError ~ "std/netmon is disabled" fix: "Set NTNT_NETMON_ENABLE=1 for the process"
+    // @error RuntimeError ~ "snmp_walk() auth.community must be Secret" fix: "Load it with std/secrets.require_secret()"
+    // @see_also snmp_get, require_secret, net_capabilities
+    // @since v0.5.3
+    // @tags #network, #monitoring, #snmp, #security
+    // @example snmp_walk("10.0.50.1", map { "version": "2c", "community": require_secret("SNMP_COMMUNITY") }, "1.3.6.1.2.1.2.2", map { "allow_private": true, "max_results": 128 }) ~ "Walk a bounded interface table"
+    module.insert(
+        "snmp_walk".to_string(),
+        Value::NativeFunction {
+            name: "snmp_walk".to_string(),
+            arity: 3,
+            max_arity: 4,
+            requires: None,
+            func: snmp_walk_fn,
+        },
+    );
+
     module
+}
+
+fn snmp_walk_fn(args: &[Value]) -> Result<Value> {
+    let target = expect_string(&args[0], "snmp_walk() argument 1")?;
+    let auth = expect_map(&args[1], "snmp_walk() argument 2")?;
+    let oid = expect_string(&args[2], "snmp_walk() argument 3")?;
+    let opts = match args.get(3) {
+        Some(value) => Some(expect_map(value, "snmp_walk() argument 4")?),
+        None => None,
+    };
+
+    Ok(match snmp_walk(target, auth, oid, opts) {
+        Ok(result) => Value::ok(Value::Map(result)),
+        Err(error) => Value::err(Value::String(error)),
+    })
+}
+
+struct WalkReply {
+    oid: Vec<u32>,
+    value: Value,
+    terminal_reason: Option<&'static str>,
+    normalized_size: usize,
+}
+
+fn snmp_walk(
+    target: &str,
+    auth: &HashMap<String, Value>,
+    oid: &str,
+    opts: Option<&HashMap<String, Value>>,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    require_netmon_enabled()?;
+    let target_ip = parse_target(target).map_err(as_walk_error)?;
+    let auth = parse_v2c_auth(auth).map_err(as_walk_error)?;
+    let options = parse_walk_options(opts).map_err(as_walk_error)?;
+    let root = parse_single_oid(oid).map_err(as_walk_error)?;
+    let address = SocketAddr::new(target_ip, options.common.port);
+    enforce_resolved_target_policy(
+        &[(options.common.port, address)],
+        options.common.allow_private,
+    )?;
+
+    let started = Instant::now();
+    let deadline = started + options.common.timeout;
+    let mut cursor = root.arcs.clone();
+    let mut values = Vec::with_capacity(options.max_results);
+    let mut requests = 0usize;
+    let mut attempts = 0usize;
+    let mut received_bytes = 0usize;
+    let mut output_bytes = conservative_walk_envelope_size(target, address, &root.canonical);
+
+    loop {
+        remaining_until(deadline, "SNMP WALK global timeout expired")?;
+        requests += 1;
+        let reply = walk_cursor_request(
+            address,
+            auth.community.as_bytes(),
+            &cursor,
+            options.common.retries,
+            deadline,
+            &mut attempts,
+            &mut received_bytes,
+        )?;
+
+        if let Some(reason) = reply.terminal_reason {
+            return finish_walk(
+                target,
+                address,
+                &root.canonical,
+                started,
+                deadline,
+                requests,
+                attempts,
+                true,
+                reason,
+                values,
+            );
+        }
+        if !oid_is_in_subtree(&reply.oid, &root.arcs) {
+            return finish_walk(
+                target,
+                address,
+                &root.canonical,
+                started,
+                deadline,
+                requests,
+                attempts,
+                true,
+                "out_of_subtree",
+                values,
+            );
+        }
+        if values.len() == options.max_results {
+            return match options.on_limit {
+                OnLimit::Error => Err(format!(
+                    "SNMP WALK exceeded max_results ({})",
+                    options.max_results
+                )),
+                OnLimit::Partial => finish_walk(
+                    target,
+                    address,
+                    &root.canonical,
+                    started,
+                    deadline,
+                    requests,
+                    attempts,
+                    false,
+                    "max_results",
+                    values,
+                ),
+            };
+        }
+        output_bytes = add_walk_budget(
+            output_bytes,
+            reply.normalized_size,
+            MAX_WALK_OUTPUT_BYTES,
+            "normalized output",
+        )?;
+        values.push(reply.value);
+        cursor = reply.oid;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_cursor_request(
+    address: SocketAddr,
+    community: &[u8],
+    cursor: &[u32],
+    retries: usize,
+    deadline: Instant,
+    attempts: &mut usize,
+    received_bytes: &mut usize,
+) -> std::result::Result<WalkReply, String> {
+    let attempt_limit = retries.saturating_add(1).clamp(1, MAX_ATTEMPTS);
+    let mut last_error = "request failed".to_string();
+
+    for attempt in 0..attempt_limit {
+        let remaining = remaining_until(deadline, "SNMP WALK global timeout expired")?;
+        let remaining_attempts = attempt_limit - attempt;
+        let attempt_budget = remaining / remaining_attempts as u32;
+        let attempt_deadline = Instant::now()
+            .checked_add(attempt_budget)
+            .map(|candidate| candidate.min(deadline))
+            .unwrap_or(deadline);
+        let request_id = rand::random::<i32>() & i32::MAX;
+        let request = encode_bounded_get_next_request(request_id, community, cursor)?;
+        *attempts += 1;
+
+        let packet = match send_walk_and_receive(
+            address,
+            request,
+            attempt_deadline,
+            request_id,
+            community,
+            received_bytes,
+        ) {
+            Ok(packet) => packet,
+            Err(error) => {
+                if error.starts_with("SNMP WALK cumulative responses") {
+                    return Err(error);
+                }
+                last_error = error;
+                continue;
+            }
+        };
+        let response = match decode_response(packet.as_slice(), request_id, community) {
+            Ok(response) => response,
+            Err(error) => {
+                last_error = error;
+                continue;
+            }
+        };
+        if response.error_status != 0 {
+            return Err(format!(
+                "SNMP agent returned error status {} at varbind index {}",
+                response.error_status, response.error_index
+            ));
+        }
+        if response.varbinds.len() != 1 {
+            return Err(format!(
+                "SNMP WALK response returned {} varbind(s), expected exactly 1",
+                response.varbinds.len()
+            ));
+        }
+        let varbind = response
+            .varbinds
+            .into_iter()
+            .next()
+            .expect("checked one varbind");
+        let terminal_reason = match &varbind.value {
+            DecodedValue::EndOfMibView => Some("end_of_mib_view"),
+            DecodedValue::NoSuchObject => Some("no_such_object"),
+            DecodedValue::NoSuchInstance => Some("no_such_instance"),
+            _ => None,
+        };
+        if terminal_reason.is_some() && varbind.oid.as_slice() != cursor {
+            return Err(format!(
+                "SNMP WALK terminal exception OID {} must match cursor {}",
+                format_oid(&varbind.oid),
+                format_oid(cursor)
+            ));
+        }
+        if terminal_reason.is_none() && varbind.oid.as_slice() <= cursor {
+            return Err(format!(
+                "SNMP WALK response OID {} must be strictly increasing after {}",
+                format_oid(&varbind.oid),
+                format_oid(cursor)
+            ));
+        }
+        let canonical = format_oid(&varbind.oid);
+        let value = normalize_varbind(&canonical, varbind.value)?;
+        let normalized_size = conservative_value_size(&value);
+        remaining_until(
+            deadline,
+            "SNMP WALK global timeout expired while decoding response",
+        )?;
+        return Ok(WalkReply {
+            oid: varbind.oid,
+            value,
+            terminal_reason,
+            normalized_size,
+        });
+    }
+
+    Err(format!(
+        "SNMP WALK request failed after {attempt_limit} bounded attempt(s): {last_error}"
+    ))
+}
+
+fn encode_bounded_get_next_request(
+    request_id: i32,
+    community: &[u8],
+    oid: &[u32],
+) -> std::result::Result<Zeroizing<Vec<u8>>, String> {
+    let request = encode_get_next_request(request_id, community, oid)?;
+    if request.len() > MAX_REQUEST_BYTES {
+        return Err(format!(
+            "snmp_walk() encoded request exceeds {MAX_REQUEST_BYTES} bytes"
+        ));
+    }
+    Ok(request)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish_walk(
+    target: &str,
+    address: SocketAddr,
+    root_oid: &str,
+    started: Instant,
+    deadline: Instant,
+    requests: usize,
+    attempts: usize,
+    complete: bool,
+    stop_reason: &str,
+    values: Vec<Value>,
+) -> std::result::Result<HashMap<String, Value>, String> {
+    remaining_until(
+        deadline,
+        "SNMP WALK global timeout expired before result construction",
+    )?;
+    let mut result = HashMap::new();
+    result.insert("target".to_string(), Value::String(target.to_string()));
+    result.insert(
+        "address".to_string(),
+        Value::String(address.ip().to_string()),
+    );
+    result.insert("port".to_string(), Value::Int(i64::from(address.port())));
+    result.insert("version".to_string(), Value::String("2c".to_string()));
+    result.insert("root_oid".to_string(), Value::String(root_oid.to_string()));
+    result.insert("duration_ms".to_string(), Value::Int(elapsed_ms(started)));
+    result.insert("requests".to_string(), Value::Int(requests as i64));
+    result.insert("attempts".to_string(), Value::Int(attempts as i64));
+    result.insert("complete".to_string(), Value::Bool(complete));
+    result.insert(
+        "stop_reason".to_string(),
+        Value::String(stop_reason.to_string()),
+    );
+    result.insert("values".to_string(), Value::Array(values));
+    let final_output_size = conservative_map_size(&result);
+    if final_output_size > MAX_WALK_OUTPUT_BYTES {
+        return Err(format!(
+            "SNMP WALK normalized output exceeds {MAX_WALK_OUTPUT_BYTES} bytes"
+        ));
+    }
+    remaining_until(
+        deadline,
+        "SNMP WALK global timeout expired while constructing result",
+    )?;
+    Ok(result)
+}
+
+fn conservative_walk_envelope_size(target: &str, address: SocketAddr, root_oid: &str) -> usize {
+    let envelope = HashMap::from([
+        ("target".to_string(), Value::String(target.to_string())),
+        (
+            "address".to_string(),
+            Value::String(address.ip().to_string()),
+        ),
+        ("port".to_string(), Value::Int(i64::from(address.port()))),
+        ("version".to_string(), Value::String("2c".to_string())),
+        ("root_oid".to_string(), Value::String(root_oid.to_string())),
+        ("duration_ms".to_string(), Value::Int(0)),
+        ("requests".to_string(), Value::Int(0)),
+        ("attempts".to_string(), Value::Int(0)),
+        ("complete".to_string(), Value::Bool(false)),
+        (
+            "stop_reason".to_string(),
+            Value::String("no_such_instance".to_string()),
+        ),
+        ("values".to_string(), Value::Array(Vec::new())),
+    ]);
+    conservative_map_size(&envelope)
+}
+
+fn oid_is_in_subtree(oid: &[u32], root: &[u32]) -> bool {
+    oid.starts_with(root)
+}
+
+fn conservative_value_size(value: &Value) -> usize {
+    match value {
+        Value::String(value) => value.len().saturating_add(32),
+        Value::Array(values) => values.iter().fold(32usize, |size, value| {
+            size.saturating_add(conservative_value_size(value))
+        }),
+        Value::Map(values) => conservative_map_size(values),
+        _ => 64,
+    }
+}
+
+fn conservative_map_size(values: &HashMap<String, Value>) -> usize {
+    values.iter().fold(64usize, |size, (key, value)| {
+        size.saturating_add(key.len())
+            .saturating_add(conservative_value_size(value))
+            .saturating_add(32)
+    })
+}
+
+fn add_walk_budget(
+    current: usize,
+    amount: usize,
+    maximum: usize,
+    label: &str,
+) -> std::result::Result<usize, String> {
+    let total = current
+        .checked_add(amount)
+        .ok_or_else(|| format!("SNMP WALK {label} budget overflow"))?;
+    if total > maximum {
+        return Err(format!("SNMP WALK {label} exceed {maximum} bytes"));
+    }
+    Ok(total)
+}
+
+fn parse_walk_options(
+    opts: Option<&HashMap<String, Value>>,
+) -> std::result::Result<SnmpWalkOptions, String> {
+    let empty = HashMap::new();
+    let opts = opts.unwrap_or(&empty);
+    reject_unknown_keys(
+        opts,
+        &[
+            "port",
+            "timeout_ms",
+            "retries",
+            "allow_private",
+            "max_results",
+            "on_limit",
+        ],
+        "options",
+    )?;
+    let port = parse_bounded_int(
+        opts,
+        "port",
+        i64::from(DEFAULT_SNMP_PORT),
+        1,
+        i64::from(u16::MAX),
+    )? as u16;
+    let timeout_ms = parse_bounded_int(
+        opts,
+        "timeout_ms",
+        DEFAULT_TIMEOUT_MS as i64,
+        MIN_TIMEOUT_MS as i64,
+        MAX_TIMEOUT_MS as i64,
+    )? as u64;
+    let retries = parse_bounded_int(opts, "retries", 0, 0, MAX_RETRIES as i64)? as usize;
+    let allow_private = match opts.get("allow_private") {
+        Some(Value::Bool(value)) => *value,
+        Some(value) => {
+            return Err(format!(
+                "snmp_walk() options.allow_private must be Bool, got {}",
+                value.type_name()
+            ))
+        }
+        None => false,
+    };
+    let max_results = parse_bounded_int(
+        opts,
+        "max_results",
+        DEFAULT_MAX_RESULTS as i64,
+        1,
+        MAX_WALK_RESULTS as i64,
+    )? as usize;
+    let on_limit = match opts.get("on_limit") {
+        Some(Value::String(value)) if value == "error" => OnLimit::Error,
+        Some(Value::String(value)) if value == "partial" => OnLimit::Partial,
+        Some(Value::String(_)) => {
+            return Err("snmp_walk() options.on_limit must be 'error' or 'partial'".to_string())
+        }
+        Some(value) => {
+            return Err(format!(
+                "snmp_walk() options.on_limit must be String, got {}",
+                value.type_name()
+            ))
+        }
+        None => OnLimit::Error,
+    };
+    let operations = max_results
+        .checked_add(1)
+        .and_then(|requests| requests.checked_mul(retries + 1))
+        .ok_or_else(|| "snmp_walk() operation budget overflow".to_string())?;
+    if operations > MAX_WALK_OPERATIONS {
+        return Err(format!(
+            "snmp_walk() requires {operations} possible attempts; maximum is {MAX_WALK_OPERATIONS}"
+        ));
+    }
+    Ok(SnmpWalkOptions {
+        common: SnmpOptions {
+            port,
+            timeout: Duration::from_millis(timeout_ms),
+            retries,
+            allow_private,
+        },
+        max_results,
+        on_limit,
+    })
+}
+
+fn parse_single_oid(raw: &str) -> std::result::Result<ParsedOid, String> {
+    parse_oids(&[Value::String(raw.to_string())]).and_then(|mut parsed| {
+        parsed
+            .pop()
+            .ok_or_else(|| "snmp_walk() oid is required".to_string())
+    })
+}
+
+fn as_walk_error(error: String) -> String {
+    error.replace("snmp_get()", "snmp_walk()")
 }
 
 fn snmp_get_fn(args: &[Value]) -> Result<Value> {
@@ -231,6 +745,122 @@ fn encode_bounded_request(
         ));
     }
     Ok(request)
+}
+
+fn send_walk_and_receive(
+    address: SocketAddr,
+    request: Zeroizing<Vec<u8>>,
+    attempt_deadline: Instant,
+    expected_request_id: i32,
+    expected_community: &[u8],
+    received_bytes: &mut usize,
+) -> std::result::Result<Zeroizing<Vec<u8>>, String> {
+    let bind_address = match address {
+        SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+    };
+    let socket =
+        UdpSocket::bind(bind_address).map_err(|error| format!("SNMP UDP bind failed: {error}"))?;
+    socket
+        .connect(address)
+        .map_err(|error| format!("SNMP UDP connect failed: {error}"))?;
+    socket
+        .set_write_timeout(Some(remaining_until(
+            attempt_deadline,
+            "attempt timeout expired before send",
+        )?))
+        .map_err(|error| format!("SNMP UDP write-timeout setup failed: {error}"))?;
+    let sent = socket
+        .send(request.as_slice())
+        .map_err(|error| format!("SNMP UDP send failed: {error}"))?;
+    if sent != request.len() {
+        return Err(format!(
+            "SNMP UDP send wrote {sent} bytes, expected {}",
+            request.len()
+        ));
+    }
+    drop(request);
+
+    let mut packet = Zeroizing::new(vec![0_u8; MAX_RESPONSE_BYTES + 1]);
+    loop {
+        socket
+            .set_read_timeout(Some(remaining_until(
+                attempt_deadline,
+                "attempt timeout expired after send",
+            )?))
+            .map_err(|error| format!("SNMP UDP read-timeout setup failed: {error}"))?;
+        packet.resize(MAX_RESPONSE_BYTES + 1, 0);
+        let received = match socket.recv(packet.as_mut_slice()) {
+            Ok(received) => received,
+            Err(error) if is_oversized_datagram_error(&error) => {
+                *received_bytes = add_walk_budget(
+                    *received_bytes,
+                    MAX_RESPONSE_BYTES + 1,
+                    MAX_WALK_RESPONSE_BYTES,
+                    "cumulative responses",
+                )?;
+                return Err(format!("SNMP response exceeds {MAX_RESPONSE_BYTES} bytes"));
+            }
+            Err(error) => return Err(format!("SNMP UDP receive failed: {error}")),
+        };
+        *received_bytes = add_walk_budget(
+            *received_bytes,
+            received,
+            MAX_WALK_RESPONSE_BYTES,
+            "cumulative responses",
+        )?;
+        if Instant::now() >= attempt_deadline {
+            return Err("SNMP attempt timeout expired while receiving response".to_string());
+        }
+        if received > MAX_RESPONSE_BYTES {
+            return Err(format!("SNMP response exceeds {MAX_RESPONSE_BYTES} bytes"));
+        }
+        packet.truncate(received);
+        match decode_response_allow_stale(
+            packet.as_slice(),
+            expected_request_id,
+            expected_community,
+        ) {
+            Ok(Some(_)) => return Ok(packet),
+            Ok(None) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn is_oversized_datagram_error(error: &std::io::Error) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        error.raw_os_error() == Some(90)
+    }
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))]
+    {
+        error.raw_os_error() == Some(40)
+    }
+    #[cfg(windows)]
+    {
+        error.raw_os_error() == Some(10_040)
+    }
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        windows
+    )))]
+    {
+        let _ = error;
+        false
+    }
 }
 
 fn send_and_receive(
@@ -759,5 +1389,104 @@ mod tests {
         let error = encode_bounded_request(7, b"secret", &oversized_oids)
             .expect_err("oversized request must fail before transport");
         assert!(error.contains("encoded request exceeds"));
+    }
+
+    #[test]
+    fn walk_cumulative_receive_and_output_budgets_are_exact_and_overflow_safe() {
+        assert_eq!(
+            add_walk_budget(
+                MAX_WALK_RESPONSE_BYTES - 1,
+                1,
+                MAX_WALK_RESPONSE_BYTES,
+                "cumulative responses",
+            )
+            .expect("exact receive limit is allowed"),
+            MAX_WALK_RESPONSE_BYTES
+        );
+        assert!(add_walk_budget(
+            MAX_WALK_RESPONSE_BYTES,
+            1,
+            MAX_WALK_RESPONSE_BYTES,
+            "cumulative responses",
+        )
+        .expect_err("receive limit plus one must fail")
+        .contains("cumulative responses"));
+        assert_eq!(
+            add_walk_budget(
+                MAX_WALK_OUTPUT_BYTES - 1,
+                1,
+                MAX_WALK_OUTPUT_BYTES,
+                "normalized output",
+            )
+            .expect("exact output limit is allowed"),
+            MAX_WALK_OUTPUT_BYTES
+        );
+        assert!(
+            add_walk_budget(usize::MAX, 1, MAX_WALK_OUTPUT_BYTES, "normalized output",)
+                .expect_err("counter overflow must fail")
+                .contains("overflow")
+        );
+    }
+
+    #[test]
+    fn walk_receive_budget_charges_oversized_datagram_before_rejection() {
+        let server = UdpSocket::bind("127.0.0.1:0").expect("bind fixture");
+        let address = server.local_addr().expect("fixture address");
+        let fixture = std::thread::spawn(move || {
+            let mut request = [0u8; 16];
+            let (_, peer) = server.recv_from(&mut request).expect("receive request");
+            server
+                .send_to(&vec![0u8; MAX_RESPONSE_BYTES + 1], peer)
+                .expect("send oversized response");
+        });
+        let mut received_bytes = MAX_WALK_RESPONSE_BYTES - MAX_RESPONSE_BYTES;
+        let error = send_walk_and_receive(
+            address,
+            Zeroizing::new(vec![0]),
+            Instant::now() + Duration::from_secs(1),
+            7,
+            b"secret",
+            &mut received_bytes,
+        )
+        .expect_err("oversized datagram must consume the cumulative budget first");
+        fixture.join().expect("fixture thread");
+        assert!(error.contains("cumulative responses"), "{error}");
+    }
+
+    #[test]
+    fn finish_walk_enforces_the_exact_conservative_output_boundary() {
+        let address: SocketAddr = "127.0.0.1:161".parse().expect("socket address");
+        let finish = |payload_len: usize| {
+            let started = Instant::now();
+            finish_walk(
+                "127.0.0.1",
+                address,
+                "1.3.6.1.2.1",
+                started,
+                started + Duration::from_secs(5),
+                1,
+                1,
+                true,
+                "end_of_mib_view",
+                vec![Value::String("x".repeat(payload_len))],
+            )
+        };
+
+        let mut accepted = 0usize;
+        let mut rejected = MAX_WALK_OUTPUT_BYTES + 1;
+        while accepted + 1 < rejected {
+            let midpoint = accepted + (rejected - accepted) / 2;
+            if finish(midpoint).is_ok() {
+                accepted = midpoint;
+            } else {
+                rejected = midpoint;
+            }
+        }
+
+        let exact = finish(accepted).expect("exact conservative output limit must pass");
+        assert_eq!(conservative_map_size(&exact), MAX_WALK_OUTPUT_BYTES);
+        assert!(finish(accepted + 1)
+            .expect_err("one byte beyond conservative output limit must fail")
+            .contains("normalized output exceeds"));
     }
 }

--- a/src/stdlib/netmon_codec.rs
+++ b/src/stdlib/netmon_codec.rs
@@ -13,6 +13,7 @@ const TAG_TIMETICKS: u8 = 0x43;
 const TAG_OPAQUE: u8 = 0x44;
 const TAG_COUNTER64: u8 = 0x46;
 const TAG_GET_REQUEST: u8 = 0xa0;
+const TAG_GET_NEXT_REQUEST: u8 = 0xa1;
 const TAG_GET_RESPONSE: u8 = 0xa2;
 const TAG_NO_SUCH_OBJECT: u8 = 0x80;
 const TAG_NO_SUCH_INSTANCE: u8 = 0x81;
@@ -54,6 +55,29 @@ pub(crate) fn encode_get_request(
     community: &[u8],
     oids: &[Vec<u32>],
 ) -> Result<Zeroizing<Vec<u8>>, String> {
+    encode_request(request_id, community, oids, TAG_GET_REQUEST)
+}
+
+pub(crate) fn encode_get_next_request(
+    request_id: i32,
+    community: &[u8],
+    oid: &[u32],
+) -> Result<Zeroizing<Vec<u8>>, String> {
+    let oid = oid.to_vec();
+    encode_request(
+        request_id,
+        community,
+        std::slice::from_ref(&oid),
+        TAG_GET_NEXT_REQUEST,
+    )
+}
+
+fn encode_request(
+    request_id: i32,
+    community: &[u8],
+    oids: &[Vec<u32>],
+    pdu_tag: u8,
+) -> Result<Zeroizing<Vec<u8>>, String> {
     let mut varbind_list = Vec::new();
     for oid in oids {
         let mut varbind = Vec::new();
@@ -76,7 +100,7 @@ pub(crate) fn encode_get_request(
     let mut message = Zeroizing::new(Vec::with_capacity(message_capacity));
     append_tlv(&mut message, TAG_INTEGER, &[1]);
     append_tlv(&mut message, TAG_OCTET_STRING, community);
-    append_tlv(&mut message, TAG_GET_REQUEST, &pdu);
+    append_tlv(&mut message, pdu_tag, &pdu);
     debug_assert_eq!(message.len(), message_capacity);
 
     let request_capacity = tlv_size(message.len());
@@ -91,6 +115,24 @@ pub(crate) fn decode_response<'a>(
     expected_request_id: i32,
     expected_community: &[u8],
 ) -> Result<DecodedResponse<'a>, String> {
+    decode_response_internal(packet, expected_request_id, expected_community, false)?
+        .ok_or_else(|| "SNMP response request id mismatch".to_string())
+}
+
+pub(crate) fn decode_response_allow_stale<'a>(
+    packet: &'a [u8],
+    expected_request_id: i32,
+    expected_community: &[u8],
+) -> Result<Option<DecodedResponse<'a>>, String> {
+    decode_response_internal(packet, expected_request_id, expected_community, true)
+}
+
+fn decode_response_internal<'a>(
+    packet: &'a [u8],
+    expected_request_id: i32,
+    expected_community: &[u8],
+    allow_stale_request_id: bool,
+) -> Result<Option<DecodedResponse<'a>>, String> {
     let mut packet_reader = Reader::new(packet);
     let message_bytes = packet_reader.expect(TAG_SEQUENCE, "SNMP message")?;
     packet_reader.finish("SNMP datagram")?;
@@ -117,12 +159,20 @@ pub(crate) fn decode_response<'a>(
     let mut pdu = Reader::new(pdu_bytes);
     let request_id = decode_signed_integer(pdu.expect(TAG_INTEGER, "request id")?)?;
     if request_id != i64::from(expected_request_id) {
+        if allow_stale_request_id {
+            return Ok(None);
+        }
         return Err(format!(
             "SNMP response request id mismatch: expected {expected_request_id}, got {request_id}"
         ));
     }
     let error_status = decode_nonnegative_u32(pdu.expect(TAG_INTEGER, "error status")?)?;
     let error_index = decode_nonnegative_u32(pdu.expect(TAG_INTEGER, "error index")?)?;
+    if error_status == 0 && error_index != 0 {
+        return Err(format!(
+            "SNMP response error index must be zero when error status is zero, got {error_index}"
+        ));
+    }
     let varbind_list = pdu.expect(TAG_SEQUENCE, "varbind list")?;
     pdu.finish("SNMP response PDU")?;
 
@@ -138,11 +188,11 @@ pub(crate) fn decode_response<'a>(
         varbinds.push(DecodedVarbind { oid, value });
     }
 
-    Ok(DecodedResponse {
+    Ok(Some(DecodedResponse {
         error_status,
         error_index,
         varbinds,
-    })
+    }))
 }
 
 fn decode_value<'a>(tag: u8, bytes: &'a [u8]) -> Result<DecodedValue<'a>, String> {
@@ -471,6 +521,8 @@ mod tests {
 
     const RESPONSE_HEX: &str = "30550201010406736563726574a248020412345678020100020100303a300d06082b060102010101000101ff301506082b06010201010300460900ffffffffffffffff301206082b060102010105000406726f75746572";
     const REQUEST_HEX: &str = "30370201010406736563726574a02a020412345678020100020100301c300c06082b060102010101000500300c06082b060102010105000500";
+    const GET_NEXT_REQUEST_HEX: &str =
+        "30290201010406736563726574a11c020412345678020100020100300e300c06082b060102010101000500";
 
     fn response() -> Vec<u8> {
         hex::decode(RESPONSE_HEX).expect("valid golden response")
@@ -488,6 +540,13 @@ mod tests {
         )
         .expect("request encodes");
         assert_eq!(hex::encode(encoded.as_slice()), REQUEST_HEX);
+    }
+
+    #[test]
+    fn encodes_canonical_v2c_get_next_request() {
+        let encoded = encode_get_next_request(0x1234_5678, b"secret", &[1, 3, 6, 1, 2, 1, 1, 1, 0])
+            .expect("GETNEXT request encodes");
+        assert_eq!(hex::encode(encoded.as_slice()), GET_NEXT_REQUEST_HEX);
     }
 
     #[test]
@@ -512,6 +571,9 @@ mod tests {
         assert!(decode_response(&packet, 7, b"secret")
             .expect_err("request id mismatch")
             .contains("request id"));
+        assert!(decode_response_allow_stale(&packet, 7, b"secret")
+            .expect("stale response is classified")
+            .is_none());
         assert!(decode_response(&packet, 0x1234_5678, b"wrong")
             .expect_err("community mismatch")
             .contains("community"));

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4560,6 +4560,17 @@ fn get_module_signatures(module: &str) -> HashMap<String, FunctionSig> {
                     "target" => Type::String,
                     "auth" => map.clone(),
                     "oids" => Type::Array(Box::new(Type::String)),
+                    "opts" => map.clone()
+                ],
+                result_map.clone(),
+                required(3)
+            );
+            sig!(
+                "snmp_walk",
+                [
+                    "target" => Type::String,
+                    "auth" => map.clone(),
+                    "oid" => Type::String,
                     "opts" => map
                 ],
                 result_map,

--- a/tests/std_netmon_tests.rs
+++ b/tests/std_netmon_tests.rs
@@ -23,18 +23,8 @@ fn unique_test_file(prefix: &str) -> String {
         .to_string()
 }
 
-fn ntnt_binary() -> String {
-    let exe = std::env::consts::EXE_SUFFIX;
-    for path in [
-        format!("./target/debug/ntnt{exe}"),
-        format!("./target/dev-release/ntnt{exe}"),
-        format!("./target/release/ntnt{exe}"),
-    ] {
-        if std::path::Path::new(&path).exists() {
-            return path;
-        }
-    }
-    panic!("No ntnt binary found. Run 'cargo build' first.");
+fn ntnt_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_ntnt")
 }
 
 fn run_ntnt_code(code: &str, envs: &[(&str, &str)]) -> (String, String, i32) {
@@ -104,6 +94,7 @@ fn read_tlv(bytes: &[u8], offset: &mut usize) -> Option<(u8, usize, Range<usize>
 struct RequestLayout {
     pdu_tag_offset: usize,
     version_value_offset: usize,
+    error_index_value_offset: usize,
 }
 
 fn inspect_get_request(bytes: &[u8]) -> Option<RequestLayout> {
@@ -137,7 +128,7 @@ fn inspect_get_request(bytes: &[u8]) -> Option<RequestLayout> {
         || error_status_tag != 0x02
         || &bytes[error_status] != [0]
         || error_index_tag != 0x02
-        || &bytes[error_index] != [0]
+        || bytes[error_index.clone()] != [0]
         || varbind_list_tag != 0x30
         || pdu_offset != pdu.end
     {
@@ -171,6 +162,7 @@ fn inspect_get_request(bytes: &[u8]) -> Option<RequestLayout> {
     Some(RequestLayout {
         pdu_tag_offset,
         version_value_offset: version.start,
+        error_index_value_offset: error_index.start,
     })
 }
 
@@ -191,6 +183,7 @@ enum AgentBehavior {
     WrongVersion,
     TrailingBytes,
     OversizedResponse,
+    NonzeroSuccessIndex,
 }
 
 fn start_mock_snmp_agent(behavior: AgentBehavior) -> (u16, std::thread::JoinHandle<usize>) {
@@ -239,6 +232,10 @@ fn start_mock_snmp_agent(behavior: AgentBehavior) -> (u16, std::thread::JoinHand
                 }
                 AgentBehavior::TrailingBytes => response.push(0),
                 AgentBehavior::OversizedResponse => response = vec![0; 8 * 1024 + 1],
+                AgentBehavior::NonzeroSuccessIndex => {
+                    let layout = inspect_get_request(&request[..length]).expect("validated layout");
+                    response[layout.error_index_value_offset] = 1;
+                }
                 AgentBehavior::Respond | AgentBehavior::DropFirst | AgentBehavior::Silent => {}
             }
             let _ = socket.send_to(&response, peer);
@@ -368,6 +365,10 @@ fn snmp_get_rejects_unrequested_oid_wrong_version_and_trailing_bytes() {
         (
             AgentBehavior::OversizedResponse,
             "response exceeds 8192 bytes",
+        ),
+        (
+            AgentBehavior::NonzeroSuccessIndex,
+            "error index must be zero",
         ),
     ] {
         let (port, agent) = start_mock_snmp_agent(behavior);

--- a/tests/std_netmon_walk_tests.rs
+++ b/tests/std_netmon_walk_tests.rs
@@ -1,0 +1,893 @@
+//! End-to-end tests for bounded SNMPv2c GETNEXT WALK.
+//!
+//! The UDP fixture hand-encodes responses and independently parses request BER;
+//! it does not reuse the production codec.
+
+use std::fs;
+use std::io::Write;
+use std::net::UdpSocket;
+use std::ops::Range;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+const SECRET_CANARY: &str = "walk-community-canary-never-render";
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_test_file() -> String {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir()
+        .join(format!(
+            "ntnt_std_netmon_walk_{}_{}.tnt",
+            std::process::id(),
+            counter
+        ))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn ntnt_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_ntnt")
+}
+
+fn run_ntnt_code(code: &str, envs: &[(&str, &str)]) -> (String, String, i32) {
+    let test_file = unique_test_file();
+    let mut file = fs::File::create(&test_file).expect("create test source");
+    writeln!(file, "{code}").expect("write test source");
+    drop(file);
+
+    let mut command = Command::new(ntnt_binary());
+    command
+        .args(["run", &test_file])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("NTNT_ENV", "development")
+        .env("APP_ENV", "development")
+        .env("NTNT_SECRETS_PROVIDER", "env")
+        .env_remove("NTNT_NETMON_ENABLE")
+        .env_remove("NTNT_NET_ALLOW_PRIVATE")
+        .env_remove("NTNT_TYPE_MODE")
+        .env_remove("NTNT_LINT_MODE")
+        .env_remove("NTNT_STRICT")
+        .env_remove("NTNT_OOB_MODE");
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    let output = command.output().expect("run ntnt");
+    let _ = fs::remove_file(test_file);
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+fn read_length(bytes: &[u8], offset: &mut usize) -> Option<usize> {
+    let first = *bytes.get(*offset)?;
+    *offset += 1;
+    if first & 0x80 == 0 {
+        return Some(usize::from(first));
+    }
+    let count = usize::from(first & 0x7f);
+    if count == 0 || count > std::mem::size_of::<usize>() {
+        return None;
+    }
+    let mut length = 0usize;
+    for _ in 0..count {
+        length = length.checked_mul(256)?;
+        length = length.checked_add(usize::from(*bytes.get(*offset)?))?;
+        *offset += 1;
+    }
+    Some(length)
+}
+
+fn read_tlv(bytes: &[u8], offset: &mut usize) -> Option<(u8, Range<usize>)> {
+    let tag = *bytes.get(*offset)?;
+    *offset += 1;
+    let length = read_length(bytes, offset)?;
+    let start = *offset;
+    let end = start.checked_add(length)?;
+    if end > bytes.len() {
+        return None;
+    }
+    *offset = end;
+    Some((tag, start..end))
+}
+
+fn append_length(output: &mut Vec<u8>, length: usize) {
+    if length < 128 {
+        output.push(length as u8);
+        return;
+    }
+    let bytes = length.to_be_bytes();
+    let start = bytes
+        .iter()
+        .position(|byte| *byte != 0)
+        .unwrap_or(bytes.len() - 1);
+    output.push(0x80 | (bytes.len() - start) as u8);
+    output.extend_from_slice(&bytes[start..]);
+}
+
+fn tlv(tag: u8, content: &[u8]) -> Vec<u8> {
+    let mut output = vec![tag];
+    append_length(&mut output, content.len());
+    output.extend_from_slice(content);
+    output
+}
+
+fn encode_base128(mut value: u64, output: &mut Vec<u8>) {
+    let mut bytes = [0u8; 10];
+    let mut index = bytes.len() - 1;
+    bytes[index] = (value & 0x7f) as u8;
+    value >>= 7;
+    while value != 0 {
+        index -= 1;
+        bytes[index] = ((value & 0x7f) as u8) | 0x80;
+        value >>= 7;
+    }
+    output.extend_from_slice(&bytes[index..]);
+}
+
+fn encode_oid(arcs: &[u32]) -> Vec<u8> {
+    let mut output = Vec::new();
+    encode_base128(u64::from(arcs[0]) * 40 + u64::from(arcs[1]), &mut output);
+    for arc in &arcs[2..] {
+        encode_base128(u64::from(*arc), &mut output);
+    }
+    output
+}
+
+fn decode_oid(bytes: &[u8]) -> Option<Vec<u32>> {
+    let mut encoded_arcs = Vec::new();
+    let mut value = 0u64;
+    for byte in bytes {
+        value = value.checked_shl(7)?.checked_add(u64::from(byte & 0x7f))?;
+        if byte & 0x80 == 0 {
+            encoded_arcs.push(u32::try_from(value).ok()?);
+            value = 0;
+        }
+    }
+    if value != 0 || encoded_arcs.is_empty() {
+        return None;
+    }
+    let combined = encoded_arcs.remove(0);
+    let (first, second) = if combined < 40 {
+        (0, combined)
+    } else if combined < 80 {
+        (1, combined - 40)
+    } else {
+        (2, combined - 80)
+    };
+    let mut arcs = vec![first, second];
+    arcs.extend(encoded_arcs);
+    Some(arcs)
+}
+
+#[derive(Debug)]
+struct ParsedRequest {
+    request_id: Vec<u8>,
+    community: Vec<u8>,
+    cursor: Vec<u32>,
+    pdu_tag: u8,
+}
+
+fn parse_request(bytes: &[u8]) -> Option<ParsedRequest> {
+    let mut root_offset = 0;
+    let (outer_tag, outer) = read_tlv(bytes, &mut root_offset)?;
+    if outer_tag != 0x30 || root_offset != bytes.len() {
+        return None;
+    }
+
+    let mut message_offset = outer.start;
+    let (version_tag, version) = read_tlv(bytes, &mut message_offset)?;
+    let (community_tag, community) = read_tlv(bytes, &mut message_offset)?;
+    let (pdu_tag, pdu) = read_tlv(bytes, &mut message_offset)?;
+    if version_tag != 0x02
+        || bytes[version] != [1]
+        || community_tag != 0x04
+        || message_offset != outer.end
+    {
+        return None;
+    }
+
+    let mut pdu_offset = pdu.start;
+    let (request_id_tag, request_id) = read_tlv(bytes, &mut pdu_offset)?;
+    let (error_status_tag, error_status) = read_tlv(bytes, &mut pdu_offset)?;
+    let (error_index_tag, error_index) = read_tlv(bytes, &mut pdu_offset)?;
+    let (list_tag, list) = read_tlv(bytes, &mut pdu_offset)?;
+    if request_id_tag != 0x02
+        || request_id.is_empty()
+        || error_status_tag != 0x02
+        || bytes[error_status] != [0]
+        || error_index_tag != 0x02
+        || bytes[error_index] != [0]
+        || list_tag != 0x30
+        || pdu_offset != pdu.end
+    {
+        return None;
+    }
+
+    let mut list_offset = list.start;
+    let (varbind_tag, varbind) = read_tlv(bytes, &mut list_offset)?;
+    if varbind_tag != 0x30 || list_offset != list.end {
+        return None;
+    }
+    let mut varbind_offset = varbind.start;
+    let (oid_tag, oid) = read_tlv(bytes, &mut varbind_offset)?;
+    let (null_tag, null) = read_tlv(bytes, &mut varbind_offset)?;
+    if oid_tag != 0x06 || null_tag != 0x05 || !null.is_empty() || varbind_offset != varbind.end {
+        return None;
+    }
+
+    Some(ParsedRequest {
+        request_id: bytes[request_id].to_vec(),
+        community: bytes[community].to_vec(),
+        cursor: decode_oid(&bytes[oid])?,
+        pdu_tag,
+    })
+}
+
+#[derive(Clone)]
+enum ValueSpec {
+    Integer(u8),
+    Octets(Vec<u8>),
+    EndOfMibView,
+    NoSuchObject,
+    NoSuchInstance,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Corruption {
+    None,
+    WrongVersion,
+    WrongCommunity,
+    WrongPdu,
+    WrongRequestId,
+    Trailing,
+    Malformed,
+    MultipleVarbinds,
+    Oversized,
+    AgentError,
+    NonzeroSuccessIndex,
+}
+
+#[derive(Clone)]
+enum Action {
+    Respond {
+        oid: Vec<u32>,
+        value: ValueSpec,
+        corruption: Corruption,
+    },
+    RememberResponse {
+        oid: Vec<u32>,
+        value: ValueSpec,
+    },
+    SendRememberedThenRespond {
+        oid: Vec<u32>,
+        value: ValueSpec,
+    },
+    ForgedThenRespond {
+        oid: Vec<u32>,
+        value: ValueSpec,
+    },
+    Drop,
+}
+
+fn encoded_value(value: &ValueSpec) -> Vec<u8> {
+    match value {
+        ValueSpec::Integer(value) => tlv(0x02, &[*value]),
+        ValueSpec::Octets(value) => tlv(0x04, value),
+        ValueSpec::EndOfMibView => tlv(0x82, &[]),
+        ValueSpec::NoSuchObject => tlv(0x80, &[]),
+        ValueSpec::NoSuchInstance => tlv(0x81, &[]),
+    }
+}
+
+fn build_response(
+    request: &ParsedRequest,
+    oid: &[u32],
+    value: &ValueSpec,
+    corruption: Corruption,
+) -> Vec<u8> {
+    if matches!(corruption, Corruption::Oversized) {
+        return vec![0; 8 * 1024 + 1];
+    }
+
+    let mut varbind_content = tlv(0x06, &encode_oid(oid));
+    varbind_content.extend_from_slice(&encoded_value(value));
+    let varbind = tlv(0x30, &varbind_content);
+    let mut list_content = varbind.clone();
+    if matches!(corruption, Corruption::MultipleVarbinds) {
+        list_content.extend_from_slice(&varbind);
+    }
+
+    let request_id = if matches!(corruption, Corruption::WrongRequestId) {
+        vec![0x7f]
+    } else {
+        request.request_id.clone()
+    };
+    let mut pdu_content = tlv(0x02, &request_id);
+    let error_status = if matches!(corruption, Corruption::AgentError) {
+        5
+    } else {
+        0
+    };
+    let error_index = if matches!(
+        corruption,
+        Corruption::AgentError | Corruption::NonzeroSuccessIndex
+    ) {
+        1
+    } else {
+        0
+    };
+    pdu_content.extend_from_slice(&tlv(0x02, &[error_status]));
+    pdu_content.extend_from_slice(&tlv(0x02, &[error_index]));
+    pdu_content.extend_from_slice(&tlv(0x30, &list_content));
+    let pdu_tag = if matches!(corruption, Corruption::WrongPdu) {
+        0xa0
+    } else {
+        0xa2
+    };
+
+    let version = if matches!(corruption, Corruption::WrongVersion) {
+        0
+    } else {
+        1
+    };
+    let community = if matches!(corruption, Corruption::WrongCommunity) {
+        b"wrong".as_slice()
+    } else {
+        request.community.as_slice()
+    };
+    let mut message = tlv(0x02, &[version]);
+    message.extend_from_slice(&tlv(0x04, community));
+    message.extend_from_slice(&tlv(pdu_tag, &pdu_content));
+    let mut response = tlv(0x30, &message);
+    if matches!(corruption, Corruption::Trailing) {
+        response.push(0);
+    }
+    if matches!(corruption, Corruption::Malformed) {
+        response[1] = response[1].saturating_add(1);
+    }
+    response
+}
+
+#[derive(Debug)]
+struct AgentReport {
+    requests: usize,
+    cursors: Vec<Vec<u32>>,
+    pdu_tags: Vec<u8>,
+}
+
+fn start_agent(actions: Vec<Action>) -> (u16, std::thread::JoinHandle<AgentReport>) {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("bind mock WALK agent");
+    socket
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .expect("set fixture timeout");
+    let port = socket.local_addr().expect("fixture address").port();
+    let handle = std::thread::spawn(move || {
+        let mut report = AgentReport {
+            requests: 0,
+            cursors: Vec::new(),
+            pdu_tags: Vec::new(),
+        };
+        let mut packet = [0u8; 65_535];
+        let mut remembered_response: Option<Vec<u8>> = None;
+        for action in actions {
+            let Ok((length, peer)) = socket.recv_from(&mut packet) else {
+                break;
+            };
+            report.requests += 1;
+            let Some(request) = parse_request(&packet[..length]) else {
+                break;
+            };
+            assert_eq!(
+                request.community.as_slice(),
+                SECRET_CANARY.as_bytes(),
+                "WALK request carried an unexpected community"
+            );
+            report.cursors.push(request.cursor.clone());
+            report.pdu_tags.push(request.pdu_tag);
+            match action {
+                Action::Respond {
+                    oid,
+                    value,
+                    corruption,
+                } => {
+                    let response = build_response(&request, &oid, &value, corruption);
+                    let _ = socket.send_to(&response, peer);
+                }
+                Action::RememberResponse { oid, value } => {
+                    remembered_response =
+                        Some(build_response(&request, &oid, &value, Corruption::None));
+                }
+                Action::SendRememberedThenRespond { oid, value } => {
+                    let old = remembered_response
+                        .take()
+                        .expect("fixture remembered response");
+                    let current = build_response(&request, &oid, &value, Corruption::None);
+                    let _ = socket.send_to(&old, peer);
+                    let _ = socket.send_to(&current, peer);
+                }
+                Action::ForgedThenRespond { oid, value } => {
+                    let response = build_response(&request, &oid, &value, Corruption::None);
+                    let attacker = UdpSocket::bind("127.0.0.1:0").expect("bind forged source");
+                    let _ = attacker.send_to(&response, peer);
+                    let _ = socket.send_to(&response, peer);
+                }
+                Action::Drop => {}
+            }
+        }
+        report
+    });
+    (port, handle)
+}
+
+fn enabled_env() -> [(&'static str, &'static str); 3] {
+    [
+        ("SNMP_TEST_COMMUNITY", SECRET_CANARY),
+        ("NTNT_NETMON_ENABLE", "1"),
+        ("NTNT_NET_ALLOW_PRIVATE", "1"),
+    ]
+}
+
+fn walk_source(port: u16, options: &str, body: &str) -> String {
+    format!(
+        r#"
+import {{ require_secret }} from "std/secrets"
+import {{ snmp_walk }} from "std/netmon"
+
+let auth = map {{
+    "version": "2c",
+    "community": require_secret("SNMP_TEST_COMMUNITY")
+}}
+match snmp_walk(
+    "127.0.0.1",
+    auth,
+    "1.3.6.1.2.1.2.2",
+    map {{
+        "port": {port},
+        "timeout_ms": 1000,
+        "allow_private": true,
+        {options}
+    }}
+) {{
+    Ok(result) => {{ {body} }},
+    Err(error) => print("ERR: " + error)
+}}
+"#
+    )
+}
+
+fn response(oid: &[u32], value: ValueSpec) -> Action {
+    corrupted_response(oid, value, Corruption::None)
+}
+
+fn corrupted_response(oid: &[u32], value: ValueSpec, corruption: Corruption) -> Action {
+    Action::Respond {
+        oid: oid.to_vec(),
+        value,
+        corruption,
+    }
+}
+
+#[test]
+fn snmp_walk_collects_ordered_rows_and_stops_outside_the_root() {
+    let root = vec![1, 3, 6, 1, 2, 1, 2, 2];
+    let first = vec![1, 3, 6, 1, 2, 1, 2, 2, 1, 1];
+    let second = vec![1, 3, 6, 1, 2, 1, 2, 2, 1, 2];
+    let outside = vec![1, 3, 6, 1, 2, 1, 3, 1];
+    let (port, agent) = start_agent(vec![
+        response(&first, ValueSpec::Integer(7)),
+        response(&second, ValueSpec::Octets(b"eth0".to_vec())),
+        response(&outside, ValueSpec::Integer(9)),
+    ]);
+    let source = walk_source(
+        port,
+        r#""max_results": 10, "retries": 0"#,
+        r#"
+let values = result["values"]
+print(result["root_oid"])
+print(result["requests"])
+print(result["attempts"])
+print(result["complete"])
+print(result["stop_reason"])
+print(len(values))
+print(values[0]["oid"])
+print(values[1]["value"])
+"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert_eq!(report.requests, 3);
+    assert_eq!(report.pdu_tags, [0xa1, 0xa1, 0xa1]);
+    assert_eq!(report.cursors, [root, first.clone(), second.clone()]);
+    assert_eq!(
+        stdout.lines().map(str::trim).collect::<Vec<_>>(),
+        [
+            "1.3.6.1.2.1.2.2",
+            "3",
+            "3",
+            "true",
+            "out_of_subtree",
+            "2",
+            "1.3.6.1.2.1.2.2.1.1",
+            "eth0",
+        ]
+    );
+    assert!(!stdout.contains(SECRET_CANARY));
+    assert!(!stderr.contains(SECRET_CANARY));
+}
+
+#[test]
+fn snmp_walk_ignores_forged_source_and_accepts_connected_agent_response() {
+    let first = vec![1, 3, 6, 1, 2, 1, 2, 2, 1];
+    let outside = vec![1, 3, 6, 1, 2, 1, 3];
+    let (port, agent) = start_agent(vec![
+        Action::ForgedThenRespond {
+            oid: first.clone(),
+            value: ValueSpec::Integer(1),
+        },
+        response(&outside, ValueSpec::Integer(2)),
+    ]);
+    let source = walk_source(
+        port,
+        r#""max_results": 10, "retries": 0"#,
+        r#"print(len(result["values"]))"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(report.requests, 2);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert_eq!(stdout.trim(), "1");
+}
+
+#[test]
+fn snmp_walk_ignores_delayed_old_attempt_before_current_response() {
+    let first = vec![1, 3, 6, 1, 2, 1, 2, 2, 1];
+    let outside = vec![1, 3, 6, 1, 2, 1, 3];
+    let (port, agent) = start_agent(vec![
+        Action::RememberResponse {
+            oid: first.clone(),
+            value: ValueSpec::Integer(1),
+        },
+        Action::SendRememberedThenRespond {
+            oid: first,
+            value: ValueSpec::Integer(1),
+        },
+        response(&outside, ValueSpec::Integer(2)),
+    ]);
+    let source = walk_source(
+        port,
+        r#""max_results": 10, "retries": 1, "timeout_ms": 1000"#,
+        r#"
+print(result["requests"])
+print(result["attempts"])
+print(len(result["values"]))
+"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(report.requests, 3);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert_eq!(
+        stdout.lines().map(str::trim).collect::<Vec<_>>(),
+        ["2", "3", "1"]
+    );
+}
+
+#[test]
+fn snmp_walk_omits_protocol_exceptions_and_completes_empty_walk() {
+    let root = vec![1, 3, 6, 1, 2, 1, 2, 2];
+    for (value, reason) in [
+        (ValueSpec::EndOfMibView, "end_of_mib_view"),
+        (ValueSpec::NoSuchObject, "no_such_object"),
+        (ValueSpec::NoSuchInstance, "no_such_instance"),
+    ] {
+        let (port, agent) = start_agent(vec![response(&root, value)]);
+        let source = walk_source(
+            port,
+            r#""max_results": 10, "retries": 0"#,
+            r#"
+print(result["complete"])
+print(result["stop_reason"])
+print(len(result["values"]))
+"#,
+        );
+        let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+        let report = agent.join().expect("fixture thread");
+        assert_eq!(report.requests, 1);
+        assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+        assert_eq!(
+            stdout.lines().map(str::trim).collect::<Vec<_>>(),
+            ["true", reason, "0"]
+        );
+        assert!(!stdout.contains(SECRET_CANARY));
+        assert!(!stderr.contains(SECRET_CANARY));
+    }
+}
+
+#[test]
+fn snmp_walk_rejects_terminal_exception_with_mismatched_cursor_oid() {
+    let mismatched = vec![1, 3, 6, 1, 2, 1, 2, 2, 99];
+    let (port, agent) = start_agent(vec![response(&mismatched, ValueSpec::EndOfMibView)]);
+    let source = walk_source(
+        port,
+        r#""max_results": 10, "retries": 0"#,
+        r#"print("unexpected success")"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(report.requests, 1);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("terminal exception OID"), "{stdout}");
+    assert!(!stdout.contains(SECRET_CANARY));
+    assert!(!stderr.contains(SECRET_CANARY));
+}
+
+#[test]
+fn snmp_walk_exact_max_uses_lookahead_terminal_reason() {
+    let first = vec![1, 3, 6, 1, 2, 1, 2, 2, 1];
+    let second = vec![1, 3, 6, 1, 2, 1, 2, 2, 2];
+    let (port, agent) = start_agent(vec![
+        response(&first, ValueSpec::Integer(1)),
+        response(&second, ValueSpec::Integer(2)),
+        response(&second, ValueSpec::EndOfMibView),
+    ]);
+    let source = walk_source(
+        port,
+        r#""max_results": 2, "retries": 0"#,
+        r#"
+print(result["complete"])
+print(result["stop_reason"])
+print(result["requests"])
+print(len(result["values"]))
+"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert_eq!(report.requests, 3, "look-ahead request is mandatory");
+    assert_eq!(
+        stdout.lines().map(str::trim).collect::<Vec<_>>(),
+        ["true", "end_of_mib_view", "3", "2"]
+    );
+}
+
+#[test]
+fn snmp_walk_partial_limit_omits_valid_lookahead() {
+    let first = vec![1, 3, 6, 1, 2, 1, 2, 2, 1];
+    let lookahead = vec![1, 3, 6, 1, 2, 1, 2, 2, 2];
+    let (port, agent) = start_agent(vec![
+        response(&first, ValueSpec::Integer(1)),
+        response(&lookahead, ValueSpec::Integer(2)),
+    ]);
+    let source = walk_source(
+        port,
+        r#""max_results": 1, "on_limit": "partial", "retries": 0"#,
+        r#"
+print(result["complete"])
+print(result["stop_reason"])
+print(result["requests"])
+print(len(result["values"]))
+print(result["values"][0]["oid"])
+"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert_eq!(report.requests, 2);
+    assert_eq!(
+        stdout.lines().map(str::trim).collect::<Vec<_>>(),
+        ["false", "max_results", "2", "1", "1.3.6.1.2.1.2.2.1",]
+    );
+}
+
+#[test]
+fn snmp_walk_limit_error_returns_no_partial_telemetry() {
+    let first = vec![1, 3, 6, 1, 2, 1, 2, 2, 1];
+    let lookahead = vec![1, 3, 6, 1, 2, 1, 2, 2, 2];
+    let (port, agent) = start_agent(vec![
+        response(&first, ValueSpec::Integer(1)),
+        response(&lookahead, ValueSpec::Integer(2)),
+    ]);
+    let source = walk_source(
+        port,
+        r#""max_results": 1, "retries": 0"#,
+        r#"print("unexpected success")"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert_eq!(report.requests, 2);
+    assert_eq!(stdout.trim(), "ERR: SNMP WALK exceeded max_results (1)");
+    assert!(!stdout.contains("1.3.6.1.2.1.2.2.1"));
+    assert!(!stdout.contains(SECRET_CANARY));
+    assert!(!stderr.contains(SECRET_CANARY));
+}
+
+#[test]
+fn snmp_walk_rejects_equal_repeated_and_descending_oids() {
+    let root = vec![1, 3, 6, 1, 2, 1, 2, 2];
+    let first = vec![1, 3, 6, 1, 2, 1, 2, 2, 2];
+    let descending = vec![1, 3, 6, 1, 2, 1, 2, 2, 1];
+    let cases = vec![
+        vec![response(&root, ValueSpec::Integer(1))],
+        vec![
+            response(&first, ValueSpec::Integer(1)),
+            response(&first, ValueSpec::Integer(2)),
+        ],
+        vec![
+            response(&first, ValueSpec::Integer(1)),
+            response(&descending, ValueSpec::Integer(2)),
+        ],
+    ];
+
+    for actions in cases {
+        let (port, agent) = start_agent(actions);
+        let source = walk_source(
+            port,
+            r#""max_results": 10, "retries": 0"#,
+            r#"print("unexpected success")"#,
+        );
+        let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+        let _ = agent.join().expect("fixture thread");
+        assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+        assert!(
+            stdout.contains("strictly increasing"),
+            "unexpected ordering result: {stdout}"
+        );
+        assert!(!stdout.contains(SECRET_CANARY));
+        assert!(!stderr.contains(SECRET_CANARY));
+    }
+}
+
+#[test]
+fn snmp_walk_rejects_malformed_mismatched_and_oversized_responses() {
+    let row = vec![1, 3, 6, 1, 2, 1, 2, 2, 1];
+    let cases = [
+        (Corruption::WrongVersion, "version"),
+        (Corruption::WrongCommunity, "community"),
+        (Corruption::WrongPdu, "PDU type"),
+        (Corruption::WrongRequestId, "failed after 1 bounded attempt"),
+        (Corruption::Trailing, "datagram"),
+        (Corruption::Malformed, "truncated"),
+        (Corruption::MultipleVarbinds, "exactly 1"),
+        (Corruption::Oversized, "exceeds 8192 bytes"),
+        (Corruption::AgentError, "error status"),
+        (Corruption::NonzeroSuccessIndex, "error index"),
+    ];
+
+    for (corruption, expected) in cases {
+        let (port, agent) = start_agent(vec![corrupted_response(
+            &row,
+            ValueSpec::Integer(1),
+            corruption,
+        )]);
+        let source = walk_source(
+            port,
+            r#""max_results": 10, "retries": 0"#,
+            r#"print("unexpected success")"#,
+        );
+        let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+        let report = agent.join().expect("fixture thread");
+        assert_eq!(report.requests, 1);
+        assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+        assert!(
+            stdout.contains(expected),
+            "expected {expected:?} for {corruption:?}, got {stdout:?}"
+        );
+        assert!(!stdout.contains(SECRET_CANARY));
+        assert!(!stderr.contains(SECRET_CANARY));
+    }
+}
+
+#[test]
+fn snmp_walk_discards_prior_rows_when_a_later_response_is_invalid() {
+    let first = vec![1, 3, 6, 1, 2, 1, 2, 2, 1];
+    let second = vec![1, 3, 6, 1, 2, 1, 2, 2, 2];
+    let (port, agent) = start_agent(vec![
+        response(&first, ValueSpec::Integer(1)),
+        corrupted_response(&second, ValueSpec::Integer(2), Corruption::WrongCommunity),
+    ]);
+    let source = walk_source(
+        port,
+        r#""max_results": 10, "retries": 0"#,
+        r#"print("unexpected success")"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(report.requests, 2);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("community mismatch"), "{stdout}");
+    assert!(!stdout.contains("1.3.6.1.2.1.2.2.1"));
+    assert!(!stdout.contains(SECRET_CANARY));
+    assert!(!stderr.contains(SECRET_CANARY));
+}
+
+#[test]
+fn snmp_walk_retry_budget_remains_inside_one_global_deadline() {
+    let (port, agent) = start_agent(vec![Action::Drop, Action::Drop]);
+    let source = walk_source(
+        port,
+        r#""max_results": 10, "retries": 1, "timeout_ms": 150"#,
+        r#"print("unexpected success")"#,
+    );
+    let started = Instant::now();
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    let elapsed = started.elapsed();
+    let report = agent.join().expect("fixture thread");
+    assert_eq!(report.requests, 2);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("global timeout") || stdout.contains("bounded attempt"));
+    assert!(
+        elapsed < Duration::from_millis(700),
+        "deadline multiplied across retries: {elapsed:?}"
+    );
+    assert!(!stdout.contains(SECRET_CANARY));
+    assert!(!stderr.contains(SECRET_CANARY));
+}
+
+#[test]
+fn snmp_walk_preflight_and_policy_fail_before_transport() {
+    let source = walk_source(
+        9,
+        r#""max_results": 2048, "retries": 1"#,
+        r#"print("unexpected success")"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("4098 possible attempts"), "{stdout}");
+
+    let source = walk_source(
+        9,
+        r#""max_results": 10, "retries": 0, "unknown": true"#,
+        r#"print("unexpected success")"#,
+    );
+    let (stdout, stderr, code) = run_ntnt_code(&source, &enabled_env());
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("unknown field"), "{stdout}");
+
+    let source = walk_source(
+        9,
+        r#""max_results": 10, "retries": 0"#,
+        r#"print("unexpected success")"#,
+    );
+    let env = [("SNMP_TEST_COMMUNITY", SECRET_CANARY)];
+    let (stdout, stderr, code) = run_ntnt_code(&source, &env);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("std/netmon is disabled"), "{stdout}");
+
+    let env = [
+        ("SNMP_TEST_COMMUNITY", SECRET_CANARY),
+        ("NTNT_NETMON_ENABLE", "1"),
+    ];
+    let (stdout, stderr, code) = run_ntnt_code(&source, &env);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(
+        stdout.contains("private") || stdout.contains("loopback"),
+        "{stdout}"
+    );
+
+    for text in [stdout, stderr] {
+        assert!(!text.contains(SECRET_CANARY));
+    }
+}
+
+#[test]
+fn snmp_walk_rejects_plaintext_community_without_rendering_it() {
+    let source = r#"
+import { snmp_walk } from "std/netmon"
+let auth = map { "version": "2c", "community": "walk-community-canary-never-render" }
+match snmp_walk("127.0.0.1", auth, "1.3.6.1", map { "allow_private": true }) {
+    Ok(_) => print("unexpected success"),
+    Err(error) => print("ERR: " + error)
+}
+"#;
+    let env = [("NTNT_NETMON_ENABLE", "1"), ("NTNT_NET_ALLOW_PRIVATE", "1")];
+    let (stdout, stderr, code) = run_ntnt_code(source, &env);
+    assert_eq!(code, 0, "stderr: {stderr}\nstdout: {stdout}");
+    assert!(stdout.contains("must be Secret"), "{stdout}");
+    assert!(!stdout.contains(SECRET_CANARY));
+    assert!(!stderr.contains(SECRET_CANARY));
+}

--- a/tests/type_checker_tests.rs
+++ b/tests/type_checker_tests.rs
@@ -1222,6 +1222,54 @@ let bad_oids = snmp_get("router.example.com", map {}, "1.3.6.1.2.1.1.1.0")
     assert_ne!(exit_code, 0);
 }
 
+#[test]
+fn test_std_netmon_snmp_walk_signature_accepts_valid_usage() {
+    let source = r#"
+import { require_secret } from "std/secrets"
+import { snmp_walk } from "std/netmon"
+
+let auth = map {
+    "version": "2c",
+    "community": require_secret("SNMP_COMMUNITY")
+}
+let result: Result<Map<String, Any>, String> = snmp_walk(
+    "10.0.0.1",
+    auth,
+    "1.3.6.1.2.1.2.2",
+    map { "max_results": 128, "on_limit": "partial" }
+)
+"#;
+    let (stdout, _stderr, _exit_code) = lint_code(source);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let errors = json["summary"]["errors"].as_i64().unwrap_or(0);
+    assert_eq!(
+        errors, 0,
+        "valid std/netmon WALK usage should not type error: {stdout}"
+    );
+}
+
+#[test]
+fn test_std_netmon_snmp_walk_signature_rejects_wrong_argument_types() {
+    let source = r#"
+import { snmp_walk } from "std/netmon"
+
+let bad_target = snmp_walk(123, map {}, "1.3.6.1")
+let bad_auth = snmp_walk("10.0.0.1", "public", "1.3.6.1")
+let bad_oid = snmp_walk("10.0.0.1", map {}, ["1.3.6.1"])
+let bad_opts = snmp_walk("10.0.0.1", map {}, "1.3.6.1", 5)
+let too_few = snmp_walk("10.0.0.1", map {})
+let too_many = snmp_walk("10.0.0.1", map {}, "1.3.6.1", map {}, map {})
+"#;
+    let (stdout, _stderr, exit_code) = lint_code(source);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let errors = json["summary"]["errors"].as_i64().unwrap_or(0);
+    assert!(
+        errors >= 6,
+        "wrong std/netmon WALK argument types or arity should error: {stdout}"
+    );
+    assert_ne!(exit_code, 0);
+}
+
 // ===========================================================================
 // Unknown-method lint (DD-063 Rec 4b)
 // ===========================================================================


### PR DESCRIPTION
## Summary

Extend DD-047 with the implementation, compatibility, and security contract for updateable third-party MIB-driven device inventory.

The design separates three typed layers and compiles them into one immutable catalog:

1. MIB schemas (SMIv1/SMIv2 symbols, types, tables, indexes, and access metadata)
2. Device-recognition profiles (numeric `sysObjectID` rules plus bounded literal evidence)
3. Finite read-only inventory plans compiled to numeric OIDs

It also freezes the bounded GETNEXT WALK envelope and exact resource algebra before that API ships.

## Key decisions

- Raw MIB/profile/plan source is compiled in a bounded isolated worker through `ntnt netmon mib compile`; polling and ordinary stdlib calls never parse source text.
- Source schemas are closed and explicitly list every path plus expected module/profile/plan identity.
- The `.ntntc` artifact has exact framing, RFC 8785 canonical JSON, per-symbol/record/aggregate hashes, and a full-artifact SHA-256.
- Runtime recomputes every semantic hash before publishing one immutable `Arc<CatalogSnapshot>`.
- Content-addressed publication is atomic no-replace. Compiler failure cannot select or replace application configuration; prior artifacts remain deployment-owned rollback candidates.
- Catalog paths are application-root confined, no-follow, regular-file and size bounded, and validated from the same opened handle.
- Missing catalog configuration leaves numeric GET/WALK usable. Invalid configured artifacts abort every application/worker startup path before traffic or job claims.
- Ordinary ntnt programs do not receive a mutable `mib_load(path)` API.
- Recognition is advisory and cannot grant network authority, select credentials, raise caps, execute code, or use SNMP SET.
- Low-level `snmp_get`/`snmp_walk` remain numeric; named resolution occurs explicitly against one snapshot.
- Production v1 uses immutable artifacts plus restart/rolling restart. Runtime performs no automatic downloads or live reload.
- Generic `std/jobs` semantics remain application-owned. PR 2's optional `device_inventory.expected` fence returns a no-network `catalog_mismatch` envelope for queued runs.

## WALK contract frozen here

- GETNEXT first; GETBULK later.
- One cursor and exactly one correlated response varbind per logical request.
- One whole-operation deadline.
- Strict increasing OIDs, subtree enforcement, loop rejection, and explicit protocol-exception completion.
- Mandatory look-ahead at `max_results` to distinguish exact completion from truncation.
- Checked preflight equation: `(max_results + 1) * (retries + 1) <= 4096`.
- Independent dynamic ceilings for cumulative received bytes and conservative normalized output.
- Exact termination matrix: low-level protocol/transport/budget failures never become partial telemetry.

## Inventory contract

- Recognition probes and every plan section share one aggregate deadline/request/attempt/row/byte/output budget.
- Exact profile, plan, section, and catalog provenance is returned.
- Static profile ties fail compilation; runtime evidence ambiguity returns an explicit non-inventory result.
- Optional unsupported sections may be partial; security, protocol, global-budget, and required-section failures fail closed.

## Parser research

A throwaway `mib-rs 0.8.0` spike verified SMIv1/SMIv2 imports, symbolic and instance OID resolution, and `Send + Sync` registry state. Independent ecosystem review found it is the strongest Rust parser/resolver base, but too young and insufficiently budgeted to expose directly to untrusted runtime input.

The design therefore requires an ntnt-controlled exact-source fork/vendor snapshot with implicit/system loaders removed, parser concurrency fixed to one by default, checked byte/token/node/import/depth/time/heap budgets, three-platform corpus tests, and an ntnt-owned canonical runtime reader independent of parser-native types.

## Validation

- `git diff --check`
- Markdown fence-balance validation
- `cargo run --locked -- docs --validate`
- Greptile 5/5 with no unresolved threads on the initial head
- Two independent architecture/implementation reviews identified blocking contradictions
- Two exact-staged-diff re-reviews verified the fixes
- Final bounded adjudication: **PASS** at staged diff `4484a712a6058cd7a772cc31272fc907f76705318210277da3d1a3abe97aa3e2`

## Delivery sequence

1. Bounded numeric GETNEXT WALK
2. Canonical MIB/profile/plan compiler plus immutable runtime registry and pure lookup APIs
3. Device recognition and profile-selected inventory execution with expected-hash fencing
4. IF-MIB normalization and counters
5. Rate/reset/wrap semantics
