### PR TITLE
feat: add DD-078 evidence report ledger

### DIFF
--- a/docs/IAL_REFERENCE.md
+++ b/docs/IAL_REFERENCE.md
@@ -14,6 +14,7 @@ IAL is a term rewriting engine that translates natural language assertions into 
 - [Context Paths](#context-paths)
 - [Glossary System](#glossary-system)
 - [Intent File Format](#intent-file-format)
+- [Verification Reports](#verification-reports)
 - [Commands](#commands)
 
 ---
@@ -456,15 +457,29 @@ Known limitations and workarounds for assertion terms
 |----------------|-------|
 | `response is valid JSON` | Uses regex matching on the response body. Works for single-line and multiline JSON. For more reliable JSON validation, prefer `content-type is json` (checks the Content-Type header) or `body has field "key"` (checks for a specific field). |
 
+## Verification Reports
+
+`ntnt intent check` and `ntnt intent coverage` render one versioned `RunReport` evidence ledger. Human totals, JSON totals, coverage, thresholds, and process exit status are projections of that same ledger.
+
+- `ntnt intent check <file> --json` writes banner-free schema-v1 JSON to stdout. Compatibility live checks are profile-qualified as `legacy-live` and cannot be promoted to a global or `full` claim.
+- `ntnt intent coverage <file> --json` reports implementation, executable, and current verified obligation coverage separately. Use `--min-implementation PERCENT`, `--min-executable PERCENT`, and `--min-verified PERCENT` to set explicit thresholds.
+- A selected required binding satisfies an obligation only when it is bound, executable, current, assertion-resolved, passed, and contains at least one concrete evidence atom. Every selected required binding must satisfy this rule.
+- Unbound, unsupported, blocked, skipped, stale, failed, flaky, cancelled, and zero-assertion (`no-result`) evidence fails strict verification. A fail-then-pass remains flaky with both attempts retained.
+- Advisory and profile-excluded bindings remain visible but never satisfy required obligations. `@implements` remains linkage metadata, not execution evidence.
+
+The committed JSON Schema is `tests/fixtures/verification/reports/schema-v1.json`.
+
+JUnit output is intentionally deferred; future renderers must consume the same ledger.
+
 ## Commands
 
 CLI commands for IAL
 
 | Command | Description |
 |---------|-------------|
-| `ntnt intent check <file>` | Run tests defined in intent file against implementation |
+| `ntnt intent check <file>` | Run tests and enforce every required binding through the shared evidence ledger; `--json` emits only schema-v1 JSON |
 | `ntnt intent lint <file>` | Statically validate glossary and scenarios without running tests: unresolved terms and when-clauses (with did-you-mean suggestions), definition cycles, and orphan glossary entries. Exit 1 on unresolved terms or cycles; orphans are warnings only. --json for CI |
-| `ntnt intent coverage <file>` | Show which features have implementations |
+| `ntnt intent coverage <file>` | Render implementation, executable, and verified obligation coverage; supports `--json` and minimum coverage threshold flags |
 | `ntnt intent init <file.intent> -o <output.tnt>` | Generate code scaffolding from intent file |
 | `ntnt intent studio <file.intent>` | Visual preview with live test execution |
 

--- a/docs/ial.toml
+++ b/docs/ial.toml
@@ -561,6 +561,22 @@ description = "Known limitations and workarounds for assertion terms"
 notes = 'Uses regex matching on the response body. Works for single-line and multiline JSON. For more reliable JSON validation, prefer `content-type is json` (checks the Content-Type header) or `body has field "key"` (checks for a specific field).'
 
 # =============================================================================
+# VERIFICATION REPORTS
+# =============================================================================
+
+[verification_reports]
+description = "`ntnt intent check` and `ntnt intent coverage` render one versioned `RunReport` evidence ledger. Human totals, JSON totals, coverage, thresholds, and process exit status are projections of that same ledger."
+details = [
+  "`ntnt intent check <file> --json` writes banner-free schema-v1 JSON to stdout. Compatibility live checks are profile-qualified as `legacy-live` and cannot be promoted to a global or `full` claim.",
+  "`ntnt intent coverage <file> --json` reports implementation, executable, and current verified obligation coverage separately. Use `--min-implementation PERCENT`, `--min-executable PERCENT`, and `--min-verified PERCENT` to set explicit thresholds.",
+  "A selected required binding satisfies an obligation only when it is bound, executable, current, assertion-resolved, passed, and contains at least one concrete evidence atom. Every selected required binding must satisfy this rule.",
+  "Unbound, unsupported, blocked, skipped, stale, failed, flaky, cancelled, and zero-assertion (`no-result`) evidence fails strict verification. A fail-then-pass remains flaky with both attempts retained.",
+  "Advisory and profile-excluded bindings remain visible but never satisfy required obligations. `@implements` remains linkage metadata, not execution evidence."
+]
+schema = "tests/fixtures/verification/reports/schema-v1.json"
+note = "JUnit output is intentionally deferred; future renderers must consume the same ledger."
+
+# =============================================================================
 # COMMANDS
 # =============================================================================
 
@@ -569,7 +585,7 @@ description = "CLI commands for IAL"
 
 [commands.check]
 command = "ntnt intent check <file>"
-description = "Run tests defined in intent file against implementation"
+description = "Run tests and enforce every required binding through the shared evidence ledger; `--json` emits only schema-v1 JSON"
 example = "ntnt intent check server.tnt"
 
 [commands.lint]
@@ -579,7 +595,7 @@ example = "ntnt intent lint server.intent"
 
 [commands.coverage]
 command = "ntnt intent coverage <file>"
-description = "Show which features have implementations"
+description = "Render implementation, executable, and verified obligation coverage; supports `--json` and minimum coverage threshold flags"
 example = "ntnt intent coverage server.tnt"
 
 [commands.init]

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -6172,7 +6172,7 @@ pub fn print_intent_results(result: &IntentCheckResult) {
 }
 
 /// Format an assertion for display
-fn format_assertion(assertion: &Assertion) -> String {
+pub(crate) fn format_assertion(assertion: &Assertion) -> String {
     match assertion {
         Assertion::Status(code) => format!("status: {}", code),
         Assertion::BodyContains(text) => format!("body contains \"{}\"", text),

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,6 +432,22 @@ enum IntentCommands {
         /// Path to intent file (default: looks for <name>.intent)
         #[arg(long = "intent", short = 'i')]
         intent_file: Option<PathBuf>,
+
+        /// Output the versioned report as JSON only
+        #[arg(long)]
+        json: bool,
+
+        /// Minimum implementation coverage percentage
+        #[arg(long, default_value_t = 0.0)]
+        min_implementation: f64,
+
+        /// Minimum executable coverage percentage
+        #[arg(long, default_value_t = 0.0)]
+        min_executable: f64,
+
+        /// Minimum current verified coverage percentage
+        #[arg(long, default_value_t = 0.0)]
+        min_verified: f64,
     },
     /// Statically validate an intent file's glossary and scenarios
     ///
@@ -4080,9 +4096,21 @@ fn run_intent_command(cmd: IntentCommands) -> anyhow::Result<()> {
             verbose,
             json,
         } => run_intent_check_command(&file, intent_file.as_ref(), port, verbose as usize, json),
-        IntentCommands::Coverage { file, intent_file } => {
-            run_intent_coverage_command(&file, intent_file.as_ref())
-        }
+        IntentCommands::Coverage {
+            file,
+            intent_file,
+            json,
+            min_implementation,
+            min_executable,
+            min_verified,
+        } => run_intent_coverage_command(
+            &file,
+            intent_file.as_ref(),
+            json,
+            min_implementation,
+            min_executable,
+            min_verified,
+        ),
         IntentCommands::Lint { file, json } => run_intent_lint_command(&file, json),
         IntentCommands::Init {
             intent_file,
@@ -4323,261 +4351,27 @@ fn run_intent_check_command(
         anyhow::bail!("Server failed to start within 30 seconds on port {}", port);
     }
 
-    // Run tests using the new IAL engine
-    let results = intent::run_tests_against_server(&intent_file, port, &source_files);
+    // The compatibility adapter executes the live checker itself and consumes
+    // concrete assertion atoms rather than trusting caller-provided summary
+    // counters or feature `passed` booleans.
+    let report =
+        ntnt::verification::RunReport::run_compatibility_live(&intent_file, port, &source_files);
 
-    // JSON output mode: print JSON and exit
+    // JSON mode is stdout-clean and serializes exactly the ledger used below.
     if json_output {
-        // Kill app server before output
         let _ = app_process.kill();
-
-        let json = serde_json::to_string_pretty(&results)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize results: {}", e))?;
-        println!("{}", json);
-
-        // Exit with appropriate code
-        if results.failed_assertions > 0 {
-            std::process::exit(1);
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        if report.exit_code() != 0 {
+            std::process::exit(report.exit_code());
         }
         return Ok(());
     }
 
-    // Print results based on verbosity level
-    // 0: Summary only (feature names + totals)
-    // 1: Show scenarios
-    // 2+: Show assertions and term resolution
-    println!();
-    println!("{}", "=== Test Results ===".cyan().bold());
-    println!();
-
-    // Calculate stats
-    let mut scenarios_passed = 0;
-    let mut scenarios_failed = 0;
-    let mut scenarios_skipped = 0;
-    let mut features_failed = 0;
-
-    // Count scenarios for all features (needed for summary)
-    for feature in &results.features {
-        for scenario in &feature.scenarios {
-            match scenario.status.as_str() {
-                "pass" => scenarios_passed += 1,
-                "fail" => scenarios_failed += 1,
-                "skip" => scenarios_skipped += 1,
-                // "warning", "pending", or any unknown status counts as failed
-                _ => scenarios_failed += 1,
-            }
-        }
-        if !feature.passed {
-            features_failed += 1;
-        }
-    }
-    for component in &results.components {
-        for scenario in &component.scenarios {
-            match scenario.status.as_str() {
-                "pass" => scenarios_passed += 1,
-                "fail" => scenarios_failed += 1,
-                "skip" => scenarios_skipped += 1,
-                // "warning", "pending", or any unknown status counts as failed
-                _ => scenarios_failed += 1,
-            }
-        }
-    }
-
-    // Verbosity 0: Summary only - just feature names with pass/fail counts
-    if verbosity == 0 {
-        for feature in &results.features {
-            let status_icon = if feature.passed {
-                "✓".green()
-            } else {
-                "✗".red()
-            };
-            let scenario_count = feature.scenarios.len() + feature.tests.len();
-            let passed_count = feature
-                .scenarios
-                .iter()
-                .filter(|s| s.status == "pass")
-                .count()
-                + feature.tests.iter().filter(|t| t.passed).count();
-
-            if feature.passed {
-                println!(
-                    "{} {}  {} scenarios",
-                    status_icon,
-                    feature.feature_name.bold(),
-                    scenario_count
-                );
-            } else {
-                println!(
-                    "{} {}  {}/{} scenarios passed",
-                    status_icon,
-                    feature.feature_name.bold(),
-                    passed_count,
-                    scenario_count
-                );
-            }
-        }
-        for component in &results.components {
-            let status_icon = if component.passed {
-                "✓".green()
-            } else {
-                "✗".red()
-            };
-            println!(
-                "{} Component: {}",
-                status_icon,
-                component.component_name.bold()
-            );
-        }
-        println!();
-    } else {
-        // Verbosity 1+: Show scenarios
-        for feature in &results.features {
-            let status_icon = if feature.passed {
-                "✓".green()
-            } else {
-                "✗".red()
-            };
-            println!("{} Feature: {}", status_icon, feature.feature_name.bold());
-
-            for scenario in &feature.scenarios {
-                let icon = match scenario.status.as_str() {
-                    "pass" => "  ✓".green(),
-                    "fail" => "  ✗".red(),
-                    "skip" => "  ⏭️ ".yellow(),
-                    _ => "  ⧗".yellow(),
-                };
-                println!("{} {}", icon, scenario.name);
-
-                // Verbosity 2+: Show assertions and term resolution
-                if verbosity >= 2 {
-                    if let Some(ref given) = scenario.given_clause {
-                        println!("      Given {}", given.dimmed());
-                    }
-                    println!("      When {}", scenario.when_clause.dimmed());
-                    for outcome in &scenario.outcomes {
-                        println!("      → {}", outcome.dimmed());
-                    }
-                    if let Some(ref test_result) = scenario.test_result {
-                        for assertion in &test_result.assertions {
-                            let a_icon = if assertion.passed {
-                                "✓".green()
-                            } else {
-                                "✗".red()
-                            };
-                            println!("        {} {}", a_icon, assertion.assertion_text.dimmed());
-                            // Show failure message if present
-                            if !assertion.passed {
-                                if let Some(ref msg) = assertion.message {
-                                    println!("          {}", msg.red());
-                                }
-                            }
-                        }
-                    }
-                }
-                // Always show details for failed scenarios (even at verbosity 1)
-                else if scenario.status == "fail" {
-                    if let Some(ref test_result) = scenario.test_result {
-                        for assertion in &test_result.assertions {
-                            if !assertion.passed {
-                                println!("      ✗ {}", assertion.assertion_text.red());
-                                if let Some(ref msg) = assertion.message {
-                                    println!("        {}", msg.red());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            for test in &feature.tests {
-                let icon = if test.passed {
-                    "  ✓".green()
-                } else {
-                    "  ✗".red()
-                };
-                println!("{} {} {}", icon, test.method, test.path);
-
-                // Verbosity 2+: Show all assertions
-                if verbosity >= 2 {
-                    for assertion in &test.assertions {
-                        let a_icon = if assertion.passed {
-                            "✓".green()
-                        } else {
-                            "✗".red()
-                        };
-                        println!("      {} {}", a_icon, assertion.assertion_text.dimmed());
-                        if !assertion.passed {
-                            if let Some(ref msg) = assertion.message {
-                                println!("        {}", msg.red());
-                            }
-                        }
-                    }
-                }
-                // Always show details for failed tests (even at verbosity 1)
-                else if !test.passed {
-                    for assertion in &test.assertions {
-                        if !assertion.passed {
-                            println!("      ✗ {}", assertion.assertion_text.red());
-                            if let Some(ref msg) = assertion.message {
-                                println!("        {}", msg.red());
-                            }
-                        }
-                    }
-                }
-            }
-
-            println!();
-        }
-
-        for component in &results.components {
-            let status_icon = if component.passed {
-                "✓".green()
-            } else {
-                "✗".red()
-            };
-            println!(
-                "{} Component: {}",
-                status_icon,
-                component.component_name.bold()
-            );
-
-            for scenario in &component.scenarios {
-                let icon = match scenario.status.as_str() {
-                    "pass" => "  ✓".green(),
-                    "fail" => "  ✗".red(),
-                    "skip" => "  ⏭️ ".yellow(),
-                    _ => "  ⧗".yellow(),
-                };
-                println!("{} {}", icon, scenario.name);
-            }
-            println!();
-        }
-    }
-
-    println!("{}", "=== Summary ===".cyan().bold());
-    println!(
-        "Features: {} total, {} passed, {} failed",
-        results.total_features,
-        results.total_features - features_failed,
-        features_failed
-    );
-    println!(
-        "Scenarios: {} passed, {} failed, {} skipped",
-        scenarios_passed, scenarios_failed, scenarios_skipped
-    );
-    println!(
-        "Assertions: {} passed, {} failed",
-        results.passed_assertions, results.failed_assertions
-    );
-    println!();
-
-    // Cleanup: kill the app server
+    print!("{}", report.render_human(verbosity));
     let _ = app_process.kill();
-
-    if scenarios_failed > 0 || features_failed > 0 {
-        anyhow::bail!("Some tests failed");
+    if report.exit_code() != 0 {
+        anyhow::bail!("Intent verification failed");
     }
-
     Ok(())
 }
 
@@ -4585,6 +4379,10 @@ fn run_intent_check_command(
 fn run_intent_coverage_command(
     input_path: &PathBuf,
     explicit_intent_path: Option<&PathBuf>,
+    json_output: bool,
+    min_implementation: f64,
+    min_executable: f64,
+    min_verified: f64,
 ) -> anyhow::Result<()> {
     // Verify file exists
     if !input_path.exists() {
@@ -4662,15 +4460,26 @@ fn run_intent_coverage_command(
         collect_route_files(&routes_dir, &mut source_files);
     }
 
-    // Generate and print coverage report
-    let report = intent::generate_coverage_report(&intent_file, &source_files);
-    intent::print_coverage_report(&report);
+    let thresholds = ntnt::verification::CoverageThresholds::new(
+        min_implementation,
+        min_executable,
+        min_verified,
+    )
+    .map_err(anyhow::Error::msg)?;
+    let report = ntnt::verification::RunReport::implementation_coverage(
+        &intent_file,
+        &source_files,
+        thresholds,
+    );
 
-    // Exit with error if coverage is 0%
-    if report.covered_features == 0 && report.total_features > 0 {
-        std::process::exit(1);
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", report.render_human(0));
     }
-
+    if report.exit_code() != 0 {
+        std::process::exit(report.exit_code());
+    }
     Ok(())
 }
 
@@ -6951,6 +6760,7 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
     md.push_str("- [Context Paths](#context-paths)\n");
     md.push_str("- [Glossary System](#glossary-system)\n");
     md.push_str("- [Intent File Format](#intent-file-format)\n");
+    md.push_str("- [Verification Reports](#verification-reports)\n");
     md.push_str("- [Commands](#commands)\n");
     md.push_str("\n---\n\n");
 
@@ -7310,6 +7120,26 @@ fn generate_ial_markdown(docs_dir: &std::path::Path) -> anyhow::Result<()> {
             }
         }
         md.push('\n');
+    }
+
+    // Verification Reports
+    if let Some(reports) = ial.get("verification_reports") {
+        md.push_str("## Verification Reports\n\n");
+        if let Some(desc) = reports.get("description").and_then(|v| v.as_str()) {
+            md.push_str(&format!("{desc}\n\n"));
+        }
+        if let Some(details) = reports.get("details").and_then(|v| v.as_array()) {
+            for detail in details.iter().filter_map(|v| v.as_str()) {
+                md.push_str(&format!("- {detail}\n"));
+            }
+            md.push('\n');
+        }
+        if let Some(schema) = reports.get("schema").and_then(|v| v.as_str()) {
+            md.push_str(&format!("The committed JSON Schema is `{schema}`.\n\n"));
+        }
+        if let Some(note) = reports.get("note").and_then(|v| v.as_str()) {
+            md.push_str(&format!("{note}\n\n"));
+        }
     }
 
     // Commands

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -5,10 +5,16 @@
 
 pub mod ids;
 pub mod model;
+mod report;
 
 pub use ids::{IdKind, IdMode, IdOrigin, IdWarning, SourceSpan, StableId};
 pub use model::{
     AssertionResolution, BindingStatus, DeclarationStatus, Disposition, EvidenceBinding,
     ExecutabilityStatus, ExecutableCoverage, FeatureProofStatus, FeatureTruth, Freshness,
     ImplementationCoverage, LinkageStatus, Obligation, VerificationTruth, VerifiedCoverage,
+};
+pub use report::{
+    CoverageMetric, CoverageSummary, CoverageThresholds, EvidenceAtom, EvidenceAttempt,
+    EvidenceRequirement, EvidenceResult, EvidenceSelection, RunReport, REPORT_SCHEMA_ID,
+    REPORT_SCHEMA_VERSION,
 };

--- a/src/verification/report.rs
+++ b/src/verification/report.rs
@@ -1,0 +1,1774 @@
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+
+use crate::intent::{CoverageReport, IntentFile, LiveScenarioResult, LiveTestResults};
+
+use super::model::{
+    AssertionResolution, BindingStatus, DeclarationStatus, Disposition, ExecutabilityStatus,
+    FeatureTruth, Freshness, LinkageStatus, Obligation, VerificationTruth,
+};
+use super::SourceSpan;
+
+pub const REPORT_SCHEMA_VERSION: u32 = 1;
+pub const REPORT_SCHEMA_ID: &str = "https://ntnt.dev/schemas/verification/run-report-v1.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EvidenceRequirement {
+    Required,
+    Advisory,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EvidenceSelection {
+    Selected,
+    Excluded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EvidenceAtom {
+    id: String,
+    assertion: String,
+    passed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diagnostic: Option<String>,
+}
+
+impl EvidenceAtom {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn assertion(&self) -> &str {
+        &self.assertion
+    }
+
+    pub fn passed(&self) -> bool {
+        self.passed
+    }
+
+    pub fn diagnostic(&self) -> Option<&str> {
+        self.diagnostic.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EvidenceAttempt {
+    sequence: usize,
+    disposition: Disposition,
+    evidence_atoms: Vec<EvidenceAtom>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diagnostic: Option<String>,
+}
+
+impl EvidenceAttempt {
+    pub fn sequence(&self) -> usize {
+        self.sequence
+    }
+
+    pub fn disposition(&self) -> Disposition {
+        self.disposition
+    }
+
+    pub fn evidence_atoms(&self) -> &[EvidenceAtom] {
+        &self.evidence_atoms
+    }
+
+    pub fn diagnostic(&self) -> Option<&str> {
+        self.diagnostic.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EvidenceResult {
+    id: String,
+    obligation_id: String,
+    source: SourceSpan,
+    profile: String,
+    requirement: EvidenceRequirement,
+    selection: EvidenceSelection,
+    declaration: DeclarationStatus,
+    linkage: LinkageStatus,
+    binding: BindingStatus,
+    executability: ExecutabilityStatus,
+    disposition: Disposition,
+    freshness: Freshness,
+    assertion_resolution: AssertionResolution,
+    evidence_atoms: usize,
+    attempts: Vec<EvidenceAttempt>,
+}
+
+impl EvidenceResult {
+    #[allow(clippy::too_many_arguments)]
+    fn recorded(
+        id: impl Into<String>,
+        obligation_id: impl Into<String>,
+        source: SourceSpan,
+        requirement: EvidenceRequirement,
+        selection: EvidenceSelection,
+        declaration: DeclarationStatus,
+        linkage: LinkageStatus,
+        binding: BindingStatus,
+        executability: ExecutabilityStatus,
+        freshness: Freshness,
+        assertion_resolution: AssertionResolution,
+        attempts: Vec<EvidenceAttempt>,
+    ) -> Self {
+        let disposition = effective_disposition(&attempts);
+        let evidence_atoms = attempts
+            .last()
+            .map_or(0, |attempt| attempt.evidence_atoms.len());
+        Self {
+            id: id.into(),
+            obligation_id: obligation_id.into(),
+            source,
+            profile: String::new(),
+            requirement,
+            selection,
+            declaration,
+            linkage,
+            binding,
+            executability,
+            disposition,
+            freshness,
+            assertion_resolution,
+            evidence_atoms,
+            attempts,
+        }
+    }
+
+    fn qualify(mut self, profile: &str) -> Self {
+        self.profile = profile.to_string();
+        self
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn obligation_id(&self) -> &str {
+        &self.obligation_id
+    }
+
+    pub fn profile(&self) -> &str {
+        &self.profile
+    }
+
+    pub fn requirement(&self) -> EvidenceRequirement {
+        self.requirement
+    }
+
+    pub fn selection(&self) -> EvidenceSelection {
+        self.selection
+    }
+
+    pub fn freshness(&self) -> Freshness {
+        self.freshness
+    }
+
+    pub fn evidence_atom_count(&self) -> usize {
+        self.evidence_atoms
+    }
+
+    pub fn disposition(&self) -> Disposition {
+        self.disposition
+    }
+
+    pub fn attempts(&self) -> &[EvidenceAttempt] {
+        &self.attempts
+    }
+
+    pub fn satisfies_required(&self) -> bool {
+        self.requirement == EvidenceRequirement::Required
+            && self.selection == EvidenceSelection::Selected
+            && self.declaration == DeclarationStatus::Declared
+            && self.binding == BindingStatus::Bound
+            && self.executability == ExecutabilityStatus::Executable
+            && self.disposition == Disposition::Passed
+            && self.freshness == Freshness::Current
+            && self.assertion_resolution == AssertionResolution::Resolved
+            && self.evidence_atoms > 0
+            && self.attempts.last().is_some_and(|attempt| {
+                !attempt.evidence_atoms.is_empty()
+                    && attempt.evidence_atoms.iter().all(|atom| atom.passed)
+            })
+    }
+}
+
+fn effective_disposition(attempts: &[EvidenceAttempt]) -> Disposition {
+    let Some(latest) = attempts.last() else {
+        return Disposition::NoResult;
+    };
+    let latest_disposition = effective_attempt_disposition(latest);
+    if latest_disposition == Disposition::Passed {
+        if attempts[..attempts.len() - 1]
+            .iter()
+            .any(|attempt| effective_attempt_disposition(attempt) == Disposition::Failed)
+        {
+            return Disposition::Flaky;
+        }
+    }
+    latest_disposition
+}
+
+fn effective_attempt_disposition(attempt: &EvidenceAttempt) -> Disposition {
+    if attempt.disposition != Disposition::Passed {
+        return attempt.disposition;
+    }
+    if attempt.evidence_atoms.is_empty() {
+        Disposition::NoResult
+    } else if attempt.evidence_atoms.iter().any(|atom| !atom.passed) {
+        Disposition::Failed
+    } else {
+        Disposition::Passed
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
+pub struct CoverageMetric {
+    pub covered: usize,
+    pub total: usize,
+}
+
+impl CoverageMetric {
+    pub fn percentage(self) -> f64 {
+        if self.total == 0 {
+            0.0
+        } else {
+            (self.covered as f64 / self.total as f64) * 100.0
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct CoverageSummary {
+    pub implementation: CoverageMetric,
+    pub executable: CoverageMetric,
+    pub verified: CoverageMetric,
+    pub required_bindings: CoverageMetric,
+    pub documentation_only_features: usize,
+    pub advisory_bindings: usize,
+    pub excluded_bindings: usize,
+    pub evidence_atoms: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct CoverageThresholds {
+    implementation: f64,
+    executable: f64,
+    verified: f64,
+}
+
+impl CoverageThresholds {
+    pub fn new(implementation: f64, executable: f64, verified: f64) -> Result<Self, String> {
+        for (name, value) in [
+            ("implementation", implementation),
+            ("executable", executable),
+            ("verified", verified),
+        ] {
+            if !value.is_finite() || !(0.0..=100.0).contains(&value) {
+                return Err(format!("{name} threshold must be between 0 and 100"));
+            }
+        }
+        Ok(Self {
+            implementation,
+            executable,
+            verified,
+        })
+    }
+}
+
+impl Default for CoverageThresholds {
+    fn default() -> Self {
+        Self {
+            implementation: 0.0,
+            executable: 0.0,
+            verified: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum ExitReason {
+    Success,
+    VerificationFailed,
+    ThresholdFailed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct ExitDecision {
+    code: i32,
+    reason: ExitReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ReportObligation {
+    id: String,
+    feature_id: String,
+    scenario_id: String,
+    statement: String,
+    source: SourceSpan,
+    declaration: DeclarationStatus,
+    linkage: LinkageStatus,
+    binding: BindingStatus,
+    executability: ExecutabilityStatus,
+    disposition: Disposition,
+    freshness: Freshness,
+}
+
+impl From<&Obligation> for ReportObligation {
+    fn from(obligation: &Obligation) -> Self {
+        Self {
+            id: obligation.id.to_string(),
+            feature_id: obligation.feature_id.to_string(),
+            scenario_id: obligation.scenario_id.to_string(),
+            statement: obligation.statement.clone(),
+            source: obligation.source.clone(),
+            declaration: obligation.declaration,
+            linkage: obligation.linkage,
+            binding: obligation.binding,
+            executability: obligation.executability,
+            disposition: obligation.disposition,
+            freshness: obligation.freshness,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ReportFeature {
+    id: String,
+    name: String,
+    source: SourceSpan,
+    declaration: DeclarationStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rationale: Option<String>,
+}
+
+impl From<&FeatureTruth> for ReportFeature {
+    fn from(feature: &FeatureTruth) -> Self {
+        Self {
+            id: feature.id.to_string(),
+            name: feature.name.clone(),
+            source: feature.source.clone(),
+            declaration: feature.declaration,
+            rationale: feature.rationale.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RunReport {
+    schema: &'static str,
+    schema_version: u32,
+    ntnt_version: &'static str,
+    ntnt_commit: Option<&'static str>,
+    profile: String,
+    profile_qualification: String,
+    freshness: Freshness,
+    strict: bool,
+    coverage: CoverageSummary,
+    thresholds: CoverageThresholds,
+    features: Vec<ReportFeature>,
+    obligations: Vec<ReportObligation>,
+    evidence: Vec<EvidenceResult>,
+    unmet_required_binding_ids: Vec<String>,
+    exit: ExitDecision,
+}
+
+impl RunReport {
+    /// Execute the legacy live checker and convert only its concrete assertion
+    /// results into evidence. Callers cannot provide summary counters or
+    /// preconstructed live results through this compatibility path.
+    pub fn run_compatibility_live(
+        intent: &IntentFile,
+        port: u16,
+        source_files: &[(String, String)],
+    ) -> Self {
+        let live = crate::intent::run_tests_against_server(intent, port, source_files);
+        Self::from_live_results(intent, &live, "legacy-live", true)
+    }
+
+    fn from_truth(truth: &VerificationTruth, profile: &str, strict: bool) -> Self {
+        let mut evidence = Vec::new();
+        for obligation in &truth.obligations {
+            if obligation.evidence_bindings.is_empty() {
+                evidence.push(
+                    EvidenceResult::recorded(
+                        format!("binding.unbound.{}", obligation.id),
+                        obligation.id.to_string(),
+                        obligation.source.clone(),
+                        EvidenceRequirement::Required,
+                        EvidenceSelection::Selected,
+                        obligation.declaration,
+                        obligation.linkage,
+                        BindingStatus::Unbound,
+                        obligation.executability,
+                        obligation.freshness,
+                        AssertionResolution::Unresolved,
+                        Vec::new(),
+                    )
+                    .qualify(profile),
+                );
+            } else {
+                for binding in &obligation.evidence_bindings {
+                    // Slice 1A stores only a summary atom count. It is intentionally
+                    // not expanded into evidence: only executor/live compatibility
+                    // paths carrying concrete assertion atoms may verify coverage.
+                    evidence.push(
+                        EvidenceResult::recorded(
+                            binding.id.clone(),
+                            obligation.id.to_string(),
+                            binding.source.clone(),
+                            EvidenceRequirement::Required,
+                            EvidenceSelection::Selected,
+                            binding.declaration,
+                            binding.linkage,
+                            binding.binding,
+                            binding.executability,
+                            binding.freshness,
+                            binding.assertion_resolution,
+                            Vec::new(),
+                        )
+                        .qualify(profile),
+                    );
+                }
+            }
+        }
+        Self::assemble(
+            profile,
+            strict,
+            evidence,
+            truth.features.iter().map(ReportFeature::from).collect(),
+            truth
+                .obligations
+                .iter()
+                .map(ReportObligation::from)
+                .collect(),
+            CoverageThresholds::default(),
+        )
+    }
+
+    fn from_live_results(
+        intent: &IntentFile,
+        live: &LiveTestResults,
+        profile: &str,
+        strict: bool,
+    ) -> Self {
+        let mut truth = VerificationTruth::from_intent(intent);
+        let mut evidence = Vec::new();
+
+        for (feature_index, feature) in truth.features.iter_mut().enumerate() {
+            let (Some(intent_feature), Some(live_feature)) = (
+                intent.features.get(feature_index),
+                live.features.get(feature_index),
+            ) else {
+                continue;
+            };
+            let expected_live_id = intent_feature.id.as_deref().unwrap_or("unknown");
+            if live_feature.feature_id != expected_live_id
+                || live_feature.feature_name != intent_feature.name
+            {
+                continue;
+            }
+            let linkage = if live_feature.has_implementation {
+                LinkageStatus::Linked
+            } else {
+                LinkageStatus::Unlinked
+            };
+            for obligation in truth
+                .obligations
+                .iter_mut()
+                .filter(|obligation| obligation.feature_id == feature.id)
+            {
+                obligation.linkage = linkage;
+            }
+
+            for scenario in &intent_feature.scenarios {
+                let matching: Vec<&LiveScenarioResult> = live_feature
+                    .scenarios
+                    .iter()
+                    .filter(|candidate| {
+                        candidate.name == scenario.name
+                            || candidate.name.starts_with(&format!("{} [", scenario.name))
+                    })
+                    .collect();
+                for (run_index, live_scenario) in matching.iter().enumerate() {
+                    append_live_scenario_evidence(
+                        &mut evidence,
+                        scenario,
+                        live_scenario,
+                        linkage,
+                        profile,
+                        run_index,
+                    );
+                }
+            }
+        }
+
+        let evidenced: BTreeSet<String> = evidence
+            .iter()
+            .map(|result| result.obligation_id.clone())
+            .collect();
+        for obligation in &truth.obligations {
+            if !evidenced.contains(obligation.id.as_str()) {
+                evidence.push(
+                    EvidenceResult::recorded(
+                        format!("binding.unbound.{}", obligation.id),
+                        obligation.id.to_string(),
+                        obligation.source.clone(),
+                        EvidenceRequirement::Required,
+                        EvidenceSelection::Selected,
+                        obligation.declaration,
+                        obligation.linkage,
+                        BindingStatus::Unbound,
+                        ExecutabilityStatus::Unsupported,
+                        Freshness::Current,
+                        AssertionResolution::Unresolved,
+                        Vec::new(),
+                    )
+                    .qualify(profile),
+                );
+            }
+        }
+
+        Self::assemble(
+            profile,
+            strict,
+            evidence,
+            truth.features.iter().map(ReportFeature::from).collect(),
+            truth
+                .obligations
+                .iter()
+                .map(ReportObligation::from)
+                .collect(),
+            CoverageThresholds::default(),
+        )
+    }
+
+    /// Build a non-verifying implementation-coverage report from concrete
+    /// annotations discovered in the supplied source files. The compatibility
+    /// profile is fixed so callers cannot relabel this report as full evidence.
+    pub fn implementation_coverage(
+        intent: &IntentFile,
+        source_files: &[(String, String)],
+        thresholds: CoverageThresholds,
+    ) -> Self {
+        let legacy = crate::intent::generate_coverage_report(intent, source_files);
+        Self::from_implementation_coverage(intent, &legacy, thresholds)
+    }
+
+    fn from_implementation_coverage(
+        intent: &IntentFile,
+        legacy: &CoverageReport,
+        thresholds: CoverageThresholds,
+    ) -> Self {
+        let mut truth = VerificationTruth::from_intent(intent);
+        for feature in &legacy.features {
+            if !feature.implementations.is_empty() {
+                for obligation in truth
+                    .obligations
+                    .iter_mut()
+                    .filter(|obligation| obligation.feature_id.as_str() == feature.feature_id)
+                {
+                    obligation.linkage = LinkageStatus::Linked;
+                }
+            }
+        }
+        let mut report = Self::from_truth(&truth, "implementation", false);
+        report.thresholds = thresholds;
+        report.coverage =
+            coverage_from_ledger(&report.features, &report.obligations, &report.evidence);
+        let has_unproven_behavioral_feature = report.features.iter().any(|feature| {
+            feature.declaration == DeclarationStatus::Declared
+                && !report
+                    .obligations
+                    .iter()
+                    .any(|obligation| obligation.feature_id == feature.id)
+        });
+        report.exit = decide_exit(
+            false,
+            true,
+            false,
+            has_unproven_behavioral_feature,
+            &report.coverage,
+            thresholds,
+            &report.evidence,
+        );
+        report
+    }
+
+    fn assemble(
+        profile: &str,
+        strict: bool,
+        evidence: Vec<EvidenceResult>,
+        features: Vec<ReportFeature>,
+        obligations: Vec<ReportObligation>,
+        thresholds: CoverageThresholds,
+    ) -> Self {
+        let evidence: Vec<_> = evidence
+            .into_iter()
+            .map(|result| result.qualify(profile))
+            .collect();
+        let obligations = obligations
+            .into_iter()
+            .map(|obligation| summarize_obligation(obligation, &evidence))
+            .collect::<Vec<_>>();
+        let coverage = coverage_from_ledger(&features, &obligations, &evidence);
+        let unmet_required_binding_ids = evidence
+            .iter()
+            .filter(|result| {
+                result.requirement == EvidenceRequirement::Required
+                    && ((result.selection == EvidenceSelection::Selected
+                        && !result.satisfies_required())
+                        || (profile == "full" && result.selection == EvidenceSelection::Excluded))
+            })
+            .map(|result| result.id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let has_unproven_behavioral_feature = features.iter().any(|feature| {
+            feature.declaration == DeclarationStatus::Declared
+                && !obligations
+                    .iter()
+                    .any(|obligation| obligation.feature_id == feature.id)
+        });
+        let exit = decide_exit(
+            strict,
+            false,
+            profile == "full",
+            has_unproven_behavioral_feature,
+            &coverage,
+            thresholds,
+            &evidence,
+        );
+        Self {
+            schema: REPORT_SCHEMA_ID,
+            schema_version: REPORT_SCHEMA_VERSION,
+            ntnt_version: env!("CARGO_PKG_VERSION"),
+            ntnt_commit: option_env!("NTNT_GIT_COMMIT"),
+            profile: profile.to_string(),
+            profile_qualification: format!("profile:{profile}"),
+            freshness: if evidence
+                .iter()
+                .any(|result| result.freshness == Freshness::Stale)
+            {
+                Freshness::Stale
+            } else {
+                Freshness::Current
+            },
+            strict,
+            coverage,
+            thresholds,
+            features,
+            obligations,
+            evidence,
+            unmet_required_binding_ids,
+            exit,
+        }
+    }
+
+    #[cfg(test)]
+    fn assemble_for_tests(profile: &str, strict: bool, evidence: Vec<EvidenceResult>) -> Self {
+        let obligation_ids: BTreeSet<String> = evidence
+            .iter()
+            .map(|result| result.obligation_id.clone())
+            .collect();
+        let obligations = obligation_ids
+            .into_iter()
+            .map(|id| ReportObligation {
+                id,
+                feature_id: "feature.report".to_string(),
+                scenario_id: "scenario.report".to_string(),
+                statement: "report truth".to_string(),
+                source: SourceSpan::single_line("report.intent", 1, 1, 1),
+                declaration: DeclarationStatus::Declared,
+                linkage: LinkageStatus::Linked,
+                binding: BindingStatus::Unbound,
+                executability: ExecutabilityStatus::Unsupported,
+                disposition: Disposition::NoResult,
+                freshness: Freshness::Current,
+            })
+            .collect();
+        Self::assemble(
+            profile,
+            strict,
+            evidence,
+            vec![ReportFeature {
+                id: "feature.report".to_string(),
+                name: "Report".to_string(),
+                source: SourceSpan::single_line("report.intent", 1, 1, 1),
+                declaration: DeclarationStatus::Declared,
+                rationale: None,
+            }],
+            obligations,
+            CoverageThresholds::default(),
+        )
+    }
+
+    pub fn evidence(&self) -> &[EvidenceResult] {
+        &self.evidence
+    }
+
+    pub fn coverage(&self) -> &CoverageSummary {
+        &self.coverage
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        self.exit.code
+    }
+
+    pub fn profile_qualification(&self) -> &str {
+        &self.profile_qualification
+    }
+
+    pub fn render_human(&self, verbosity: usize) -> String {
+        let passed = self.coverage.required_bindings.covered;
+        let failed = self.coverage.required_bindings.total - passed;
+        let mut output = String::new();
+        output.push_str("=== NTNT Intent Verification ===\n");
+        output.push_str(&format!(
+            "Profile: {} ({})\n",
+            self.profile, self.profile_qualification
+        ));
+        if verbosity > 0 {
+            for result in &self.evidence {
+                output.push_str(&format!(
+                    "- {} [{}]: {:?}\n",
+                    result.obligation_id, result.id, result.disposition
+                ));
+                if verbosity > 1 {
+                    for attempt in &result.attempts {
+                        output.push_str(&format!(
+                            "  attempt {}: {:?}, {} evidence atoms\n",
+                            attempt.sequence,
+                            attempt.disposition,
+                            attempt.evidence_atoms.len()
+                        ));
+                        for atom in &attempt.evidence_atoms {
+                            output.push_str(&format!(
+                                "    {} {}\n",
+                                if atom.passed { "pass" } else { "fail" },
+                                atom.assertion
+                            ));
+                            if let Some(diagnostic) = &atom.diagnostic {
+                                output.push_str(&format!("      {diagnostic}\n"));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        output.push_str(&format!(
+            "Obligations: {} verified, {} unmet; features: {} documentation-only\n",
+            self.coverage.verified.covered,
+            self.coverage.verified.total - self.coverage.verified.covered,
+            self.coverage.documentation_only_features
+        ));
+        output.push_str(&format!(
+            "Required bindings: {passed} passed, {failed} failed\n"
+        ));
+        output.push_str(&format!(
+            "Coverage: implementation {:.1}%, executable {:.1}%, verified {:.1}%\n",
+            self.coverage.implementation.percentage(),
+            self.coverage.executable.percentage(),
+            self.coverage.verified.percentage()
+        ));
+        if self.coverage.advisory_bindings > 0 || self.coverage.excluded_bindings > 0 {
+            output.push_str(&format!(
+                "Visible non-satisfying bindings: {} advisory, {} excluded\n",
+                self.coverage.advisory_bindings, self.coverage.excluded_bindings
+            ));
+        }
+        output.push_str(&format!(
+            "Exit: {} ({:?})\n",
+            self.exit.code, self.exit.reason
+        ));
+        output
+    }
+}
+
+fn append_live_scenario_evidence(
+    evidence: &mut Vec<EvidenceResult>,
+    scenario: &crate::intent::Scenario,
+    live: &LiveScenarioResult,
+    linkage: LinkageStatus,
+    profile: &str,
+    run_index: usize,
+) {
+    let assertions = live
+        .test_result
+        .as_ref()
+        .map(|result| result.assertions.as_slice())
+        .unwrap_or_default();
+    let exact_mapping = assertions.len() == scenario.outcome_metadata.len();
+
+    for (outcome_index, metadata) in scenario.outcome_metadata.iter().enumerate() {
+        let (binding, executability, resolution, attempts) = match live.status.as_str() {
+            "skip" => (
+                BindingStatus::Bound,
+                ExecutabilityStatus::Executable,
+                AssertionResolution::Resolved,
+                vec![EvidenceAttempt {
+                    sequence: 1,
+                    disposition: Disposition::Skipped,
+                    evidence_atoms: Vec::new(),
+                    diagnostic: Some("precondition was not met".to_string()),
+                }],
+            ),
+            "pass" | "fail" if exact_mapping => {
+                let assertion = &assertions[outcome_index];
+                let disposition = if assertion.passed {
+                    Disposition::Passed
+                } else {
+                    Disposition::Failed
+                };
+                (
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    AssertionResolution::Resolved,
+                    vec![EvidenceAttempt {
+                        sequence: 1,
+                        disposition,
+                        evidence_atoms: vec![EvidenceAtom {
+                            id: format!(
+                                "atom.{}.{}.{}",
+                                metadata.id,
+                                run_index + 1,
+                                outcome_index + 1
+                            ),
+                            assertion: assertion.assertion_text.clone(),
+                            passed: assertion.passed,
+                            diagnostic: assertion.message.clone(),
+                        }],
+                        diagnostic: None,
+                    }],
+                )
+            }
+            "pass" | "fail" => (
+                BindingStatus::Bound,
+                ExecutabilityStatus::Executable,
+                AssertionResolution::Unresolved,
+                vec![EvidenceAttempt {
+                    sequence: 1,
+                    disposition: Disposition::NoResult,
+                    evidence_atoms: Vec::new(),
+                    diagnostic: Some(format!(
+                        "cannot safely map {} assertions to {} outcomes",
+                        assertions.len(),
+                        scenario.outcome_metadata.len()
+                    )),
+                }],
+            ),
+            _ => (
+                BindingStatus::Unbound,
+                ExecutabilityStatus::Unsupported,
+                AssertionResolution::Unresolved,
+                Vec::new(),
+            ),
+        };
+        evidence.push(
+            EvidenceResult::recorded(
+                format!(
+                    "binding.compat.{}.{}.{}",
+                    scenario.verification_id,
+                    run_index + 1,
+                    outcome_index + 1
+                ),
+                metadata.id.to_string(),
+                metadata.source.clone(),
+                EvidenceRequirement::Required,
+                EvidenceSelection::Selected,
+                DeclarationStatus::Declared,
+                linkage,
+                binding,
+                executability,
+                Freshness::Current,
+                resolution,
+                attempts,
+            )
+            .qualify(profile),
+        );
+    }
+}
+
+fn summarize_obligation(
+    mut obligation: ReportObligation,
+    evidence: &[EvidenceResult],
+) -> ReportObligation {
+    let selected = evidence
+        .iter()
+        .filter(|result| {
+            result.obligation_id == obligation.id
+                && result.requirement == EvidenceRequirement::Required
+                && result.selection == EvidenceSelection::Selected
+        })
+        .collect::<Vec<_>>();
+    if selected.is_empty() {
+        return obligation;
+    }
+
+    obligation.linkage = if selected
+        .iter()
+        .any(|result| result.linkage == LinkageStatus::Linked)
+    {
+        LinkageStatus::Linked
+    } else {
+        LinkageStatus::Unlinked
+    };
+    obligation.binding = if selected
+        .iter()
+        .any(|result| result.binding == BindingStatus::Ambiguous)
+    {
+        BindingStatus::Ambiguous
+    } else if selected
+        .iter()
+        .all(|result| result.binding == BindingStatus::Bound)
+    {
+        BindingStatus::Bound
+    } else {
+        BindingStatus::Unbound
+    };
+    obligation.executability = if selected
+        .iter()
+        .all(|result| result.executability == ExecutabilityStatus::Executable)
+    {
+        ExecutabilityStatus::Executable
+    } else if selected
+        .iter()
+        .any(|result| result.executability == ExecutabilityStatus::Blocked)
+    {
+        ExecutabilityStatus::Blocked
+    } else {
+        ExecutabilityStatus::Unsupported
+    };
+    obligation.disposition = aggregate_disposition(&selected);
+    obligation.freshness = if selected
+        .iter()
+        .any(|result| result.freshness == Freshness::Stale)
+    {
+        Freshness::Stale
+    } else {
+        Freshness::Current
+    };
+    obligation
+}
+
+fn aggregate_disposition(evidence: &[&EvidenceResult]) -> Disposition {
+    for disposition in [
+        Disposition::Failed,
+        Disposition::Flaky,
+        Disposition::Cancelled,
+        Disposition::Skipped,
+        Disposition::NoResult,
+        Disposition::Running,
+        Disposition::Planned,
+    ] {
+        if evidence
+            .iter()
+            .any(|result| result.disposition == disposition)
+        {
+            return disposition;
+        }
+    }
+    Disposition::Passed
+}
+
+fn coverage_from_ledger(
+    features: &[ReportFeature],
+    obligations: &[ReportObligation],
+    evidence: &[EvidenceResult],
+) -> CoverageSummary {
+    let behavioral_obligations: Vec<_> = obligations
+        .iter()
+        .filter(|obligation| obligation.declaration == DeclarationStatus::Declared)
+        .collect();
+    let total = behavioral_obligations.len();
+    let implementation = behavioral_obligations
+        .iter()
+        .filter(|obligation| obligation.linkage == LinkageStatus::Linked)
+        .count();
+    let executable = behavioral_obligations
+        .iter()
+        .filter(|obligation| {
+            let selected = evidence
+                .iter()
+                .filter(|result| {
+                    result.obligation_id == obligation.id
+                        && result.requirement == EvidenceRequirement::Required
+                        && result.selection == EvidenceSelection::Selected
+                })
+                .collect::<Vec<_>>();
+            !selected.is_empty()
+                && selected.iter().all(|result| {
+                    result.binding == BindingStatus::Bound
+                        && result.executability == ExecutabilityStatus::Executable
+                })
+        })
+        .count();
+    let verified = behavioral_obligations
+        .iter()
+        .filter(|obligation| {
+            let selected: Vec<_> = evidence
+                .iter()
+                .filter(|result| {
+                    result.obligation_id == obligation.id
+                        && result.requirement == EvidenceRequirement::Required
+                        && result.selection == EvidenceSelection::Selected
+                })
+                .collect();
+            !selected.is_empty() && selected.iter().all(|result| result.satisfies_required())
+        })
+        .count();
+    let selected_required: Vec<_> = evidence
+        .iter()
+        .filter(|result| {
+            result.requirement == EvidenceRequirement::Required
+                && result.selection == EvidenceSelection::Selected
+        })
+        .collect();
+
+    CoverageSummary {
+        implementation: CoverageMetric {
+            covered: implementation,
+            total,
+        },
+        executable: CoverageMetric {
+            covered: executable,
+            total,
+        },
+        verified: CoverageMetric {
+            covered: verified,
+            total,
+        },
+        required_bindings: CoverageMetric {
+            covered: selected_required
+                .iter()
+                .filter(|result| result.satisfies_required())
+                .count(),
+            total: selected_required.len(),
+        },
+        documentation_only_features: features
+            .iter()
+            .filter(|feature| feature.declaration == DeclarationStatus::DocumentationOnly)
+            .count(),
+        advisory_bindings: evidence
+            .iter()
+            .filter(|result| result.requirement == EvidenceRequirement::Advisory)
+            .count(),
+        excluded_bindings: evidence
+            .iter()
+            .filter(|result| result.selection == EvidenceSelection::Excluded)
+            .count(),
+        evidence_atoms: evidence.iter().map(|result| result.evidence_atoms).sum(),
+    }
+}
+
+fn decide_exit(
+    strict: bool,
+    require_implementation: bool,
+    require_all_obligations: bool,
+    has_unproven_behavioral_feature: bool,
+    coverage: &CoverageSummary,
+    thresholds: CoverageThresholds,
+    evidence: &[EvidenceResult],
+) -> ExitDecision {
+    let selected_required: Vec<_> = evidence
+        .iter()
+        .filter(|result| {
+            result.requirement == EvidenceRequirement::Required
+                && result.selection == EvidenceSelection::Selected
+        })
+        .collect();
+    if ((strict || require_implementation) && has_unproven_behavioral_feature)
+        || (strict
+            && ((require_all_obligations && coverage.verified.covered != coverage.verified.total)
+                || (coverage.verified.total > 0 && selected_required.is_empty())
+                || selected_required
+                    .iter()
+                    .any(|result| !result.satisfies_required())))
+    {
+        return ExitDecision {
+            code: 1,
+            reason: ExitReason::VerificationFailed,
+        };
+    }
+    if require_implementation
+        && coverage.implementation.total > 0
+        && coverage.implementation.covered == 0
+    {
+        return ExitDecision {
+            code: 1,
+            reason: ExitReason::VerificationFailed,
+        };
+    }
+    if coverage.implementation.percentage() < thresholds.implementation
+        || coverage.executable.percentage() < thresholds.executable
+        || coverage.verified.percentage() < thresholds.verified
+    {
+        return ExitDecision {
+            code: 1,
+            reason: ExitReason::ThresholdFailed,
+        };
+    }
+    ExitDecision {
+        code: 0,
+        reason: ExitReason::Success,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verification::{
+        AssertionResolution, BindingStatus, DeclarationStatus, Disposition, EvidenceBinding,
+        ExecutabilityStatus, Freshness, IdMode, LinkageStatus, SourceSpan, VerificationTruth,
+    };
+
+    fn atom(id: &str, passed: bool) -> EvidenceAtom {
+        EvidenceAtom {
+            id: id.to_string(),
+            assertion: format!("assertion {id}"),
+            passed,
+            diagnostic: (!passed).then(|| format!("{id} failed")),
+        }
+    }
+
+    fn attempt(
+        sequence: usize,
+        disposition: Disposition,
+        atoms: Vec<EvidenceAtom>,
+    ) -> EvidenceAttempt {
+        EvidenceAttempt {
+            sequence,
+            disposition,
+            evidence_atoms: atoms,
+            diagnostic: None,
+        }
+    }
+
+    fn evidence(
+        id: &str,
+        requirement: EvidenceRequirement,
+        selection: EvidenceSelection,
+        binding: BindingStatus,
+        executability: ExecutabilityStatus,
+        freshness: Freshness,
+        attempts: Vec<EvidenceAttempt>,
+    ) -> EvidenceResult {
+        EvidenceResult::recorded(
+            id,
+            "outcome.report.example",
+            SourceSpan::single_line("verification.tnt", 7, 1, 20),
+            requirement,
+            selection,
+            DeclarationStatus::Declared,
+            LinkageStatus::Linked,
+            binding,
+            executability,
+            freshness,
+            AssertionResolution::Resolved,
+            attempts,
+        )
+    }
+
+    fn report(profile: &str, evidence: Vec<EvidenceResult>) -> RunReport {
+        RunReport::assemble_for_tests(profile, true, evidence)
+    }
+
+    #[test]
+    fn every_task_1b_disposition_is_truthful() {
+        let cases = [
+            (
+                "planned",
+                evidence(
+                    "binding.planned",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    vec![attempt(1, Disposition::Planned, vec![])],
+                ),
+                Disposition::Planned,
+                false,
+            ),
+            (
+                "running",
+                evidence(
+                    "binding.running",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    vec![attempt(1, Disposition::Running, vec![])],
+                ),
+                Disposition::Running,
+                false,
+            ),
+            (
+                "unbound",
+                evidence(
+                    "binding.unbound",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Unbound,
+                    ExecutabilityStatus::Unsupported,
+                    Freshness::Current,
+                    vec![],
+                ),
+                Disposition::NoResult,
+                false,
+            ),
+            (
+                "unsupported",
+                evidence(
+                    "binding.unsupported",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Unsupported,
+                    Freshness::Current,
+                    vec![],
+                ),
+                Disposition::NoResult,
+                false,
+            ),
+            (
+                "blocked",
+                evidence(
+                    "binding.blocked",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Blocked,
+                    Freshness::Current,
+                    vec![],
+                ),
+                Disposition::NoResult,
+                false,
+            ),
+            (
+                "skipped",
+                evidence(
+                    "binding.skipped",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    vec![attempt(1, Disposition::Skipped, vec![])],
+                ),
+                Disposition::Skipped,
+                false,
+            ),
+            (
+                "stale",
+                evidence(
+                    "binding.stale",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Stale,
+                    vec![attempt(1, Disposition::Passed, vec![atom("stale", true)])],
+                ),
+                Disposition::Passed,
+                false,
+            ),
+            (
+                "failed",
+                evidence(
+                    "binding.failed",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    vec![attempt(1, Disposition::Failed, vec![atom("failed", false)])],
+                ),
+                Disposition::Failed,
+                false,
+            ),
+            (
+                "flaky",
+                evidence(
+                    "binding.flaky",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    vec![
+                        attempt(1, Disposition::Failed, vec![atom("first", false)]),
+                        attempt(2, Disposition::Passed, vec![atom("second", true)]),
+                    ],
+                ),
+                Disposition::Flaky,
+                false,
+            ),
+            (
+                "cancelled",
+                evidence(
+                    "binding.cancelled",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    vec![attempt(1, Disposition::Cancelled, vec![])],
+                ),
+                Disposition::Cancelled,
+                false,
+            ),
+            (
+                "no-result",
+                evidence(
+                    "binding.no-result",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    vec![attempt(1, Disposition::Passed, vec![])],
+                ),
+                Disposition::NoResult,
+                false,
+            ),
+            (
+                "current-passed",
+                evidence(
+                    "binding.current-passed",
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    vec![attempt(1, Disposition::Passed, vec![atom("pass", true)])],
+                ),
+                Disposition::Passed,
+                true,
+            ),
+        ];
+
+        for (name, evidence, disposition, satisfies) in cases {
+            let report = report("full", vec![evidence]);
+            assert_eq!(report.evidence()[0].disposition(), disposition, "{name}");
+            assert_eq!(
+                report.evidence()[0].satisfies_required(),
+                satisfies,
+                "{name}"
+            );
+            assert_eq!(report.exit_code(), if satisfies { 0 } else { 1 }, "{name}");
+        }
+    }
+
+    #[test]
+    fn strict_exit_fails_each_unmet_required_binding_and_all_required_can_pass() {
+        let passed = evidence(
+            "binding.passed",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Passed, vec![atom("pass", true)])],
+        );
+        let failed = evidence(
+            "binding.failed",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Failed, vec![atom("fail", false)])],
+        );
+
+        assert_eq!(report("full", vec![passed.clone(), failed]).exit_code(), 1);
+        assert_eq!(report("full", vec![passed.clone(), passed]).exit_code(), 0);
+    }
+
+    #[test]
+    fn fail_then_pass_is_flaky_and_retains_both_diagnostics() {
+        let evidence = evidence(
+            "binding.retry",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![
+                attempt(1, Disposition::Failed, vec![atom("first", false)]),
+                attempt(2, Disposition::Passed, vec![atom("second", true)]),
+            ],
+        );
+        let report = report("full", vec![evidence]);
+        let result = &report.evidence()[0];
+
+        assert_eq!(result.disposition(), Disposition::Flaky);
+        assert_eq!(result.attempts().len(), 2);
+        assert_eq!(
+            result.attempts()[0].evidence_atoms[0].diagnostic.as_deref(),
+            Some("first failed")
+        );
+        assert_eq!(report.exit_code(), 1);
+    }
+
+    #[test]
+    fn concrete_atoms_override_live_summary_booleans_for_compatibility_ids() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            "Feature: Legacy report\n\n  Scenario: Execute\n    When execution is recorded\n    → result is observed\n",
+            "legacy-report.intent".to_string(),
+            IdMode::Compatibility,
+        )
+        .unwrap();
+        let live_assertion = crate::intent::LiveAssertionResult {
+            assertion_text: "result is observed".to_string(),
+            passed: true,
+            message: None,
+            resolution_trace: None,
+            checks: Vec::new(),
+        };
+        let live_test = crate::intent::LiveTestResult {
+            method: "GET".to_string(),
+            path: "/".to_string(),
+            passed: false,
+            assertions: vec![live_assertion],
+            preconditions: Vec::new(),
+            scenario_name: Some("Execute".to_string()),
+        };
+        let live = LiveTestResults {
+            features: vec![crate::intent::LiveFeatureResult {
+                feature_id: "unknown".to_string(),
+                feature_name: "Legacy report".to_string(),
+                description: None,
+                passed: false,
+                tests: Vec::new(),
+                scenarios: vec![LiveScenarioResult {
+                    name: "Execute".to_string(),
+                    description: None,
+                    given_clause: None,
+                    when_clause: "execution is recorded".to_string(),
+                    outcomes: vec!["result is observed".to_string()],
+                    status: "pass".to_string(),
+                    test_result: Some(live_test),
+                    unresolved_outcomes: Vec::new(),
+                    component_refs: Vec::new(),
+                }],
+                has_implementation: false,
+            }],
+            components: Vec::new(),
+            total_assertions: 0,
+            passed_assertions: 0,
+            failed_assertions: 99,
+            linked_features: 0,
+            total_features: 0,
+            title: None,
+            glossary: None,
+            summary: None,
+        };
+
+        let report = RunReport::from_live_results(&intent, &live, "legacy-live", true);
+
+        assert_eq!(report.exit_code(), 0);
+        assert_eq!(
+            report.coverage().verified,
+            CoverageMetric {
+                covered: 1,
+                total: 1,
+            }
+        );
+        assert!(report.evidence()[0].satisfies_required());
+    }
+
+    #[test]
+    fn failed_atom_then_pass_is_flaky_even_if_attempt_summary_claimed_pass() {
+        let evidence = evidence(
+            "binding.retry-summary",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![
+                attempt(1, Disposition::Passed, vec![atom("first", false)]),
+                attempt(2, Disposition::Passed, vec![atom("second", true)]),
+            ],
+        );
+
+        let report = report("full", vec![evidence]);
+
+        assert_eq!(report.evidence()[0].disposition(), Disposition::Flaky);
+        assert_eq!(report.exit_code(), 1);
+    }
+
+    #[test]
+    fn profile_qualification_does_not_promote_fast_evidence_to_full() {
+        let fast = evidence(
+            "binding.fast",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Passed, vec![atom("fast", true)])],
+        );
+        let excluded_from_full = evidence(
+            "binding.fast",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Excluded,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Passed, vec![atom("fast", true)])],
+        );
+
+        let fast_report = report("fast", vec![fast]);
+        assert_eq!(fast_report.exit_code(), 0);
+        assert_eq!(fast_report.profile_qualification(), "profile:fast");
+
+        let full_report = report("full", vec![excluded_from_full]);
+        assert_eq!(full_report.exit_code(), 1);
+        assert_eq!(full_report.coverage().verified.covered, 0);
+    }
+
+    #[test]
+    fn full_profile_cannot_hide_an_obligation_behind_other_selected_evidence() {
+        let selected = evidence(
+            "binding.selected",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(
+                1,
+                Disposition::Passed,
+                vec![atom("selected", true)],
+            )],
+        );
+        let mut excluded = evidence(
+            "binding.excluded-other",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Excluded,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(
+                1,
+                Disposition::Passed,
+                vec![atom("excluded", true)],
+            )],
+        );
+        excluded.obligation_id = "outcome.report.other".to_string();
+
+        let fast = report("fast", vec![selected.clone(), excluded.clone()]);
+        assert_eq!(fast.exit_code(), 0);
+        assert_eq!(fast.profile_qualification(), "profile:fast");
+
+        let full = report("full", vec![selected, excluded]);
+        assert_eq!(
+            full.coverage().verified,
+            CoverageMetric {
+                covered: 1,
+                total: 2,
+            }
+        );
+        assert_eq!(full.exit_code(), 1);
+        assert_eq!(
+            serde_json::to_value(&full).unwrap()["unmet_required_binding_ids"],
+            serde_json::json!(["binding.excluded-other"])
+        );
+    }
+
+    #[test]
+    fn executable_coverage_requires_every_selected_required_binding() {
+        let executable = evidence(
+            "binding.executable",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Passed, vec![atom("pass", true)])],
+        );
+        let unsupported = evidence(
+            "binding.unsupported",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Unsupported,
+            Freshness::Current,
+            Vec::new(),
+        );
+
+        let report = report("full", vec![executable, unsupported]);
+
+        assert_eq!(
+            report.coverage().executable,
+            CoverageMetric {
+                covered: 0,
+                total: 1,
+            }
+        );
+        assert_eq!(report.exit_code(), 1);
+    }
+
+    #[test]
+    fn every_selected_binding_requires_its_own_current_evidence_atom() {
+        let with_atom = evidence(
+            "binding.with-atom",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Passed, vec![atom("present", true)])],
+        );
+        let without_atom = evidence(
+            "binding.without-atom",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Passed, vec![])],
+        );
+
+        let report = report("full", vec![with_atom, without_atom]);
+        assert_eq!(report.exit_code(), 1);
+        assert_eq!(report.coverage().required_bindings.total, 2);
+        assert_eq!(report.coverage().required_bindings.covered, 1);
+    }
+
+    #[test]
+    fn advisory_and_excluded_bindings_remain_visible_but_never_satisfy() {
+        let advisory = evidence(
+            "binding.advisory",
+            EvidenceRequirement::Advisory,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(
+                1,
+                Disposition::Passed,
+                vec![atom("advisory", true)],
+            )],
+        );
+        let excluded = evidence(
+            "binding.excluded",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Excluded,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(
+                1,
+                Disposition::Passed,
+                vec![atom("excluded", true)],
+            )],
+        );
+
+        let report = report("full", vec![advisory, excluded]);
+        assert_eq!(report.evidence().len(), 2);
+        assert_eq!(report.coverage().advisory_bindings, 1);
+        assert_eq!(report.coverage().excluded_bindings, 1);
+        assert_eq!(report.coverage().required_bindings.covered, 0);
+        assert_eq!(report.exit_code(), 1);
+    }
+
+    #[test]
+    fn human_totals_and_exit_status_come_from_the_serialized_ledger() {
+        let passed = evidence(
+            "binding.pass",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Passed, vec![atom("pass", true)])],
+        );
+        let failed = evidence(
+            "binding.fail",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Failed, vec![atom("fail", false)])],
+        );
+        let report = report("full", vec![passed, failed]);
+        let human = report.render_human(0);
+        let json = serde_json::to_value(&report).unwrap();
+
+        assert!(human.contains("1 passed, 1 failed"), "{human}");
+        assert!(
+            human.contains("Obligations: 0 verified, 1 unmet"),
+            "{human}"
+        );
+        assert!(human.contains("Exit: 1"), "{human}");
+        assert_eq!(json["coverage"]["required_bindings"]["covered"], 1);
+        assert_eq!(json["coverage"]["required_bindings"]["total"], 2);
+        assert_eq!(json["exit"]["code"], 1);
+        assert_eq!(json["obligations"][0]["binding"], "Bound");
+        assert_eq!(json["obligations"][0]["executability"], "Executable");
+        assert_eq!(json["obligations"][0]["disposition"], "Failed");
+        assert_eq!(json["obligations"][0]["freshness"], "Current");
+    }
+
+    #[test]
+    fn implementation_coverage_fails_closed_for_unproven_behavioral_feature() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            "Feature: Empty behavior\n  id: feature.empty-behavior\n",
+            "empty-behavior.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+
+        let report =
+            RunReport::implementation_coverage(&intent, &[], CoverageThresholds::default());
+        let json = serde_json::to_value(&report).unwrap();
+
+        assert_eq!(report.profile_qualification(), "profile:implementation");
+        assert_eq!(report.exit_code(), 1);
+        assert_eq!(json["profile"], "implementation");
+        assert_eq!(json["exit"]["reason"], "verification-failed");
+    }
+
+    #[test]
+    fn summary_only_truth_cannot_fabricate_verified_evidence() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            "Feature: Safe report\n  id: feature.safe-report\n\n  Scenario: Execute\n    id: scenario.safe-report.execute\n    When execution is recorded\n    → id: outcome.safe-report.executed; result is observed\n",
+            "safe-report.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        let mut truth = VerificationTruth::from_intent(&intent);
+        let obligation = &mut truth.obligations[0];
+        obligation.binding = BindingStatus::Bound;
+        obligation.executability = ExecutabilityStatus::Executable;
+        obligation.disposition = Disposition::Passed;
+        obligation.evidence_bindings.push(EvidenceBinding {
+            id: "binding.summary-only".to_string(),
+            obligation_id: obligation.id.to_string(),
+            source: SourceSpan::single_line("verification.tnt", 1, 1, 10),
+            declaration: DeclarationStatus::Declared,
+            linkage: LinkageStatus::Linked,
+            binding: BindingStatus::Bound,
+            executability: ExecutabilityStatus::Executable,
+            disposition: Disposition::Passed,
+            freshness: Freshness::Current,
+            assertion_resolution: AssertionResolution::Resolved,
+            evidence_atoms: 99,
+        });
+
+        let report = RunReport::from_truth(&truth, "full", true);
+        assert_eq!(report.coverage().verified.covered, 0);
+        assert_eq!(report.evidence()[0].disposition(), Disposition::NoResult);
+        assert_eq!(report.exit_code(), 1);
+    }
+}

--- a/src/verification/report.rs
+++ b/src/verification/report.rs
@@ -883,12 +883,17 @@ impl RunReport {
         thresholds: CoverageThresholds,
     ) -> Self {
         let mut truth = VerificationTruth::from_intent(intent);
-        for feature in &legacy.features {
-            if !feature.implementations.is_empty() {
+        if legacy.features.len() == intent.features.len() {
+            for (feature, intent_feature) in legacy.features.iter().zip(&intent.features) {
+                if feature.feature_name != intent_feature.name || feature.implementations.is_empty()
+                {
+                    continue;
+                }
+                let verification_id = intent_feature.verification_id.as_str();
                 for obligation in truth
                     .obligations
                     .iter_mut()
-                    .filter(|obligation| obligation.feature_id.as_str() == feature.feature_id)
+                    .filter(|obligation| obligation.feature_id.as_str() == verification_id)
                 {
                     obligation.linkage = LinkageStatus::Linked;
                 }
@@ -1073,6 +1078,9 @@ impl RunReport {
     }
 
     pub fn render_human(&self, verbosity: usize) -> String {
+        if self.profile == "implementation" {
+            return self.render_implementation_human();
+        }
         let passed = self.coverage.required_bindings.covered;
         let failed = self.coverage.required_bindings.total - passed;
         let mut scenario_total = 0;
@@ -1156,6 +1164,67 @@ impl RunReport {
                 self.coverage.advisory_bindings, self.coverage.excluded_bindings
             ));
         }
+        output.push_str(&format!(
+            "Exit: {} ({:?})\n",
+            self.exit.code, self.exit.reason
+        ));
+        output
+    }
+
+    fn render_implementation_human(&self) -> String {
+        let mut output = String::new();
+        let mut linked_features = 0;
+        let mut unlinked_features = 0;
+        output.push_str("=== NTNT Intent Verification ===\n");
+        output.push_str(&format!(
+            "Profile: {} ({})\n",
+            self.profile, self.profile_qualification
+        ));
+
+        for feature in &self.features {
+            if feature.declaration == DeclarationStatus::DocumentationOnly {
+                output.push_str(&format!(
+                    "[DOCS] {} (documentation-only, non-verifying)\n",
+                    human_feature_name(&feature.name)
+                ));
+                continue;
+            }
+            let obligations = self
+                .obligations
+                .iter()
+                .filter(|obligation| obligation.feature_id == feature.id)
+                .collect::<Vec<_>>();
+            let linked = !obligations.is_empty()
+                && obligations
+                    .iter()
+                    .all(|obligation| obligation.linkage == LinkageStatus::Linked);
+            let linked_obligations = obligations
+                .iter()
+                .filter(|obligation| obligation.linkage == LinkageStatus::Linked)
+                .count();
+            if linked {
+                linked_features += 1;
+            } else {
+                unlinked_features += 1;
+            }
+            output.push_str(&format!(
+                "[{}] {} ({linked_obligations}/{} obligations linked)\n",
+                if linked { "LINKED" } else { "UNLINKED" },
+                human_feature_name(&feature.name),
+                obligations.len()
+            ));
+        }
+
+        output.push_str(&format!(
+            "Features: {linked_features} linked, {unlinked_features} unlinked; {} documentation-only\n",
+            self.coverage.documentation_only_features
+        ));
+        output.push_str(&format!(
+            "Coverage: implementation {:.1}%, executable {:.1}%, verified {:.1}%\n",
+            self.coverage.implementation.percentage(),
+            self.coverage.executable.percentage(),
+            self.coverage.verified.percentage()
+        ));
         output.push_str(&format!(
             "Exit: {} ({:?})\n",
             self.exit.code, self.exit.reason

--- a/src/verification/report.rs
+++ b/src/verification/report.rs
@@ -395,45 +395,39 @@ impl RunReport {
         let mut evidence = Vec::new();
         for obligation in &truth.obligations {
             if obligation.evidence_bindings.is_empty() {
-                evidence.push(
-                    EvidenceResult::recorded(
-                        format!("binding.unbound.{}", obligation.id),
-                        obligation.id.to_string(),
-                        obligation.source.clone(),
-                        EvidenceRequirement::Required,
-                        EvidenceSelection::Selected,
-                        obligation.declaration,
-                        obligation.linkage,
-                        BindingStatus::Unbound,
-                        obligation.executability,
-                        obligation.freshness,
-                        AssertionResolution::Unresolved,
-                        Vec::new(),
-                    )
-                    .qualify(profile),
-                );
+                evidence.push(EvidenceResult::recorded(
+                    format!("binding.unbound.{}", obligation.id),
+                    obligation.id.to_string(),
+                    obligation.source.clone(),
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    obligation.declaration,
+                    obligation.linkage,
+                    BindingStatus::Unbound,
+                    obligation.executability,
+                    obligation.freshness,
+                    AssertionResolution::Unresolved,
+                    Vec::new(),
+                ));
             } else {
                 for binding in &obligation.evidence_bindings {
                     // Slice 1A stores only a summary atom count. It is intentionally
                     // not expanded into evidence: only executor/live compatibility
                     // paths carrying concrete assertion atoms may verify coverage.
-                    evidence.push(
-                        EvidenceResult::recorded(
-                            binding.id.clone(),
-                            obligation.id.to_string(),
-                            binding.source.clone(),
-                            EvidenceRequirement::Required,
-                            EvidenceSelection::Selected,
-                            binding.declaration,
-                            binding.linkage,
-                            binding.binding,
-                            binding.executability,
-                            binding.freshness,
-                            binding.assertion_resolution,
-                            Vec::new(),
-                        )
-                        .qualify(profile),
-                    );
+                    evidence.push(EvidenceResult::recorded(
+                        binding.id.clone(),
+                        obligation.id.to_string(),
+                        binding.source.clone(),
+                        EvidenceRequirement::Required,
+                        EvidenceSelection::Selected,
+                        binding.declaration,
+                        binding.linkage,
+                        binding.binding,
+                        binding.executability,
+                        binding.freshness,
+                        binding.assertion_resolution,
+                        Vec::new(),
+                    ));
                 }
             }
         }
@@ -459,21 +453,26 @@ impl RunReport {
     ) -> Self {
         let mut truth = VerificationTruth::from_intent(intent);
         let mut evidence = Vec::new();
+        let mut compatibility_obligations = Vec::new();
+        let mut report_features = truth
+            .features
+            .iter()
+            .map(ReportFeature::from)
+            .collect::<Vec<_>>();
 
         for (feature_index, feature) in truth.features.iter_mut().enumerate() {
-            let (Some(intent_feature), Some(live_feature)) = (
-                intent.features.get(feature_index),
-                live.features.get(feature_index),
-            ) else {
+            let Some(intent_feature) = intent.features.get(feature_index) else {
                 continue;
             };
+            let live_feature = live.features.get(feature_index);
             let expected_live_id = intent_feature.id.as_deref().unwrap_or("unknown");
-            if live_feature.feature_id != expected_live_id
-                || live_feature.feature_name != intent_feature.name
+            let exact_feature_mapping = live_feature.is_some_and(|candidate| {
+                candidate.feature_id == expected_live_id
+                    && candidate.feature_name == intent_feature.name
+            });
+            let linkage = if exact_feature_mapping
+                && live_feature.is_some_and(|candidate| candidate.has_implementation)
             {
-                continue;
-            }
-            let linkage = if live_feature.has_implementation {
                 LinkageStatus::Linked
             } else {
                 LinkageStatus::Unlinked
@@ -486,51 +485,321 @@ impl RunReport {
                 obligation.linkage = linkage;
             }
 
+            append_legacy_test_projection(
+                &mut evidence,
+                &mut compatibility_obligations,
+                intent_feature,
+                live_feature.filter(|_| exact_feature_mapping),
+                linkage,
+            );
+
+            let Some(live_feature) = live_feature else {
+                continue;
+            };
+            if !exact_feature_mapping {
+                append_unmapped_feature_results(
+                    &mut evidence,
+                    &mut compatibility_obligations,
+                    intent_feature,
+                    live_feature,
+                    feature_index,
+                    "live feature identity does not match parsed feature declaration",
+                );
+                continue;
+            }
+
+            let mut consumed_live_scenarios = BTreeSet::new();
             for scenario in &intent_feature.scenarios {
-                let matching: Vec<&LiveScenarioResult> = live_feature
+                let matching: Vec<(usize, &LiveScenarioResult)> = live_feature
                     .scenarios
                     .iter()
+                    .enumerate()
                     .filter(|candidate| {
-                        candidate.name == scenario.name
-                            || candidate.name.starts_with(&format!("{} [", scenario.name))
+                        live_scenario_name_matches(&candidate.1.name, &scenario.name)
+                            && intent_feature
+                                .scenarios
+                                .iter()
+                                .filter(|parsed| {
+                                    live_scenario_name_matches(&candidate.1.name, &parsed.name)
+                                })
+                                .count()
+                                == 1
                     })
                     .collect();
-                for (run_index, live_scenario) in matching.iter().enumerate() {
-                    append_live_scenario_evidence(
+                for (run_index, (live_index, live_scenario)) in matching.iter().enumerate() {
+                    consumed_live_scenarios.insert(*live_index);
+                    if scenario.outcome_metadata.is_empty() {
+                        append_mapping_failure(
+                            &mut evidence,
+                            &mut compatibility_obligations,
+                            format!(
+                                "outcome.compat.{}.run.{}.undeclared",
+                                scenario.verification_id,
+                                run_index + 1
+                            ),
+                            format!(
+                                "binding.compat.{}.run.{}.undeclared",
+                                scenario.verification_id,
+                                run_index + 1
+                            ),
+                            intent_feature.verification_id.to_string(),
+                            scenario.source.clone(),
+                            format!("scenario result '{}'", live_scenario.name),
+                            linkage,
+                            "live scenario result has no declared outcome obligation",
+                            live_scenario
+                                .test_result
+                                .as_ref()
+                                .map(live_test_atoms)
+                                .unwrap_or_default(),
+                        );
+                    } else {
+                        append_live_scenario_evidence(
+                            &mut evidence,
+                            scenario,
+                            live_scenario,
+                            linkage,
+                            run_index,
+                        );
+                    }
+                }
+            }
+
+            for (live_index, live_scenario) in live_feature.scenarios.iter().enumerate() {
+                if !consumed_live_scenarios.contains(&live_index) {
+                    append_mapping_failure(
                         &mut evidence,
-                        scenario,
-                        live_scenario,
+                        &mut compatibility_obligations,
+                        format!(
+                            "outcome.compat.{}.unmapped-scenario.{}",
+                            intent_feature.verification_id,
+                            live_index + 1
+                        ),
+                        format!(
+                            "binding.compat.{}.unmapped-scenario.{}",
+                            intent_feature.verification_id,
+                            live_index + 1
+                        ),
+                        intent_feature.verification_id.to_string(),
+                        intent_feature.source.clone(),
+                        format!("unmapped live scenario '{}'", live_scenario.name),
                         linkage,
-                        profile,
-                        run_index,
+                        "live scenario cannot map exactly to a parsed scenario declaration",
+                        live_scenario
+                            .test_result
+                            .as_ref()
+                            .map(live_test_atoms)
+                            .unwrap_or_default(),
                     );
                 }
             }
         }
 
+        for (feature_index, live_feature) in
+            live.features.iter().enumerate().skip(intent.features.len())
+        {
+            let source = SourceSpan::single_line(&intent.source_path, 1, 1, 1);
+            append_unmapped_live_feature(
+                &mut evidence,
+                &mut compatibility_obligations,
+                live_feature,
+                feature_index,
+                source,
+                "live feature has no parsed feature declaration",
+            );
+        }
+
+        for (component_index, component) in intent.components.iter().enumerate() {
+            if component.scenarios.is_empty() {
+                continue;
+            }
+            let component_feature_id = compatibility_component_id(component, component_index);
+            let component_source = component
+                .scenarios
+                .first()
+                .map(|scenario| scenario.source.clone())
+                .unwrap_or_else(|| SourceSpan::single_line(&intent.source_path, 1, 1, 1));
+            report_features.push(ReportFeature {
+                id: component_feature_id.clone(),
+                name: format!("Component: {}", component.name),
+                source: component_source,
+                declaration: DeclarationStatus::Declared,
+                rationale: None,
+            });
+            for scenario in &component.scenarios {
+                for (statement, metadata) in
+                    scenario.outcomes.iter().zip(&scenario.outcome_metadata)
+                {
+                    compatibility_obligations.push(ReportObligation {
+                        id: metadata.id.to_string(),
+                        feature_id: component_feature_id.clone(),
+                        scenario_id: scenario.verification_id.to_string(),
+                        statement: statement.clone(),
+                        source: metadata.source.clone(),
+                        declaration: DeclarationStatus::Declared,
+                        linkage: LinkageStatus::Linked,
+                        binding: BindingStatus::Unbound,
+                        executability: ExecutabilityStatus::Unsupported,
+                        disposition: Disposition::NoResult,
+                        freshness: Freshness::Current,
+                    });
+                }
+            }
+
+            let live_component = live.components.get(component_index);
+            let exact_component_mapping = live_component.is_some_and(|candidate| {
+                candidate.component_id == component.id && candidate.component_name == component.name
+            });
+            let Some(live_component) = live_component else {
+                continue;
+            };
+            if !exact_component_mapping {
+                append_unmapped_component_results(
+                    &mut evidence,
+                    &mut compatibility_obligations,
+                    &component_feature_id,
+                    component,
+                    live_component,
+                    component_index,
+                    "live component identity does not match parsed component declaration",
+                );
+                continue;
+            }
+
+            let mut consumed_live_scenarios = BTreeSet::new();
+            for scenario in &component.scenarios {
+                let matching = live_component
+                    .scenarios
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, candidate)| {
+                        live_scenario_name_matches(&candidate.name, &scenario.name)
+                            && component
+                                .scenarios
+                                .iter()
+                                .filter(|parsed| {
+                                    live_scenario_name_matches(&candidate.name, &parsed.name)
+                                })
+                                .count()
+                                == 1
+                    })
+                    .collect::<Vec<_>>();
+                for (run_index, (live_index, live_scenario)) in matching.iter().enumerate() {
+                    consumed_live_scenarios.insert(*live_index);
+                    if scenario.outcome_metadata.is_empty() {
+                        append_mapping_failure(
+                            &mut evidence,
+                            &mut compatibility_obligations,
+                            format!(
+                                "outcome.compat.{}.run.{}.undeclared",
+                                scenario.verification_id,
+                                run_index + 1
+                            ),
+                            format!(
+                                "binding.compat.{}.run.{}.undeclared",
+                                scenario.verification_id,
+                                run_index + 1
+                            ),
+                            component_feature_id.clone(),
+                            scenario.source.clone(),
+                            format!("component scenario result '{}'", live_scenario.name),
+                            LinkageStatus::Linked,
+                            "live component scenario result has no declared outcome obligation",
+                            live_scenario
+                                .test_result
+                                .as_ref()
+                                .map(live_test_atoms)
+                                .unwrap_or_default(),
+                        );
+                    } else {
+                        append_live_scenario_evidence(
+                            &mut evidence,
+                            scenario,
+                            live_scenario,
+                            LinkageStatus::Linked,
+                            run_index,
+                        );
+                    }
+                }
+            }
+            for (live_index, live_scenario) in live_component.scenarios.iter().enumerate() {
+                if !consumed_live_scenarios.contains(&live_index) {
+                    append_mapping_failure(
+                        &mut evidence,
+                        &mut compatibility_obligations,
+                        format!(
+                            "outcome.compat.{}.unmapped-scenario.{}",
+                            component_feature_id,
+                            live_index + 1
+                        ),
+                        format!(
+                            "binding.compat.{}.unmapped-scenario.{}",
+                            component_feature_id,
+                            live_index + 1
+                        ),
+                        component_feature_id.clone(),
+                        component
+                            .scenarios
+                            .first()
+                            .map(|scenario| scenario.source.clone())
+                            .unwrap_or_else(|| {
+                                SourceSpan::single_line(&intent.source_path, 1, 1, 1)
+                            }),
+                        format!("unmapped live scenario '{}'", live_scenario.name),
+                        LinkageStatus::Linked,
+                        "live component scenario cannot map exactly to a parsed declaration",
+                        live_scenario
+                            .test_result
+                            .as_ref()
+                            .map(live_test_atoms)
+                            .unwrap_or_default(),
+                    );
+                }
+            }
+        }
+
+        for (component_index, live_component) in live
+            .components
+            .iter()
+            .enumerate()
+            .skip(intent.components.len())
+        {
+            append_unmapped_live_component(
+                &mut evidence,
+                &mut compatibility_obligations,
+                live_component,
+                component_index,
+                SourceSpan::single_line(&intent.source_path, 1, 1, 1),
+                "live component has no parsed component declaration",
+            );
+        }
+
+        let mut report_obligations = truth
+            .obligations
+            .iter()
+            .map(ReportObligation::from)
+            .collect::<Vec<_>>();
+        report_obligations.extend(compatibility_obligations);
         let evidenced: BTreeSet<String> = evidence
             .iter()
             .map(|result| result.obligation_id.clone())
             .collect();
-        for obligation in &truth.obligations {
-            if !evidenced.contains(obligation.id.as_str()) {
-                evidence.push(
-                    EvidenceResult::recorded(
-                        format!("binding.unbound.{}", obligation.id),
-                        obligation.id.to_string(),
-                        obligation.source.clone(),
-                        EvidenceRequirement::Required,
-                        EvidenceSelection::Selected,
-                        obligation.declaration,
-                        obligation.linkage,
-                        BindingStatus::Unbound,
-                        ExecutabilityStatus::Unsupported,
-                        Freshness::Current,
-                        AssertionResolution::Unresolved,
-                        Vec::new(),
-                    )
-                    .qualify(profile),
-                );
+        for obligation in &report_obligations {
+            if !evidenced.contains(&obligation.id) {
+                evidence.push(EvidenceResult::recorded(
+                    format!("binding.unbound.{}", obligation.id),
+                    obligation.id.clone(),
+                    obligation.source.clone(),
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    obligation.declaration,
+                    obligation.linkage,
+                    BindingStatus::Unbound,
+                    ExecutabilityStatus::Unsupported,
+                    Freshness::Current,
+                    AssertionResolution::Unresolved,
+                    Vec::new(),
+                ));
             }
         }
 
@@ -538,12 +807,8 @@ impl RunReport {
             profile,
             strict,
             evidence,
-            truth.features.iter().map(ReportFeature::from).collect(),
-            truth
-                .obligations
-                .iter()
-                .map(ReportObligation::from)
-                .collect(),
+            report_features,
+            report_obligations,
             CoverageThresholds::default(),
         )
     }
@@ -579,8 +844,6 @@ impl RunReport {
         }
         let mut report = Self::from_truth(&truth, "implementation", false);
         report.thresholds = thresholds;
-        report.coverage =
-            coverage_from_ledger(&report.features, &report.obligations, &report.evidence);
         let has_unproven_behavioral_feature = report.features.iter().any(|feature| {
             feature.declaration == DeclarationStatus::Declared
                 && !report
@@ -790,12 +1053,519 @@ impl RunReport {
     }
 }
 
+fn live_scenario_name_matches(live_name: &str, parsed_name: &str) -> bool {
+    live_name == parsed_name || live_name.starts_with(&format!("{parsed_name} ["))
+}
+
+fn legacy_test_obligation_id(
+    feature: &crate::intent::Feature,
+    test_index: usize,
+    assertion_index: usize,
+) -> String {
+    format!(
+        "outcome.compat.{}.test.{}.assertion.{}",
+        feature.verification_id,
+        test_index + 1,
+        assertion_index + 1
+    )
+}
+
+fn legacy_test_binding_id(
+    feature: &crate::intent::Feature,
+    test_index: usize,
+    assertion_index: usize,
+) -> String {
+    format!(
+        "binding.compat.{}.test.{}.assertion.{}",
+        feature.verification_id,
+        test_index + 1,
+        assertion_index + 1
+    )
+}
+
+fn append_legacy_test_projection(
+    evidence: &mut Vec<EvidenceResult>,
+    obligations: &mut Vec<ReportObligation>,
+    feature: &crate::intent::Feature,
+    live_feature: Option<&crate::intent::LiveFeatureResult>,
+    linkage: LinkageStatus,
+) {
+    for (test_index, test) in feature.tests.iter().enumerate() {
+        let assertion_count = test.assertions.len().max(1);
+        let live_test = live_feature.and_then(|candidate| candidate.tests.get(test_index));
+        let exact_test_mapping =
+            live_test.is_some_and(|candidate| {
+                candidate.method == test.method
+                    && candidate.path == test.path
+                    && candidate.preconditions.len() == test.preconditions.len()
+                    && test.preconditions.iter().zip(&candidate.preconditions).all(
+                        |(expected, actual)| {
+                            crate::intent::format_assertion(expected) == actual.assertion_text
+                        },
+                    )
+                    && candidate.assertions.len() == test.assertions.len()
+                    && test.assertions.iter().zip(&candidate.assertions).all(
+                        |(expected, actual)| {
+                            crate::intent::format_assertion(expected) == actual.assertion_text
+                        },
+                    )
+            });
+
+        for assertion_index in 0..assertion_count {
+            let obligation_id = legacy_test_obligation_id(feature, test_index, assertion_index);
+            let binding_id = legacy_test_binding_id(feature, test_index, assertion_index);
+            let statement = test
+                .assertions
+                .get(assertion_index)
+                .map(crate::intent::format_assertion)
+                .unwrap_or_else(|| {
+                    format!(
+                        "{} {} produces concrete assertion evidence",
+                        test.method, test.path
+                    )
+                });
+            obligations.push(ReportObligation {
+                id: obligation_id.clone(),
+                feature_id: feature.verification_id.to_string(),
+                scenario_id: format!(
+                    "scenario.compat.{}.test.{}",
+                    feature.verification_id,
+                    test_index + 1
+                ),
+                statement,
+                source: feature.source.clone(),
+                declaration: DeclarationStatus::Declared,
+                linkage,
+                binding: BindingStatus::Unbound,
+                executability: ExecutabilityStatus::Unsupported,
+                disposition: Disposition::NoResult,
+                freshness: Freshness::Current,
+            });
+
+            let Some(live_test) = live_test else {
+                evidence.push(EvidenceResult::recorded(
+                    binding_id,
+                    obligation_id,
+                    feature.source.clone(),
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    DeclarationStatus::Declared,
+                    linkage,
+                    BindingStatus::Unbound,
+                    ExecutabilityStatus::Unsupported,
+                    Freshness::Current,
+                    AssertionResolution::Unresolved,
+                    vec![EvidenceAttempt {
+                        sequence: 1,
+                        disposition: Disposition::NoResult,
+                        evidence_atoms: Vec::new(),
+                        diagnostic: Some(
+                            "parsed technical test has no corresponding live result".to_string(),
+                        ),
+                    }],
+                ));
+                continue;
+            };
+
+            if !exact_test_mapping {
+                let expected = test.assertions.len();
+                let actual = live_test.assertions.len();
+                evidence.push(EvidenceResult::recorded(
+                    binding_id,
+                    obligation_id,
+                    feature.source.clone(),
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    DeclarationStatus::Declared,
+                    linkage,
+                    BindingStatus::Ambiguous,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    AssertionResolution::Unresolved,
+                    vec![EvidenceAttempt {
+                        sequence: 1,
+                        disposition: Disposition::NoResult,
+                        evidence_atoms: live_test_atoms(live_test),
+                        diagnostic: Some(format!(
+                            "cannot safely map live technical test {} {} with {actual} assertions \
+                             to parsed declaration {} {} with {expected} assertions",
+                            live_test.method, live_test.path, test.method, test.path
+                        )),
+                    }],
+                ));
+                continue;
+            }
+
+            let Some(live_assertion) = live_test.assertions.get(assertion_index) else {
+                // A zero-assertion technical test has no concrete evidence atom
+                // and therefore cannot satisfy its compatibility obligation.
+                evidence.push(EvidenceResult::recorded(
+                    binding_id,
+                    obligation_id,
+                    feature.source.clone(),
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    DeclarationStatus::Declared,
+                    linkage,
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Executable,
+                    Freshness::Current,
+                    AssertionResolution::Unresolved,
+                    vec![EvidenceAttempt {
+                        sequence: 1,
+                        disposition: Disposition::NoResult,
+                        evidence_atoms: live_test_atoms(live_test),
+                        diagnostic: Some(
+                            "technical test produced no concrete assertion evidence".to_string(),
+                        ),
+                    }],
+                ));
+                continue;
+            };
+
+            let mut atoms = live_precondition_atoms(live_test, &binding_id);
+            atoms.push(EvidenceAtom {
+                id: format!("{binding_id}.assertion.{}", assertion_index + 1),
+                assertion: live_assertion.assertion_text.clone(),
+                passed: live_assertion.passed,
+                diagnostic: live_assertion.message.clone(),
+            });
+            let failed_precondition = live_test
+                .preconditions
+                .iter()
+                .any(|precondition| !precondition.passed);
+            let disposition = if failed_precondition || !live_assertion.passed {
+                Disposition::Failed
+            } else {
+                Disposition::Passed
+            };
+            evidence.push(EvidenceResult::recorded(
+                binding_id,
+                obligation_id,
+                feature.source.clone(),
+                EvidenceRequirement::Required,
+                EvidenceSelection::Selected,
+                DeclarationStatus::Declared,
+                linkage,
+                BindingStatus::Bound,
+                if failed_precondition {
+                    ExecutabilityStatus::Blocked
+                } else {
+                    ExecutabilityStatus::Executable
+                },
+                Freshness::Current,
+                AssertionResolution::Resolved,
+                vec![EvidenceAttempt {
+                    sequence: 1,
+                    disposition,
+                    evidence_atoms: atoms,
+                    diagnostic: failed_precondition
+                        .then(|| "one or more test preconditions failed".to_string()),
+                }],
+            ));
+        }
+    }
+
+    let Some(live_feature) = live_feature else {
+        return;
+    };
+    for (test_index, live_test) in live_feature
+        .tests
+        .iter()
+        .enumerate()
+        .skip(feature.tests.len())
+    {
+        append_mapping_failure(
+            evidence,
+            obligations,
+            format!(
+                "outcome.compat.{}.unmapped-test.{}",
+                feature.verification_id,
+                test_index + 1
+            ),
+            format!(
+                "binding.compat.{}.unmapped-test.{}",
+                feature.verification_id,
+                test_index + 1
+            ),
+            feature.verification_id.to_string(),
+            feature.source.clone(),
+            format!(
+                "unmapped live technical test {} {}",
+                live_test.method, live_test.path
+            ),
+            linkage,
+            "live technical test has no parsed test declaration",
+            live_test_atoms(live_test),
+        );
+    }
+}
+
+fn live_precondition_atoms(
+    live_test: &crate::intent::LiveTestResult,
+    binding_id: &str,
+) -> Vec<EvidenceAtom> {
+    live_test
+        .preconditions
+        .iter()
+        .enumerate()
+        .map(|(index, result)| EvidenceAtom {
+            id: format!("{binding_id}.precondition.{}", index + 1),
+            assertion: result.assertion_text.clone(),
+            passed: result.passed,
+            diagnostic: result.message.clone(),
+        })
+        .collect()
+}
+
+fn live_test_atoms(live_test: &crate::intent::LiveTestResult) -> Vec<EvidenceAtom> {
+    let mut atoms = live_precondition_atoms(live_test, "atom.compat.unmapped");
+    atoms.extend(
+        live_test
+            .assertions
+            .iter()
+            .enumerate()
+            .map(|(index, result)| EvidenceAtom {
+                id: format!("atom.compat.unmapped.assertion.{}", index + 1),
+                assertion: result.assertion_text.clone(),
+                passed: result.passed,
+                diagnostic: result.message.clone(),
+            }),
+    );
+    atoms
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_mapping_failure(
+    evidence: &mut Vec<EvidenceResult>,
+    obligations: &mut Vec<ReportObligation>,
+    obligation_id: String,
+    binding_id: String,
+    feature_id: String,
+    source: SourceSpan,
+    statement: String,
+    linkage: LinkageStatus,
+    diagnostic: &str,
+    atoms: Vec<EvidenceAtom>,
+) {
+    obligations.push(ReportObligation {
+        id: obligation_id.clone(),
+        feature_id,
+        scenario_id: format!("scenario.{obligation_id}"),
+        statement,
+        source: source.clone(),
+        declaration: DeclarationStatus::Declared,
+        linkage,
+        binding: BindingStatus::Ambiguous,
+        executability: ExecutabilityStatus::Unsupported,
+        disposition: Disposition::NoResult,
+        freshness: Freshness::Current,
+    });
+    evidence.push(EvidenceResult::recorded(
+        binding_id,
+        obligation_id,
+        source,
+        EvidenceRequirement::Required,
+        EvidenceSelection::Selected,
+        DeclarationStatus::Declared,
+        linkage,
+        BindingStatus::Ambiguous,
+        ExecutabilityStatus::Unsupported,
+        Freshness::Current,
+        AssertionResolution::Unresolved,
+        vec![EvidenceAttempt {
+            sequence: 1,
+            disposition: Disposition::NoResult,
+            evidence_atoms: atoms,
+            diagnostic: Some(diagnostic.to_string()),
+        }],
+    ));
+}
+
+fn append_unmapped_feature_results(
+    evidence: &mut Vec<EvidenceResult>,
+    obligations: &mut Vec<ReportObligation>,
+    feature: &crate::intent::Feature,
+    live_feature: &crate::intent::LiveFeatureResult,
+    feature_index: usize,
+    diagnostic: &str,
+) {
+    append_unmapped_live_feature(
+        evidence,
+        obligations,
+        live_feature,
+        feature_index,
+        feature.source.clone(),
+        diagnostic,
+    );
+}
+
+fn append_unmapped_live_feature(
+    evidence: &mut Vec<EvidenceResult>,
+    obligations: &mut Vec<ReportObligation>,
+    live_feature: &crate::intent::LiveFeatureResult,
+    feature_index: usize,
+    source: SourceSpan,
+    diagnostic: &str,
+) {
+    for (test_index, live_test) in live_feature.tests.iter().enumerate() {
+        append_mapping_failure(
+            evidence,
+            obligations,
+            format!(
+                "outcome.compat.unmapped-feature.{}.test.{}",
+                feature_index + 1,
+                test_index + 1
+            ),
+            format!(
+                "binding.compat.unmapped-feature.{}.test.{}",
+                feature_index + 1,
+                test_index + 1
+            ),
+            if live_feature.feature_id.is_empty() {
+                format!("feature.compat.unmapped.{}", feature_index + 1)
+            } else {
+                live_feature.feature_id.clone()
+            },
+            source.clone(),
+            format!(
+                "unmapped live technical test {} {}",
+                live_test.method, live_test.path
+            ),
+            LinkageStatus::Unlinked,
+            diagnostic,
+            live_test_atoms(live_test),
+        );
+    }
+    for (scenario_index, live_scenario) in live_feature.scenarios.iter().enumerate() {
+        append_mapping_failure(
+            evidence,
+            obligations,
+            format!(
+                "outcome.compat.unmapped-feature.{}.scenario.{}",
+                feature_index + 1,
+                scenario_index + 1
+            ),
+            format!(
+                "binding.compat.unmapped-feature.{}.scenario.{}",
+                feature_index + 1,
+                scenario_index + 1
+            ),
+            if live_feature.feature_id.is_empty() {
+                format!("feature.compat.unmapped.{}", feature_index + 1)
+            } else {
+                live_feature.feature_id.clone()
+            },
+            source.clone(),
+            format!("unmapped live scenario '{}'", live_scenario.name),
+            LinkageStatus::Unlinked,
+            diagnostic,
+            live_scenario
+                .test_result
+                .as_ref()
+                .map(live_test_atoms)
+                .unwrap_or_default(),
+        );
+    }
+}
+
+fn compatibility_component_id(component: &crate::intent::Component, index: usize) -> String {
+    if component.id.is_empty() {
+        format!("component.compat.{}", index + 1)
+    } else {
+        component.id.clone()
+    }
+}
+
+fn append_unmapped_component_results(
+    evidence: &mut Vec<EvidenceResult>,
+    obligations: &mut Vec<ReportObligation>,
+    component_feature_id: &str,
+    component: &crate::intent::Component,
+    live_component: &crate::intent::LiveComponentResult,
+    component_index: usize,
+    diagnostic: &str,
+) {
+    let source = component
+        .scenarios
+        .first()
+        .map(|scenario| scenario.source.clone())
+        .unwrap_or_else(|| SourceSpan::single_line("", 1, 1, 1));
+    append_unmapped_live_component_with_id(
+        evidence,
+        obligations,
+        live_component,
+        component_index,
+        component_feature_id,
+        source,
+        diagnostic,
+    );
+}
+
+fn append_unmapped_live_component(
+    evidence: &mut Vec<EvidenceResult>,
+    obligations: &mut Vec<ReportObligation>,
+    live_component: &crate::intent::LiveComponentResult,
+    component_index: usize,
+    source: SourceSpan,
+    diagnostic: &str,
+) {
+    append_unmapped_live_component_with_id(
+        evidence,
+        obligations,
+        live_component,
+        component_index,
+        &format!("component.compat.unmapped.{}", component_index + 1),
+        source,
+        diagnostic,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_unmapped_live_component_with_id(
+    evidence: &mut Vec<EvidenceResult>,
+    obligations: &mut Vec<ReportObligation>,
+    live_component: &crate::intent::LiveComponentResult,
+    component_index: usize,
+    component_feature_id: &str,
+    source: SourceSpan,
+    diagnostic: &str,
+) {
+    for (scenario_index, live_scenario) in live_component.scenarios.iter().enumerate() {
+        append_mapping_failure(
+            evidence,
+            obligations,
+            format!(
+                "outcome.compat.{}.unmapped-component.{}.scenario.{}",
+                component_feature_id,
+                component_index + 1,
+                scenario_index + 1
+            ),
+            format!(
+                "binding.compat.{}.unmapped-component.{}.scenario.{}",
+                component_feature_id,
+                component_index + 1,
+                scenario_index + 1
+            ),
+            component_feature_id.to_string(),
+            source.clone(),
+            format!("unmapped live component scenario '{}'", live_scenario.name),
+            LinkageStatus::Linked,
+            diagnostic,
+            live_scenario
+                .test_result
+                .as_ref()
+                .map(live_test_atoms)
+                .unwrap_or_default(),
+        );
+    }
+}
+
 fn append_live_scenario_evidence(
     evidence: &mut Vec<EvidenceResult>,
     scenario: &crate::intent::Scenario,
     live: &LiveScenarioResult,
     linkage: LinkageStatus,
-    profile: &str,
     run_index: usize,
 ) {
     let assertions = live
@@ -803,94 +1573,160 @@ fn append_live_scenario_evidence(
         .as_ref()
         .map(|result| result.assertions.as_slice())
         .unwrap_or_default();
-    let exact_mapping = assertions.len() == scenario.outcome_metadata.len();
+    let exact_mapping =
+        assertions.len() == scenario.outcome_metadata.len() && live.outcomes == scenario.outcomes;
 
     for (outcome_index, metadata) in scenario.outcome_metadata.iter().enumerate() {
-        let (binding, executability, resolution, attempts) = match live.status.as_str() {
-            "skip" => (
+        let binding_id = format!(
+            "binding.compat.{}.{}.{}",
+            scenario.verification_id,
+            run_index + 1,
+            outcome_index + 1
+        );
+        let failed_precondition = live.test_result.as_ref().is_some_and(|result| {
+            result
+                .preconditions
+                .iter()
+                .any(|precondition| !precondition.passed)
+        });
+        let all_atoms = live
+            .test_result
+            .as_ref()
+            .map(|test| {
+                let mut atoms = live_precondition_atoms(test, &binding_id);
+                if let Some(assertion) = test.assertions.get(outcome_index) {
+                    atoms.push(EvidenceAtom {
+                        id: format!("{binding_id}.assertion.{}", outcome_index + 1),
+                        assertion: assertion.assertion_text.clone(),
+                        passed: assertion.passed,
+                        diagnostic: assertion.message.clone(),
+                    });
+                }
+                atoms
+            })
+            .unwrap_or_default();
+        let (binding, executability, resolution, attempts) = if failed_precondition {
+            (
                 BindingStatus::Bound,
-                ExecutabilityStatus::Executable,
+                ExecutabilityStatus::Blocked,
                 AssertionResolution::Resolved,
                 vec![EvidenceAttempt {
                     sequence: 1,
-                    disposition: Disposition::Skipped,
-                    evidence_atoms: Vec::new(),
-                    diagnostic: Some("precondition was not met".to_string()),
+                    disposition: Disposition::Failed,
+                    evidence_atoms: all_atoms,
+                    diagnostic: Some("one or more scenario preconditions failed".to_string()),
                 }],
-            ),
-            "pass" | "fail" if exact_mapping => {
-                let assertion = &assertions[outcome_index];
-                let disposition = if assertion.passed {
-                    Disposition::Passed
-                } else {
-                    Disposition::Failed
-                };
-                (
+            )
+        } else {
+            match live.status.as_str() {
+                "pass" | "fail" if exact_mapping => {
+                    let assertion = &assertions[outcome_index];
+                    let disposition = if live.status == "pass" && assertion.passed {
+                        Disposition::Passed
+                    } else {
+                        Disposition::Failed
+                    };
+                    (
+                        BindingStatus::Bound,
+                        ExecutabilityStatus::Executable,
+                        AssertionResolution::Resolved,
+                        vec![EvidenceAttempt {
+                            sequence: 1,
+                            disposition,
+                            evidence_atoms: all_atoms,
+                            diagnostic: None,
+                        }],
+                    )
+                }
+                "pass" | "fail" => (
+                    BindingStatus::Ambiguous,
+                    ExecutabilityStatus::Executable,
+                    AssertionResolution::Unresolved,
+                    vec![EvidenceAttempt {
+                        sequence: 1,
+                        disposition: Disposition::NoResult,
+                        evidence_atoms: live
+                            .test_result
+                            .as_ref()
+                            .map(live_test_atoms)
+                            .unwrap_or_default(),
+                        diagnostic: Some(format!(
+                            "cannot safely map {} assertions to {} outcomes",
+                            assertions.len(),
+                            scenario.outcome_metadata.len()
+                        )),
+                    }],
+                ),
+                "warning" => (
                     BindingStatus::Bound,
                     ExecutabilityStatus::Executable,
+                    AssertionResolution::Unresolved,
+                    vec![EvidenceAttempt {
+                        sequence: 1,
+                        disposition: Disposition::NoResult,
+                        evidence_atoms: live
+                            .test_result
+                            .as_ref()
+                            .map(live_test_atoms)
+                            .unwrap_or_default(),
+                        diagnostic: Some(if live.unresolved_outcomes.is_empty() {
+                            "scenario completed with unresolved warning status".to_string()
+                        } else {
+                            format!(
+                                "scenario has unresolved outcomes: {}",
+                                live.unresolved_outcomes.join(", ")
+                            )
+                        }),
+                    }],
+                ),
+                "skip" => (
+                    BindingStatus::Bound,
+                    ExecutabilityStatus::Blocked,
                     AssertionResolution::Resolved,
                     vec![EvidenceAttempt {
                         sequence: 1,
-                        disposition,
-                        evidence_atoms: vec![EvidenceAtom {
-                            id: format!(
-                                "atom.{}.{}.{}",
-                                metadata.id,
-                                run_index + 1,
-                                outcome_index + 1
-                            ),
-                            assertion: assertion.assertion_text.clone(),
-                            passed: assertion.passed,
-                            diagnostic: assertion.message.clone(),
-                        }],
-                        diagnostic: None,
+                        disposition: Disposition::Skipped,
+                        evidence_atoms: live
+                            .test_result
+                            .as_ref()
+                            .map(live_test_atoms)
+                            .unwrap_or_default(),
+                        diagnostic: Some("precondition was not met".to_string()),
                     }],
-                )
-            }
-            "pass" | "fail" => (
-                BindingStatus::Bound,
-                ExecutabilityStatus::Executable,
-                AssertionResolution::Unresolved,
-                vec![EvidenceAttempt {
-                    sequence: 1,
-                    disposition: Disposition::NoResult,
-                    evidence_atoms: Vec::new(),
-                    diagnostic: Some(format!(
-                        "cannot safely map {} assertions to {} outcomes",
-                        assertions.len(),
-                        scenario.outcome_metadata.len()
-                    )),
-                }],
-            ),
-            _ => (
-                BindingStatus::Unbound,
-                ExecutabilityStatus::Unsupported,
-                AssertionResolution::Unresolved,
-                Vec::new(),
-            ),
-        };
-        evidence.push(
-            EvidenceResult::recorded(
-                format!(
-                    "binding.compat.{}.{}.{}",
-                    scenario.verification_id,
-                    run_index + 1,
-                    outcome_index + 1
                 ),
-                metadata.id.to_string(),
-                metadata.source.clone(),
-                EvidenceRequirement::Required,
-                EvidenceSelection::Selected,
-                DeclarationStatus::Declared,
-                linkage,
-                binding,
-                executability,
-                Freshness::Current,
-                resolution,
-                attempts,
-            )
-            .qualify(profile),
-        );
+                status => (
+                    BindingStatus::Unbound,
+                    ExecutabilityStatus::Unsupported,
+                    AssertionResolution::Unresolved,
+                    vec![EvidenceAttempt {
+                        sequence: 1,
+                        disposition: Disposition::NoResult,
+                        evidence_atoms: live
+                            .test_result
+                            .as_ref()
+                            .map(live_test_atoms)
+                            .unwrap_or_default(),
+                        diagnostic: Some(format!(
+                            "scenario produced non-verifying status '{status}'"
+                        )),
+                    }],
+                ),
+            }
+        };
+        evidence.push(EvidenceResult::recorded(
+            binding_id,
+            metadata.id.to_string(),
+            metadata.source.clone(),
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            DeclarationStatus::Declared,
+            linkage,
+            binding,
+            executability,
+            Freshness::Current,
+            resolution,
+            attempts,
+        ));
     }
 }
 
@@ -1122,6 +1958,9 @@ fn decide_exit(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::intent::{
+        LiveAssertionResult, LiveComponentResult, LiveFeatureResult, LiveTestResult,
+    };
     use crate::verification::{
         AssertionResolution, BindingStatus, DeclarationStatus, Disposition, EvidenceBinding,
         ExecutabilityStatus, Freshness, IdMode, LinkageStatus, SourceSpan, VerificationTruth,
@@ -1176,6 +2015,79 @@ mod tests {
 
     fn report(profile: &str, evidence: Vec<EvidenceResult>) -> RunReport {
         RunReport::assemble_for_tests(profile, true, evidence)
+    }
+
+    fn live_assertion(text: &str, passed: bool) -> LiveAssertionResult {
+        LiveAssertionResult {
+            assertion_text: text.to_string(),
+            passed,
+            message: (!passed).then(|| format!("{text} failed")),
+            resolution_trace: None,
+            checks: Vec::new(),
+        }
+    }
+
+    fn live_test(
+        method: &str,
+        path: &str,
+        passed: bool,
+        assertions: Vec<LiveAssertionResult>,
+    ) -> LiveTestResult {
+        LiveTestResult {
+            method: method.to_string(),
+            path: path.to_string(),
+            passed,
+            assertions,
+            preconditions: Vec::new(),
+            scenario_name: None,
+        }
+    }
+
+    fn live_scenario(
+        name: &str,
+        status: &str,
+        assertions: Option<Vec<LiveAssertionResult>>,
+    ) -> LiveScenarioResult {
+        LiveScenarioResult {
+            name: name.to_string(),
+            description: None,
+            given_clause: None,
+            when_clause: "the check runs".to_string(),
+            outcomes: assertions
+                .as_ref()
+                .map(|assertions| {
+                    assertions
+                        .iter()
+                        .map(|assertion| assertion.assertion_text.clone())
+                        .collect()
+                })
+                .unwrap_or_default(),
+            status: status.to_string(),
+            test_result: assertions
+                .map(|assertions| live_test("GET", "/", status == "pass", assertions)),
+            unresolved_outcomes: Vec::new(),
+            component_refs: Vec::new(),
+        }
+    }
+
+    fn live_results(
+        features: Vec<LiveFeatureResult>,
+        components: Vec<LiveComponentResult>,
+    ) -> LiveTestResults {
+        LiveTestResults {
+            features,
+            components,
+            // Deliberately nonsensical: compatibility projection must consume
+            // concrete results, never these cached summaries.
+            total_assertions: 0,
+            passed_assertions: 0,
+            failed_assertions: 999,
+            linked_features: 0,
+            total_features: 999,
+            title: None,
+            glossary: None,
+            summary: None,
+        }
     }
 
     #[test]
@@ -1482,6 +2394,559 @@ mod tests {
             }
         );
         assert!(report.evidence()[0].satisfies_required());
+    }
+
+    #[test]
+    fn legacy_technical_tests_are_required_with_deterministic_qualified_ids() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Feature: Legacy technical
+  id: feature.legacy-technical
+  test:
+    - request: GET /health
+      assert:
+        - status: 200
+        - body contains "ok"
+"#,
+            "legacy-technical.intent".to_string(),
+            IdMode::Compatibility,
+        )
+        .unwrap();
+        let feature = |assertions: Vec<LiveAssertionResult>| {
+            let test_passed = assertions.iter().all(|assertion| assertion.passed);
+            LiveFeatureResult {
+                feature_id: "feature.legacy-technical".to_string(),
+                feature_name: "Legacy technical".to_string(),
+                description: None,
+                // This cached feature boolean deliberately lies.
+                passed: false,
+                tests: vec![live_test("GET", "/health", test_passed, assertions)],
+                scenarios: Vec::new(),
+                has_implementation: true,
+            }
+        };
+
+        let passing = RunReport::from_live_results(
+            &intent,
+            &live_results(
+                vec![feature(vec![
+                    live_assertion("status: 200", true),
+                    live_assertion("body contains \"ok\"", true),
+                ])],
+                Vec::new(),
+            ),
+            "legacy-live",
+            true,
+        );
+        assert_eq!(passing.exit_code(), 0);
+        assert_eq!(passing.evidence().len(), 2);
+        assert!(passing
+            .evidence()
+            .iter()
+            .all(EvidenceResult::satisfies_required));
+        assert_eq!(
+            passing.evidence()[0].obligation_id(),
+            "outcome.compat.feature.legacy-technical.test.1.assertion.1"
+        );
+        assert_eq!(
+            passing.evidence()[0].id(),
+            "binding.compat.feature.legacy-technical.test.1.assertion.1"
+        );
+        assert_eq!(passing.evidence()[0].profile(), "legacy-live");
+        assert_eq!(passing.evidence()[0].source.path, "legacy-technical.intent");
+
+        let failing = RunReport::from_live_results(
+            &intent,
+            &live_results(
+                vec![feature(vec![
+                    live_assertion("status: 200", true),
+                    live_assertion("body contains \"ok\"", false),
+                ])],
+                Vec::new(),
+            ),
+            "legacy-live",
+            true,
+        );
+        assert_eq!(failing.exit_code(), 1);
+        assert_eq!(failing.coverage().required_bindings.total, 2);
+        assert_eq!(failing.coverage().required_bindings.covered, 1);
+    }
+
+    #[test]
+    fn legacy_technical_mapping_is_fail_closed_for_missing_extra_and_mismatched_results() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Feature: Mapping
+  id: feature.mapping
+  test:
+    - request: GET /mapped
+      assert:
+        - status: 200
+        - body contains "mapped"
+"#,
+            "mapping.intent".to_string(),
+            IdMode::Compatibility,
+        )
+        .unwrap();
+        let report_for = |tests| {
+            RunReport::from_live_results(
+                &intent,
+                &live_results(
+                    vec![LiveFeatureResult {
+                        feature_id: "feature.mapping".to_string(),
+                        feature_name: "Mapping".to_string(),
+                        description: None,
+                        passed: true,
+                        tests,
+                        scenarios: Vec::new(),
+                        has_implementation: true,
+                    }],
+                    Vec::new(),
+                ),
+                "legacy-live",
+                true,
+            )
+        };
+
+        for (case, tests) in [
+            (
+                "missing assertion",
+                vec![live_test(
+                    "GET",
+                    "/mapped",
+                    true,
+                    vec![live_assertion("status: 200", true)],
+                )],
+            ),
+            (
+                "extra assertion",
+                vec![live_test(
+                    "GET",
+                    "/mapped",
+                    true,
+                    vec![
+                        live_assertion("status: 200", true),
+                        live_assertion("body contains \"mapped\"", true),
+                        live_assertion("unexpected", true),
+                    ],
+                )],
+            ),
+            (
+                "mismatched test",
+                vec![live_test(
+                    "POST",
+                    "/different",
+                    true,
+                    vec![
+                        live_assertion("status: 200", true),
+                        live_assertion("body contains \"mapped\"", true),
+                    ],
+                )],
+            ),
+            (
+                "mismatched assertions",
+                vec![live_test(
+                    "GET",
+                    "/mapped",
+                    true,
+                    vec![
+                        live_assertion("body contains \"mapped\"", true),
+                        live_assertion("status: 200", true),
+                    ],
+                )],
+            ),
+            ("missing test", Vec::new()),
+            (
+                "extra test",
+                vec![
+                    live_test(
+                        "GET",
+                        "/mapped",
+                        true,
+                        vec![
+                            live_assertion("status: 200", true),
+                            live_assertion("body contains \"mapped\"", true),
+                        ],
+                    ),
+                    live_test(
+                        "GET",
+                        "/extra",
+                        true,
+                        vec![live_assertion("extra result", true)],
+                    ),
+                ],
+            ),
+        ] {
+            let report = report_for(tests);
+            assert_eq!(report.exit_code(), 1, "{case}");
+            assert!(
+                report.evidence().iter().any(|result| {
+                    result.disposition() == Disposition::NoResult
+                        || result.assertion_resolution == AssertionResolution::Unresolved
+                }),
+                "{case}: {:?}",
+                report.evidence()
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_technical_preconditions_must_map_exactly() {
+        let mut intent = IntentFile::parse_content_with_id_mode(
+            r#"Feature: Preconditions
+  id: feature.technical-preconditions
+  test:
+    - request: GET /guarded
+      assert:
+        - status: 200
+"#,
+            "technical-preconditions.intent".to_string(),
+            IdMode::Compatibility,
+        )
+        .unwrap();
+        intent.features[0].tests[0].preconditions = vec![crate::intent::Assertion::Status(204)];
+
+        let report_for = |preconditions: Vec<LiveAssertionResult>| {
+            let mut test = live_test(
+                "GET",
+                "/guarded",
+                true,
+                vec![live_assertion("status: 200", true)],
+            );
+            test.preconditions = preconditions;
+            RunReport::from_live_results(
+                &intent,
+                &live_results(
+                    vec![LiveFeatureResult {
+                        feature_id: "feature.technical-preconditions".to_string(),
+                        feature_name: "Preconditions".to_string(),
+                        description: None,
+                        passed: true,
+                        tests: vec![test],
+                        scenarios: Vec::new(),
+                        has_implementation: true,
+                    }],
+                    Vec::new(),
+                ),
+                "legacy-live",
+                true,
+            )
+        };
+
+        assert_eq!(
+            report_for(vec![live_assertion("status: 204", true)]).exit_code(),
+            0
+        );
+        assert_eq!(report_for(Vec::new()).exit_code(), 1);
+        assert_eq!(
+            report_for(vec![
+                live_assertion("status: 204", true),
+                live_assertion("extra", true),
+            ])
+            .exit_code(),
+            1
+        );
+        assert_eq!(
+            report_for(vec![live_assertion("status: 205", true)]).exit_code(),
+            1
+        );
+    }
+
+    #[test]
+    fn failed_preconditions_override_passing_outcome_atoms() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Feature: Preconditions
+  id: feature.preconditions
+
+  Scenario: Protected action
+    id: scenario.preconditions.protected
+    Given access is allowed
+    When the check runs
+    → id: outcome.preconditions.completed; action completes
+"#,
+            "preconditions.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        let mut scenario = live_scenario(
+            "Protected action",
+            "fail",
+            Some(vec![live_assertion("action completes", true)]),
+        );
+        scenario.test_result.as_mut().unwrap().preconditions =
+            vec![live_assertion("access is allowed", false)];
+        let report = RunReport::from_live_results(
+            &intent,
+            &live_results(
+                vec![LiveFeatureResult {
+                    feature_id: "feature.preconditions".to_string(),
+                    feature_name: "Preconditions".to_string(),
+                    description: None,
+                    passed: false,
+                    tests: Vec::new(),
+                    scenarios: vec![scenario],
+                    has_implementation: true,
+                }],
+                Vec::new(),
+            ),
+            "legacy-live",
+            true,
+        );
+
+        assert_eq!(report.exit_code(), 1);
+        assert_eq!(report.evidence()[0].disposition(), Disposition::Failed);
+        assert!(report.evidence()[0].attempts()[0]
+            .evidence_atoms()
+            .iter()
+            .any(|atom| !atom.passed()));
+    }
+
+    #[test]
+    fn warning_pending_and_unresolved_scenarios_never_become_no_evidence_successes() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Feature: Incomplete
+  id: feature.incomplete
+
+  Scenario: Resolve me
+    id: scenario.incomplete.resolve
+    When the check runs
+    → id: outcome.incomplete.resolved; result resolves
+"#,
+            "incomplete.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        for status in ["warning", "pending", "unresolved", "unknown"] {
+            let mut scenario = live_scenario(
+                "Resolve me",
+                status,
+                (status == "warning").then(|| vec![live_assertion("result resolves", true)]),
+            );
+            scenario.unresolved_outcomes = vec!["result resolves".to_string()];
+            let report = RunReport::from_live_results(
+                &intent,
+                &live_results(
+                    vec![LiveFeatureResult {
+                        feature_id: "feature.incomplete".to_string(),
+                        feature_name: "Incomplete".to_string(),
+                        description: None,
+                        passed: true,
+                        tests: Vec::new(),
+                        scenarios: vec![scenario],
+                        has_implementation: true,
+                    }],
+                    Vec::new(),
+                ),
+                "legacy-live",
+                true,
+            );
+            assert_eq!(report.exit_code(), 1, "{status}");
+            assert!(!report.evidence()[0].satisfies_required(), "{status}");
+        }
+    }
+
+    #[test]
+    fn every_expanded_scenario_run_is_a_required_binding() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Feature: Expanded
+  id: feature.expanded
+
+  Scenario: Row check
+    id: scenario.expanded.row-check
+    When the check runs
+    → id: outcome.expanded.row-valid; row is valid
+"#,
+            "expanded.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        let feature = |second_passes| LiveFeatureResult {
+            feature_id: "feature.expanded".to_string(),
+            feature_name: "Expanded".to_string(),
+            description: None,
+            passed: second_passes,
+            tests: Vec::new(),
+            scenarios: vec![
+                live_scenario(
+                    "Row check [first]",
+                    "pass",
+                    Some(vec![live_assertion("row is valid", true)]),
+                ),
+                live_scenario(
+                    "Row check [second]",
+                    if second_passes { "pass" } else { "fail" },
+                    Some(vec![live_assertion("row is valid", second_passes)]),
+                ),
+            ],
+            has_implementation: true,
+        };
+
+        let passing = RunReport::from_live_results(
+            &intent,
+            &live_results(vec![feature(true)], Vec::new()),
+            "legacy-live",
+            true,
+        );
+        assert_eq!(passing.exit_code(), 0);
+        assert_eq!(passing.coverage().required_bindings.total, 2);
+
+        let failing = RunReport::from_live_results(
+            &intent,
+            &live_results(vec![feature(false)], Vec::new()),
+            "legacy-live",
+            true,
+        );
+        assert_eq!(failing.exit_code(), 1);
+        assert_eq!(failing.coverage().required_bindings.covered, 1);
+    }
+
+    #[test]
+    fn component_scenario_outcomes_use_explicit_ids_and_fail_closed() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Component: Reusable
+  id: component.reusable
+
+  Scenario: Component check
+    id: scenario.component.reusable-check
+    When the check runs
+    → id: outcome.component.reusable-valid; component is valid
+
+Feature: Host
+  id: feature.host
+  verification: documentation-only
+  rationale: Component-only compatibility fixture
+"#,
+            "component.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        let component = |status, assertion_passes| LiveComponentResult {
+            component_id: "component.reusable".to_string(),
+            component_name: "Reusable".to_string(),
+            description: String::new(),
+            inherent_behavior: Vec::new(),
+            passed: assertion_passes,
+            scenarios: vec![live_scenario(
+                "Component check",
+                status,
+                Some(vec![live_assertion("component is valid", assertion_passes)]),
+            )],
+        };
+
+        let passing = RunReport::from_live_results(
+            &intent,
+            &live_results(Vec::new(), vec![component("pass", true)]),
+            "legacy-live",
+            true,
+        );
+        assert_eq!(passing.exit_code(), 0);
+        assert_eq!(
+            passing.evidence()[0].obligation_id(),
+            "outcome.component.reusable-valid"
+        );
+        assert_eq!(passing.evidence()[0].profile(), "legacy-live");
+        assert_eq!(passing.evidence()[0].source.start_line, 7);
+
+        for failing_component in [
+            component("fail", false),
+            component("warning", true),
+            LiveComponentResult {
+                scenarios: Vec::new(),
+                ..component("pass", true)
+            },
+        ] {
+            let failing = RunReport::from_live_results(
+                &intent,
+                &live_results(Vec::new(), vec![failing_component]),
+                "legacy-live",
+                true,
+            );
+            assert_eq!(failing.exit_code(), 1);
+        }
+    }
+
+    #[test]
+    fn component_mapping_preconditions_and_repeated_runs_are_all_required() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Component: Expanded component
+  id: component.expanded
+
+  Scenario: Component row
+    id: scenario.component.expanded-row
+    Given component access is allowed
+    When the check runs
+    → id: outcome.component.expanded-valid; component row is valid
+
+Feature: Host
+  id: feature.host
+  verification: documentation-only
+  rationale: Component-only compatibility fixture
+"#,
+            "component-expanded.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        let component_report = |scenarios| {
+            RunReport::from_live_results(
+                &intent,
+                &live_results(
+                    Vec::new(),
+                    vec![LiveComponentResult {
+                        component_id: "component.expanded".to_string(),
+                        component_name: "Expanded component".to_string(),
+                        description: String::new(),
+                        inherent_behavior: Vec::new(),
+                        passed: true,
+                        scenarios,
+                    }],
+                ),
+                "legacy-live",
+                true,
+            )
+        };
+
+        let passing = component_report(vec![
+            live_scenario(
+                "Component row [first]",
+                "pass",
+                Some(vec![live_assertion("component row is valid", true)]),
+            ),
+            live_scenario(
+                "Component row [second]",
+                "pass",
+                Some(vec![live_assertion("component row is valid", true)]),
+            ),
+        ]);
+        assert_eq!(passing.exit_code(), 0);
+        assert_eq!(passing.coverage().required_bindings.total, 2);
+
+        let mut failed_precondition = live_scenario(
+            "Component row",
+            "fail",
+            Some(vec![live_assertion("component row is valid", true)]),
+        );
+        failed_precondition
+            .test_result
+            .as_mut()
+            .unwrap()
+            .preconditions = vec![live_assertion("component access is allowed", false)];
+        assert_eq!(component_report(vec![failed_precondition]).exit_code(), 1);
+
+        for assertions in [
+            Vec::new(),
+            vec![
+                live_assertion("component row is valid", true),
+                live_assertion("extra", true),
+            ],
+        ] {
+            assert_eq!(
+                component_report(vec![live_scenario(
+                    "Component row",
+                    "pass",
+                    Some(assertions),
+                )])
+                .exit_code(),
+                1
+            );
+        }
     }
 
     #[test]

--- a/src/verification/report.rs
+++ b/src/verification/report.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
@@ -923,10 +923,42 @@ impl RunReport {
         obligations: Vec<ReportObligation>,
         thresholds: CoverageThresholds,
     ) -> Self {
-        let evidence: Vec<_> = evidence
+        let duplicate_obligation_ids = duplicate_obligation_ids(&obligations);
+        let mut evidence: Vec<_> = evidence
             .into_iter()
             .map(|result| result.qualify(profile))
             .collect();
+        for (index, obligation_id) in duplicate_obligation_ids.iter().enumerate() {
+            let obligation = obligations
+                .iter()
+                .find(|obligation| obligation.id == *obligation_id)
+                .expect("duplicate obligation id came from this ledger");
+            evidence.push(
+                EvidenceResult::recorded(
+                    format!("binding.obligation-id-collision.{}", index + 1),
+                    obligation_id.clone(),
+                    obligation.source.clone(),
+                    EvidenceRequirement::Required,
+                    EvidenceSelection::Selected,
+                    DeclarationStatus::Declared,
+                    LinkageStatus::Unlinked,
+                    BindingStatus::Ambiguous,
+                    ExecutabilityStatus::Unsupported,
+                    Freshness::Current,
+                    AssertionResolution::Unresolved,
+                    vec![EvidenceAttempt {
+                        sequence: 1,
+                        disposition: Disposition::NoResult,
+                        evidence_atoms: Vec::new(),
+                        diagnostic: Some(format!(
+                            "duplicate obligation id '{obligation_id}' cannot be verified"
+                        )),
+                    }],
+                )
+                .in_scenario("Obligation identity collision")
+                .qualify(profile),
+            );
+        }
         let obligations = obligations
             .into_iter()
             .map(|obligation| summarize_obligation(obligation, &evidence))
@@ -1155,7 +1187,16 @@ impl RunReport {
         }
 
         let mut scenarios = Vec::new();
+        let duplicate_ids = duplicate_obligation_ids(&self.obligations);
         for scenario in declared {
+            if scenario
+                .obligations
+                .iter()
+                .any(|obligation| duplicate_ids.contains(&obligation.id))
+            {
+                scenarios.push(scenario);
+                continue;
+            }
             let matching = self
                 .evidence
                 .iter()
@@ -2038,6 +2079,17 @@ fn aggregate_disposition(evidence: &[&EvidenceResult]) -> Disposition {
     Disposition::Passed
 }
 
+fn duplicate_obligation_ids(obligations: &[ReportObligation]) -> BTreeSet<String> {
+    let mut counts = BTreeMap::new();
+    for obligation in obligations {
+        *counts.entry(obligation.id.clone()).or_insert(0usize) += 1;
+    }
+    counts
+        .into_iter()
+        .filter_map(|(id, count)| (count > 1).then_some(id))
+        .collect()
+}
+
 fn satisfies_ledger(result: &EvidenceResult, evidence: &[EvidenceResult]) -> bool {
     result.satisfies_required() && selected_binding_id_count(result, evidence) == 1
 }
@@ -2063,13 +2115,19 @@ fn coverage_from_ledger(
         .filter(|obligation| obligation.declaration == DeclarationStatus::Declared)
         .collect();
     let total = behavioral_obligations.len();
+    let duplicate_ids = duplicate_obligation_ids(obligations);
     let implementation = behavioral_obligations
         .iter()
-        .filter(|obligation| obligation.linkage == LinkageStatus::Linked)
+        .filter(|obligation| {
+            !duplicate_ids.contains(&obligation.id) && obligation.linkage == LinkageStatus::Linked
+        })
         .count();
     let executable = behavioral_obligations
         .iter()
         .filter(|obligation| {
+            if duplicate_ids.contains(&obligation.id) {
+                return false;
+            }
             let selected = evidence
                 .iter()
                 .filter(|result| {
@@ -2088,6 +2146,9 @@ fn coverage_from_ledger(
     let verified = behavioral_obligations
         .iter()
         .filter(|obligation| {
+            if duplicate_ids.contains(&obligation.id) {
+                return false;
+            }
             let selected: Vec<_> = evidence
                 .iter()
                 .filter(|result| {
@@ -3344,6 +3405,72 @@ Feature: Host
             ),
             "{human}"
         );
+    }
+
+    #[test]
+    fn generated_inherent_ids_cannot_collide_into_a_false_pass() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Component: Collision
+  id: component.collision
+  Inherent Behavior:
+    → status 200
+
+  Scenario: Concrete check
+    id: scenario.component.collision.concrete
+    When the component is requested
+    → id: outcome.compat.component.collision.inherent.1; status 200
+
+Feature: Host
+  id: feature.host
+  verification: documentation-only
+  rationale: Component-only compatibility fixture
+"#,
+            "component-collision.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        let live_component = LiveComponentResult {
+            component_id: "component.collision".to_string(),
+            component_name: "Collision".to_string(),
+            description: String::new(),
+            inherent_behavior: intent.components[0].inherent_behavior.clone(),
+            passed: true,
+            scenarios: vec![live_scenario(
+                "Concrete check",
+                "pass",
+                Some(vec![live_assertion("status 200", true)]),
+            )],
+        };
+
+        let report = RunReport::from_live_results(
+            &intent,
+            &live_results(Vec::new(), vec![live_component]),
+            "legacy-live",
+            true,
+        );
+
+        assert_eq!(report.exit_code(), 1);
+        assert_eq!(report.coverage().implementation.covered, 0);
+        assert_eq!(report.coverage().executable.covered, 0);
+        assert_eq!(report.coverage().verified.covered, 0);
+        assert_eq!(report.coverage().required_bindings.total, 2);
+        assert_eq!(report.coverage().required_bindings.covered, 1);
+        assert!(report
+            .unmet_required_binding_ids
+            .iter()
+            .any(|id| id.starts_with("binding.obligation-id-collision.")));
+        assert!(report.evidence().iter().any(|result| {
+            result
+                .attempts()
+                .iter()
+                .filter_map(EvidenceAttempt::diagnostic)
+                .any(|diagnostic| diagnostic.contains("duplicate obligation id"))
+        }));
+        let human = report.render_human(1);
+        assert!(human.contains("[FAIL] Component: Collision"), "{human}");
+        assert!(human.contains("[NO RESULT] Concrete check"), "{human}");
+        assert!(human.contains("[NO RESULT] Inherent behavior"), "{human}");
+        assert!(human.contains("duplicate obligation id"), "{human}");
     }
 
     #[test]

--- a/src/verification/report.rs
+++ b/src/verification/report.rs
@@ -497,12 +497,12 @@ impl RunReport {
                 continue;
             };
             if !exact_feature_mapping {
-                append_unmapped_feature_results(
+                append_unmapped_live_feature(
                     &mut evidence,
                     &mut compatibility_obligations,
-                    intent_feature,
                     live_feature,
                     feature_index,
+                    intent_feature.source.clone(),
                     "live feature identity does not match parsed feature declaration",
                 );
                 continue;
@@ -547,11 +547,7 @@ impl RunReport {
                             format!("scenario result '{}'", live_scenario.name),
                             linkage,
                             "live scenario result has no declared outcome obligation",
-                            live_scenario
-                                .test_result
-                                .as_ref()
-                                .map(live_test_atoms)
-                                .unwrap_or_default(),
+                            live_scenario_atoms(live_scenario),
                         );
                     } else {
                         append_live_scenario_evidence(
@@ -585,11 +581,7 @@ impl RunReport {
                         format!("unmapped live scenario '{}'", live_scenario.name),
                         linkage,
                         "live scenario cannot map exactly to a parsed scenario declaration",
-                        live_scenario
-                            .test_result
-                            .as_ref()
-                            .map(live_test_atoms)
-                            .unwrap_or_default(),
+                        live_scenario_atoms(live_scenario),
                     );
                 }
             }
@@ -614,15 +606,11 @@ impl RunReport {
                 continue;
             }
             let component_feature_id = compatibility_component_id(component, component_index);
-            let component_source = component
-                .scenarios
-                .first()
-                .map(|scenario| scenario.source.clone())
-                .unwrap_or_else(|| SourceSpan::single_line(&intent.source_path, 1, 1, 1));
+            let component_source = component.scenarios[0].source.clone();
             report_features.push(ReportFeature {
                 id: component_feature_id.clone(),
                 name: format!("Component: {}", component.name),
-                source: component_source,
+                source: component_source.clone(),
                 declaration: DeclarationStatus::Declared,
                 rationale: None,
             });
@@ -654,13 +642,13 @@ impl RunReport {
                 continue;
             };
             if !exact_component_mapping {
-                append_unmapped_component_results(
+                append_unmapped_live_component_with_id(
                     &mut evidence,
                     &mut compatibility_obligations,
-                    &component_feature_id,
-                    component,
                     live_component,
                     component_index,
+                    &component_feature_id,
+                    component_source.clone(),
                     "live component identity does not match parsed component declaration",
                 );
                 continue;
@@ -705,11 +693,7 @@ impl RunReport {
                             format!("component scenario result '{}'", live_scenario.name),
                             LinkageStatus::Linked,
                             "live component scenario result has no declared outcome obligation",
-                            live_scenario
-                                .test_result
-                                .as_ref()
-                                .map(live_test_atoms)
-                                .unwrap_or_default(),
+                            live_scenario_atoms(live_scenario),
                         );
                     } else {
                         append_live_scenario_evidence(
@@ -738,21 +722,11 @@ impl RunReport {
                             live_index + 1
                         ),
                         component_feature_id.clone(),
-                        component
-                            .scenarios
-                            .first()
-                            .map(|scenario| scenario.source.clone())
-                            .unwrap_or_else(|| {
-                                SourceSpan::single_line(&intent.source_path, 1, 1, 1)
-                            }),
+                        component_source.clone(),
                         format!("unmapped live scenario '{}'", live_scenario.name),
                         LinkageStatus::Linked,
                         "live component scenario cannot map exactly to a parsed declaration",
-                        live_scenario
-                            .test_result
-                            .as_ref()
-                            .map(live_test_atoms)
-                            .unwrap_or_default(),
+                        live_scenario_atoms(live_scenario),
                     );
                 }
             }
@@ -764,11 +738,12 @@ impl RunReport {
             .enumerate()
             .skip(intent.components.len())
         {
-            append_unmapped_live_component(
+            append_unmapped_live_component_with_id(
                 &mut evidence,
                 &mut compatibility_obligations,
                 live_component,
                 component_index,
+                &format!("component.compat.unmapped.{}", component_index + 1),
                 SourceSpan::single_line(&intent.source_path, 1, 1, 1),
                 "live component has no parsed component declaration",
             );
@@ -1335,6 +1310,13 @@ fn live_test_atoms(live_test: &crate::intent::LiveTestResult) -> Vec<EvidenceAto
     atoms
 }
 
+fn live_scenario_atoms(live: &LiveScenarioResult) -> Vec<EvidenceAtom> {
+    live.test_result
+        .as_ref()
+        .map(live_test_atoms)
+        .unwrap_or_default()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn append_mapping_failure(
     evidence: &mut Vec<EvidenceResult>,
@@ -1380,24 +1362,6 @@ fn append_mapping_failure(
             diagnostic: Some(diagnostic.to_string()),
         }],
     ));
-}
-
-fn append_unmapped_feature_results(
-    evidence: &mut Vec<EvidenceResult>,
-    obligations: &mut Vec<ReportObligation>,
-    feature: &crate::intent::Feature,
-    live_feature: &crate::intent::LiveFeatureResult,
-    feature_index: usize,
-    diagnostic: &str,
-) {
-    append_unmapped_live_feature(
-        evidence,
-        obligations,
-        live_feature,
-        feature_index,
-        feature.source.clone(),
-        diagnostic,
-    );
 }
 
 fn append_unmapped_live_feature(
@@ -1460,11 +1424,7 @@ fn append_unmapped_live_feature(
             format!("unmapped live scenario '{}'", live_scenario.name),
             LinkageStatus::Unlinked,
             diagnostic,
-            live_scenario
-                .test_result
-                .as_ref()
-                .map(live_test_atoms)
-                .unwrap_or_default(),
+            live_scenario_atoms(live_scenario),
         );
     }
 }
@@ -1475,50 +1435,6 @@ fn compatibility_component_id(component: &crate::intent::Component, index: usize
     } else {
         component.id.clone()
     }
-}
-
-fn append_unmapped_component_results(
-    evidence: &mut Vec<EvidenceResult>,
-    obligations: &mut Vec<ReportObligation>,
-    component_feature_id: &str,
-    component: &crate::intent::Component,
-    live_component: &crate::intent::LiveComponentResult,
-    component_index: usize,
-    diagnostic: &str,
-) {
-    let source = component
-        .scenarios
-        .first()
-        .map(|scenario| scenario.source.clone())
-        .unwrap_or_else(|| SourceSpan::single_line("", 1, 1, 1));
-    append_unmapped_live_component_with_id(
-        evidence,
-        obligations,
-        live_component,
-        component_index,
-        component_feature_id,
-        source,
-        diagnostic,
-    );
-}
-
-fn append_unmapped_live_component(
-    evidence: &mut Vec<EvidenceResult>,
-    obligations: &mut Vec<ReportObligation>,
-    live_component: &crate::intent::LiveComponentResult,
-    component_index: usize,
-    source: SourceSpan,
-    diagnostic: &str,
-) {
-    append_unmapped_live_component_with_id(
-        evidence,
-        obligations,
-        live_component,
-        component_index,
-        &format!("component.compat.unmapped.{}", component_index + 1),
-        source,
-        diagnostic,
-    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1552,11 +1468,7 @@ fn append_unmapped_live_component_with_id(
             format!("unmapped live component scenario '{}'", live_scenario.name),
             LinkageStatus::Linked,
             diagnostic,
-            live_scenario
-                .test_result
-                .as_ref()
-                .map(live_test_atoms)
-                .unwrap_or_default(),
+            live_scenario_atoms(live_scenario),
         );
     }
 }
@@ -1645,11 +1557,7 @@ fn append_live_scenario_evidence(
                     vec![EvidenceAttempt {
                         sequence: 1,
                         disposition: Disposition::NoResult,
-                        evidence_atoms: live
-                            .test_result
-                            .as_ref()
-                            .map(live_test_atoms)
-                            .unwrap_or_default(),
+                        evidence_atoms: live_scenario_atoms(live),
                         diagnostic: Some(format!(
                             "cannot safely map {} assertions to {} outcomes",
                             assertions.len(),
@@ -1664,11 +1572,7 @@ fn append_live_scenario_evidence(
                     vec![EvidenceAttempt {
                         sequence: 1,
                         disposition: Disposition::NoResult,
-                        evidence_atoms: live
-                            .test_result
-                            .as_ref()
-                            .map(live_test_atoms)
-                            .unwrap_or_default(),
+                        evidence_atoms: live_scenario_atoms(live),
                         diagnostic: Some(if live.unresolved_outcomes.is_empty() {
                             "scenario completed with unresolved warning status".to_string()
                         } else {
@@ -1686,11 +1590,7 @@ fn append_live_scenario_evidence(
                     vec![EvidenceAttempt {
                         sequence: 1,
                         disposition: Disposition::Skipped,
-                        evidence_atoms: live
-                            .test_result
-                            .as_ref()
-                            .map(live_test_atoms)
-                            .unwrap_or_default(),
+                        evidence_atoms: live_scenario_atoms(live),
                         diagnostic: Some("precondition was not met".to_string()),
                     }],
                 ),
@@ -1701,11 +1601,7 @@ fn append_live_scenario_evidence(
                     vec![EvidenceAttempt {
                         sequence: 1,
                         disposition: Disposition::NoResult,
-                        evidence_atoms: live
-                            .test_result
-                            .as_ref()
-                            .map(live_test_atoms)
-                            .unwrap_or_default(),
+                        evidence_atoms: live_scenario_atoms(live),
                         diagnostic: Some(format!(
                             "scenario produced non-verifying status '{status}'"
                         )),

--- a/src/verification/report.rs
+++ b/src/verification/report.rs
@@ -85,6 +85,8 @@ impl EvidenceAttempt {
 pub struct EvidenceResult {
     id: String,
     obligation_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scenario_name: Option<String>,
     source: SourceSpan,
     profile: String,
     requirement: EvidenceRequirement,
@@ -123,6 +125,7 @@ impl EvidenceResult {
         Self {
             id: id.into(),
             obligation_id: obligation_id.into(),
+            scenario_name: None,
             source,
             profile: String::new(),
             requirement,
@@ -141,6 +144,11 @@ impl EvidenceResult {
 
     fn qualify(mut self, profile: &str) -> Self {
         self.profile = profile.to_string();
+        self
+    }
+
+    fn in_scenario(mut self, name: &str) -> Self {
+        self.scenario_name = Some(name.to_string());
         self
     }
 
@@ -309,6 +317,7 @@ struct ReportObligation {
     id: String,
     feature_id: String,
     scenario_id: String,
+    scenario_name: String,
     statement: String,
     source: SourceSpan,
     declaration: DeclarationStatus,
@@ -319,12 +328,25 @@ struct ReportObligation {
     freshness: Freshness,
 }
 
-impl From<&Obligation> for ReportObligation {
-    fn from(obligation: &Obligation) -> Self {
+impl ReportObligation {
+    fn from_obligation(obligation: &Obligation, intent: Option<&IntentFile>) -> Self {
+        let scenario_name = intent
+            .and_then(|intent| {
+                intent
+                    .features
+                    .iter()
+                    .flat_map(|feature| &feature.scenarios)
+                    .find(|scenario| scenario.verification_id == obligation.scenario_id)
+            })
+            .map_or_else(
+                || obligation.scenario_id.to_string(),
+                |scenario| scenario.name.clone(),
+            );
         Self {
             id: obligation.id.to_string(),
             feature_id: obligation.feature_id.to_string(),
             scenario_id: obligation.scenario_id.to_string(),
+            scenario_name,
             statement: obligation.statement.clone(),
             source: obligation.source.clone(),
             declaration: obligation.declaration,
@@ -345,6 +367,14 @@ struct ReportFeature {
     declaration: DeclarationStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     rationale: Option<String>,
+}
+
+struct HumanScenario<'a> {
+    id: &'a str,
+    name: &'a str,
+    obligations: Vec<&'a ReportObligation>,
+    evidence_name: Option<&'a str>,
+    split_by_evidence_name: bool,
 }
 
 impl From<&FeatureTruth> for ReportFeature {
@@ -391,7 +421,12 @@ impl RunReport {
         Self::from_live_results(intent, &live, "legacy-live", true)
     }
 
-    fn from_truth(truth: &VerificationTruth, profile: &str, strict: bool) -> Self {
+    fn from_truth(
+        truth: &VerificationTruth,
+        intent: Option<&IntentFile>,
+        profile: &str,
+        strict: bool,
+    ) -> Self {
         let mut evidence = Vec::new();
         for obligation in &truth.obligations {
             if obligation.evidence_bindings.is_empty() {
@@ -439,7 +474,7 @@ impl RunReport {
             truth
                 .obligations
                 .iter()
-                .map(ReportObligation::from)
+                .map(|obligation| ReportObligation::from_obligation(obligation, intent))
                 .collect(),
             CoverageThresholds::default(),
         )
@@ -602,11 +637,15 @@ impl RunReport {
         }
 
         for (component_index, component) in intent.components.iter().enumerate() {
-            if component.scenarios.is_empty() {
+            if component.scenarios.is_empty() && component.inherent_behavior.is_empty() {
                 continue;
             }
             let component_feature_id = compatibility_component_id(component, component_index);
-            let component_source = component.scenarios[0].source.clone();
+            let component_source = component
+                .scenarios
+                .first()
+                .map(|scenario| scenario.source.clone())
+                .unwrap_or_else(|| SourceSpan::single_line(&intent.source_path, 1, 1, 1));
             report_features.push(ReportFeature {
                 id: component_feature_id.clone(),
                 name: format!("Component: {}", component.name),
@@ -622,16 +661,37 @@ impl RunReport {
                         id: metadata.id.to_string(),
                         feature_id: component_feature_id.clone(),
                         scenario_id: scenario.verification_id.to_string(),
+                        scenario_name: scenario.name.clone(),
                         statement: statement.clone(),
                         source: metadata.source.clone(),
                         declaration: DeclarationStatus::Declared,
-                        linkage: LinkageStatus::Linked,
+                        linkage: LinkageStatus::Unlinked,
                         binding: BindingStatus::Unbound,
                         executability: ExecutabilityStatus::Unsupported,
                         disposition: Disposition::NoResult,
                         freshness: Freshness::Current,
                     });
                 }
+            }
+            for (behavior_index, statement) in component.inherent_behavior.iter().enumerate() {
+                compatibility_obligations.push(ReportObligation {
+                    id: format!(
+                        "outcome.compat.{}.inherent.{}",
+                        component_feature_id,
+                        behavior_index + 1
+                    ),
+                    feature_id: component_feature_id.clone(),
+                    scenario_id: format!("scenario.compat.{}.inherent", component_feature_id),
+                    scenario_name: "Inherent behavior".to_string(),
+                    statement: statement.clone(),
+                    source: component_source.clone(),
+                    declaration: DeclarationStatus::Declared,
+                    linkage: LinkageStatus::Unlinked,
+                    binding: BindingStatus::Unbound,
+                    executability: ExecutabilityStatus::Unsupported,
+                    disposition: Disposition::NoResult,
+                    freshness: Freshness::Current,
+                });
             }
 
             let live_component = live.components.get(component_index);
@@ -691,7 +751,7 @@ impl RunReport {
                             component_feature_id.clone(),
                             scenario.source.clone(),
                             format!("component scenario result '{}'", live_scenario.name),
-                            LinkageStatus::Linked,
+                            LinkageStatus::Unlinked,
                             "live component scenario result has no declared outcome obligation",
                             live_scenario_atoms(live_scenario),
                         );
@@ -700,7 +760,7 @@ impl RunReport {
                             &mut evidence,
                             scenario,
                             live_scenario,
-                            LinkageStatus::Linked,
+                            LinkageStatus::Unlinked,
                             run_index,
                         );
                     }
@@ -724,7 +784,7 @@ impl RunReport {
                         component_feature_id.clone(),
                         component_source.clone(),
                         format!("unmapped live scenario '{}'", live_scenario.name),
-                        LinkageStatus::Linked,
+                        LinkageStatus::Unlinked,
                         "live component scenario cannot map exactly to a parsed declaration",
                         live_scenario_atoms(live_scenario),
                     );
@@ -752,29 +812,46 @@ impl RunReport {
         let mut report_obligations = truth
             .obligations
             .iter()
-            .map(ReportObligation::from)
+            .map(|obligation| ReportObligation::from_obligation(obligation, Some(intent)))
             .collect::<Vec<_>>();
         report_obligations.extend(compatibility_obligations);
+        for obligation in &report_obligations {
+            if !report_features
+                .iter()
+                .any(|feature| feature.id == obligation.feature_id)
+            {
+                report_features.push(ReportFeature {
+                    id: obligation.feature_id.clone(),
+                    name: format!("Unmapped {}", obligation.feature_id),
+                    source: obligation.source.clone(),
+                    declaration: DeclarationStatus::Declared,
+                    rationale: None,
+                });
+            }
+        }
         let evidenced: BTreeSet<String> = evidence
             .iter()
             .map(|result| result.obligation_id.clone())
             .collect();
         for obligation in &report_obligations {
             if !evidenced.contains(&obligation.id) {
-                evidence.push(EvidenceResult::recorded(
-                    format!("binding.unbound.{}", obligation.id),
-                    obligation.id.clone(),
-                    obligation.source.clone(),
-                    EvidenceRequirement::Required,
-                    EvidenceSelection::Selected,
-                    obligation.declaration,
-                    obligation.linkage,
-                    BindingStatus::Unbound,
-                    ExecutabilityStatus::Unsupported,
-                    Freshness::Current,
-                    AssertionResolution::Unresolved,
-                    Vec::new(),
-                ));
+                evidence.push(
+                    EvidenceResult::recorded(
+                        format!("binding.unbound.{}", obligation.id),
+                        obligation.id.clone(),
+                        obligation.source.clone(),
+                        EvidenceRequirement::Required,
+                        EvidenceSelection::Selected,
+                        obligation.declaration,
+                        obligation.linkage,
+                        BindingStatus::Unbound,
+                        ExecutabilityStatus::Unsupported,
+                        Freshness::Current,
+                        AssertionResolution::Unresolved,
+                        Vec::new(),
+                    )
+                    .in_scenario(&obligation.scenario_name),
+                );
             }
         }
 
@@ -817,7 +894,7 @@ impl RunReport {
                 }
             }
         }
-        let mut report = Self::from_truth(&truth, "implementation", false);
+        let mut report = Self::from_truth(&truth, Some(intent), "implementation", false);
         report.thresholds = thresholds;
         let has_unproven_behavioral_feature = report.features.iter().any(|feature| {
             feature.declaration == DeclarationStatus::Declared
@@ -860,7 +937,7 @@ impl RunReport {
             .filter(|result| {
                 result.requirement == EvidenceRequirement::Required
                     && ((result.selection == EvidenceSelection::Selected
-                        && !result.satisfies_required())
+                        && !satisfies_ledger(result, &evidence))
                         || (profile == "full" && result.selection == EvidenceSelection::Excluded))
             })
             .map(|result| result.id.clone())
@@ -920,6 +997,7 @@ impl RunReport {
                 id,
                 feature_id: "feature.report".to_string(),
                 scenario_id: "scenario.report".to_string(),
+                scenario_name: "Report scenario".to_string(),
                 statement: "report truth".to_string(),
                 source: SourceSpan::single_line("report.intent", 1, 1, 1),
                 declaration: DeclarationStatus::Declared,
@@ -965,40 +1043,66 @@ impl RunReport {
     pub fn render_human(&self, verbosity: usize) -> String {
         let passed = self.coverage.required_bindings.covered;
         let failed = self.coverage.required_bindings.total - passed;
+        let mut scenario_total = 0;
+        let mut scenario_passed = 0;
         let mut output = String::new();
         output.push_str("=== NTNT Intent Verification ===\n");
         output.push_str(&format!(
             "Profile: {} ({})\n",
             self.profile, self.profile_qualification
         ));
-        if verbosity > 0 {
-            for result in &self.evidence {
+
+        for feature in &self.features {
+            if feature.declaration == DeclarationStatus::DocumentationOnly {
                 output.push_str(&format!(
-                    "- {} [{}]: {:?}\n",
-                    result.obligation_id, result.id, result.disposition
+                    "[DOCS] {} (documentation-only, non-verifying",
+                    human_feature_name(&feature.name)
                 ));
-                if verbosity > 1 {
-                    for attempt in &result.attempts {
-                        output.push_str(&format!(
-                            "  attempt {}: {:?}, {} evidence atoms\n",
-                            attempt.sequence,
-                            attempt.disposition,
-                            attempt.evidence_atoms.len()
-                        ));
-                        for atom in &attempt.evidence_atoms {
-                            output.push_str(&format!(
-                                "    {} {}\n",
-                                if atom.passed { "pass" } else { "fail" },
-                                atom.assertion
-                            ));
-                            if let Some(diagnostic) = &atom.diagnostic {
-                                output.push_str(&format!("      {diagnostic}\n"));
-                            }
-                        }
+                if let Some(rationale) = &feature.rationale {
+                    output.push_str(&format!(": {rationale}"));
+                }
+                output.push_str(")\n");
+                continue;
+            }
+
+            let scenarios = self.human_scenarios(&feature.id);
+            let feature_passed = !scenarios.is_empty()
+                && scenarios.iter().all(|scenario| {
+                    self.human_scenario_disposition(scenario) == Disposition::Passed
+                });
+            let passed_in_feature = scenarios
+                .iter()
+                .filter(|scenario| self.human_scenario_disposition(scenario) == Disposition::Passed)
+                .count();
+            scenario_total += scenarios.len();
+            scenario_passed += passed_in_feature;
+            output.push_str(&format!(
+                "[{}] {} ({passed_in_feature}/{} scenarios passed)\n",
+                if feature_passed { "PASS" } else { "FAIL" },
+                human_feature_name(&feature.name),
+                scenarios.len()
+            ));
+
+            if verbosity > 0 {
+                for scenario in scenarios {
+                    let disposition = self.human_scenario_disposition(&scenario);
+                    output.push_str(&format!(
+                        "  [{}] {}\n",
+                        human_disposition(disposition),
+                        scenario.name
+                    ));
+                    if verbosity > 1 {
+                        self.render_scenario_attempts(&mut output, &scenario);
+                    } else if disposition != Disposition::Passed {
+                        self.render_scenario_failure(&mut output, &scenario);
                     }
                 }
             }
         }
+
+        output.push_str(&format!(
+            "Scenarios: {scenario_passed}/{scenario_total} passed\n"
+        ));
         output.push_str(&format!(
             "Obligations: {} verified, {} unmet; features: {} documentation-only\n",
             self.coverage.verified.covered,
@@ -1025,6 +1129,222 @@ impl RunReport {
             self.exit.code, self.exit.reason
         ));
         output
+    }
+
+    fn human_scenarios<'a>(&'a self, feature_id: &str) -> Vec<HumanScenario<'a>> {
+        let mut declared: Vec<HumanScenario<'a>> = Vec::new();
+        for obligation in self
+            .obligations
+            .iter()
+            .filter(|obligation| obligation.feature_id == feature_id)
+        {
+            if let Some(scenario) = declared
+                .iter_mut()
+                .find(|scenario| scenario.id == obligation.scenario_id)
+            {
+                scenario.obligations.push(obligation);
+            } else {
+                declared.push(HumanScenario {
+                    id: &obligation.scenario_id,
+                    name: &obligation.scenario_name,
+                    obligations: vec![obligation],
+                    evidence_name: None,
+                    split_by_evidence_name: false,
+                });
+            }
+        }
+
+        let mut scenarios = Vec::new();
+        for scenario in declared {
+            let matching = self
+                .evidence
+                .iter()
+                .filter(|result| {
+                    result.requirement == EvidenceRequirement::Required
+                        && result.selection == EvidenceSelection::Selected
+                        && scenario
+                            .obligations
+                            .iter()
+                            .any(|obligation| obligation.id == result.obligation_id)
+                })
+                .collect::<Vec<_>>();
+            let mut names = Vec::new();
+            for name in matching
+                .iter()
+                .filter_map(|result| result.scenario_name.as_deref())
+            {
+                if !names.contains(&name) {
+                    names.push(name);
+                }
+            }
+            if names.is_empty() {
+                scenarios.push(scenario);
+                continue;
+            }
+            for name in names {
+                scenarios.push(HumanScenario {
+                    id: scenario.id,
+                    name,
+                    obligations: scenario.obligations.clone(),
+                    evidence_name: Some(name),
+                    split_by_evidence_name: true,
+                });
+            }
+            if matching.iter().any(|result| result.scenario_name.is_none()) {
+                scenarios.push(HumanScenario {
+                    split_by_evidence_name: true,
+                    ..scenario
+                });
+            }
+        }
+        scenarios
+    }
+
+    fn scenario_contains_result(scenario: &HumanScenario<'_>, result: &EvidenceResult) -> bool {
+        scenario
+            .obligations
+            .iter()
+            .any(|obligation| obligation.id == result.obligation_id)
+            && (!scenario.split_by_evidence_name
+                || result.scenario_name.as_deref() == scenario.evidence_name)
+    }
+
+    fn selected_scenario_evidence<'a>(
+        &'a self,
+        scenario: &HumanScenario<'_>,
+    ) -> Vec<&'a EvidenceResult> {
+        self.evidence
+            .iter()
+            .filter(|result| {
+                result.requirement == EvidenceRequirement::Required
+                    && result.selection == EvidenceSelection::Selected
+                    && Self::scenario_contains_result(scenario, result)
+            })
+            .collect()
+    }
+
+    fn human_scenario_disposition(&self, scenario: &HumanScenario<'_>) -> Disposition {
+        let selected = self.selected_scenario_evidence(scenario);
+        if !selected.is_empty()
+            && selected
+                .iter()
+                .all(|result| satisfies_ledger(result, &self.evidence))
+        {
+            return Disposition::Passed;
+        }
+        match aggregate_disposition(&selected) {
+            Disposition::Passed => Disposition::NoResult,
+            disposition => disposition,
+        }
+    }
+
+    fn render_scenario_failure(&self, output: &mut String, scenario: &HumanScenario<'_>) {
+        let mut rendered = BTreeSet::new();
+        for result in self
+            .selected_scenario_evidence(scenario)
+            .into_iter()
+            .filter(|result| !satisfies_ledger(result, &self.evidence))
+        {
+            let rendered_before = rendered.len();
+            if selected_binding_id_count(result, &self.evidence) > 1 {
+                let line = format!(
+                    "    Diagnostic: duplicate selected binding id '{}'",
+                    result.id
+                );
+                if rendered.insert(line.clone()) {
+                    output.push_str(&line);
+                    output.push('\n');
+                }
+            }
+            for attempt in &result.attempts {
+                for atom in attempt.evidence_atoms.iter().filter(|atom| !atom.passed) {
+                    let line = format!("    FAIL {}", atom.assertion);
+                    if rendered.insert(line.clone()) {
+                        output.push_str(&line);
+                        output.push('\n');
+                    }
+                    if let Some(diagnostic) = &atom.diagnostic {
+                        let line = format!("      {diagnostic}");
+                        if rendered.insert(line.clone()) {
+                            output.push_str(&line);
+                            output.push('\n');
+                        }
+                    }
+                }
+                if let Some(diagnostic) = &attempt.diagnostic {
+                    let line = format!("    Diagnostic: {diagnostic}");
+                    if rendered.insert(line.clone()) {
+                        output.push_str(&line);
+                        output.push('\n');
+                    }
+                }
+            }
+            if rendered.len() == rendered_before {
+                if let Some(obligation) = scenario
+                    .obligations
+                    .iter()
+                    .find(|obligation| obligation.id == result.obligation_id)
+                {
+                    output.push_str(&format!("    Unmet: {}\n", obligation.statement));
+                }
+            }
+        }
+    }
+
+    fn render_scenario_attempts(&self, output: &mut String, scenario: &HumanScenario<'_>) {
+        for result in self
+            .evidence
+            .iter()
+            .filter(|result| Self::scenario_contains_result(scenario, result))
+        {
+            output.push_str(&format!(
+                "    Evidence: {} [{}]\n",
+                result.id,
+                human_disposition(result.disposition)
+            ));
+            for attempt in &result.attempts {
+                output.push_str(&format!(
+                    "      Attempt {}: {} ({} atoms)\n",
+                    attempt.sequence,
+                    human_disposition(effective_attempt_disposition(attempt)),
+                    attempt.evidence_atoms.len()
+                ));
+                for atom in &attempt.evidence_atoms {
+                    output.push_str(&format!(
+                        "        {} {}\n",
+                        if atom.passed { "PASS" } else { "FAIL" },
+                        atom.assertion
+                    ));
+                    if let Some(diagnostic) = &atom.diagnostic {
+                        output.push_str(&format!("          {diagnostic}\n"));
+                    }
+                }
+                if let Some(diagnostic) = &attempt.diagnostic {
+                    output.push_str(&format!("        Diagnostic: {diagnostic}\n"));
+                }
+            }
+        }
+    }
+}
+
+fn human_feature_name(name: &str) -> String {
+    if name.starts_with("Component: ") {
+        name.to_string()
+    } else {
+        format!("Feature: {name}")
+    }
+}
+
+fn human_disposition(disposition: Disposition) -> &'static str {
+    match disposition {
+        Disposition::Planned => "PLANNED",
+        Disposition::Running => "RUNNING",
+        Disposition::Passed => "PASS",
+        Disposition::Failed => "FAIL",
+        Disposition::Flaky => "FLAKY",
+        Disposition::Skipped => "SKIP",
+        Disposition::Cancelled => "CANCELLED",
+        Disposition::NoResult => "NO RESULT",
     }
 }
 
@@ -1106,6 +1426,12 @@ fn append_legacy_test_projection(
                     "scenario.compat.{}.test.{}",
                     feature.verification_id,
                     test_index + 1
+                ),
+                scenario_name: format!(
+                    "Technical test {}: {} {}",
+                    test_index + 1,
+                    test.method,
+                    test.path
                 ),
                 statement,
                 source: feature.source.clone(),
@@ -1334,6 +1660,7 @@ fn append_mapping_failure(
         id: obligation_id.clone(),
         feature_id,
         scenario_id: format!("scenario.{obligation_id}"),
+        scenario_name: statement.clone(),
         statement,
         source: source.clone(),
         declaration: DeclarationStatus::Declared,
@@ -1466,7 +1793,7 @@ fn append_unmapped_live_component_with_id(
             component_feature_id.to_string(),
             source.clone(),
             format!("unmapped live component scenario '{}'", live_scenario.name),
-            LinkageStatus::Linked,
+            LinkageStatus::Unlinked,
             diagnostic,
             live_scenario_atoms(live_scenario),
         );
@@ -1609,20 +1936,23 @@ fn append_live_scenario_evidence(
                 ),
             }
         };
-        evidence.push(EvidenceResult::recorded(
-            binding_id,
-            metadata.id.to_string(),
-            metadata.source.clone(),
-            EvidenceRequirement::Required,
-            EvidenceSelection::Selected,
-            DeclarationStatus::Declared,
-            linkage,
-            binding,
-            executability,
-            Freshness::Current,
-            resolution,
-            attempts,
-        ));
+        evidence.push(
+            EvidenceResult::recorded(
+                binding_id,
+                metadata.id.to_string(),
+                metadata.source.clone(),
+                EvidenceRequirement::Required,
+                EvidenceSelection::Selected,
+                DeclarationStatus::Declared,
+                linkage,
+                binding,
+                executability,
+                Freshness::Current,
+                resolution,
+                attempts,
+            )
+            .in_scenario(&live.name),
+        );
     }
 }
 
@@ -1708,6 +2038,21 @@ fn aggregate_disposition(evidence: &[&EvidenceResult]) -> Disposition {
     Disposition::Passed
 }
 
+fn satisfies_ledger(result: &EvidenceResult, evidence: &[EvidenceResult]) -> bool {
+    result.satisfies_required() && selected_binding_id_count(result, evidence) == 1
+}
+
+fn selected_binding_id_count(result: &EvidenceResult, evidence: &[EvidenceResult]) -> usize {
+    evidence
+        .iter()
+        .filter(|candidate| {
+            candidate.requirement == EvidenceRequirement::Required
+                && candidate.selection == EvidenceSelection::Selected
+                && candidate.id == result.id
+        })
+        .count()
+}
+
 fn coverage_from_ledger(
     features: &[ReportFeature],
     obligations: &[ReportObligation],
@@ -1751,7 +2096,10 @@ fn coverage_from_ledger(
                         && result.selection == EvidenceSelection::Selected
                 })
                 .collect();
-            !selected.is_empty() && selected.iter().all(|result| result.satisfies_required())
+            !selected.is_empty()
+                && selected
+                    .iter()
+                    .all(|result| satisfies_ledger(result, evidence))
         })
         .count();
     let selected_required: Vec<_> = evidence
@@ -1778,7 +2126,7 @@ fn coverage_from_ledger(
         required_bindings: CoverageMetric {
             covered: selected_required
                 .iter()
-                .filter(|result| result.satisfies_required())
+                .filter(|result| satisfies_ledger(result, evidence))
                 .count(),
             total: selected_required.len(),
         },
@@ -1820,7 +2168,7 @@ fn decide_exit(
                 || (coverage.verified.total > 0 && selected_required.is_empty())
                 || selected_required
                     .iter()
-                    .any(|result| !result.satisfies_required())))
+                    .any(|result| !satisfies_ledger(result, evidence))))
     {
         return ExitDecision {
             code: 1,
@@ -1984,6 +2332,143 @@ mod tests {
             glossary: None,
             summary: None,
         }
+    }
+
+    fn human_renderer_report() -> RunReport {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Feature: Passing feature
+  id: feature.human-pass
+
+  Scenario: Accepted request
+    id: scenario.human-pass.accepted
+    When the request is checked
+    → id: outcome.human-pass.accepted; response is accepted
+
+Feature: Failing feature
+  id: feature.human-fail
+
+  Scenario: Denied request
+    id: scenario.human-fail.denied
+    When the request is checked
+    → id: outcome.human-fail.denied; response is denied
+
+Feature: Handbook
+  id: feature.handbook
+  verification: documentation-only
+  rationale: Explains the operator workflow
+"#,
+            "human-renderer.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        RunReport::from_live_results(
+            &intent,
+            &live_results(
+                vec![
+                    LiveFeatureResult {
+                        feature_id: "feature.human-pass".to_string(),
+                        feature_name: "Passing feature".to_string(),
+                        description: None,
+                        passed: true,
+                        tests: Vec::new(),
+                        scenarios: vec![live_scenario(
+                            "Accepted request",
+                            "pass",
+                            Some(vec![live_assertion("response is accepted", true)]),
+                        )],
+                        has_implementation: true,
+                    },
+                    LiveFeatureResult {
+                        feature_id: "feature.human-fail".to_string(),
+                        feature_name: "Failing feature".to_string(),
+                        description: None,
+                        passed: true,
+                        tests: Vec::new(),
+                        scenarios: vec![live_scenario(
+                            "Denied request",
+                            "fail",
+                            Some(vec![live_assertion("response is denied", false)]),
+                        )],
+                        has_implementation: true,
+                    },
+                    LiveFeatureResult {
+                        feature_id: "feature.handbook".to_string(),
+                        feature_name: "Handbook".to_string(),
+                        description: None,
+                        passed: true,
+                        tests: Vec::new(),
+                        scenarios: Vec::new(),
+                        has_implementation: false,
+                    },
+                ],
+                Vec::new(),
+            ),
+            "legacy-live",
+            true,
+        )
+    }
+
+    #[test]
+    fn human_verbosity_zero_exactly_restores_feature_scenario_counts_and_totals() {
+        let report = human_renderer_report();
+
+        assert_eq!(
+            report.render_human(0),
+            "\
+=== NTNT Intent Verification ===
+Profile: legacy-live (profile:legacy-live)
+[PASS] Feature: Passing feature (1/1 scenarios passed)
+[FAIL] Feature: Failing feature (0/1 scenarios passed)
+[DOCS] Feature: Handbook (documentation-only, non-verifying: Explains the operator workflow)
+Scenarios: 1/2 passed
+Obligations: 1 verified, 1 unmet; features: 1 documentation-only
+Required bindings: 1 passed, 1 failed
+Coverage: implementation 100.0%, executable 100.0%, verified 50.0%
+Exit: 1 (VerificationFailed)
+"
+        );
+    }
+
+    #[test]
+    fn human_verbosity_one_exactly_shows_scenarios_and_failed_diagnostics() {
+        let report = human_renderer_report();
+
+        assert_eq!(
+            report.render_human(1),
+            "\
+=== NTNT Intent Verification ===
+Profile: legacy-live (profile:legacy-live)
+[PASS] Feature: Passing feature (1/1 scenarios passed)
+  [PASS] Accepted request
+[FAIL] Feature: Failing feature (0/1 scenarios passed)
+  [FAIL] Denied request
+    FAIL response is denied
+      response is denied failed
+[DOCS] Feature: Handbook (documentation-only, non-verifying: Explains the operator workflow)
+Scenarios: 1/2 passed
+Obligations: 1 verified, 1 unmet; features: 1 documentation-only
+Required bindings: 1 passed, 1 failed
+Coverage: implementation 100.0%, executable 100.0%, verified 50.0%
+Exit: 1 (VerificationFailed)
+"
+        );
+    }
+
+    #[test]
+    fn human_verbosity_two_includes_all_atoms_and_attempt_history() {
+        let human = human_renderer_report().render_human(2);
+
+        assert!(human.contains(concat!(
+            "Evidence: binding.compat.scenario.human-pass.accepted.1.1 [PASS]\n",
+            "      Attempt 1: PASS (1 atoms)\n",
+            "        PASS response is accepted"
+        )));
+        assert!(human.contains(concat!(
+            "Evidence: binding.compat.scenario.human-fail.denied.1.1 [FAIL]\n",
+            "      Attempt 1: FAIL (1 atoms)\n",
+            "        FAIL response is denied\n",
+            "          response is denied failed"
+        )));
     }
 
     #[test]
@@ -2196,7 +2681,9 @@ mod tests {
         );
 
         assert_eq!(report("full", vec![passed.clone(), failed]).exit_code(), 1);
-        assert_eq!(report("full", vec![passed.clone(), passed]).exit_code(), 0);
+        let mut second_passed = passed.clone();
+        second_passed.id = "binding.passed-second".to_string();
+        assert_eq!(report("full", vec![passed, second_passed]).exit_code(), 0);
     }
 
     #[test]
@@ -2222,6 +2709,11 @@ mod tests {
             result.attempts()[0].evidence_atoms[0].diagnostic.as_deref(),
             Some("first failed")
         );
+        let human = report.render_human(2);
+        assert!(human.contains("Attempt 1: FAIL (1 atoms)"), "{human}");
+        assert!(human.contains("Attempt 2: PASS (1 atoms)"), "{human}");
+        assert!(human.contains("FAIL assertion first"), "{human}");
+        assert!(human.contains("PASS assertion second"), "{human}");
         assert_eq!(report.exit_code(), 1);
     }
 
@@ -2349,6 +2841,14 @@ mod tests {
         );
         assert_eq!(passing.evidence()[0].profile(), "legacy-live");
         assert_eq!(passing.evidence()[0].source.path, "legacy-technical.intent");
+        assert!(passing.render_human(1).contains(concat!(
+            "[PASS] Feature: Legacy technical (1/1 scenarios passed)\n",
+            "  [PASS] Technical test 1: GET /health"
+        )));
+        assert_eq!(
+            serde_json::to_value(&passing).unwrap()["obligations"][0]["scenario_name"],
+            "Technical test 1: GET /health"
+        );
 
         let failing = RunReport::from_live_results(
             &intent,
@@ -2481,6 +2981,8 @@ mod tests {
                 "{case}: {:?}",
                 report.evidence()
             );
+            let human = report.render_human(1);
+            assert!(human.contains("Diagnostic:"), "{case}: {human}");
         }
     }
 
@@ -2649,6 +3151,7 @@ mod tests {
     id: scenario.expanded.row-check
     When the check runs
     → id: outcome.expanded.row-valid; row is valid
+    → id: outcome.expanded.value-valid; value is valid
 "#,
             "expanded.intent".to_string(),
             IdMode::Strict,
@@ -2664,12 +3167,18 @@ mod tests {
                 live_scenario(
                     "Row check [first]",
                     "pass",
-                    Some(vec![live_assertion("row is valid", true)]),
+                    Some(vec![
+                        live_assertion("row is valid", true),
+                        live_assertion("value is valid", true),
+                    ]),
                 ),
                 live_scenario(
                     "Row check [second]",
                     if second_passes { "pass" } else { "fail" },
-                    Some(vec![live_assertion("row is valid", second_passes)]),
+                    Some(vec![
+                        live_assertion("row is valid", true),
+                        live_assertion("value is valid", second_passes),
+                    ]),
                 ),
             ],
             has_implementation: true,
@@ -2682,7 +3191,12 @@ mod tests {
             true,
         );
         assert_eq!(passing.exit_code(), 0);
-        assert_eq!(passing.coverage().required_bindings.total, 2);
+        assert_eq!(passing.coverage().required_bindings.total, 4);
+        assert!(passing.render_human(1).contains(concat!(
+            "[PASS] Feature: Expanded (2/2 scenarios passed)\n",
+            "  [PASS] Row check [first]\n",
+            "  [PASS] Row check [second]"
+        )));
 
         let failing = RunReport::from_live_results(
             &intent,
@@ -2691,7 +3205,12 @@ mod tests {
             true,
         );
         assert_eq!(failing.exit_code(), 1);
-        assert_eq!(failing.coverage().required_bindings.covered, 1);
+        assert_eq!(failing.coverage().required_bindings.covered, 2);
+        assert!(failing.render_human(1).contains(concat!(
+            "[FAIL] Feature: Expanded (1/2 scenarios passed)\n",
+            "  [PASS] Row check [first]\n",
+            "  [FAIL] Row check [second]"
+        )));
     }
 
     #[test]
@@ -2740,6 +3259,16 @@ Feature: Host
         );
         assert_eq!(passing.evidence()[0].profile(), "legacy-live");
         assert_eq!(passing.evidence()[0].source.start_line, 7);
+        assert_eq!(passing.evidence()[0].linkage, LinkageStatus::Unlinked);
+        assert_eq!(passing.obligations[0].linkage, LinkageStatus::Unlinked);
+        assert_eq!(passing.coverage().implementation.covered, 0);
+        let human = passing.render_human(1);
+        assert!(
+            human.contains(
+                "[PASS] Component: Reusable (1/1 scenarios passed)\n  [PASS] Component check"
+            ),
+            "{human}"
+        );
 
         for failing_component in [
             component("fail", false),
@@ -2757,6 +3286,64 @@ Feature: Host
             );
             assert_eq!(failing.exit_code(), 1);
         }
+    }
+
+    #[test]
+    fn inherent_component_behavior_is_visible_unlinked_and_unverified() {
+        let intent = IntentFile::parse_content_with_id_mode(
+            r#"Component: Required behavior
+  id: component.required-behavior
+  Inherent Behavior:
+    → status 418
+    → body contains "never returned"
+
+Feature: Host
+  id: feature.host
+  verification: documentation-only
+  rationale: Component-only compatibility fixture
+"#,
+            "component-inherent.intent".to_string(),
+            IdMode::Strict,
+        )
+        .unwrap();
+        let live_component = LiveComponentResult {
+            component_id: "component.required-behavior".to_string(),
+            component_name: "Required behavior".to_string(),
+            description: String::new(),
+            inherent_behavior: intent.components[0].inherent_behavior.clone(),
+            passed: true,
+            scenarios: Vec::new(),
+        };
+
+        let report = RunReport::from_live_results(
+            &intent,
+            &live_results(Vec::new(), vec![live_component]),
+            "legacy-live",
+            true,
+        );
+
+        assert_eq!(report.exit_code(), 1);
+        assert_eq!(report.coverage().required_bindings.total, 2);
+        assert_eq!(report.coverage().required_bindings.covered, 0);
+        assert_eq!(report.coverage().implementation.covered, 0);
+        assert_eq!(report.coverage().verified.covered, 0);
+        assert!(report.obligations.iter().all(|obligation| {
+            obligation.linkage == LinkageStatus::Unlinked
+                && obligation.scenario_name == "Inherent behavior"
+        }));
+        assert!(report.evidence().iter().all(|result| {
+            result.linkage == LinkageStatus::Unlinked
+                && result.binding == BindingStatus::Unbound
+                && result.disposition() == Disposition::NoResult
+                && result.scenario_name.as_deref() == Some("Inherent behavior")
+        }));
+        let human = report.render_human(1);
+        assert!(
+            human.contains(
+                "[FAIL] Component: Required behavior (0/1 scenarios passed)\n  [NO RESULT] Inherent behavior"
+            ),
+            "{human}"
+        );
     }
 
     #[test]
@@ -3006,6 +3593,28 @@ Feature: Host
     }
 
     #[test]
+    fn duplicate_selected_binding_ids_cannot_produce_a_human_or_ledger_pass() {
+        let duplicated = evidence(
+            "binding.duplicated",
+            EvidenceRequirement::Required,
+            EvidenceSelection::Selected,
+            BindingStatus::Bound,
+            ExecutabilityStatus::Executable,
+            Freshness::Current,
+            vec![attempt(1, Disposition::Passed, vec![atom("pass", true)])],
+        );
+
+        let report = report("full", vec![duplicated.clone(), duplicated]);
+
+        assert_eq!(report.coverage().verified.covered, 0);
+        assert_eq!(report.coverage().required_bindings.covered, 0);
+        assert_eq!(report.exit_code(), 1);
+        assert!(report
+            .render_human(0)
+            .contains("[FAIL] Feature: Report (0/1 scenarios passed)"));
+    }
+
+    #[test]
     fn advisory_and_excluded_bindings_remain_visible_but_never_satisfy() {
         let advisory = evidence(
             "binding.advisory",
@@ -3127,7 +3736,7 @@ Feature: Host
             evidence_atoms: 99,
         });
 
-        let report = RunReport::from_truth(&truth, "full", true);
+        let report = RunReport::from_truth(&truth, None, "full", true);
         assert_eq!(report.coverage().verified.covered, 0);
         assert_eq!(report.evidence()[0].disposition(), Disposition::NoResult);
         assert_eq!(report.exit_code(), 1);

--- a/tests/fixtures/verification/reports/schema-v1.json
+++ b/tests/fixtures/verification/reports/schema-v1.json
@@ -117,6 +117,7 @@
         "id",
         "feature_id",
         "scenario_id",
+        "scenario_name",
         "statement",
         "source",
         "declaration",
@@ -130,6 +131,7 @@
         "id": { "type": "string", "minLength": 1 },
         "feature_id": { "type": "string", "minLength": 1 },
         "scenario_id": { "type": "string", "minLength": 1 },
+        "scenario_name": { "type": "string", "minLength": 1 },
         "statement": { "type": "string" },
         "source": { "$ref": "#/$defs/span" },
         "declaration": { "enum": ["Declared", "DocumentationOnly"] },
@@ -189,6 +191,7 @@
       "properties": {
         "id": { "type": "string", "minLength": 1 },
         "obligation_id": { "type": "string", "minLength": 1 },
+        "scenario_name": { "type": "string", "minLength": 1 },
         "source": { "$ref": "#/$defs/span" },
         "profile": { "type": "string", "minLength": 1 },
         "requirement": { "enum": ["required", "advisory"] },

--- a/tests/fixtures/verification/reports/schema-v1.json
+++ b/tests/fixtures/verification/reports/schema-v1.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ntnt.dev/schemas/verification/run-report-v1.json",
+  "title": "NTNT verification RunReport v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "ntnt_version",
+    "ntnt_commit",
+    "profile",
+    "profile_qualification",
+    "freshness",
+    "strict",
+    "coverage",
+    "thresholds",
+    "features",
+    "obligations",
+    "evidence",
+    "unmet_required_binding_ids",
+    "exit"
+  ],
+  "properties": {
+    "schema": { "const": "https://ntnt.dev/schemas/verification/run-report-v1.json" },
+    "schema_version": { "const": 1 },
+    "ntnt_version": { "type": "string", "minLength": 1 },
+    "ntnt_commit": { "type": ["string", "null"] },
+    "profile": { "type": "string", "minLength": 1 },
+    "profile_qualification": { "type": "string", "pattern": "^profile:.+$" },
+    "freshness": { "enum": ["Current", "Stale"] },
+    "strict": { "type": "boolean" },
+    "coverage": { "$ref": "#/$defs/coverage" },
+    "thresholds": { "$ref": "#/$defs/thresholds" },
+    "features": { "type": "array", "items": { "$ref": "#/$defs/feature" } },
+    "obligations": { "type": "array", "items": { "$ref": "#/$defs/obligation" } },
+    "evidence": { "type": "array", "items": { "$ref": "#/$defs/evidence" } },
+    "unmet_required_binding_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "exit": { "$ref": "#/$defs/exit" }
+  },
+  "$defs": {
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["covered", "total"],
+      "properties": {
+        "covered": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "implementation",
+        "executable",
+        "verified",
+        "required_bindings",
+        "documentation_only_features",
+        "advisory_bindings",
+        "excluded_bindings",
+        "evidence_atoms"
+      ],
+      "properties": {
+        "implementation": { "$ref": "#/$defs/metric" },
+        "executable": { "$ref": "#/$defs/metric" },
+        "verified": { "$ref": "#/$defs/metric" },
+        "required_bindings": { "$ref": "#/$defs/metric" },
+        "documentation_only_features": { "type": "integer", "minimum": 0 },
+        "advisory_bindings": { "type": "integer", "minimum": 0 },
+        "excluded_bindings": { "type": "integer", "minimum": 0 },
+        "evidence_atoms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implementation", "executable", "verified"],
+      "properties": {
+        "implementation": { "type": "number", "minimum": 0, "maximum": 100 },
+        "executable": { "type": "number", "minimum": 0, "maximum": 100 },
+        "verified": { "type": "number", "minimum": 0, "maximum": 100 }
+      }
+    },
+    "span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "start_line", "start_column", "end_line", "end_column"],
+      "properties": {
+        "path": { "type": "string" },
+        "start_line": { "type": "integer", "minimum": 1 },
+        "start_column": { "type": "integer", "minimum": 1 },
+        "end_line": { "type": "integer", "minimum": 1 },
+        "end_column": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "feature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "source", "declaration"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string" },
+        "source": { "$ref": "#/$defs/span" },
+        "declaration": { "enum": ["Declared", "DocumentationOnly"] },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
+    "obligation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "feature_id",
+        "scenario_id",
+        "statement",
+        "source",
+        "declaration",
+        "linkage",
+        "binding",
+        "executability",
+        "disposition",
+        "freshness"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "feature_id": { "type": "string", "minLength": 1 },
+        "scenario_id": { "type": "string", "minLength": 1 },
+        "statement": { "type": "string" },
+        "source": { "$ref": "#/$defs/span" },
+        "declaration": { "enum": ["Declared", "DocumentationOnly"] },
+        "linkage": { "enum": ["Linked", "Unlinked"] },
+        "binding": { "enum": ["Bound", "Unbound", "Ambiguous"] },
+        "executability": { "enum": ["Executable", "Unsupported", "Blocked"] },
+        "disposition": {
+          "enum": ["Planned", "Running", "Passed", "Failed", "Flaky", "Skipped", "Cancelled", "NoResult"]
+        },
+        "freshness": { "enum": ["Current", "Stale"] }
+      }
+    },
+    "atom": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "assertion", "passed"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "assertion": { "type": "string" },
+        "passed": { "type": "boolean" },
+        "diagnostic": { "type": "string" }
+      }
+    },
+    "attempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sequence", "disposition", "evidence_atoms"],
+      "properties": {
+        "sequence": { "type": "integer", "minimum": 1 },
+        "disposition": {
+          "enum": ["Planned", "Running", "Passed", "Failed", "Flaky", "Skipped", "Cancelled", "NoResult"]
+        },
+        "evidence_atoms": { "type": "array", "items": { "$ref": "#/$defs/atom" } },
+        "diagnostic": { "type": "string" }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "obligation_id",
+        "source",
+        "profile",
+        "requirement",
+        "selection",
+        "declaration",
+        "linkage",
+        "binding",
+        "executability",
+        "disposition",
+        "freshness",
+        "assertion_resolution",
+        "evidence_atoms",
+        "attempts"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "obligation_id": { "type": "string", "minLength": 1 },
+        "source": { "$ref": "#/$defs/span" },
+        "profile": { "type": "string", "minLength": 1 },
+        "requirement": { "enum": ["required", "advisory"] },
+        "selection": { "enum": ["selected", "excluded"] },
+        "declaration": { "enum": ["Declared", "DocumentationOnly"] },
+        "linkage": { "enum": ["Linked", "Unlinked"] },
+        "binding": { "enum": ["Bound", "Unbound", "Ambiguous"] },
+        "executability": { "enum": ["Executable", "Unsupported", "Blocked"] },
+        "disposition": {
+          "enum": ["Planned", "Running", "Passed", "Failed", "Flaky", "Skipped", "Cancelled", "NoResult"]
+        },
+        "freshness": { "enum": ["Current", "Stale"] },
+        "assertion_resolution": { "enum": ["Resolved", "Unknown", "Unresolved"] },
+        "evidence_atoms": { "type": "integer", "minimum": 0 },
+        "attempts": { "type": "array", "items": { "$ref": "#/$defs/attempt" } }
+      }
+    },
+    "exit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "reason"],
+      "properties": {
+        "code": { "enum": [0, 1, 2, 3] },
+        "reason": { "enum": ["success", "verification-failed", "threshold-failed"] }
+      }
+    }
+  }
+}

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -15,6 +15,135 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
+fn validate_report_schema(instance: &serde_json::Value) -> Result<(), String> {
+    let schema: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/verification/reports/schema-v1.json"))
+            .map_err(|error| error.to_string())?;
+    validate_schema_node(&schema, instance, &schema, "$")
+}
+
+fn validate_schema_node(
+    schema: &serde_json::Value,
+    instance: &serde_json::Value,
+    root: &serde_json::Value,
+    path: &str,
+) -> Result<(), String> {
+    if let Some(reference) = schema.get("$ref").and_then(serde_json::Value::as_str) {
+        let pointer = reference
+            .strip_prefix('#')
+            .ok_or_else(|| format!("unsupported external schema reference {reference}"))?;
+        let target = root
+            .pointer(pointer)
+            .ok_or_else(|| format!("unknown schema reference {reference}"))?;
+        return validate_schema_node(target, instance, root, path);
+    }
+    if let Some(expected) = schema.get("const") {
+        if instance != expected {
+            return Err(format!(
+                "{path}: expected constant {expected}, got {instance}"
+            ));
+        }
+    }
+    if let Some(values) = schema.get("enum").and_then(serde_json::Value::as_array) {
+        if !values.contains(instance) {
+            return Err(format!("{path}: {instance} is not in enum {values:?}"));
+        }
+    }
+    if let Some(expected) = schema.get("type") {
+        let matches = match expected {
+            serde_json::Value::String(kind) => json_type_matches(instance, kind),
+            serde_json::Value::Array(kinds) => kinds
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .any(|kind| json_type_matches(instance, kind)),
+            _ => false,
+        };
+        if !matches {
+            return Err(format!(
+                "{path}: value {instance} has wrong type for {expected}"
+            ));
+        }
+    }
+    if let Some(minimum) = schema.get("minimum").and_then(serde_json::Value::as_f64) {
+        if instance.as_f64().is_some_and(|value| value < minimum) {
+            return Err(format!("{path}: value is below {minimum}"));
+        }
+    }
+    if let Some(maximum) = schema.get("maximum").and_then(serde_json::Value::as_f64) {
+        if instance.as_f64().is_some_and(|value| value > maximum) {
+            return Err(format!("{path}: value is above {maximum}"));
+        }
+    }
+    if let Some(minimum) = schema.get("minLength").and_then(serde_json::Value::as_u64) {
+        if instance
+            .as_str()
+            .is_some_and(|value| value.chars().count() < minimum as usize)
+        {
+            return Err(format!("{path}: string is shorter than {minimum}"));
+        }
+    }
+    if schema.get("pattern").and_then(serde_json::Value::as_str) == Some("^profile:.+$")
+        && !instance
+            .as_str()
+            .is_some_and(|value| value.starts_with("profile:") && value.len() > 8)
+    {
+        return Err(format!("{path}: invalid profile qualification"));
+    }
+    if let Some(object) = instance.as_object() {
+        if let Some(required) = schema.get("required").and_then(serde_json::Value::as_array) {
+            for field in required.iter().filter_map(serde_json::Value::as_str) {
+                if !object.contains_key(field) {
+                    return Err(format!("{path}: missing required field {field}"));
+                }
+            }
+        }
+        if let Some(properties) = schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+        {
+            if schema.get("additionalProperties") == Some(&serde_json::Value::Bool(false)) {
+                for field in object.keys() {
+                    if !properties.contains_key(field) {
+                        return Err(format!("{path}: unexpected field {field}"));
+                    }
+                }
+            }
+            for (field, value) in object {
+                if let Some(property_schema) = properties.get(field) {
+                    validate_schema_node(property_schema, value, root, &format!("{path}.{field}"))?;
+                }
+            }
+        }
+    }
+    if let (Some(items), Some(array)) = (schema.get("items"), instance.as_array()) {
+        for (index, value) in array.iter().enumerate() {
+            validate_schema_node(items, value, root, &format!("{path}[{index}]"))?;
+        }
+        if schema.get("uniqueItems") == Some(&serde_json::Value::Bool(true)) {
+            let mut seen = std::collections::BTreeSet::new();
+            for value in array {
+                if !seen.insert(value.to_string()) {
+                    return Err(format!("{path}: duplicate array item {value}"));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn json_type_matches(value: &serde_json::Value, kind: &str) -> bool {
+    match kind {
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "string" => value.is_string(),
+        "boolean" => value.is_boolean(),
+        "number" => value.is_number(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "null" => value.is_null(),
+        _ => false,
+    }
+}
+
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
@@ -430,23 +559,27 @@ fn test_intent_check_json_flag() {
         "--json",
     ]);
 
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "JSON must be banner-free: {stdout}"
+    );
+    assert!(!stdout.contains("NTNT Intent Check"), "{stdout}");
     let json: serde_json::Value =
         serde_json::from_str(&stdout).expect("--json should output valid JSON");
+    let schema: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/verification/reports/schema-v1.json"))
+            .expect("committed report schema must be valid JSON");
 
-    assert!(json["features"].is_array(), "Should have features array");
-    assert!(
-        json["total_assertions"].is_number(),
-        "Should have total_assertions"
-    );
-    assert!(
-        json["passed_assertions"].is_number(),
-        "Should have passed_assertions"
-    );
-    assert!(
-        json["failed_assertions"].is_number(),
-        "Should have failed_assertions"
-    );
-    assert_eq!(code, 0, "Simple server tests should pass");
+    assert_eq!(json["schema"], schema["$id"]);
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["profile"], "legacy-live");
+    assert_eq!(json["profile_qualification"], "profile:legacy-live");
+    assert!(json["coverage"]["verified"]["covered"].is_number());
+    assert!(json["coverage"]["required_bindings"]["total"].is_number());
+    assert!(json["evidence"].is_array());
+    assert_eq!(json["exit"]["code"], code);
+    validate_report_schema(&json).expect("check JSON must validate against committed schema");
+    assert_eq!(code, 0, "Simple server tests should pass: {stdout}");
 }
 
 #[test]
@@ -745,18 +878,39 @@ fn test_intent_check_valid_file() {
 
 #[test]
 fn test_intent_coverage_command() {
-    let (stdout, stderr, code) =
-        run_ntnt(&["intent", "coverage", "examples/intent_demo/server.tnt"]);
+    let (stdout, stderr, code) = run_ntnt(&[
+        "intent",
+        "coverage",
+        "examples/intent_demo/server.tnt",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.trim_start().starts_with('{'), "{stdout}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid report JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["profile"], "implementation");
+    assert!(json["coverage"]["implementation"]["total"].is_number());
+    assert!(json["coverage"]["executable"]["total"].is_number());
+    assert!(json["coverage"]["verified"]["total"].is_number());
+    validate_report_schema(&json).expect("coverage JSON must validate against committed schema");
+}
 
-    if code == 0 {
-        assert!(
-            stdout.contains("%")
-                || stderr.contains("%")
-                || stdout.contains("Feature")
-                || stderr.contains("Feature"),
-            "Coverage should show percentage or feature info"
-        );
-    }
+#[test]
+fn intent_coverage_threshold_flags_share_the_report_exit_decision() {
+    let (stdout, stderr, code) = run_ntnt(&[
+        "intent",
+        "coverage",
+        "examples/intent_demo/server.tnt",
+        "--json",
+        "--min-verified",
+        "100",
+    ]);
+    assert_eq!(code, 1, "{stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid report JSON");
+    assert_eq!(json["thresholds"]["verified"], 100.0);
+    assert_eq!(json["exit"]["code"], code);
+    assert_eq!(json["exit"]["reason"], "threshold-failed");
+    validate_report_schema(&json).expect("threshold JSON must validate against committed schema");
 }
 
 // ============================================================================

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -82,12 +82,14 @@ fn validate_schema_node(
             return Err(format!("{path}: string is shorter than {minimum}"));
         }
     }
-    if schema.get("pattern").and_then(serde_json::Value::as_str) == Some("^profile:.+$")
-        && !instance
-            .as_str()
-            .is_some_and(|value| value.starts_with("profile:") && value.len() > 8)
-    {
-        return Err(format!("{path}: invalid profile qualification"));
+    if let Some(pattern) = schema.get("pattern").and_then(serde_json::Value::as_str) {
+        let regex = regex::Regex::new(pattern)
+            .map_err(|error| format!("{path}: invalid schema pattern {pattern:?}: {error}"))?;
+        if !instance.as_str().is_some_and(|value| regex.is_match(value)) {
+            return Err(format!(
+                "{path}: value does not match schema pattern {pattern:?}"
+            ));
+        }
     }
     if let Some(object) = instance.as_object() {
         if let Some(required) = schema.get("required").and_then(serde_json::Value::as_array) {
@@ -675,6 +677,93 @@ Feature: Bad Test
         "intent check should fail when assertions don't match.\nOutput:\n{}",
         output
     );
+}
+
+#[test]
+fn test_intent_check_projects_legacy_test_blocks_into_the_report_ledger() {
+    let fixture_stem = format!("ntnt_legacy_report_{}", std::process::id());
+    let test_tnt = std::env::temp_dir().join(format!("{fixture_stem}.tnt"));
+    let test_intent = std::env::temp_dir().join(format!("{fixture_stem}.intent"));
+    fs::write(
+        &test_tnt,
+        r#"
+import { html } from "std/http/server"
+
+// @implements: feature.legacy-report
+fn handler(req) {
+    return html("<html><body>legacy ok</body></html>")
+}
+
+get("/", handler)
+listen(8080)
+"#,
+    )
+    .unwrap();
+    let write_intent = |expected: &str| {
+        fs::write(
+            &test_intent,
+            format!(
+                r#"Feature: Legacy report
+  id: feature.legacy-report
+  test:
+    - request: GET /
+      assert:
+        - status: 200
+        - body contains "{expected}"
+"#
+            ),
+        )
+        .unwrap();
+    };
+    let tnt_path = test_tnt.to_string_lossy().to_string();
+
+    write_intent("legacy ok");
+    let (passing_stdout, passing_stderr, passing_code) =
+        run_ntnt(&["intent", "check", &tnt_path, "--port", "18093", "--json"]);
+    assert_eq!(
+        passing_code, 0,
+        "passing legacy test block must verify:\n{passing_stdout}\n{passing_stderr}"
+    );
+    let passing: serde_json::Value =
+        serde_json::from_str(&passing_stdout).expect("passing report JSON");
+    validate_report_schema(&passing).expect("passing compatibility report must match schema");
+    assert_eq!(passing["coverage"]["required_bindings"]["total"], 2);
+    assert_eq!(passing["coverage"]["required_bindings"]["covered"], 2);
+    assert!(passing["evidence"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|result| {
+            result["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("binding.compat.feature.legacy-report.test.1."))
+                && result["profile"] == "legacy-live"
+        }));
+
+    write_intent("never returned");
+    let (failing_stdout, failing_stderr, failing_code) =
+        run_ntnt(&["intent", "check", &tnt_path, "--port", "18094", "--json"]);
+    fs::remove_file(&test_tnt).ok();
+    fs::remove_file(&test_intent).ok();
+
+    assert_ne!(
+        failing_code, 0,
+        "failing legacy test block must remain selected evidence:\n{failing_stdout}\n{failing_stderr}"
+    );
+    let failing: serde_json::Value =
+        serde_json::from_str(&failing_stdout).expect("failing report JSON");
+    validate_report_schema(&failing).expect("failing compatibility report must match schema");
+    assert_eq!(failing["exit"]["code"], failing_code);
+    assert!(failing["evidence"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|result| {
+            result["disposition"] == "Failed"
+                && result["obligation_id"].as_str().is_some_and(|id| {
+                    id.starts_with("outcome.compat.feature.legacy-report.test.1.")
+                })
+        }));
 }
 
 #[test]

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -579,6 +579,16 @@ fn test_intent_check_json_flag() {
     assert!(json["coverage"]["verified"]["covered"].is_number());
     assert!(json["coverage"]["required_bindings"]["total"].is_number());
     assert!(json["evidence"].is_array());
+    assert!(
+        json["obligations"]
+            .as_array()
+            .is_some_and(|obligations| obligations
+                .iter()
+                .all(|obligation| obligation["scenario_name"]
+                    .as_str()
+                    .is_some_and(|name| !name.is_empty()))),
+        "every serialized obligation needs a human scenario name"
+    );
     assert_eq!(json["exit"]["code"], code);
     validate_report_schema(&json).expect("check JSON must validate against committed schema");
     assert_eq!(code, 0, "Simple server tests should pass: {stdout}");

--- a/tests/intent_studio_tests.rs
+++ b/tests/intent_studio_tests.rs
@@ -995,6 +995,54 @@ fn test_intent_coverage_command() {
 }
 
 #[test]
+fn intent_coverage_human_output_uses_linkage_status() {
+    let (stdout, stderr, code) =
+        run_ntnt(&["intent", "coverage", "examples/intent_demo/server.tnt"]);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.contains("Profile: implementation"), "{stdout}");
+    assert!(stdout.contains("[LINKED]"), "{stdout}");
+    assert!(!stdout.contains("[FAIL]"), "{stdout}");
+    assert!(stdout.contains("Coverage: implementation"), "{stdout}");
+}
+
+#[test]
+fn legacy_feature_ids_retain_implementation_coverage() {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let directory = std::env::temp_dir().join(format!(
+        "ntnt_legacy_coverage_{}_{}",
+        std::process::id(),
+        counter
+    ));
+    fs::create_dir_all(&directory).unwrap();
+    let source = directory.join("app.tnt");
+    let intent = directory.join("app.intent");
+    fs::write(
+        &source,
+        "// @implements: home_page\nfn home() { return 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        &intent,
+        "Feature: Home Page\n  Scenario: Render home\n    When home renders\n    → result is visible\n",
+    )
+    .unwrap();
+
+    let source_arg = source.to_string_lossy().into_owned();
+    let (stdout, stderr, code) = run_ntnt(&["intent", "coverage", &source_arg, "--json"]);
+    fs::remove_dir_all(&directory).ok();
+
+    assert_eq!(code, 0, "{stderr}\n{stdout}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid report JSON");
+    assert!(
+        json["coverage"]["implementation"]["covered"]
+            .as_u64()
+            .is_some_and(|covered| covered > 0),
+        "{json}"
+    );
+}
+
+#[test]
 fn intent_coverage_threshold_flags_share_the_report_exit_decision() {
     let (stdout, stderr, code) = run_ntnt(&[
         "intent",


### PR DESCRIPTION
## Summary

Implements DD-078 Task/Slice 1B on top of Slice 1A (#178):

- adds the versioned `RunReport` evidence ledger and committed schema v1;
- makes human output, JSON, coverage, thresholds, and exit status projections of one ledger;
- adds `intent check --json` and `intent coverage --json` plus implementation/executable/verified thresholds;
- preserves concrete legacy technical tests, feature scenarios, expanded runs, preconditions, and component scenarios through fail-closed compatibility projection;
- restores feature/scenario human output and failure diagnostics without reintroducing ad hoc summary arithmetic;
- keeps component linkage authority honest and represents unsupported inherent behavior as selected unbound/no-result evidence;
- rejects duplicate binding and obligation identities so generated/explicit collisions cannot produce false success.

## Truth guarantees

- Every selected required binding must be bound, executable, current, resolved, passed, and carry concrete evidence atoms.
- Missing, extra, reordered, ambiguous, warning, pending, skipped, zero-assertion, or otherwise unmappable live results remain visible and fail closed.
- Pass-after-failure remains flaky with attempt history.
- Advisory and profile-excluded evidence remains visible but cannot satisfy required obligations.
- `@implements`/linkage metadata cannot prove execution.
- Fast/profile-qualified evidence cannot become a global/full claim.
- Duplicate obligation or binding IDs cannot share evidence or manipulate coverage denominators.

## Validation

Exact head: `296c0a6bd747e92830a9b4333d95393addb7bbe9`

- `cargo fmt --check`
- `cargo test --lib`
- `RUST_MIN_STACK=8388608 cargo nextest run` — **2,009/2,009 passed**
- `RUST_MIN_STACK=8388608 cargo test --doc`
- `cargo build --profile dev-release`
- schema JSON parse and integration validation
- focused report tests — **27/27 passed**
- Intent Studio tests — **39/39 passed**
- `git diff c3d179e...HEAD --check`
- exact-head Greptile — **5/5, safe to merge, no comments**
- exact-head immutable cold review — **PASS, no blocker/major findings**

## Review notes

This is a stacked PR. Its base is `feat/dd078-slice-1a-truth-model` / #178, not `main`.

JUnit, project discovery, policy/grants, planning, execution providers, fixtures/resources, and later DD-078 slices remain out of scope.
